### PR TITLE
Enhance Mandala UI and CLI tools

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,9 @@
+echo "husky - DEPRECATED
+
+Please remove the following two lines from $0:
+
+#!/usr/bin/env sh
+. \"\$(dirname -- \"\$0\")/_/husky.sh\"
+
+They WILL FAIL in v10.0.0
+"

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+node scripts/generate-chronopoem.js

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "tsc -b",
     "lint": "tsc -p tsconfig.json --noEmit",
     "test": "jest",
-    "dev": "echo 'dev script placeholder'"
+    "dev": "echo 'dev script placeholder'",
+    "prepare": "husky install"
   },
   "dependencies": {
     "ajv": "^8.0.0",
@@ -22,7 +23,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-tooltip": "^5.18.0",
-    "socket.io-client": "^4.7.5"
+    "socket.io-client": "^4.7.5",
+    "recharts": "^2.8.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
@@ -36,6 +38,7 @@
     "jest": "^29.6.4",
     "jest-environment-jsdom": "30.0.0-beta.3",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "husky": "^9.0.0"
   }
 }

--- a/packages/cli-tools/sigillin-cli.js
+++ b/packages/cli-tools/sigillin-cli.js
@@ -36,12 +36,35 @@ program
 
 program
   .command('list')
-  .description('Listet vorhandene *.sigil.json Dateien im aktuellen Verzeichnis')
+  .description('Listet vorhandene *.sigil.json Dateien im Projekt')
   .action(() => {
-    const files = fs.readdirSync(process.cwd())
-      .filter(f => f.endsWith('.sigil.json'));
+    const glob = require('glob');
+    const files = glob.sync('**/*.sigil.json', { ignore: 'node_modules/**' });
     console.log('Gefundene Sigillin-Dateien:');
     files.forEach(f => console.log(' -', f));
+  });
+
+program
+  .command('graph')
+  .description('Erzeugt eine Mermaid-Datei aller Sigillin-Verkn\xFCpfungen')
+  .option('--json', 'JSON-Ausgabe statt Mermaid')
+  .action((opts) => {
+    const glob = require('glob');
+    const sigilFiles = glob.sync('**/*.sigil.json', { ignore: 'node_modules/**' });
+    const sigils = sigilFiles.map(f => JSON.parse(fs.readFileSync(f, 'utf8')));
+    if (opts.json) {
+      fs.writeFileSync('sigillin-graph.json', JSON.stringify(sigils, null, 2));
+      console.log('sigillin-graph.json erstellt');
+      return;
+    }
+    let out = 'graph TD\n';
+    sigils.forEach(s => {
+      (s.related_sigils || []).forEach(r => {
+        out += `  ${s.id} -->|${r.relation}| ${r.id}\n`;
+      });
+    });
+    fs.writeFileSync('sigillin-relations.mmd', out);
+    console.log('sigillin-relations.mmd erstellt');
   });
 
 program.parse(process.argv);

--- a/packages/unifiedmandala-ui/components/CREPChart.tsx
+++ b/packages/unifiedmandala-ui/components/CREPChart.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
+import { CREPEntry } from '../../crep-engine/types';
+
+interface CREPChartProps {
+  history: CREPEntry[];
+}
+
+const CREPChart: React.FC<CREPChartProps> = ({ history }) => (
+  <LineChart width={600} height={300} data={history}>
+    <CartesianGrid stroke="#ccc" />
+    <XAxis dataKey="timestamp" tickFormatter={(v) => new Date(v).toLocaleTimeString()} />
+    <YAxis domain={[0, 10]} />
+    <Tooltip />
+    <Line type="monotone" dataKey="C" stroke="#8884d8" />
+    <Line type="monotone" dataKey="R" stroke="#82ca9d" />
+    <Line type="monotone" dataKey="E" stroke="#ff7300" />
+    <Line type="monotone" dataKey="P" stroke="#ff0000" />
+  </LineChart>
+);
+
+export default CREPChart;

--- a/packages/unifiedmandala-ui/components/MandalaNetworkView.stories.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaNetworkView.stories.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import MandalaNetworkView from './MandalaNetworkView';
+
+export default {
+  title: 'UnifiedMandala/MandalaNetworkView',
+  component: MandalaNetworkView,
+};
+
+export const Interaktiv = () => <MandalaNetworkView />;

--- a/packages/unifiedmandala-ui/components/MandalaNetworkView.test.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaNetworkView.test.tsx
@@ -2,6 +2,7 @@
 jest.mock('d3', () => ({
   select: () => ({
     selectAll: () => ({ remove: jest.fn() }),
+    call: jest.fn().mockReturnThis(),
     append: () => ({
       attr: jest.fn().mockReturnThis(),
       selectAll: jest.fn().mockReturnThis(),
@@ -17,6 +18,7 @@ jest.mock('d3', () => ({
   forceManyBody: () => ({ strength: jest.fn().mockReturnThis() }),
   forceCenter: jest.fn(),
   drag: () => ({ on: jest.fn().mockReturnThis() }),
+  zoom: () => ({ on: jest.fn().mockReturnThis() }),
   interpolateRainbow: jest.fn(() => '#fff'),
 }));
 
@@ -27,7 +29,9 @@ import MandalaNetworkView from './MandalaNetworkView';
 test('renders svg and filter options', () => {
   render(<MandalaNetworkView />);
   expect(screen.getByLabelText('Mandala Netzwerk')).toBeInTheDocument();
+  const selects = screen.getAllByRole('combobox');
+  expect(selects.length).toBe(2);
   // one option per type plus "Alle"
   const options = screen.getAllByRole('option');
-  expect(options.length).toBeGreaterThan(1);
+  expect(options.length).toBeGreaterThan(2);
 });

--- a/packages/unifiedmandala-ui/components/MandalaNetworkView.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaNetworkView.tsx
@@ -25,6 +25,7 @@ const colorForCREP = ({ C, R, E, P }: MandalaNode["crep"]) =>
 export const MandalaNetworkView: React.FC = () => {
   const svgRef = useRef<SVGSVGElement>(null);
   const [filterType, setFilterType] = useState<string>('all');
+  const [filterLevel, setFilterLevel] = useState<string>('all');
   // verfügbare Sigillin-Typen für die Filter-UI ermitteln
   const types = Array.from(new Set(nodesData.map(n => n.type)));
 
@@ -34,7 +35,14 @@ export const MandalaNetworkView: React.FC = () => {
     const svg = d3.select(svgRef.current);
     svg.selectAll("*").remove();
 
-    const nodes: MandalaNode[] = nodesData.filter(n => filterType === 'all' || n.type === filterType);
+    const nodes: MandalaNode[] = nodesData.filter(n => {
+      if (filterType !== 'all' && n.type !== filterType) return false;
+      const sum = n.crep.C + n.crep.R + n.crep.E + n.crep.P;
+      if (filterLevel === 'low' && sum >= 10) return false;
+      if (filterLevel === 'medium' && (sum < 10 || sum > 20)) return false;
+      if (filterLevel === 'high' && sum <= 20) return false;
+      return true;
+    });
     const links = nodes.flatMap(n =>
       (n.related || []).map(r => ({
         source: n.id,
@@ -68,7 +76,10 @@ export const MandalaNetworkView: React.FC = () => {
       .attr("stroke", "#222")
       .attr("stroke-width", 2)
       .attr("data-tooltip-id", "node-tooltip")
-      .attr("data-tooltip-content", d => `${d.label}\n${d.poetry ?? ''}`)
+      .attr(
+        "data-tooltip-content",
+        d => `${d.label}\nC:${d.crep.C} R:${d.crep.R} E:${d.crep.E} P:${d.crep.P}\n${d.poetry ?? ''}`
+      )
       .call(
         d3
           .drag<SVGCircleElement, MandalaNode>()
@@ -98,6 +109,12 @@ export const MandalaNetworkView: React.FC = () => {
       .attr("dy", 40)
       .text(d => d.label);
 
+    svg.call(
+      d3.zoom<any, any>().on('zoom', (event) => {
+        svg.selectAll('g').attr('transform', event.transform.toString());
+      })
+    );
+
     simulation.on("tick", () => {
       link
       .attr("x1", d => (d.source as any).x)
@@ -111,7 +128,7 @@ export const MandalaNetworkView: React.FC = () => {
         .attr("x", d => d.x!)
         .attr("y", d => d.y!);
     });
-  }, [filterType]);
+  }, [filterType, filterLevel]);
 
   const handleExportSVG = () => {
     const svg = svgRef.current;
@@ -142,11 +159,24 @@ export const MandalaNetworkView: React.FC = () => {
           ))}
         </select>
       </label>
+      <label className="mb-2">
+        CREP-Level:
+        <select
+          value={filterLevel}
+          onChange={e => setFilterLevel(e.target.value)}
+          className="ml-2 border p-1 rounded"
+        >
+          <option value="all">Alle</option>
+          <option value="low">Niedrig</option>
+          <option value="medium">Mittel</option>
+          <option value="high">Hoch</option>
+        </select>
+      </label>
       <svg ref={svgRef} width={800} height={600} tabIndex={0} aria-label="Mandala Netzwerk" />
       <button onClick={handleExportSVG} className="mt-4 p-2 bg-blue-600 text-white rounded-lg shadow">
         Export as SVG
       </button>
-      <Tooltip id="node-tooltip" />
+      <Tooltip id="node-tooltip" data-testid="tooltip-anchor" />
     </div>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-tooltip:
         specifier: ^5.18.0
         version: 5.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts:
+        specifier: ^2.8.0
+        version: 2.15.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       socket.io-client:
         specifier: ^4.7.5
         version: 4.8.1
@@ -66,6 +69,9 @@ importers:
       '@types/react-tooltip':
         specifier: ^4.2.4
         version: 4.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      husky:
+        specifier: ^9.0.0
+        version: 9.1.7
       jest:
         specifier: ^29.6.4
         version: 29.7.0(@types/node@20.17.57)
@@ -761,6 +767,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -957,6 +967,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
   decimal.js@10.5.0:
     resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
 
@@ -992,6 +1005,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -1035,6 +1051,9 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -1049,6 +1068,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.2.2:
+    resolution: {integrity: sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==}
+    engines: {node: '>=6.0.0'}
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -1149,6 +1172,11 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -1623,15 +1651,37 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-tooltip@5.28.1:
     resolution: {integrity: sha512-ZA4oHwoIIK09TS7PvSLFcRlje1wGZaxw6xHvfrzn6T82UcMEfEmHVCad16Gnr4NDNDh93HyN037VK4HDi5odfQ==}
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'
 
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.3:
+    resolution: {integrity: sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -1780,6 +1830,9 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
@@ -1855,6 +1908,9 @@ packages:
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -2832,6 +2888,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clsx@2.1.1: {}
+
   co@4.6.0: {}
 
   collect-v8-coverage@1.0.2: {}
@@ -3045,6 +3103,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js-light@2.5.1: {}
+
   decimal.js@10.5.0: {}
 
   dedent@1.6.0: {}
@@ -3064,6 +3124,11 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.27.4
+      csstype: 3.1.3
 
   ejs@3.1.10:
     dependencies:
@@ -3101,6 +3166,8 @@ snapshots:
 
   esprima@4.0.1: {}
 
+  eventemitter3@4.0.7: {}
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -3124,6 +3191,8 @@ snapshots:
       jest-util: 29.7.0
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.2.2: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
@@ -3221,6 +3290,8 @@ snapshots:
       - supports-color
 
   human-signals@2.1.0: {}
+
+  husky@9.1.7: {}
 
   iconv-lite@0.6.3:
     dependencies:
@@ -3874,6 +3945,14 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      fast-equals: 5.2.2
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
   react-tooltip@5.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@floating-ui/dom': 1.7.1
@@ -3881,9 +3960,35 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.4
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.17.21
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   redent@3.0.0:
     dependencies:
@@ -4016,6 +4121,8 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.2
 
+  tiny-invariant@1.3.3: {}
+
   tldts-core@6.1.86: {}
 
   tldts@6.1.86:
@@ -4077,6 +4184,23 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.1
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- extend MandalaNetworkView with zoom, CREP filtering and improved tooltips
- add interactive story and chart component
- expand sigillin CLI with recursive list and graph generation
- add husky post-commit hook to generate CHRONOPOEM
- include Recharts dependency

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68406b6293388322b5580b3765a42d79