### PR TITLE
Fix CLI docs export under Node

### DIFF
--- a/packages/cli-tools/export-doc.js
+++ b/packages/cli-tools/export-doc.js
@@ -1,6 +1,18 @@
 #!/usr/bin/env node
 const fs = require('fs');
-const { CREPManager } = require('../crep-engine/CREPManager');
+let CREPManager;
+if (typeof globalThis.localStorage === 'undefined') {
+  globalThis.localStorage = {
+    getItem: () => null,
+    setItem: () => {},
+  };
+}
+try {
+  // use compiled version if available
+  ({ CREPManager } = require('../../dist/crep-engine/CREPManager.js'));
+} catch (e) {
+  ({ CREPManager } = require('../crep-engine/CREPManager'));
+}
 
 const crep = new CREPManager();
 const history = crep.getCREPHistory();


### PR DESCRIPTION
## Summary
- improve `export-doc` CLI to run when localStorage is missing
- prefer compiled `CREPManager` when available

## Testing
- `pnpm test`
- `node packages/cli-tools/export-doc.js`

------
https://chatgpt.com/codex/tasks/task_e_6840710c558083229a4d596e201607f2