### PR TITLE
Implement CLI conversion and dynamic symbol phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ narrative Interfaces und adaptive Bewusstseinsräume.
   ├── unifiedmandala-ui         # React-Komponenten (inkl. MandalaNetworkView)
   ├── crep-engine               # Zustandssimulation, CREP-Evaluierung
   ├── gpt-bridges               # EventHub für KI-Interaktion
-  ├── cli-tools                 # sigillin-cli, sigillin-archive, export-doc
+  ├── cli-tools                 # sigillin-cli (inkl. YAML/JSON-Konvertierung), sigillin-archive, export-doc
 /scripts/
   ├── aeon.sh                   # Poetisches Bash-CLI für Mandala-Steuerung
   ├── setup-unifiedmandala.sh   # Installer & Initialisierung
@@ -54,6 +54,7 @@ chmod +x scripts/aeon.sh
 ./scripts/aeon.sh sigil_invoke     # Exportiert Sigillin & CREP-Dokumentation
 ./scripts/aeon.sh chronopoem       # Erzeugt poetische Commit-Signatur (CHRONOPOEM.md)
 ./scripts/aeon.sh onboarding       # Zeigt Onboarding-Ritus für neue Contributors
+pnpm sigillin-cli convert beispiel.yaml # YAML/JSON-Konvertierung
 
 Das CHRONOPOEM.md entsteht automatisch – und kann bei jedem Commit erneuert werden.
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-tooltip": "^5.18.0",
+    "recharts": "^2.8.0",
     "socket.io-client": "^4.7.5",
-    "recharts": "^2.8.0"
+    "yaml": "^2.8.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
@@ -35,10 +36,10 @@
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "@types/react-tooltip": "^4.2.4",
+    "husky": "^9.0.0",
     "jest": "^29.6.4",
     "jest-environment-jsdom": "30.0.0-beta.3",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.4.0",
-    "husky": "^9.0.0"
+    "typescript": "^5.4.0"
   }
 }

--- a/packages/cli-tools/sigillin-cli.js
+++ b/packages/cli-tools/sigillin-cli.js
@@ -3,6 +3,7 @@ const { program } = require('commander');
 const fs = require('fs');
 const Ajv = require('ajv');
 const schema = require('../genesis-sigillin-core/schemas/sigillin.schema.json');
+const YAML = require('yaml');
 let SigillinGenerator;
 try {
   // use compiled version if available
@@ -17,7 +18,10 @@ program
   .action((file) => {
     const ajv = new Ajv();
     const validate = ajv.compile(schema);
-    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const content = fs.readFileSync(file, 'utf8');
+    const data = file.endsWith('.yaml') || file.endsWith('.yml')
+      ? YAML.parse(content)
+      : JSON.parse(content);
     if (!validate(data)) {
       console.error(validate.errors);
       process.exit(1);
@@ -42,6 +46,25 @@ program
     const files = glob.sync('**/*.sigil.json', { ignore: 'node_modules/**' });
     console.log('Gefundene Sigillin-Dateien:');
     files.forEach(f => console.log(' -', f));
+  });
+
+program
+  .command('convert <input> [output]')
+  .description('Konvertiert zwischen YAML und JSON')
+  .action((input, output) => {
+    const content = fs.readFileSync(input, 'utf8');
+    let data;
+    let targetFile;
+    if (input.endsWith('.yaml') || input.endsWith('.yml')) {
+      data = YAML.parse(content);
+      targetFile = output || input.replace(/\.ya?ml$/, '.json');
+      fs.writeFileSync(targetFile, JSON.stringify(data, null, 2));
+    } else {
+      data = JSON.parse(content);
+      targetFile = output || input.replace(/\.json$/, '.yaml');
+      fs.writeFileSync(targetFile, YAML.stringify(data));
+    }
+    console.log(`Konvertiert -> ${targetFile}`);
   });
 
 program

--- a/packages/unifiedmandala-ui/hooks/useSymbolzeit.test.ts
+++ b/packages/unifiedmandala-ui/hooks/useSymbolzeit.test.ts
@@ -1,0 +1,21 @@
+import { renderHook, act } from '@testing-library/react';
+import { useSymbolzeit } from './useSymbolzeit';
+
+describe('useSymbolzeit', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('updates phase based on current time', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2023-01-01T06:00:00Z'));
+    const { result } = renderHook(() => useSymbolzeit());
+    expect(result.current.phase).toBe('Initiation');
+
+    jest.setSystemTime(new Date('2023-01-01T13:00:00Z'));
+    act(() => {
+      jest.advanceTimersByTime(61000);
+    });
+    expect(result.current.phase).toBe('Aktivierung');
+  });
+});

--- a/packages/unifiedmandala-ui/hooks/useSymbolzeit.ts
+++ b/packages/unifiedmandala-ui/hooks/useSymbolzeit.ts
@@ -11,11 +11,16 @@ export const useSymbolzeit = () => {
   const [symbolPhase, setSymbolPhase] = useState(SymbolzeitTabelle.tag);
 
   useEffect(() => {
-    const hour = new Date().getHours();
-    if (hour >= 5 && hour < 12) setSymbolPhase(SymbolzeitTabelle.morgen);
-    else if (hour >= 12 && hour < 18) setSymbolPhase(SymbolzeitTabelle.tag);
-    else if (hour >= 18 && hour < 22) setSymbolPhase(SymbolzeitTabelle.abend);
-    else setSymbolPhase(SymbolzeitTabelle.nacht);
+    const update = () => {
+      const hour = new Date().getHours();
+      if (hour >= 5 && hour < 12) setSymbolPhase(SymbolzeitTabelle.morgen);
+      else if (hour >= 12 && hour < 18) setSymbolPhase(SymbolzeitTabelle.tag);
+      else if (hour >= 18 && hour < 22) setSymbolPhase(SymbolzeitTabelle.abend);
+      else setSymbolPhase(SymbolzeitTabelle.nacht);
+    };
+    update();
+    const id = setInterval(update, 60 * 1000);
+    return () => clearInterval(id);
   }, []);
 
   return symbolPhase;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       socket.io-client:
         specifier: ^4.7.5
         version: 4.8.1
+      yaml:
+        specifier: ^2.8.0
+        version: 2.8.0
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.6.3
@@ -1992,6 +1995,11 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.8.0:
+    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -4253,6 +4261,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.8.0: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Summary
- extend `sigillin-cli` with YAML/JSON conversion command
- allow `validate` to read YAML
- automatically update Symbolzeit phase over time
- add unit test for the new hook behaviour
- document CLI enhancement in README

## Testing
- `pnpm test`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840734382bc8322ba96dd3e659e5edf