### PR TITLE
Implement Sharedream phase 2 prep

### DIFF
--- a/apps/sharedream-interface/README.md
+++ b/apps/sharedream-interface/README.md
@@ -1,0 +1,4 @@
+# Sharedream Interface
+
+Dieses Verzeichnis enthält den geplanten Web- und Community-Zugang für UnifiedMandala.
+Phase 2 wird hier eine einfache React-basierte Oberfläche aufbauen.

--- a/codex/codex-roadmap.yaml
+++ b/codex/codex-roadmap.yaml
@@ -1,0 +1,14 @@
+phase: 2
+milestones:
+  - id: sigillin-loader-ui
+    description: Symbolischer SigillinLoader als React-Komponente
+  - id: mastercanvas-nodes
+    description: MasterCanvas-Knoten in sigillin_nodes.json ergänzt
+  - id: gpt-stubs
+    description: Stub-Module für aeon-gpt-synapse, AEONPOET und CREPJUDGE erstellt
+  - id: symbolzeit-config
+    description: Basiskonfiguration in symbolzeit.yaml angelegt
+  - id: crep-phase-matrix
+    description: CREPPhaseMatrix.yaml definiert Phasen-Fokus
+  - id: sharedream-interface
+    description: Repository apps/sharedream-interface vorbereitet

--- a/docs/CREPPhaseMatrix.yaml
+++ b/docs/CREPPhaseMatrix.yaml
@@ -1,0 +1,13 @@
+phases:
+  - phase: "Initiation"
+    crep_focus: "C"
+    beschreibung: "Konzept und Kohärenz"
+  - phase: "Aktivierung"
+    crep_focus: "R"
+    beschreibung: "Resonanz und Austausch"
+  - phase: "Integration"
+    crep_focus: "E"
+    beschreibung: "Emergenz und Entwicklung"
+  - phase: "Reflexion"
+    crep_focus: "P"
+    beschreibung: "Poetik und Persistenz"

--- a/docs/symbolzeit.yaml
+++ b/docs/symbolzeit.yaml
@@ -1,0 +1,13 @@
+symbolzeit:
+  morgen:
+    phase: "Initiation"
+    farbe: "#B4E3F2"
+  tag:
+    phase: "Aktivierung"
+    farbe: "#E3F4D6"
+  abend:
+    phase: "Integration"
+    farbe: "#F7D9C4"
+  nacht:
+    phase: "Reflexion"
+    farbe: "#2C3E50"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "version": "1.0.0",
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "apps/*"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/gpt-bridges/AEONPOET.ts
+++ b/packages/gpt-bridges/AEONPOET.ts
@@ -1,0 +1,4 @@
+export function AEONPOET(input: string) {
+  console.log('[AEONPOET]', input);
+  return `poetic:${input}`;
+}

--- a/packages/gpt-bridges/CREPJUDGE.ts
+++ b/packages/gpt-bridges/CREPJUDGE.ts
@@ -1,0 +1,4 @@
+export function CREPJUDGE(crep: {C:number;R:number;E:number;P:number}) {
+  console.log('[CREPJUDGE] Bewertung', crep);
+  return (crep.C + crep.R + crep.E + crep.P) / 4;
+}

--- a/packages/gpt-bridges/aeon-gpt-synapse.ts
+++ b/packages/gpt-bridges/aeon-gpt-synapse.ts
@@ -1,0 +1,13 @@
+import { GPTEventHub } from './GPTEventHub';
+
+export class AeonGPTSynapse {
+  constructor() {
+    GPTEventHub.on('crep:updated', data => {
+      this.log('CREP update', data);
+    });
+  }
+
+  log(msg: string, data: unknown) {
+    console.log('[AeonGPTSynapse]', msg, data);
+  }
+}

--- a/packages/unifiedmandala-ui/components/SigillinLoader.tsx
+++ b/packages/unifiedmandala-ui/components/SigillinLoader.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import YAML from 'yaml';
+
+interface SigillinLoaderProps {
+  onLoaded?: (data: unknown) => void;
+}
+
+const SigillinLoader: React.FC<SigillinLoaderProps> = ({ onLoaded }) => {
+  const [error, setError] = useState<string | null>(null);
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = evt => {
+      try {
+        const text = evt.target?.result as string;
+        const data = file.name.endsWith('.yaml') || file.name.endsWith('.yml')
+          ? YAML.parse(text)
+          : JSON.parse(text);
+        setError(null);
+        onLoaded?.(data);
+      } catch (err) {
+        setError('Fehler beim Laden der Datei');
+        console.error(err);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <div>
+      <input
+        type="file"
+        accept=".json,.yaml,.yml"
+        onChange={handleFile}
+        aria-label="Sigillin laden"
+      />
+      {error && <p role="alert">{error}</p>}
+    </div>
+  );
+};
+
+export default SigillinLoader;

--- a/packages/unifiedmandala-ui/data/sigillin_nodes.json
+++ b/packages/unifiedmandala-ui/data/sigillin_nodes.json
@@ -43,5 +43,95 @@
     "type": "elevation",
     "status": "ruhend",
     "poetry": "Über die Grenzen des Seins"
+  },
+  {
+    "id": "mastercanvas",
+    "label": "MasterCanvas",
+    "crep": { "C": 8, "R": 8, "E": 8, "P": 8 },
+    "related": [],
+    "type": "core",
+    "status": "aktiv",
+    "poetry": "Zentrale Übersicht aller Module"
+  },
+  {
+    "id": "aeongenesisos",
+    "label": "AeonGenesisOS",
+    "crep": { "C": 8, "R": 6, "E": 5, "P": 5 },
+    "related": [{ "id": "mastercanvas", "relation": "part-of" }],
+    "type": "master",
+    "status": "geplant",
+    "poetry": "CREP-Betriebssystem"
+  },
+  {
+    "id": "aeonshell",
+    "label": "AeonShell",
+    "crep": { "C": 7, "R": 5, "E": 4, "P": 6 },
+    "related": [{ "id": "aeongenesisos", "relation": "interfaces" }],
+    "type": "master",
+    "status": "geplant",
+    "poetry": "CLI und Symbolzeit"
+  },
+  {
+    "id": "aeonfraktalurs",
+    "label": "AeonFraktalurs",
+    "crep": { "C": 6, "R": 7, "E": 5, "P": 6 },
+    "related": [{ "id": "aeongenesisos", "relation": "archives" }],
+    "type": "master",
+    "status": "geplant",
+    "poetry": "GPT-Kontextarchiv"
+  },
+  {
+    "id": "aeonresoecho",
+    "label": "AeonResoEcho",
+    "crep": { "C": 5, "R": 8, "E": 4, "P": 5 },
+    "related": [{ "id": "aeongenesisos", "relation": "records" }],
+    "type": "master",
+    "status": "geplant",
+    "poetry": "CREP-Ereignisgedächtnis"
+  },
+  {
+    "id": "sharedream-interface",
+    "label": "SharedreamInterface",
+    "crep": { "C": 6, "R": 7, "E": 5, "P": 7 },
+    "related": [{ "id": "aeonshell", "relation": "connects" }],
+    "type": "master",
+    "status": "geplant",
+    "poetry": "Community-Webportal"
+  },
+  {
+    "id": "aeonmemorydaemon",
+    "label": "AeonMemoryDaemon",
+    "crep": { "C": 7, "R": 7, "E": 3, "P": 4 },
+    "related": [{ "id": "aeongenesisos", "relation": "stores" }],
+    "type": "master",
+    "status": "geplant",
+    "poetry": "Langzeitarchivierung"
+  },
+  {
+    "id": "aeon-gpt-synapse",
+    "label": "Aeon-GPT-Synapse",
+    "crep": { "C": 5, "R": 5, "E": 5, "P": 5 },
+    "related": [{ "id": "aeonfraktalurs", "relation": "orchestrates" }],
+    "type": "gpt-module",
+    "status": "geplant",
+    "poetry": "Verbindung zu GPT"
+  },
+  {
+    "id": "aeonpoet",
+    "label": "GPT-AEONPOET",
+    "crep": { "C": 4, "R": 6, "E": 7, "P": 8 },
+    "related": [{ "id": "aeon-gpt-synapse", "relation": "uses" }],
+    "type": "gpt-module",
+    "status": "geplant",
+    "poetry": "Poesie-Generator"
+  },
+  {
+    "id": "crepjudge",
+    "label": "GPT-CREPJUDGE",
+    "crep": { "C": 8, "R": 4, "E": 6, "P": 6 },
+    "related": [{ "id": "aeon-gpt-synapse", "relation": "uses" }],
+    "type": "gpt-module",
+    "status": "geplant",
+    "poetry": "CREP-Bewertung"
   }
 ]

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,4 @@ packages:
   - 'packages/genesis-sigillin-core'
   - 'packages/gpt-bridges'
   - 'packages/cli-tools'
+  - 'apps/*'


### PR DESCRIPTION
## Summary
- add SigillinLoader React component
- extend MasterCanvas nodes for sigillin map
- add GPT stub modules (AeonGPTSynapse, AEONPOET, CREPJUDGE)
- document symbolzeit and CREP phase matrix
- create apps/sharedream-interface skeleton
- add codex roadmap for phase 2
- update monorepo workspace config

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68417104de488322a7c1a5143bdbc0fa