### PR TITLE
Add AI policy

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,14 @@
+# Richtlinie zur KI-Nutzung
+
+Dieses Projekt nutzt GPT-Module als experimentelle Bausteine. Der Einsatz erfolgt transparent und unter Beachtung geltender Datenschutzbestimmungen.
+
+## Verantwortungsvolle Anwendung
+- GPT-Outputs werden vor einer Veröffentlichung geprüft.
+- Automatisierte Entscheidungen sollten stets menschlich gegengeprüft werden.
+
+## Datenverarbeitung
+- Bei Tests oder Trainingsdaten achten wir auf minimale personenbezogene Informationen.
+- Logs oder Nutzerbeiträge werden nur so lange wie nötig gespeichert.
+
+## Haftungsausschluss
+Nutzerbeiträge und GPT-Ergebnisse spiegeln nicht zwingend die Meinung des Projekts wider. Veröffentliche keine sensiblen Daten über Pull Requests oder Issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,4 @@
 - Feature-Branches nutzen (`feature/xyz`), dann Pull Request nach `main`.
 - Mindestens ein Review pro PR.
 - Conventional Commits verwenden.
+- Siehe [AI_POLICY.md](AI_POLICY.md) für Richtlinien zu GPT-Einsatz und Datenumgang.


### PR DESCRIPTION
## Summary
- document responsible AI usage in `AI_POLICY.md`
- reference policy from contributing guidelines

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6841809c2240832299c019add69daf0c