### PR TITLE
Improve CLI script path resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ chmod +x scripts/aeon.sh
 ./scripts/aeon.sh sigil_invoke     # exportiert Sigillin & CREP-Dokumentation
 ./scripts/aeon.sh chronopoem       # erzeugt CHRONOPOEM.md
 ./scripts/aeon.sh onboarding       # zeigt Onboarding-Ritus
-pnpm sigillin-cli convert beispiel.yaml # YAML ↔ JSON-Konvertierung
+node packages/cli-tools/sigillin-cli.js convert beispiel.yaml # YAML ↔ JSON-Konvertierung
 ```
 
 Weitere Beispiele und GIF-Demos findest du im [Wiki](https://github.com/GenesisAeon/unified-mandala/wiki).

--- a/scripts/aeon.sh
+++ b/scripts/aeon.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 # 🜂 AeonShell – poetisches Mandala CLI
 cyan='\033[1;36m'; yellow='\033[1;33m'; green='\033[1;32m'; reset='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 function sigil_invoke() {
   echo -e "${yellow}✴ Rufe den Dichter...${reset}"
-  node ../packages/cli-tools/export-doc.js
+  node "$ROOT_DIR/packages/cli-tools/export-doc.js"
 }
 function cycle_start() {
   echo -e "${green}⟳ Mandala-Kreislauf aktiviert. CREP-Tracking beginnt...${reset}"
@@ -20,14 +22,14 @@ function show_help() {
     help            – Diese Hilfe"
 }
 function chronopoem() {
-  node ../scripts/generate-chronopoem.js
-  cat ../CHRONOPOEM.md
+  node "$ROOT_DIR/scripts/generate-chronopoem.js"
+  cat "$ROOT_DIR/CHRONOPOEM.md"
 }
 function setup() {
-  bash ../scripts/setup-unifiedmandala.sh
+  bash "$ROOT_DIR/scripts/setup-unifiedmandala.sh"
 }
 function onboarding() {
-  cat ../scripts/onboarding-ritual.md
+  cat "$ROOT_DIR/scripts/onboarding-ritual.md"
 }
 case "$1" in
   sigil_invoke) sigil_invoke ;;


### PR DESCRIPTION
## Summary
- fix relative paths in `aeon.sh`
- clarify CLI invocation in README

## Testing
- `pnpm run lint`
- `pnpm test`
- `pnpm run build`
- `pnpm run docs:build`
- `bash scripts/aeon.sh onboarding`
- `bash scripts/aeon.sh cycle_start`


------
https://chatgpt.com/codex/tasks/task_e_68418b7bfab48322a299d109aedc751c