### PR TITLE
Implement codex phase3 tasks

### DIFF
--- a/packages/aeon-shell/symbolzeit.ts
+++ b/packages/aeon-shell/symbolzeit.ts
@@ -1,0 +1,4 @@
+export const SYMBOLZEIT = {
+  phase: "abend",
+  date: new Date().toISOString()
+};

--- a/packages/crep-engine/data/CREPPhaseMatrix.yaml
+++ b/packages/crep-engine/data/CREPPhaseMatrix.yaml
@@ -1,0 +1,13 @@
+phase_matrix:
+  critical:
+    coherence: "< 4"
+    resonance: "< 4"
+    emergence: "< 4"
+  safe:
+    coherence: ">= 7"
+    resonance: ">= 7"
+    emergence: ">= 7"
+  warning:
+    coherence: ">= 4 && < 7"
+    resonance: ">= 4 && < 7"
+    emergence: ">= 4 && < 7"

--- a/packages/gpt-bridges/aeon-gpt-synapse.ts
+++ b/packages/gpt-bridges/aeon-gpt-synapse.ts
@@ -1,13 +1,10 @@
-import { GPTEventHub } from './GPTEventHub';
+export interface GPTRequest {
+  role: "aeon" | "crep" | "poet";
+  input: string;
+  context?: any;
+}
 
-export class AeonGPTSynapse {
-  constructor() {
-    GPTEventHub.on('crep:updated', data => {
-      this.log('CREP update', data);
-    });
-  }
-
-  log(msg: string, data: unknown) {
-    console.log('[AeonGPTSynapse]', msg, data);
-  }
+export function sendToGPT(request: GPTRequest) {
+  console.log("Stub für GPT-Verbindung:", request);
+  return "Dies ist ein GPT-Stubsignal.";
 }

--- a/packages/gpt-bridges/gpt-aeonpoet.ts
+++ b/packages/gpt-bridges/gpt-aeonpoet.ts
@@ -1,0 +1,3 @@
+export function GPT_AEONPOET(input: string) {
+  return `🜂 Poetisches Echo: ${input}`;
+}

--- a/packages/gpt-bridges/gpt-crepjudge.ts
+++ b/packages/gpt-bridges/gpt-crepjudge.ts
@@ -1,0 +1,5 @@
+export function GPT_CREPJUDGE(crep: { C: number; R: number; E: number }) {
+  if (crep.C < 4 || crep.R < 4 || crep.E < 4) return "⚠️ Zustand kritisch";
+  if (crep.C >= 7 && crep.R >= 7 && crep.E >= 7) return "🟢 Zustand stabil";
+  return "🟠 Zustand unsicher";
+}

--- a/packages/sharedream-interface/sync.ts
+++ b/packages/sharedream-interface/sync.ts
@@ -1,0 +1,12 @@
+import sigillin from "../unifiedmandala-ui/data/sigillin_nodes.json";
+import { getCREPState } from "../crep-engine/CREPEvaluator";
+
+export function syncSharedream() {
+  return {
+    sigillin,
+    crepStates: sigillin.map(s => ({
+      id: s.id,
+      status: getCREPState(s.crep)
+    }))
+  };
+}

--- a/packages/unifiedmandala-ui/components/MandalaNetworkView.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaNetworkView.tsx
@@ -19,8 +19,15 @@ interface MandalaNode {
   fy?: number | null;
 }
 
-const colorForCREP = ({ C, R, E, P }: MandalaNode["crep"]) =>
-  d3.interpolateRainbow((C + R + E + P) / 40);
+function getCREPPhaseColor(crep: { C: number; R: number; E: number }) {
+  const { C, R, E } = crep;
+  if (C < 4 || R < 4 || E < 4) return "red";
+  if (C >= 7 && R >= 7 && E >= 7) return "green";
+  return "orange";
+}
+
+const colorForCREP = ({ C, R, E }: MandalaNode["crep"]) =>
+  getCREPPhaseColor({ C, R, E });
 
 export const MandalaNetworkView: React.FC = () => {
   const svgRef = useRef<SVGSVGElement>(null);

--- a/packages/unifiedmandala-ui/components/SigillinLoader.tsx
+++ b/packages/unifiedmandala-ui/components/SigillinLoader.tsx
@@ -7,6 +7,8 @@ interface SigillinLoaderProps {
 
 const SigillinLoader: React.FC<SigillinLoaderProps> = ({ onLoaded }) => {
   const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState('');
+  const [data, setData] = useState<any[]>([]);
 
   const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -15,11 +17,12 @@ const SigillinLoader: React.FC<SigillinLoaderProps> = ({ onLoaded }) => {
     reader.onload = evt => {
       try {
         const text = evt.target?.result as string;
-        const data = file.name.endsWith('.yaml') || file.name.endsWith('.yml')
+        const parsed = file.name.endsWith('.yaml') || file.name.endsWith('.yml')
           ? YAML.parse(text)
           : JSON.parse(text);
+        setData(Array.isArray(parsed) ? parsed : [parsed]);
         setError(null);
-        onLoaded?.(data);
+        onLoaded?.(parsed);
       } catch (err) {
         setError('Fehler beim Laden der Datei');
         console.error(err);
@@ -27,6 +30,10 @@ const SigillinLoader: React.FC<SigillinLoaderProps> = ({ onLoaded }) => {
     };
     reader.readAsText(file);
   };
+
+  const filtered = data.filter(item =>
+    filter ? JSON.stringify(item).toLowerCase().includes(filter.toLowerCase()) : true
+  );
 
   return (
     <div>
@@ -36,7 +43,15 @@ const SigillinLoader: React.FC<SigillinLoaderProps> = ({ onLoaded }) => {
         onChange={handleFile}
         aria-label="Sigillin laden"
       />
+      <input
+        type="text"
+        placeholder="Filter"
+        value={filter}
+        onChange={e => setFilter(e.target.value)}
+        aria-label="Filter"
+      />
       {error && <p role="alert">{error}</p>}
+      <pre>{filtered.length} Einträge geladen</pre>
     </div>
   );
 };

--- a/packages/unifiedmandala-ui/components/onboarding-flow.tsx
+++ b/packages/unifiedmandala-ui/components/onboarding-flow.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const OnboardingFlow: React.FC = () => {
+  return (
+    <div>
+      <h1>Willkommen im Unified Mandala</h1>
+      <p>Poetischer Einstieg folgt...</p>
+    </div>
+  );
+};
+
+export default OnboardingFlow;

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,4 +8,5 @@ packages:
   - 'packages/aeon-genesisos'
   - 'packages/aeon-fraktalurs'
   - 'packages/aeon-resoecho'
+  - 'packages/sharedream-interface'
   - 'apps/*'


### PR DESCRIPTION
## Summary
- add CREPPhaseMatrix data
- provide Symbolzeit trigger module
- update MandalaNetworkView color logic
- enhance SigillinLoader with simple filtering
- implement GPT bridges and stubs
- add sharedream sync module
- stub onboarding flow component
- include sharedream-interface in workspace

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6841a654721c8322af41b361f92abab8