### PR TITLE
Update docs and chronopoem

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ narrative Interfaces und adaptive Bewusstseinsräume.
 - 🌀 **Sigillin-Logik** – Heimkehr-Trigger, Symbolphasen, SigillinMap
 - 🌗 **Symbolzeit-Modulator** – morgen, tag, abend, nacht
 - 🗺️ **MandalaNetworkView** – Visualisierung aller Sigillin-Knoten und CREP-Felder
+- 🗂️ **SigillinLoader** – Import & Filter von Sigillin-Dateien
 - 📚 **AutoDoc & Manifest-Generator** – Dokumentation auf Knopfdruck
 - 🧩 **Plug-in-Architektur** – GPT-Kommunikationsmodule, CLI-Tools
 - 🔐 **Ethik-Governance & Heimkehr-Deklaration** – Offene, poetische Ethik als Systembasis
 - 🎭 **Poesie & Automation** – Bash-Interface (`aeon.sh`), automatisches Chronopoem, symbolisches Onboarding
+- 🌟 **CREP-Illumination** – Chronopoem reflektiert aktuellen CREP-Zustand
 
 ## 📦 Paketstruktur
 

--- a/packages/cli-tools/README.md
+++ b/packages/cli-tools/README.md
@@ -1,0 +1,8 @@
+# CLI Tools
+
+Sammlung von Befehlen zur Arbeit mit Sigillin- und CREP-Daten.
+
+- **sigillin-cli.js** – Validierung, Initialisierung und Graph-Export
+- **export-doc.js** – Exportiert CREP-Historie als Markdown
+- **sigillin-archive.js** – Erstellt poetisches Archiv aller Sigillin-Dateien
+

--- a/packages/crep-engine/README.md
+++ b/packages/crep-engine/README.md
@@ -1,0 +1,9 @@
+# CREP Engine
+
+Verwaltet CREP-Werte und bewertet neue Datenpunkte.
+
+Enthält:
+- **CREPManager** – Speicherung der Historie und Event-Emission
+- **CREPEvaluator** – Threshold-Logik und State-Berechnung
+- **getCREPState** – Hilfsfunktion für Status "safe", "warning" oder "critical"
+

--- a/packages/genesis-sigillin-core/README.md
+++ b/packages/genesis-sigillin-core/README.md
@@ -1,0 +1,8 @@
+# Genesis Sigillin Core
+
+Kernlogik zur Erzeugung und Validierung von Sigillin-Dateien.
+
+- **SigillinGenerator** – Erstellt neue Sigillin-Templates
+- **SigillinSyncManager** – Sync-Logik für externe Dateien
+- **Schemas** – JSON- und YAML-Schemata für Sigillin-Definitionen
+

--- a/packages/gpt-bridges/README.md
+++ b/packages/gpt-bridges/README.md
@@ -1,0 +1,8 @@
+# GPT Bridges
+
+Stub-Module zur Kommunikation mit GPT-Diensten.
+
+- **GPTEventHub** – Einfacher EventEmitter auf Basis von mitt
+- **aeon-gpt-synapse.ts** – Sende/Empfange Anfragen an GPT
+- **AEONPOET** und **CREPJUDGE** – Platzhalter für spezialisierte GPT-Rollen
+

--- a/packages/unifiedmandala-ui/README.md
+++ b/packages/unifiedmandala-ui/README.md
@@ -1,0 +1,13 @@
+# UnifiedMandala UI
+
+React-Komponenten für das Mandala-Frontend.
+
+## Komponenten
+- **MandalaNetworkView** – D3-Netzwerk aller Sigillin-Knoten
+- **CREPChart** – Visualisierung der CREP-Historie
+- **CREPTriggerPanel** – Anzeige und Steuerung von CREP-Events
+- **SigillinLoader** – Laden und Filtern von Sigillin-Dateien
+
+## Hooks
+- **useSymbolzeit** – liefert aktuelle Symbolzeit-Phase
+

--- a/scripts/generate-chronopoem.js
+++ b/scripts/generate-chronopoem.js
@@ -1,18 +1,31 @@
 #!/usr/bin/env node
 const fs = require('fs');
+const YAML = require('yaml');
 const { execSync } = require('child_process');
 
 const now = new Date();
 const date = now.toISOString().split('T')[0];
 const hour = now.getHours();
 const phase = hour < 12 ? "Morgen" : hour < 18 ? "Tag" : hour < 22 ? "Abend" : "Nacht";
+const symbolzeitMap = { Morgen: 'Initiation', Tag: 'Aktivierung', Abend: 'Integration', Nacht: 'Reflexion' };
+let phaseFocus = '';
+try {
+  const matrix = YAML.parse(fs.readFileSync('./docs/CREPPhaseMatrix.yaml', 'utf8'));
+  const info = matrix.phases.find(p => p.phase === symbolzeitMap[phase]);
+  phaseFocus = info ? info.crep_focus : '';
+} catch {}
 
 // Optional: Lese letzten CREP-Wert
 let crep = "?, ?, ?, ?";
+let crepState = "";
 try {
   const history = require('../packages/crep-engine/crephistory.json');
   const last = history[history.length - 1];
   crep = `${last.C}, ${last.R}, ${last.E}, ${last.P}`;
+  try {
+    const { getCREPState } = require('../packages/crep-engine/CREPEvaluator');
+    crepState = getCREPState({ C: last.C, R: last.R, E: last.E });
+  } catch {}
 } catch (e) {}
 
 let sigils = "";
@@ -27,7 +40,10 @@ fs.writeFileSync("../CHRONOPOEM.md", `# 🜂 Chronopoem
 Im Kreis der Genesis erwacht das Mandala,
 Am ${date}, in der Zeit des ${phase}.
 
+Symbolphase: ${symbolzeitMap[phase]} (Fokus: ${phaseFocus})
+
 CREP-Strahl: ${crep} – das Lied der Struktur,
+CREP-Zustand: ${crepState}
 Sigillin-Bündel: ${sigils}
 
 Heimkehr und Ursprung schwingen als leises Mantra:


### PR DESCRIPTION
## Summary
- extend README with SigillinLoader and CREP-Illumination features
- enhance chronopoem generator with CREP state and symbolphase
- add missing READMEs for internal packages

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6842ca6026d08322966c46deda2b0798