### PR TITLE
Add text fragmentation utility and CLI command

### DIFF
--- a/packages/cli-tools/sigillin-cli.js
+++ b/packages/cli-tools/sigillin-cli.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const Ajv = require('ajv');
 const schema = require('../genesis-sigillin-core/schemas/sigillin.schema.json');
 const YAML = require('yaml');
+const { splitFile } = require('../shared-utils/textFragmenter');
 let SigillinGenerator;
 try {
   // use compiled version if available
@@ -88,6 +89,19 @@ program
     });
     fs.writeFileSync('sigillin-relations.mmd', out);
     console.log('sigillin-relations.mmd erstellt');
+  });
+
+program
+  .command('fragment <file>')
+  .option('-s, --size <size>', 'Fragmentlänge', '1000')
+  .description('Zerlegt eine Textdatei in handliche Fragmente')
+  .action((file, opts) => {
+    const size = parseInt(opts.size, 10);
+    const chunks = splitFile(file, size);
+    chunks.forEach((chunk, i) => {
+      console.log(`--- Fragment ${i + 1} ---`);
+      console.log(chunk);
+    });
   });
 
 program.parse(process.argv);

--- a/packages/shared-utils/README.md
+++ b/packages/shared-utils/README.md
@@ -1,0 +1,3 @@
+# Shared Utils
+
+Gemeinsame Hilfsfunktionen für UnifiedMandala.

--- a/packages/shared-utils/index.ts
+++ b/packages/shared-utils/index.ts
@@ -1,0 +1,1 @@
+export * from './textFragmenter';

--- a/packages/shared-utils/textFragmenter.test.ts
+++ b/packages/shared-utils/textFragmenter.test.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import { splitText, splitFile } from './textFragmenter';
+
+describe('textFragmenter', () => {
+  it('splits text into chunks', () => {
+    const chunks = splitText('abcdefgh', 3);
+    expect(chunks).toEqual(['abc', 'def', 'gh']);
+  });
+
+  it('splits file content', () => {
+    const path = __dirname + '/tmp.txt';
+    fs.writeFileSync(path, 'abcdef', 'utf8');
+    const chunks = splitFile(path, 2);
+    expect(chunks).toEqual(['ab', 'cd', 'ef']);
+    fs.unlinkSync(path);
+  });
+});

--- a/packages/shared-utils/textFragmenter.ts
+++ b/packages/shared-utils/textFragmenter.ts
@@ -1,0 +1,24 @@
+import fs from 'fs';
+
+/**
+ * Splits a text into fragments of given max length.
+ * @param text The input text.
+ * @param maxLength Maximum length of each fragment.
+ */
+export function splitText(text: string, maxLength = 1000): string[] {
+  const chunks: string[] = [];
+  for (let i = 0; i < text.length; i += maxLength) {
+    chunks.push(text.slice(i, i + maxLength));
+  }
+  return chunks;
+}
+
+/**
+ * Reads a file and splits its content into fragments.
+ * @param filePath Path to the text file.
+ * @param maxLength Maximum length of each fragment.
+ */
+export function splitFile(filePath: string, maxLength = 1000): string[] {
+  const content = fs.readFileSync(filePath, 'utf8');
+  return splitText(content, maxLength);
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - 'packages/unifiedmandala-ui'
   - 'packages/genesis-sigillin-core'
   - 'packages/gpt-bridges'
+  - 'packages/shared-utils'
   - 'packages/cli-tools'
   - 'packages/aeon-shell'
   - 'packages/aeon-genesisos'


### PR DESCRIPTION
## Summary
- create `shared-utils` package
- implement `splitText` and `splitFile` helpers
- test text fragmenter
- expose file fragmentation via new `fragment` command in `sigillin-cli.js`
- include new package in workspace config

## Testing
- `pnpm install --silent`
- `pnpm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6842cdc1e3fc8322a2cded678bfbce25