### PR TITLE
Add CREP phase helper and UI docs

### DIFF
--- a/packages/shared-utils/README.md
+++ b/packages/shared-utils/README.md
@@ -1,3 +1,7 @@
 # Shared Utils
 
 Gemeinsame Hilfsfunktionen für UnifiedMandala.
+
+## Funktionen
+- **splitText** und **splitFile** – zerlegen Texte in handliche Fragmente
+- **getCREPPhaseColor** – ordnet CREP-Werten Farbstufen zu

--- a/packages/shared-utils/crepHelpers.test.ts
+++ b/packages/shared-utils/crepHelpers.test.ts
@@ -1,0 +1,13 @@
+import { getCREPPhaseColor } from './crepHelpers';
+
+describe('getCREPPhaseColor', () => {
+  it('returns red for critical values', () => {
+    expect(getCREPPhaseColor({ C: 1, R: 3, E: 2 })).toBe('red');
+  });
+  it('returns green for safe values', () => {
+    expect(getCREPPhaseColor({ C: 8, R: 8, E: 9 })).toBe('green');
+  });
+  it('returns orange otherwise', () => {
+    expect(getCREPPhaseColor({ C: 5, R: 5, E: 5 })).toBe('orange');
+  });
+});

--- a/packages/shared-utils/crepHelpers.ts
+++ b/packages/shared-utils/crepHelpers.ts
@@ -1,0 +1,15 @@
+export interface CREPValues {
+  C: number;
+  R: number;
+  E: number;
+}
+
+/**
+ * Returns a color name based on CREP values using the phase matrix.
+ * red = critical, green = safe, orange = warning
+ */
+export function getCREPPhaseColor({ C, R, E }: CREPValues): string {
+  if (C < 4 || R < 4 || E < 4) return 'red';
+  if (C >= 7 && R >= 7 && E >= 7) return 'green';
+  return 'orange';
+}

--- a/packages/shared-utils/index.ts
+++ b/packages/shared-utils/index.ts
@@ -1,1 +1,2 @@
 export * from './textFragmenter';
+export * from './crepHelpers';

--- a/packages/unifiedmandala-ui/README.md
+++ b/packages/unifiedmandala-ui/README.md
@@ -7,7 +7,17 @@ React-Komponenten für das Mandala-Frontend.
 - **CREPChart** – Visualisierung der CREP-Historie
 - **CREPTriggerPanel** – Anzeige und Steuerung von CREP-Events
 - **SigillinLoader** – Laden und Filtern von Sigillin-Dateien
+- **SigillinViewer** – Darstellung einzelner Sigillin-Daten
+- **SigillinMap** – Übersicht aller bekannten Sigillin
+- **SoforthilfeOverlay** – Kontextabhängige Hilfedialoge
+- **SymbolicWayfinder** – Navigations-Komponente für das Mandala
+- **AeonStoryMode** – Präsentationsmodus mit poetischen Sequenzen
+- **onboarding-flow** – Einstiegskomponente für neue Nutzer
 
 ## Hooks
 - **useSymbolzeit** – liefert aktuelle Symbolzeit-Phase
+- **useCREP** – Zugriff auf CREP-Historie und Trigger
+
+Zusätzlich stellt `shared-utils` die Funktion **getCREPPhaseColor** bereit,
+um CREP-Werte in Farbzustände zu übersetzen.
 

--- a/packages/unifiedmandala-ui/components/MandalaNetworkView.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaNetworkView.tsx
@@ -4,6 +4,7 @@ import { Tooltip } from "react-tooltip";
 
 // Annahme: sigillin_nodes.json ist bereits im Projekt und importierbar
 import nodesData from "../data/sigillin_nodes.json";
+import { getCREPPhaseColor } from "../../shared-utils";
 
 interface MandalaNode {
   id: string;
@@ -19,12 +20,6 @@ interface MandalaNode {
   fy?: number | null;
 }
 
-function getCREPPhaseColor(crep: { C: number; R: number; E: number }) {
-  const { C, R, E } = crep;
-  if (C < 4 || R < 4 || E < 4) return "red";
-  if (C >= 7 && R >= 7 && E >= 7) return "green";
-  return "orange";
-}
 
 const colorForCREP = ({ C, R, E }: MandalaNode["crep"]) =>
   getCREPPhaseColor({ C, R, E });


### PR DESCRIPTION
## Summary
- export new `getCREPPhaseColor` helper in shared utils
- use helper in `MandalaNetworkView`
- document extra UI components and hooks
- document shared utils functions
- add tests for the helper

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6842d02df5108322898e780791f5b763