### PR TITLE
Add JSON fragmenter utility and conversation splitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ chmod +x scripts/aeon.sh
 ./scripts/aeon.sh chronopoem       # erzeugt CHRONOPOEM.md
 ./scripts/aeon.sh onboarding       # zeigt Onboarding-Ritus
 node packages/cli-tools/sigillin-cli.js convert beispiel.yaml # YAML ↔ JSON-Konvertierung
+node scripts/split-conversations.js 50   # zerlegt conversations.json in 50er-Stücke
 ```
 
 Weitere Beispiele und GIF-Demos findest du im [Wiki](https://github.com/GenesisAeon/unified-mandala/wiki).

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "jest",
     "dev": "echo 'dev script placeholder'",
     "docs:build": "typedoc",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "split:conversations": "node scripts/split-conversations.js"
   },
   "dependencies": {
     "ajv": "^8.0.0",

--- a/packages/shared-utils/README.md
+++ b/packages/shared-utils/README.md
@@ -5,3 +5,4 @@ Gemeinsame Hilfsfunktionen für UnifiedMandala.
 ## Funktionen
 - **splitText** und **splitFile** – zerlegen Texte in handliche Fragmente
 - **getCREPPhaseColor** – ordnet CREP-Werten Farbstufen zu
+- **splitJsonArrayFile** und **writeJsonChunks** – teilen große JSON-Arrays auf

--- a/packages/shared-utils/index.ts
+++ b/packages/shared-utils/index.ts
@@ -1,2 +1,3 @@
 export * from './textFragmenter';
 export * from './crepHelpers';
+export * from './jsonFragmenter';

--- a/packages/shared-utils/jsonFragmenter.js
+++ b/packages/shared-utils/jsonFragmenter.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+
+function splitJsonArray(items, chunkSize) {
+  const chunks = [];
+  for (let i = 0; i < items.length; i += chunkSize) {
+    chunks.push(items.slice(i, i + chunkSize));
+  }
+  return chunks;
+}
+
+function splitJsonArrayFile(filePath, chunkSize) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const data = JSON.parse(raw);
+  if (!Array.isArray(data)) {
+    throw new Error('Input JSON must be an array');
+  }
+  return splitJsonArray(data, chunkSize);
+}
+
+function writeJsonChunks(filePath, destDir, chunkSize) {
+  const chunks = splitJsonArrayFile(filePath, chunkSize);
+  if (!fs.existsSync(destDir)) fs.mkdirSync(destDir, { recursive: true });
+  const base = filePath.replace(/\.json$/i, '');
+  chunks.forEach((chunk, idx) => {
+    const outPath = `${destDir}/${base.split('/').pop()}-${idx + 1}.json`;
+    fs.writeFileSync(outPath, JSON.stringify(chunk, null, 2), 'utf8');
+  });
+}
+
+module.exports = { splitJsonArray, splitJsonArrayFile, writeJsonChunks };

--- a/packages/shared-utils/jsonFragmenter.test.ts
+++ b/packages/shared-utils/jsonFragmenter.test.ts
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import path from 'path';
+import { splitJsonArray, splitJsonArrayFile, writeJsonChunks } from './jsonFragmenter';
+
+describe('jsonFragmenter', () => {
+  const tmpDir = path.join(__dirname, '__tmp__');
+  const sampleFile = path.join(tmpDir, 'sample.json');
+
+  beforeAll(() => {
+    if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
+    fs.writeFileSync(sampleFile, JSON.stringify([1,2,3,4,5]), 'utf8');
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('splitJsonArray splits arrays', () => {
+    const chunks = splitJsonArray([1,2,3,4,5], 2);
+    expect(chunks).toEqual([[1,2],[3,4],[5]]);
+  });
+
+  test('splitJsonArrayFile reads and splits files', () => {
+    const chunks = splitJsonArrayFile<number>(sampleFile, 3);
+    expect(chunks.length).toBe(2);
+    expect(chunks[0]).toEqual([1,2,3]);
+    expect(chunks[1]).toEqual([4,5]);
+  });
+
+  test('writeJsonChunks writes files', () => {
+    const dest = path.join(tmpDir, 'out');
+    writeJsonChunks(sampleFile, dest, 2);
+    const files = fs.readdirSync(dest).sort();
+    expect(files.length).toBe(3);
+    const data1 = JSON.parse(fs.readFileSync(path.join(dest, files[0]), 'utf8'));
+    expect(data1).toEqual([1,2]);
+  });
+});

--- a/packages/shared-utils/jsonFragmenter.ts
+++ b/packages/shared-utils/jsonFragmenter.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+
+/**
+ * Splits an array into chunks of the given size.
+ * @param items Array of items to chunk.
+ * @param chunkSize Size of each chunk.
+ */
+export function splitJsonArray<T>(items: T[], chunkSize: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += chunkSize) {
+    chunks.push(items.slice(i, i + chunkSize));
+  }
+  return chunks;
+}
+
+/**
+ * Reads a JSON array file and splits its content into chunks.
+ * @param filePath Path to JSON array file.
+ * @param chunkSize Number of items per chunk.
+ */
+export function splitJsonArrayFile<T>(filePath: string, chunkSize: number): T[][] {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const data: T[] = JSON.parse(raw);
+  if (!Array.isArray(data)) {
+    throw new Error('Input JSON must be an array');
+  }
+  return splitJsonArray(data, chunkSize);
+}
+
+/**
+ * Writes chunks of a JSON array file into separate files.
+ * Resulting files are named <basename>-<index>.json in destDir.
+ * @param filePath Input JSON array file.
+ * @param destDir Destination directory for chunk files.
+ * @param chunkSize Number of items per chunk.
+ */
+export function writeJsonChunks(filePath: string, destDir: string, chunkSize: number) {
+  const chunks = splitJsonArrayFile(filePath, chunkSize);
+  if (!fs.existsSync(destDir)) fs.mkdirSync(destDir, { recursive: true });
+  const base = filePath.replace(/\.json$/i, '');
+  chunks.forEach((chunk, idx) => {
+    const outPath = `${destDir}/${base.split('/').pop()}-${idx + 1}.json`;
+    fs.writeFileSync(outPath, JSON.stringify(chunk, null, 2), 'utf8');
+  });
+}

--- a/scripts/split-conversations.js
+++ b/scripts/split-conversations.js
@@ -1,0 +1,9 @@
+const path = require('path');
+const { writeJsonChunks } = require('../packages/shared-utils/jsonFragmenter');
+
+const file = path.join(__dirname, '../docs/sigils/conversations.json');
+const dest = path.join(__dirname, '../docs/sigils/conversations');
+const chunkSize = parseInt(process.argv[2] || '100', 10);
+
+writeJsonChunks(file, dest, chunkSize);
+console.log(`Conversations split into chunks of ${chunkSize}. Output: ${dest}`);


### PR DESCRIPTION
## Summary
- add `splitJsonArray` helpers in `shared-utils`
- document new functions
- expose `jsonFragmenter` in `shared-utils` index
- add script `scripts/split-conversations.js`
- mention conversation splitter in README
- provide npm script `split:conversations`
- add tests for json fragmenter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842d313e52c83228325f454e894f95e