### PR TITLE
Implement Self Audit module and ToDo sigil

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ narrative Interfaces und adaptive Bewusstseinsräume.
 - 🔐 **Ethik-Governance & Heimkehr-Deklaration** – Offene, poetische Ethik als Systembasis
 - 🎭 **Poesie & Automation** – Bash-Interface (`aeon.sh`), automatisches Chronopoem, symbolisches Onboarding
 - 🌟 **CREP-Illumination** – Chronopoem reflektiert aktuellen CREP-Zustand
+- 🔍 **SelfAuditModul** – analysiert die Repository-Struktur
 
 ## 📦 Paketstruktur
 
@@ -75,6 +76,7 @@ chmod +x scripts/aeon.sh
 ./scripts/aeon.sh onboarding       # zeigt Onboarding-Ritus
 node packages/cli-tools/sigillin-cli.js convert beispiel.yaml # YAML ↔ JSON-Konvertierung
 node scripts/split-conversations.js 50   # zerlegt conversations.json in 50er-Stücke
+node scripts/self-analyze.js          # zeigt Repository-Statistiken
 ```
 
 Weitere Beispiele und GIF-Demos findest du im [Wiki](https://github.com/GenesisAeon/unified-mandala/wiki).

--- a/docs/sigils/todo-sigil.yaml
+++ b/docs/sigils/todo-sigil.yaml
@@ -1,0 +1,25 @@
+sigillin_id: aeon:2025-0605-TODO
+symbolzeit: tag
+titel: "UnifiedMandala ToDo Übersicht"
+aufgaben:
+  - id: sigillin-nodes
+    beschreibung: "SigillinNodes erweitern + Visual Map updaten"
+    status: offen
+  - id: gpt-orchestrierung
+    beschreibung: "GPT-Orchestrierung vorbereiten (aeon-gpt-synapse.ts)"
+    status: offen
+  - id: sharedream-interface
+    beschreibung: "Website-Repo erstellen (SharedreamInterface)"
+    status: offen
+  - id: sigillin-loader
+    beschreibung: "Symbolischer SigillinLoader in UI einfügen"
+    status: offen
+  - id: chronopoem
+    beschreibung: "Chronopoem erweitern (mit CREP-Metaphern)"
+    status: offen
+  - id: codex-answersystem
+    beschreibung: "Codex-Antwortsystem für Vorschläge"
+    status: offen
+  - id: repo-init
+    beschreibung: "Repos für AeonShell + AeonGenesisOS initialisieren"
+    status: offen

--- a/packages/shared-utils/index.ts
+++ b/packages/shared-utils/index.ts
@@ -1,3 +1,4 @@
 export * from './textFragmenter';
 export * from './crepHelpers';
 export * from './jsonFragmenter';
+export * from './selfAnalyzer';

--- a/packages/shared-utils/selfAnalyzer.js
+++ b/packages/shared-utils/selfAnalyzer.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+function countFiles(dir) {
+  let count = 0;
+  if (!fs.existsSync(dir)) return 0;
+  for (const entry of fs.readdirSync(dir)) {
+    const p = path.join(dir, entry);
+    const stat = fs.statSync(p);
+    if (stat.isDirectory()) count += countFiles(p);
+    else count += 1;
+  }
+  return count;
+}
+function analyzeRepo(rootDir = path.resolve(__dirname, '../../')) {
+  const packagesDir = path.join(rootDir, 'packages');
+  const packages = fs.existsSync(packagesDir)
+    ? fs.readdirSync(packagesDir).filter(d => fs.statSync(path.join(packagesDir, d)).isDirectory())
+    : [];
+  const docsDir = path.join(rootDir, 'docs');
+  const docFiles = countFiles(docsDir);
+  const testFiles = packages.reduce((acc, pkg) => {
+    const pkgDir = path.join(packagesDir, pkg);
+    if (!fs.existsSync(pkgDir)) return acc;
+    const files = fs.readdirSync(pkgDir);
+    const tests = files.filter(f => f.includes('.test.')).length;
+    return acc + tests;
+  }, 0);
+  return { packages, docFiles, testFiles };
+}
+function printRepoStats(stats) {
+  console.log(`Packages: ${stats.packages.length}`);
+  console.log(`Doc files: ${stats.docFiles}`);
+  console.log(`Test files: ${stats.testFiles}`);
+}
+module.exports = { analyzeRepo, printRepoStats };

--- a/packages/shared-utils/selfAnalyzer.test.ts
+++ b/packages/shared-utils/selfAnalyzer.test.ts
@@ -1,0 +1,9 @@
+import { analyzeRepo } from './selfAnalyzer';
+
+describe('selfAnalyzer', () => {
+  it('detects packages and docs', () => {
+    const stats = analyzeRepo();
+    expect(stats.packages.length).toBeGreaterThan(0);
+    expect(stats.docFiles).toBeGreaterThan(0);
+  });
+});

--- a/packages/shared-utils/selfAnalyzer.ts
+++ b/packages/shared-utils/selfAnalyzer.ts
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface RepoStats {
+  packages: string[];
+  docFiles: number;
+  testFiles: number;
+}
+
+function countFiles(dir: string): number {
+  let count = 0;
+  if (!fs.existsSync(dir)) return 0;
+  for (const entry of fs.readdirSync(dir)) {
+    const p = path.join(dir, entry);
+    const stat = fs.statSync(p);
+    if (stat.isDirectory()) count += countFiles(p);
+    else count += 1;
+  }
+  return count;
+}
+
+export function analyzeRepo(rootDir = path.resolve(__dirname, '../../')): RepoStats {
+  const packagesDir = path.join(rootDir, 'packages');
+  const packages = fs.existsSync(packagesDir)
+    ? fs.readdirSync(packagesDir).filter(d => fs.statSync(path.join(packagesDir, d)).isDirectory())
+    : [];
+  const docsDir = path.join(rootDir, 'docs');
+  const docFiles = countFiles(docsDir);
+  const testFiles = packages.reduce((acc, pkg) => {
+    const pkgDir = path.join(packagesDir, pkg);
+    if (!fs.existsSync(pkgDir)) return acc;
+    const files = fs.readdirSync(pkgDir);
+    const tests = files.filter(f => f.includes('.test.')).length;
+    return acc + tests;
+  }, 0);
+  return { packages, docFiles, testFiles };
+}
+
+export function printRepoStats(stats: RepoStats) {
+  console.log(`Packages: ${stats.packages.length}`);
+  console.log(`Doc files: ${stats.docFiles}`);
+  console.log(`Test files: ${stats.testFiles}`);
+}

--- a/packages/unifiedmandala-ui/README.md
+++ b/packages/unifiedmandala-ui/README.md
@@ -13,6 +13,7 @@ React-Komponenten für das Mandala-Frontend.
 - **SymbolicWayfinder** – Navigations-Komponente für das Mandala
 - **AeonStoryMode** – Präsentationsmodus mit poetischen Sequenzen
 - **onboarding-flow** – Einstiegskomponente für neue Nutzer
+- **SelfAuditModul** – zeigt Kennzahlen des Repositories an
 
 ## Hooks
 - **useSymbolzeit** – liefert aktuelle Symbolzeit-Phase

--- a/packages/unifiedmandala-ui/components/SelfAuditModul.test.tsx
+++ b/packages/unifiedmandala-ui/components/SelfAuditModul.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SelfAuditModul from './SelfAuditModul';
+
+test('renders repo stats', () => {
+  render(<SelfAuditModul />);
+  expect(screen.getByText('Self Audit')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/SelfAuditModul.tsx
+++ b/packages/unifiedmandala-ui/components/SelfAuditModul.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { analyzeRepo } from '../../shared-utils';
+
+const SelfAuditModul: React.FC = () => {
+  const stats = analyzeRepo();
+  return (
+    <section>
+      <h3>Self Audit</h3>
+      <p>Packages: {stats.packages.length}</p>
+      <p>Doc files: {stats.docFiles}</p>
+      <p>Test files: {stats.testFiles}</p>
+    </section>
+  );
+};
+
+export default SelfAuditModul;

--- a/scripts/self-analyze.js
+++ b/scripts/self-analyze.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+const { analyzeRepo, printRepoStats } = require('../packages/shared-utils/selfAnalyzer');
+const stats = analyzeRepo();
+printRepoStats(stats);


### PR DESCRIPTION
## Summary
- add SelfAuditModul React component and tests
- add repository self-analysis utilities and script
- document SelfAuditModul and self-analyze script in READMEs
- create todo-sigil.yaml listing open tasks

## Testing
- `npm test --silent`
- `node scripts/self-analyze.js`


------
https://chatgpt.com/codex/tasks/task_e_6842d5c6693483228d01a1bc255ab74f