### PR TITLE
Add todo sigil generation and checking scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ chmod +x scripts/aeon.sh
 ./scripts/aeon.sh onboarding       # zeigt Onboarding-Ritus
 node packages/cli-tools/sigillin-cli.js convert beispiel.yaml # YAML ↔ JSON-Konvertierung
 node packages/cli-tools/sigillin-cli.js todo-sigil           # aktualisiert todo-sigil.yaml
+node scripts/generate-todo-sigil.js      # todo-sigil ohne Abhängigkeiten erzeugen
 node scripts/split-conversations.js 50   # zerlegt conversations.json in 50er-Stücke
 node scripts/self-analyze.js          # zeigt Repository-Statistiken
+node scripts/check-todo-sigil.js      # prüft erledigte Aufgaben
 ```
 
 Weitere Beispiele und GIF-Demos findest du im [Wiki](https://github.com/GenesisAeon/unified-mandala/wiki).

--- a/docs/sigils/todo-sigil.yaml
+++ b/docs/sigils/todo-sigil.yaml
@@ -21,89 +21,89 @@ aufgaben:
     beschreibung: "`SharedreamInterface` – Community-Zugang & UI-Portal (geplant)"
     status: offen
   - id: task-7
-    beschreibung: CREP-Logik & Evaluator
+    beschreibung: "CREP-Logik & Evaluator"
     status: erledigt
   - id: task-8
-    beschreibung: Sigillin-Generator & CLI
+    beschreibung: "Sigillin-Generator & CLI"
     status: erledigt
   - id: task-9
-    beschreibung: MandalaNetworkView (D3, React)
+    beschreibung: "MandalaNetworkView (D3, React)"
     status: erledigt
   - id: task-10
     beschreibung: "`aeon.sh` CLI mit Chronopoem, Onboarding"
     status: erledigt
   - id: task-11
-    beschreibung: CHRONOPOEM.md
+    beschreibung: "CHRONOPOEM.md"
     status: erledigt
   - id: task-12
-    beschreibung: codex-roadmap.yaml
+    beschreibung: "codex-roadmap.yaml"
     status: erledigt
   - id: task-13
-    beschreibung: Basis-Knoten (`GENESIS`, `HEIMKEHR`, `FRAKTALURS`, `RESO-ECHO`) erkannt
+    beschreibung: "Basis-Knoten (`GENESIS`, `HEIMKEHR`, `FRAKTALURS`, `RESO-ECHO`) erkannt"
     status: erledigt
   - id: task-14
-    beschreibung: Noch nicht alle in Map & UI integriert (→ Phase 1 TODO)
+    beschreibung: "Noch nicht alle in Map & UI integriert (→ Phase 1 TODO)"
     status: offen
   - id: task-15
     beschreibung: "`codex-roadmap.yaml` als zentrale Datei für Codex"
     status: offen
   - id: task-16
-    beschreibung: Automatische Umwandlung von Website-Inhalten in YAML für Codex
+    beschreibung: "Automatische Umwandlung von Website-Inhalten in YAML für Codex"
     status: offen
   - id: task-17
-    beschreibung: Commit-basierte Codex-Trigger über GitHub Actions
+    beschreibung: "Commit-basierte Codex-Trigger über GitHub Actions"
     status: offen
   - id: task-18
-    beschreibung: GPT-Kommentierung (Poetik + CREP) via GPT-AEONPOET
+    beschreibung: "GPT-Kommentierung (Poetik + CREP) via GPT-AEONPOET"
     status: offen
   - id: task-19
-    beschreibung: Web-Einbindung von GPT 3.5 als Assistenzinstanz
+    beschreibung: "Web-Einbindung von GPT 3.5 als Assistenzinstanz"
     status: offen
   - id: task-20
-    beschreibung: GPT als CREP-Judge + AEONPOET via Interface
+    beschreibung: "GPT als CREP-Judge + AEONPOET via Interface"
     status: offen
   - id: task-21
-    beschreibung: Orchestrierungsmodul (Workflow-Manager, Vorschlagslenkung)
+    beschreibung: "Orchestrierungsmodul (Workflow-Manager, Vorschlagslenkung)"
     status: offen
   - id: task-22
-    beschreibung: Web-Frontend als eigenes Repository (statisch oder hybrid)
+    beschreibung: "Web-Frontend als eigenes Repository (statisch oder hybrid)"
     status: offen
   - id: task-23
-    beschreibung: Deployment via Pages, Netlify oder Vercel aus dem Repo
+    beschreibung: "Deployment via Pages, Netlify oder Vercel aus dem Repo"
     status: offen
   - id: task-24
     beschreibung: "FileZilla-Pendant: symbolisches Upload-Modul auf Site (z. B. `SigilSync`)"
     status: offen
   - id: task-25
-    beschreibung: UI-Komponente für Uploads + YAML-Ausgabe
+    beschreibung: "UI-Komponente für Uploads + YAML-Ausgabe"
     status: offen
   - id: task-26
-    beschreibung: NAS-Zugriff vorbereiten via WebDAV/SMB (modular)
+    beschreibung: "NAS-Zugriff vorbereiten via WebDAV/SMB (modular)"
     status: offen
   - id: task-27
     beschreibung: "Gedächtnisspiegel: Hash + Sigillin, kein Klartextindex"
     status: offen
   - id: task-28
-    beschreibung: MemoryDaemon + `.aeonvault/`
+    beschreibung: "MemoryDaemon + `.aeonvault/`"
     status: offen
   - id: task-29
-    beschreibung: SigillinNodes erweitern + Visual Map updaten
+    beschreibung: "SigillinNodes erweitern + Visual Map updaten"
     status: offen
   - id: task-30
-    beschreibung: GPT-Orchestrierung vorbereiten (`aeon-gpt-synapse.ts`)
+    beschreibung: "GPT-Orchestrierung vorbereiten (`aeon-gpt-synapse.ts`)"
     status: offen
   - id: task-31
-    beschreibung: Website-Repo erstellen (SharedreamInterface)
+    beschreibung: "Website-Repo erstellen (SharedreamInterface)"
     status: offen
   - id: task-32
-    beschreibung: Symbolischer „SigillinLoader“ in UI einfügen
+    beschreibung: "Symbolischer „SigillinLoader“ in UI einfügen"
     status: offen
   - id: task-33
-    beschreibung: Chronopoem erweitern (mit CREP-Metaphern)
+    beschreibung: "Chronopoem erweitern (mit CREP-Metaphern)"
     status: offen
   - id: task-34
     beschreibung: "Codex-Antwortsystem für Vorschläge (Ordner: `/codex-sync/`)"
     status: offen
   - id: task-35
-    beschreibung: Repos für AeonShell + AeonGenesisOS initialisieren
+    beschreibung: "Repos für AeonShell + AeonGenesisOS initialisieren"
     status: offen

--- a/scripts/check-todo-sigil.js
+++ b/scripts/check-todo-sigil.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+
+function parseTodoSigil(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.split(/\r?\n/);
+  const items = [];
+  let current = null;
+  for (const line of lines) {
+    const idMatch = line.match(/^\s*- id: (.+)$/);
+    if (idMatch) {
+      current = { id: idMatch[1] };
+      items.push(current);
+      continue;
+    }
+    if (!current) continue;
+    const descMatch = line.match(/^\s*beschreibung:\s+"?(.*)"?$/);
+    if (descMatch) current.beschreibung = descMatch[1];
+    const statusMatch = line.match(/^\s*status:\s+(\S+)\s*$/);
+    if (statusMatch) current.status = statusMatch[1];
+  }
+  return items;
+}
+
+const checks = {
+  'task-1': () => fs.existsSync('package.json'),
+  'task-7': () => fs.existsSync('packages/crep-engine/CREPEvaluator.ts'),
+  'task-8': () => fs.existsSync('packages/genesis-sigillin-core/SigillinGenerator.ts'),
+  'task-9': () => fs.existsSync('packages/unifiedmandala-ui'),
+  'task-10': () => fs.existsSync('scripts/aeon.sh'),
+  'task-11': () => fs.existsSync('CHRONOPOEM.md'),
+  'task-12': () => fs.existsSync('codex/codex-roadmap.yaml'),
+  'task-13': () => fs.existsSync('docs/sigils'),
+};
+
+function checkTodos(filePath) {
+  const items = parseTodoSigil(filePath);
+  let allOk = true;
+  items.forEach(item => {
+    if (item.status === 'erledigt' && checks[item.id]) {
+      const ok = checks[item.id]();
+      console.log(`${item.id}: ${item.beschreibung} -> ${ok ? 'OK' : 'FEHLT'}`);
+      if (!ok) allOk = false;
+    }
+  });
+  return allOk;
+}
+
+if (require.main === module) {
+  const ok = checkTodos(path.join(__dirname, '../docs/sigils/todo-sigil.yaml'));
+  process.exitCode = ok ? 0 : 1;
+}
+
+module.exports = { checkTodos };

--- a/scripts/generate-todo-sigil.js
+++ b/scripts/generate-todo-sigil.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+
+function extractTodos(text) {
+  const tasks = [];
+  const lines = text.split(/\r?\n/);
+  for (const line of lines) {
+    const m = line.match(/^\* \[( |x)\] (.+)$/);
+    if (m) tasks.push({ text: m[2].trim(), done: m[1] === 'x' });
+  }
+  return tasks;
+}
+
+function generateTodoSigil(sourcePath = path.join(__dirname, '../docs/mastercanvas.yaml')) {
+  const content = fs.readFileSync(sourcePath, 'utf8');
+  const tasks = extractTodos(content);
+  const yamlLines = [];
+  yamlLines.push('sigillin_id: aeon:2025-0605-TODO');
+  yamlLines.push('symbolzeit: tag');
+  yamlLines.push('titel: UnifiedMandala ToDo Übersicht');
+  yamlLines.push('aufgaben:');
+  tasks.forEach((t, idx) => {
+    yamlLines.push(`  - id: task-${idx + 1}`);
+    yamlLines.push(`    beschreibung: "${t.text.replace(/\"/g, '\\"')}"`);
+    yamlLines.push(`    status: ${t.done ? 'erledigt' : 'offen'}`);
+  });
+  const outPath = path.join(__dirname, '../docs/sigils/todo-sigil.yaml');
+  fs.writeFileSync(outPath, yamlLines.join('\n') + '\n');
+  console.log(`todo-sigil.yaml updated from ${path.basename(sourcePath)}`);
+}
+
+if (require.main === module) {
+  const src = process.argv[2];
+  generateTodoSigil(src);
+}
+
+module.exports = { generateTodoSigil };


### PR DESCRIPTION
## Summary
- add `generate-todo-sigil.js` to create the ToDo sigil without external deps
- add `check-todo-sigil.js` to verify completed tasks exist
- update README with usage for the new scripts
- regenerate `todo-sigil.yaml` using the new script

## Testing
- `node scripts/generate-todo-sigil.js docs/mastercanvas.yaml`
- `node scripts/check-todo-sigil.js`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684316179b3c83228811889429c8ae53