### PR TITLE
Implement todo-sigil status updater

### DIFF
--- a/packages/cli-tools/sigillin-cli.js
+++ b/packages/cli-tools/sigillin-cli.js
@@ -139,4 +139,20 @@ program
     console.log('todo-sigil.yaml aktualisiert.');
   });
 
+program
+  .command('todo-update [file]')
+  .description('Pr\xFCft und aktualisiert Status im todo-sigil.yaml')
+  .action(async (file = 'docs/sigils/todo-sigil.yaml') => {
+    const path = require('path');
+    let updateTodoSigilStatus;
+    try {
+      ({ updateTodoSigilStatus } = require('../../dist/shared-utils/todoSigilUpdater.js'));
+    } catch {
+      ({ updateTodoSigilStatus } = require('../shared-utils/todoSigilUpdater'));
+    }
+    const { checks } = require('../../scripts/check-todo-sigil');
+    await updateTodoSigilStatus(path.resolve(file), checks);
+    console.log('todo-sigil.yaml Status gepr\xFCft und aktualisiert.');
+  });
+
 program.parse(process.argv);

--- a/packages/shared-utils/index.ts
+++ b/packages/shared-utils/index.ts
@@ -3,3 +3,4 @@ export * from './crepHelpers';
 export * from './jsonFragmenter';
 export * from './selfAnalyzer';
 export * from './todoParser';
+export * from './todoSigilUpdater';

--- a/packages/shared-utils/todoSigilUpdater.test.ts
+++ b/packages/shared-utils/todoSigilUpdater.test.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+import { updateTodoSigilStatus } from './todoSigilUpdater';
+
+const yaml = `sigillin_id: test\naufgaben:\n  - id: t1\n    beschreibung: test\n    status: offen\n`;
+const file = path.join(__dirname, 'todo-temp.yaml');
+
+beforeEach(() => {
+  fs.writeFileSync(file, yaml, 'utf8');
+});
+
+afterEach(() => {
+  fs.unlinkSync(file);
+});
+
+test('updates status when check passes', async () => {
+  const checks = { t1: () => true };
+  await updateTodoSigilStatus(file, checks);
+  const out = fs.readFileSync(file, 'utf8');
+  expect(out).toContain('status: erledigt');
+});

--- a/packages/shared-utils/todoSigilUpdater.ts
+++ b/packages/shared-utils/todoSigilUpdater.ts
@@ -1,0 +1,28 @@
+import fs from 'fs';
+
+export interface TodoCheckMap {
+  [id: string]: () => boolean;
+}
+
+export async function updateTodoSigilStatus(filePath: string, checks: TodoCheckMap) {
+  const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
+  const out: string[] = [];
+  let currentId: string | null = null;
+  for (let line of lines) {
+    const idMatch = line.match(/^\s*- id: (.+)$/);
+    if (idMatch) {
+      currentId = idMatch[1];
+      out.push(line);
+      continue;
+    }
+    if (currentId && line.trim().startsWith('status:')) {
+      const check = checks[currentId];
+      if (check && check()) {
+        line = line.replace(/status:\s+\S+/, 'status: erledigt');
+      }
+      currentId = null;
+    }
+    out.push(line);
+  }
+  fs.writeFileSync(filePath, out.join('\n'));
+}

--- a/scripts/check-todo-sigil.js
+++ b/scripts/check-todo-sigil.js
@@ -51,4 +51,4 @@ if (require.main === module) {
   process.exitCode = ok ? 0 : 1;
 }
 
-module.exports = { checkTodos };
+module.exports = { checkTodos, checks };

--- a/scripts/update-todo-sigil.js
+++ b/scripts/update-todo-sigil.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+const path = require('path');
+const { checks } = require('./check-todo-sigil');
+let updateTodoSigilStatus;
+try {
+  ({ updateTodoSigilStatus } = require('../dist/shared-utils/todoSigilUpdater.js'));
+} catch {
+  ({ updateTodoSigilStatus } = require('../packages/shared-utils/todoSigilUpdater'));
+}
+
+const file = path.join(__dirname, '../docs/sigils/todo-sigil.yaml');
+
+async function run() {
+  await updateTodoSigilStatus(file, checks);
+  console.log('todo-sigil.yaml status aktualisiert.');
+}
+
+run();


### PR DESCRIPTION
## Summary
- add helper `updateTodoSigilStatus` and corresponding tests
- export the new helper in shared-utils index
- expose checks in `check-todo-sigil.js`
- add `todo-update` command to CLI
- provide script `update-todo-sigil.js`

## Testing
- `npm test`
- `node scripts/update-todo-sigil.js`


------
https://chatgpt.com/codex/tasks/task_e_68432111923c8322b14b8c0e55d8297c