### PR TITLE
Implement ToDo sigil generator utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ chmod +x scripts/aeon.sh
 node packages/cli-tools/sigillin-cli.js convert beispiel.yaml # YAML ↔ JSON-Konvertierung
 node packages/cli-tools/sigillin-cli.js todo-sigil           # aktualisiert todo-sigil.yaml
 node scripts/generate-todo-sigil.js      # todo-sigil ohne Abhängigkeiten erzeugen
+node scripts/update-todo-sigil.js        # Status im todo-sigil.yaml aktualisieren
 node scripts/split-conversations.js 50   # zerlegt conversations.json in 50er-Stücke
 node scripts/self-analyze.js          # zeigt Repository-Statistiken
 node scripts/check-todo-sigil.js      # prüft erledigte Aufgaben

--- a/packages/cli-tools/sigillin-cli.js
+++ b/packages/cli-tools/sigillin-cli.js
@@ -114,27 +114,15 @@ program
   .description('Generiert docs/sigils/todo-sigil.yaml aus MasterCanvas oder anderer Datei')
   .action((source = 'docs/mastercanvas.yaml') => {
     const path = require('path');
-    let extractTodosFromFile;
+    let generateTodoSigilFromFile;
     try {
-      ({ extractTodosFromFile } = require('../../dist/shared-utils/todoParser.js'));
+      ({ generateTodoSigilFromFile } = require('../../dist/shared-utils/todoSigilGenerator.js'));
     } catch {
-      ({ extractTodosFromFile } = require('../shared-utils/todoParser'));
+      ({ generateTodoSigilFromFile } = require('../shared-utils/todoSigilGenerator'));
     }
-    const tasks = extractTodosFromFile(path.resolve(source));
-    const yamlTasks = tasks.map((t, idx) => ({
-      id: `task-${idx + 1}`,
-      beschreibung: t.text,
-      status: t.done ? 'erledigt' : 'offen',
-    }));
-    const out = {
-      sigillin_id: 'aeon:2025-0605-TODO',
-      symbolzeit: 'tag',
-      titel: 'UnifiedMandala ToDo Übersicht',
-      aufgaben: yamlTasks,
-    };
-    fs.writeFileSync(
-      path.join('docs/sigils/todo-sigil.yaml'),
-      YAML.stringify(out)
+    generateTodoSigilFromFile(
+      path.resolve(source),
+      path.join('docs/sigils/todo-sigil.yaml')
     );
     console.log('todo-sigil.yaml aktualisiert.');
   });

--- a/packages/shared-utils/README.md
+++ b/packages/shared-utils/README.md
@@ -4,5 +4,9 @@ Gemeinsame Hilfsfunktionen für UnifiedMandala.
 
 ## Funktionen
 - **splitText** und **splitFile** – zerlegen Texte in handliche Fragmente
-- **getCREPPhaseColor** – ordnet CREP-Werten Farbstufen zu
 - **splitJsonArrayFile** und **writeJsonChunks** – teilen große JSON-Arrays auf
+- **getCREPPhaseColor** – ordnet CREP-Werten Farbstufen zu
+- **analyzeRepo** – liefert Paket- und Dokument-Statistiken
+- **extractTodosFromFile** – liest Aufgabenlisten aus Dateien
+- **updateTodoSigilStatus** – markiert erledigte Aufgaben im todo-sigil.yaml
+- **createTodoSigil** und **generateTodoSigilFromFile** – erzeugen ToDo-Sigilline

--- a/packages/shared-utils/index.ts
+++ b/packages/shared-utils/index.ts
@@ -4,3 +4,5 @@ export * from './jsonFragmenter';
 export * from './selfAnalyzer';
 export * from './todoParser';
 export * from './todoSigilUpdater';
+
+export * from "./todoSigilGenerator";

--- a/packages/shared-utils/todoSigilGenerator.test.ts
+++ b/packages/shared-utils/todoSigilGenerator.test.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+import { createTodoSigil, generateTodoSigilFromFile } from './todoSigilGenerator';
+import { TodoItem } from './todoParser';
+
+const tmp = path.join(__dirname, '__tmp_tsgen');
+const src = path.join(tmp, 'tasks.md');
+const dest = path.join(tmp, 'todo.yaml');
+
+beforeAll(() => {
+  if (!fs.existsSync(tmp)) fs.mkdirSync(tmp);
+  fs.writeFileSync(src, '* [ ] first\n* [x] done', 'utf8');
+});
+
+afterAll(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('createTodoSigil returns YAML', () => {
+  const yaml = createTodoSigil([
+    { text: 'a', done: false },
+    { text: 'b', done: true },
+  ] as TodoItem[]);
+  expect(yaml).toContain('sigillin_id');
+  expect(yaml).toContain('task-2');
+});
+
+test('generateTodoSigilFromFile writes file', () => {
+  generateTodoSigilFromFile(src, dest);
+  const out = fs.readFileSync(dest, 'utf8');
+  expect(out).toContain('task-1');
+});

--- a/packages/shared-utils/todoSigilGenerator.ts
+++ b/packages/shared-utils/todoSigilGenerator.ts
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import { TodoItem, extractTodosFromFile } from './todoParser';
+
+export interface TodoSigilOptions {
+  id?: string;
+  titel?: string;
+  symbolzeit?: string;
+}
+
+export function createTodoSigil(tasks: TodoItem[], options: TodoSigilOptions = {}): string {
+  const { id = 'aeon:2025-0605-TODO', titel = 'UnifiedMandala ToDo Übersicht', symbolzeit = 'tag' } = options;
+  const lines: string[] = [];
+  lines.push(`sigillin_id: ${id}`);
+  lines.push(`symbolzeit: ${symbolzeit}`);
+  lines.push(`titel: ${titel}`);
+  lines.push('aufgaben:');
+  tasks.forEach((t, idx) => {
+    lines.push(`  - id: task-${idx + 1}`);
+    lines.push(`    beschreibung: "${t.text.replace(/\"/g, '\\"')}"`);
+    lines.push(`    status: ${t.done ? 'erledigt' : 'offen'}`);
+  });
+  return lines.join('\n') + '\n';
+}
+
+export function generateTodoSigilFromFile(sourcePath: string, destPath: string, options?: TodoSigilOptions) {
+  const tasks = extractTodosFromFile(sourcePath);
+  const yaml = createTodoSigil(tasks, options);
+  fs.writeFileSync(destPath, yaml);
+}

--- a/scripts/generate-todo-sigil.js
+++ b/scripts/generate-todo-sigil.js
@@ -1,31 +1,14 @@
-const fs = require('fs');
 const path = require('path');
-
-function extractTodos(text) {
-  const tasks = [];
-  const lines = text.split(/\r?\n/);
-  for (const line of lines) {
-    const m = line.match(/^\* \[( |x)\] (.+)$/);
-    if (m) tasks.push({ text: m[2].trim(), done: m[1] === 'x' });
-  }
-  return tasks;
+let generateTodoSigilFromFile;
+try {
+  ({ generateTodoSigilFromFile } = require('../dist/shared-utils/todoSigilGenerator.js'));
+} catch {
+  ({ generateTodoSigilFromFile } = require('../packages/shared-utils/todoSigilGenerator'));
 }
 
 function generateTodoSigil(sourcePath = path.join(__dirname, '../docs/mastercanvas.yaml')) {
-  const content = fs.readFileSync(sourcePath, 'utf8');
-  const tasks = extractTodos(content);
-  const yamlLines = [];
-  yamlLines.push('sigillin_id: aeon:2025-0605-TODO');
-  yamlLines.push('symbolzeit: tag');
-  yamlLines.push('titel: UnifiedMandala ToDo Übersicht');
-  yamlLines.push('aufgaben:');
-  tasks.forEach((t, idx) => {
-    yamlLines.push(`  - id: task-${idx + 1}`);
-    yamlLines.push(`    beschreibung: "${t.text.replace(/\"/g, '\\"')}"`);
-    yamlLines.push(`    status: ${t.done ? 'erledigt' : 'offen'}`);
-  });
   const outPath = path.join(__dirname, '../docs/sigils/todo-sigil.yaml');
-  fs.writeFileSync(outPath, yamlLines.join('\n') + '\n');
+  generateTodoSigilFromFile(path.resolve(sourcePath), outPath);
   console.log(`todo-sigil.yaml updated from ${path.basename(sourcePath)}`);
 }
 


### PR DESCRIPTION
## Summary
- add reusable `createTodoSigil` and `generateTodoSigilFromFile` in shared utils
- use the new generator in CLI and helper script
- document all helper functions including the new generator
- mention new `update-todo-sigil.js` script in main README
- tests for new generator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684327b318e083229fc2bbba6bfe198a