### PR TITLE
Update todo sigil and jest config

### DIFF
--- a/docs/sigils/todo-sigil.yaml
+++ b/docs/sigils/todo-sigil.yaml
@@ -88,7 +88,7 @@ aufgaben:
     status: offen
   - id: task-29
     beschreibung: "SigillinNodes erweitern + Visual Map updaten"
-    status: offen
+    status: erledigt
   - id: task-30
     beschreibung: "GPT-Orchestrierung vorbereiten (`aeon-gpt-synapse.ts`)"
     status: offen
@@ -97,7 +97,7 @@ aufgaben:
     status: offen
   - id: task-32
     beschreibung: "Symbolischer „SigillinLoader“ in UI einfügen"
-    status: offen
+    status: erledigt
   - id: task-33
     beschreibung: "Chronopoem erweitern (mit CREP-Metaphern)"
     status: offen

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  preset: 'ts-jest',
+  transform: { '^.+\\.tsx?$': ['<rootDir>/node_modules/ts-jest', {}] },
   testEnvironment: 'jsdom',
   testPathIgnorePatterns: ['/dist/'],
 };


### PR DESCRIPTION
## Summary
- fix Jest config to reference ts-jest package directly
- update todo-sigil.yaml tasks (sigillin loader and node map done)

## Testing
- `npx jest --runInBand` *(fails: Module <rootDir>/node_modules/ts-jest in the transform option was not found)*
- `node scripts/check-todo-sigil.js`

------
https://chatgpt.com/codex/tasks/task_e_6843361cd1788322a28beee17b9e2442