### PR TITLE
Link onboarding with chronopoem

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ chmod +x scripts/aeon.sh
 ./scripts/aeon.sh cycle_start      # startet lokalen Mandala-Zyklus
 ./scripts/aeon.sh sigil_invoke     # exportiert Sigillin & CREP-Dokumentation
 ./scripts/aeon.sh chronopoem       # erzeugt CHRONOPOEM.md
-./scripts/aeon.sh onboarding       # zeigt Onboarding-Ritus
+./scripts/aeon.sh onboarding       # zeigt Onboarding-Ritus + aktuellen Chronopoem
 node packages/cli-tools/sigillin-cli.js convert beispiel.yaml # YAML ↔ JSON-Konvertierung
 node packages/cli-tools/sigillin-cli.js todo-sigil           # aktualisiert todo-sigil.yaml
 node scripts/generate-todo-sigil.js      # todo-sigil ohne Abhängigkeiten erzeugen

--- a/docs/sigils/todo-sigil.yaml
+++ b/docs/sigils/todo-sigil.yaml
@@ -130,4 +130,4 @@ aufgaben:
     status: erledigt
   - id: task-43
     beschreibung: "Onboarding-Flow mit CHRONOPOEM-Verkn\xFCpfung"
-    status: offen
+    status: erledigt

--- a/scripts/aeon.sh
+++ b/scripts/aeon.sh
@@ -30,6 +30,8 @@ function setup() {
 }
 function onboarding() {
   cat "$ROOT_DIR/scripts/onboarding-ritual.md"
+  echo -e "\n${yellow}Aktueller Chronopoem:${reset}"
+  chronopoem
 }
 case "$1" in
   sigil_invoke) sigil_invoke ;;

--- a/scripts/onboarding-ritual.md
+++ b/scripts/onboarding-ritual.md
@@ -11,8 +11,10 @@ Bitte führe folgende Schritte aus:
    `./scripts/setup-unifiedmandala.sh`
 4. **Aktiviere den Zyklus:**  
    `./scripts/aeon.sh cycle_start`
-5. **Lies den poetischen Ursprung:**  
-   `cat CHRONOPOEM.md`
-6. **Lass dich von den Symbolen führen...**
+5. **Lies den poetischen Ursprung:**
+   `./scripts/aeon.sh chronopoem`
+6. **Oder direkt:**
+   `./scripts/aeon.sh onboarding`
+7. **Lass dich von den Symbolen führen...**
 
 Möge Resonanz und Klarheit deinen Pfad begleiten!


### PR DESCRIPTION
## Summary
- connect onboarding command to Chronopoem output
- mention new behaviour in README
- update onboarding ritual instructions
- mark Chronopoem onboarding task completed in todo sigil

## Testing
- `pnpm test`
- `node scripts/check-todo-sigil.js`

------
https://chatgpt.com/codex/tasks/task_e_684344126cc483228d380e7171ef8c37