### PR TITLE
Implement CREP average calc

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ narrative Interfaces und adaptive Bewusstseinsräume.
 - 🎨 **SigillinViewer & SigillinMap** – Übersicht und Detailansicht aller Sigillin
 - 🚩 **SymbolicWayfinder & SoforthilfeOverlay** – Navigation und Hilfedialoge
 - 📈 **CREPChart & CREPTriggerPanel** – CREP-Historie und Steuerung
+- 📊 **CREPAverage-Analyse** – Durchschnittswerte aus dem CREP-Verlauf
 - 🌠 **AeonStoryMode & Onboarding-Flow** – Präsentations- und Einstiegskomponenten
 
 ## 📦 Paketstruktur

--- a/docs/sigils/todo-sigil.yaml
+++ b/docs/sigils/todo-sigil.yaml
@@ -131,3 +131,6 @@ aufgaben:
   - id: task-43
     beschreibung: "Onboarding-Flow mit CHRONOPOEM-Verkn\xFCpfung"
     status: erledigt
+  - id: task-44
+    beschreibung: "CREPManager Durchschnittsfunktion"
+    status: erledigt

--- a/packages/crep-engine/CREPManager.test.ts
+++ b/packages/crep-engine/CREPManager.test.ts
@@ -7,7 +7,9 @@ describe('CREPManager', () => {
       store: {} as Record<string, string>,
       getItem(key: string) { return this.store[key] || null; },
       setItem(key: string, value: string) { this.store[key] = value; },
+      clear() { this.store = {}; }
     };
+    (globalThis as any).localStorage.clear();
     jest.spyOn(GPTEventHub, 'emit');
   });
 
@@ -28,5 +30,16 @@ describe('CREPManager', () => {
     (globalThis as any).localStorage.setItem('crepHistory', JSON.stringify([{ timestamp: ts, C: 1, R: 1, E: 1, P: 1 }]));
     const manager = new CREPManager();
     expect(manager.getCREPHistory()).toHaveLength(1);
+  });
+
+  it('calculates average CREP values', () => {
+    const manager = new CREPManager();
+    manager.addCREPEntry(2, 4, 6, 8);
+    manager.addCREPEntry(4, 6, 8, 10);
+    const avg = manager.getAverageCREP();
+    expect(avg.C).toBe(3);
+    expect(avg.R).toBe(5);
+    expect(avg.E).toBe(7);
+    expect(avg.P).toBe(9);
   });
 });

--- a/packages/crep-engine/CREPManager.ts
+++ b/packages/crep-engine/CREPManager.ts
@@ -29,4 +29,26 @@ export class CREPManager {
   getCREPHistory() {
     return this.crepHistory;
   }
+
+  getAverageCREP(lastN = this.crepHistory.length) {
+    const slice = this.crepHistory.slice(-lastN);
+    if (!slice.length) return { C: 0, R: 0, E: 0, P: 0 };
+    const totals = slice.reduce(
+      (acc, e) => {
+        acc.C += e.C;
+        acc.R += e.R;
+        acc.E += e.E;
+        acc.P += e.P;
+        return acc;
+      },
+      { C: 0, R: 0, E: 0, P: 0 }
+    );
+    const count = slice.length;
+    return {
+      C: totals.C / count,
+      R: totals.R / count,
+      E: totals.E / count,
+      P: totals.P / count,
+    };
+  }
 }

--- a/packages/crep-engine/README.md
+++ b/packages/crep-engine/README.md
@@ -4,6 +4,7 @@ Verwaltet CREP-Werte und bewertet neue Datenpunkte.
 
 Enthält:
 - **CREPManager** – Speicherung der Historie und Event-Emission
+- **getAverageCREP** – ermittelt Durchschnittswerte über die letzten Einträge
 - **CREPEvaluator** – Threshold-Logik und State-Berechnung
 - **getCREPState** – Hilfsfunktion für Status "safe", "warning" oder "critical"
 


### PR DESCRIPTION
## Summary
- add `getAverageCREP` helper to CREPManager
- test average calculation
- document in CREP Engine README and root README
- track completion in todo-sigil

## Testing
- `npm test`
- `npm run lint`
- `node scripts/check-todo-sigil.js`

------
https://chatgpt.com/codex/tasks/task_e_684349f83c1483228ff7b8670ff0f75f