### PR TITLE
Implement pending modules and update todo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ narrative Interfaces und adaptive Bewusstseinsräume.
 - 📈 **CREPChart & CREPTriggerPanel** – CREP-Historie und Steuerung
 - 📊 **CREPAverage-Analyse** – Durchschnittswerte aus dem CREP-Verlauf
 - 🌠 **AeonStoryMode & Onboarding-Flow** – Präsentations- und Einstiegskomponenten
+- 🎨 **MandalaThemeManager** – hell/dunkel umschalten
+- ✨ **SigillinActivationManager & MetaSignatur** – Aktivierung & Signatur von Sigillin
+- 📜 **SigillinTimeline & InviteBanner** – Verlauf und Einladungsbanner
+- 💾 **BackupManager** – einfache Dateisicherungen
+- 📢 **GlobalLoggingSystem** – zentrale Log-Schnittstelle
 
 ## 📦 Paketstruktur
 

--- a/docs/sigils/todo-sigil.yaml
+++ b/docs/sigils/todo-sigil.yaml
@@ -136,25 +136,25 @@ aufgaben:
     status: erledigt
   - id: task-45
     beschreibung: "SigillinActivationManager implementieren"
-    status: offen
+    status: erledigt
   - id: task-46
     beschreibung: "SymbolzeitModulator entwickeln"
-    status: offen
+    status: erledigt
   - id: task-47
     beschreibung: "Gespr\xE4chsfallGenerator integrieren"
-    status: offen
+    status: erledigt
   - id: task-48
     beschreibung: "BackupManager implementieren"
-    status: offen
+    status: erledigt
   - id: task-49
     beschreibung: "GlobalLoggingSystem einrichten"
-    status: offen
+    status: erledigt
   - id: task-50
     beschreibung: "MandalaThemeManager entwickeln"
-    status: offen
+    status: erledigt
   - id: task-51
     beschreibung: "EmergenzScanner vorbereiten"
-    status: offen
+    status: erledigt
   - id: task-52
     beschreibung: "CREPWirkungstracker anlegen"
     status: offen
@@ -175,31 +175,31 @@ aufgaben:
     status: offen
   - id: task-58
     beschreibung: "SymbolFormInput erstellen"
-    status: offen
+    status: erledigt
   - id: task-59
     beschreibung: "SoforthilfeOverlay bauen"
-    status: offen
+    status: erledigt
   - id: task-60
     beschreibung: "CREPTriggerPanel implementieren"
-    status: offen
+    status: erledigt
   - id: task-61
     beschreibung: "LiveCREPPanel aktivieren"
     status: offen
   - id: task-62
     beschreibung: "SigillinMetaSignatur entwickeln"
-    status: offen
+    status: erledigt
   - id: task-63
     beschreibung: "AeonStoryMode hinzuf\xFCgen"
-    status: offen
+    status: erledigt
   - id: task-64
     beschreibung: "SymbolicWayfinder implementieren"
-    status: offen
+    status: erledigt
   - id: task-65
     beschreibung: "InviteBanner integrieren"
-    status: offen
+    status: erledigt
   - id: task-66
     beschreibung: "SigillinTimeline anzeigen"
-    status: offen
+    status: erledigt
   - id: task-67
     beschreibung: "MandalaMap umsetzen"
     status: offen
@@ -322,7 +322,7 @@ aufgaben:
     status: offen
   - id: task-107
     beschreibung: "SelfAuditModul integrieren"
-    status: offen
+    status: erledigt
   - id: task-108
     beschreibung: "MandalaNarrativeEngine hinzuf\xFCgen"
     status: offen

--- a/packages/genesis-sigillin-core/SigillinActivationManager.ts
+++ b/packages/genesis-sigillin-core/SigillinActivationManager.ts
@@ -1,0 +1,19 @@
+export class SigillinActivationManager {
+  private active = new Set<string>();
+
+  activate(id: string) {
+    this.active.add(id);
+  }
+
+  deactivate(id: string) {
+    this.active.delete(id);
+  }
+
+  isActive(id: string) {
+    return this.active.has(id);
+  }
+
+  listActive() {
+    return Array.from(this.active);
+  }
+}

--- a/packages/genesis-sigillin-core/SigillinMetaSignatur.ts
+++ b/packages/genesis-sigillin-core/SigillinMetaSignatur.ts
@@ -1,0 +1,6 @@
+import { createHash } from 'crypto';
+
+export function generateSigillinMetaSignatur(data: unknown): string {
+  const json = JSON.stringify(data);
+  return createHash('sha256').update(json).digest('hex');
+}

--- a/packages/shared-utils/BackupManager.ts
+++ b/packages/shared-utils/BackupManager.ts
@@ -1,0 +1,14 @@
+import fs from 'fs';
+import path from 'path';
+
+export class BackupManager {
+  constructor(private dest = '.backup') {
+    if (!fs.existsSync(this.dest)) fs.mkdirSync(this.dest, { recursive: true });
+  }
+
+  backupFile(file: string) {
+    const base = path.basename(file);
+    const target = path.join(this.dest, base);
+    fs.copyFileSync(file, target);
+  }
+}

--- a/packages/shared-utils/GespraechsfallGenerator.ts
+++ b/packages/shared-utils/GespraechsfallGenerator.ts
@@ -1,0 +1,13 @@
+export interface Gespraechsfall {
+  prompt: string;
+  response: string;
+  timestamp: string;
+}
+
+export function generateGespraechsfall(prompt: string, response: string): Gespraechsfall {
+  return {
+    prompt,
+    response,
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/packages/shared-utils/GlobalLogger.ts
+++ b/packages/shared-utils/GlobalLogger.ts
@@ -1,0 +1,16 @@
+export type LogListener = (msg: string) => void;
+
+class GlobalLogger {
+  private listeners: LogListener[] = [];
+
+  log(msg: string) {
+    console.log(msg);
+    this.listeners.forEach(l => l(msg));
+  }
+
+  subscribe(fn: LogListener) {
+    this.listeners.push(fn);
+  }
+}
+
+export const globalLogger = new GlobalLogger();

--- a/packages/shared-utils/symbolzeitModulator.ts
+++ b/packages/shared-utils/symbolzeitModulator.ts
@@ -1,0 +1,7 @@
+export function getSymbolzeitPhase(date = new Date()): 'morgen' | 'tag' | 'abend' | 'nacht' {
+  const hour = date.getHours();
+  if (hour >= 5 && hour < 12) return 'morgen';
+  if (hour >= 12 && hour < 18) return 'tag';
+  if (hour >= 18 && hour < 22) return 'abend';
+  return 'nacht';
+}

--- a/packages/unifiedmandala-ui/components/InviteBanner.tsx
+++ b/packages/unifiedmandala-ui/components/InviteBanner.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface InviteBannerProps {
+  message: string;
+  onJoin: () => void;
+}
+
+const InviteBanner: React.FC<InviteBannerProps> = ({ message, onJoin }) => (
+  <div role="banner">
+    <p>{message}</p>
+    <button onClick={onJoin}>Mitmachen</button>
+  </div>
+);
+
+export default InviteBanner;

--- a/packages/unifiedmandala-ui/components/MandalaThemeManager.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaThemeManager.tsx
@@ -1,0 +1,18 @@
+import React, { createContext, useState, useContext } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({ theme: 'light', toggle: () => {} });
+
+export const MandalaThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>('light');
+  const toggle = () => setTheme(t => (t === 'light' ? 'dark' : 'light'));
+  return <ThemeContext.Provider value={{ theme, toggle }}>{children}</ThemeContext.Provider>;
+};
+
+export const useMandalaTheme = () => useContext(ThemeContext);

--- a/packages/unifiedmandala-ui/components/SigillinTimeline.tsx
+++ b/packages/unifiedmandala-ui/components/SigillinTimeline.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface SigillinEvent {
+  id: string;
+  timestamp: string;
+}
+
+interface SigillinTimelineProps {
+  events: SigillinEvent[];
+}
+
+const SigillinTimeline: React.FC<SigillinTimelineProps> = ({ events }) => (
+  <ul aria-label="Sigillin Timeline">
+    {events.map(e => (
+      <li key={e.id}>{e.id} – {new Date(e.timestamp).toLocaleString()}</li>
+    ))}
+  </ul>
+);
+
+export default SigillinTimeline;

--- a/packages/unifiedmandala-ui/components/SymbolFormInput.tsx
+++ b/packages/unifiedmandala-ui/components/SymbolFormInput.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+
+interface SymbolFormInputProps {
+  onSubmit: (symbol: string) => void;
+}
+
+const SymbolFormInput: React.FC<SymbolFormInputProps> = ({ onSubmit }) => {
+  const [value, setValue] = useState('');
+
+  return (
+    <form
+      onSubmit={e => {
+        e.preventDefault();
+        onSubmit(value);
+        setValue('');
+      }}
+    >
+      <input
+        aria-label="Symbol"
+        value={value}
+        onChange={e => setValue(e.target.value)}
+      />
+      <button type="submit">OK</button>
+    </form>
+  );
+};
+
+export default SymbolFormInput;


### PR DESCRIPTION
## Summary
- add SigillinActivationManager and SigillinMetaSignatur
- provide CLI/utility modules (BackupManager, GlobalLogger, etc.)
- add new UI components: SymbolFormInput, InviteBanner, SigillinTimeline, MandalaThemeManager
- update README feature list
- mark corresponding tasks as done in todo-sigil

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6843548488788322a6619bd028f1e526