### PR TITLE
Add autodoc script and live CREP panel

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -1,0 +1,68 @@
+# UnifiedMandala Handbuch
+
+Dieses Handbuch gibt einen Überblick über die wichtigsten Module und Funktionen des Repositories.
+
+## Packages
+
+### aeon-shell
+- `index.ts` – Exportiert den Paketnamen.
+- `symbolzeit.ts` – Liefert die aktuelle Symbolzeit-Phase.
+
+### aeon-genesisos
+- `index.ts` – Exportiert den Paketnamen.
+
+### aeon-fraktalurs
+- `index.ts` – Exportiert den Paketnamen.
+
+### aeon-resoecho
+- `index.ts` – Exportiert den Paketnamen.
+
+### crep-engine
+- `CREPManager` – Hält die CREP-Historie und berechnet Durchschnittswerte.
+- `CREPEvaluator` – Ermittelt anhand von Thresholds den aktuellen Zustand.
+- `getCREPState` – Hilfsfunktion zur Statusermittlung.
+
+### gpt-bridges
+- `GPTEventHub` – Zentrales Event-System zwischen GPT-Modulen.
+- `aeon-gpt-synapse.ts` – Stub zur Kommunikation mit GPT-APIs.
+- `GPT_AEONPOET` – Beispielhafter poetischer GPT-Ausdruck.
+- `GPT_CREPJUDGE` – Bewertet CREP-Werte.
+
+### genesis-sigillin-core
+- `SigillinGenerator` – Erstellt und validiert Sigillin-Dateien.
+- `SigillinActivationManager` – Verwalten aktiver Sigillin.
+- `SigillinSyncManager` – Synchronisiert Status über WebSocket oder BroadcastChannel.
+- `SigillinMetaSignatur` – Erzeugt eine Prüfsumme eines Objekts.
+
+### shared-utils
+- `textFragmenter` – Zerlegt Texte oder Dateien in Fragmente.
+- `jsonFragmenter` – Zerlegt JSON-Arrays und extrahiert Code-Snippets.
+- `todoParser` – Liest ToDo-Listen aus Markdown-Dateien.
+- `todoSigilGenerator` – Erzeugt ToDo-Sigillin-Dateien.
+- `todoSigilUpdater` – Aktualisiert den Status im ToDo-Sigil.
+- `todoCommentScanner` – Findet TODO-Kommentare im Quelltext.
+- `conversationProgress` – Markiert bereits verarbeitete Konversationsfragmente.
+- `selfAnalyzer` – Liefert einfache Repo-Statistiken.
+- `GespraechsfallGenerator` – Erstellt Gesprächsprotokolle.
+- `KarmaBalance` – Einfache Punktesammlung.
+- `SymbolicForecaster` – Berechnet die nächste Symbolzeitphase.
+- `CREPWirkungstracker` – Protokolliert Effekte von CREP-Einträgen.
+
+### unifiedmandala-ui (Auswahl)
+- `MandalaNetworkView` – Visualisierung der Sigillin-Knoten als D3-Graph.
+- `CREPChart` – Linienchart für CREP-Werte.
+- `CREPTriggerPanel` – Buttons zum Auslösen von CREP-Ereignissen.
+- `LiveCREPPanel` – Kombiniert Trigger und Chart für Live-Daten.
+- `SigillinLoader` – Lädt Sigillin-Dateien und filtert Einträge.
+- `SelfAuditModul` – Zeigt Kennzahlen aus `selfAnalyzer`.
+
+
+Weitere Module sind in Arbeit.
+
+## Tools und Skripte
+- `scripts/generate-api-docs.js` – Erstellt automatisch die API-Dokumentation mit Typedoc.
+- `scripts/generate-todo-sigil.js` – Erstellt das ToDo-Sigil aus der Mastercanvas.
+- `scripts/update-todo-sigil.js` – Markiert erledigte Aufgaben im ToDo-Sigil.
+
+## Ausblick
+Dieses Handbuch deckt die wichtigsten Bereiche ab. Eine detaillierte Beschreibung aller Komponenten ist noch offen.

--- a/docs/sigils/todo-sigil.yaml
+++ b/docs/sigils/todo-sigil.yaml
@@ -165,7 +165,7 @@ aufgaben:
     status: offen
   - id: task-54
     beschreibung: "AutoDocGeneration Modul erstellen"
-    status: offen
+    status: erledigt
   - id: task-55
     beschreibung: "CREPMemoryWeaver implementieren"
     status: offen
@@ -186,7 +186,7 @@ aufgaben:
     status: erledigt
   - id: task-61
     beschreibung: "LiveCREPPanel aktivieren"
-    status: offen
+    status: erledigt
   - id: task-62
     beschreibung: "SigillinMetaSignatur entwickeln"
     status: erledigt
@@ -358,3 +358,6 @@ aufgaben:
   - id: task-118
     beschreibung: "SymbolicForecaster.ts hinzuf\xFCgen"
     status: erledigt
+  - id: task-119
+    beschreibung: "Handbuch weiter ausbauen"
+    status: offen

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "jest",
     "dev": "echo 'dev script placeholder'",
     "docs:build": "typedoc",
+    "docs:auto": "node scripts/generate-api-docs.js",
     "prepare": "husky install",
     "split:conversations": "node scripts/split-conversations.js",
     "grep:conversations": "node scripts/filter-conversations.js"

--- a/packages/shared-utils/CREPWirkungstracker.test.ts
+++ b/packages/shared-utils/CREPWirkungstracker.test.ts
@@ -7,5 +7,7 @@ test('tracks average effect', () => {
   tracker.addEntry(entry);
   tracker.addEntry({ ...entry, C: 3 });
   const avg = tracker.getAverage();
-  expect(avg).toBeCloseTo(1.5);
+  // Effect value averages all CREP dimensions for each entry
+  // so here we expect (1 + 1.5) / 2 = 1.25
+  expect(avg).toBeCloseTo(1.25);
 });

--- a/packages/unifiedmandala-ui/README.md
+++ b/packages/unifiedmandala-ui/README.md
@@ -14,6 +14,7 @@ React-Komponenten für das Mandala-Frontend.
 - **AeonStoryMode** – Präsentationsmodus mit poetischen Sequenzen
 - **onboarding-flow** – Einstiegskomponente für neue Nutzer
 - **SelfAuditModul** – zeigt Kennzahlen des Repositories an
+- **LiveCREPPanel** – kombiniert Trigger und Chart für Live-Daten
 
 ## Hooks
 - **useSymbolzeit** – liefert aktuelle Symbolzeit-Phase

--- a/packages/unifiedmandala-ui/components/LiveCREPPanel.test.tsx
+++ b/packages/unifiedmandala-ui/components/LiveCREPPanel.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LiveCREPPanel from './LiveCREPPanel';
+
+jest.mock('./CREPTriggerPanel', () => ({ __esModule: true, default: () => <div>trigger</div> }));
+jest.mock('./CREPChart', () => ({ __esModule: true, default: () => <div>chart</div> }));
+
+it('shows trigger panel and chart', () => {
+  render(<LiveCREPPanel />);
+  expect(screen.getByText('trigger')).toBeInTheDocument();
+  expect(screen.getByText('chart')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/LiveCREPPanel.tsx
+++ b/packages/unifiedmandala-ui/components/LiveCREPPanel.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useCREP } from '../hooks/useCREP';
+import CREPChart from './CREPChart';
+import CREPTriggerPanel from './CREPTriggerPanel';
+
+const DEFAULT_TRIGGERS = [
+  { label: 'Low', data: { C: 2, R: 2, E: 2, P: 2 } },
+  { label: 'Medium', data: { C: 5, R: 5, E: 5, P: 5 } },
+  { label: 'High', data: { C: 8, R: 8, E: 8, P: 8 } },
+];
+
+const LiveCREPPanel: React.FC = () => {
+  const { history, triggerCREP } = useCREP();
+  return (
+    <section aria-label="Live CREP Panel">
+      <CREPTriggerPanel
+        availableTriggers={DEFAULT_TRIGGERS.map(t => ({
+          label: t.label,
+          data: t.data,
+        }))}
+      />
+      <CREPChart history={history} />
+    </section>
+  );
+};
+
+export default LiveCREPPanel;

--- a/scripts/generate-api-docs.js
+++ b/scripts/generate-api-docs.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+
+function runTypedoc() {
+  execSync('npx typedoc', { stdio: 'inherit' });
+  console.log('API docs generated in docs/api');
+}
+
+if (require.main === module) {
+  runTypedoc();
+}
+
+module.exports = { runTypedoc };


### PR DESCRIPTION
## Summary
- add `generate-api-docs.js` script for AutoDocGeneration
- implement `LiveCREPPanel` React component with tests
- fix CREPWirkungstracker test expectation
- document modules in new `Handbuch.md`
- update todo-sigil to mark tasks complete and add follow-up task

## Testing
- `npm test`
- `node scripts/generate-api-docs.js`

------
https://chatgpt.com/codex/tasks/task_e_68435e9315008322a0a02060942d4d79