### PR TITLE
Implement Symbolzeit config and GPT logging

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -24,9 +24,11 @@ Dieses Handbuch gibt einen Überblick über die wichtigsten Module und Funktione
 
 ### gpt-bridges
 - `GPTEventHub` – Zentrales Event-System zwischen GPT-Modulen.
-- `aeon-gpt-synapse.ts` – Stub zur Kommunikation mit GPT-APIs.
+- `aeon-gpt-synapse.ts` – Stub zur Kommunikation mit GPT-APIs, passt Antworten an die Symbolzeit an.
 - `GPT_AEONPOET` – Beispielhafter poetischer GPT-Ausdruck.
 - `GPT_CREPJUDGE` – Bewertet CREP-Werte.
+- `GPTConversationLogger` – protokolliert Prompts und Antworten über den EventHub.
+
 
 ### genesis-sigillin-core
 - `SigillinGenerator` – Erstellt und validiert Sigillin-Dateien.
@@ -47,6 +49,7 @@ Dieses Handbuch gibt einen Überblick über die wichtigsten Module und Funktione
 - `KarmaBalance` – Einfache Punktesammlung.
 - `SymbolicForecaster` – Berechnet die nächste Symbolzeitphase.
 - `CREPWirkungstracker` – Protokolliert Effekte von CREP-Einträgen.
+- `loadSymbolphasen` – liest die Symbolphasen-Definition aus `config/symbolphasen.yaml`.
 
 ### unifiedmandala-ui (Auswahl)
 - `MandalaNetworkView` – Visualisierung der Sigillin-Knoten als D3-Graph.
@@ -55,6 +58,7 @@ Dieses Handbuch gibt einen Überblick über die wichtigsten Module und Funktione
 - `LiveCREPPanel` – Kombiniert Trigger und Chart für Live-Daten.
 - `SigillinLoader` – Lädt Sigillin-Dateien und filtert Einträge.
 - `SelfAuditModul` – Zeigt Kennzahlen aus `selfAnalyzer`.
+- `useSymbolzeit` – liest Symbolphasen aus der YAML und steuert Farben dynamisch.
 
 
 Weitere Module sind in Arbeit.

--- a/config/symbolphasen.yaml
+++ b/config/symbolphasen.yaml
@@ -1,0 +1,12 @@
+morgen:
+  phase: Initiation
+  farbe: "#B4E3F2"
+tag:
+  phase: Aktivierung
+  farbe: "#E3F4D6"
+abend:
+  phase: Integration
+  farbe: "#F7D9C4"
+nacht:
+  phase: Reflexion
+  farbe: "#2C3E50"

--- a/docs/sigils/todo-sigil.yaml
+++ b/docs/sigils/todo-sigil.yaml
@@ -273,16 +273,16 @@ aufgaben:
     status: offen
   - id: task-90
     beschreibung: "symbolphasen.yaml konfigurieren"
-    status: offen
+    status: erledigt
   - id: task-91
     beschreibung: "UI dynamisch nach Symbolzeit anpassen"
-    status: offen
+    status: erledigt
   - id: task-92
     beschreibung: "GPT-Antworten an Symbolzeit ausrichten"
-    status: offen
+    status: erledigt
   - id: task-93
     beschreibung: "gespr\xE4chsfall-generator.ts integrieren"
-    status: offen
+    status: erledigt
   - id: task-94
     beschreibung: "GPT-Dialoge mit Signaturankern starten"
     status: offen

--- a/packages/gpt-bridges/GPTConversationLogger.ts
+++ b/packages/gpt-bridges/GPTConversationLogger.ts
@@ -1,0 +1,10 @@
+import { GPTEventHub } from './GPTEventHub';
+import { generateGespraechsfall, Gespraechsfall } from '../shared-utils/GespraechsfallGenerator';
+
+export const gptConversations: Gespraechsfall[] = [];
+
+export function initGPTConversationLogger() {
+  GPTEventHub.on('response', (payload: { prompt: string; response: string }) => {
+    gptConversations.push(generateGespraechsfall(payload.prompt, payload.response));
+  });
+}

--- a/packages/gpt-bridges/README.md
+++ b/packages/gpt-bridges/README.md
@@ -5,4 +5,5 @@ Stub-Module zur Kommunikation mit GPT-Diensten.
 - **GPTEventHub** – Einfacher EventEmitter auf Basis von mitt
 - **aeon-gpt-synapse.ts** – Sende/Empfange Anfragen an GPT
 - **AEONPOET** und **CREPJUDGE** – Platzhalter für spezialisierte GPT-Rollen
+- **GPTConversationLogger** – zeichnet Prompts und Antworten über den EventHub auf
 

--- a/packages/gpt-bridges/aeon-gpt-synapse.ts
+++ b/packages/gpt-bridges/aeon-gpt-synapse.ts
@@ -4,7 +4,13 @@ export interface GPTRequest {
   context?: any;
 }
 
+import { getSymbolzeitPhase } from '../shared-utils/symbolzeitModulator';
+import { loadSymbolphasen } from '../shared-utils/loadSymbolphasen';
+
 export function sendToGPT(request: GPTRequest) {
-  console.log("Stub für GPT-Verbindung:", request);
-  return "Dies ist ein GPT-Stubsignal.";
+  const phaseId = getSymbolzeitPhase();
+  const phases = loadSymbolphasen();
+  const prefix = phases[phaseId]?.phase ? `[${phases[phaseId].phase}] ` : '';
+  console.log('Stub für GPT-Verbindung:', request, 'Phase:', phaseId);
+  return `${prefix}Dies ist ein GPT-Stubsignal.`;
 }

--- a/packages/gpt-bridges/index.ts
+++ b/packages/gpt-bridges/index.ts
@@ -1,0 +1,3 @@
+export * from './GPTEventHub';
+export * from './aeon-gpt-synapse';
+export * from './GPTConversationLogger';

--- a/packages/shared-utils/index.ts
+++ b/packages/shared-utils/index.ts
@@ -11,3 +11,5 @@ export * from './conversationProgress';
 export * from "./CREPWirkungstracker";
 export * from "./KarmaBalance";
 export * from "./SymbolicForecaster";
+export * from './symbolzeitModulator';
+export * from './loadSymbolphasen';

--- a/packages/shared-utils/loadSymbolphasen.ts
+++ b/packages/shared-utils/loadSymbolphasen.ts
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface Symbolphase {
+  phase: string;
+  farbe: string;
+}
+
+function parseSimpleYaml(content: string): Record<string, Symbolphase> {
+  const result: Record<string, Symbolphase> = {};
+  const lines = content.split(/\r?\n/);
+  let current: Symbolphase | null = null;
+  let key: string | null = null;
+  for (const line of lines) {
+    const keyMatch = line.match(/^(\w+):$/);
+    if (keyMatch) {
+      key = keyMatch[1];
+      current = { phase: '', farbe: '' };
+      result[key] = current;
+      continue;
+    }
+    const propMatch = line.match(/^\s+(\w+):\s*"?([^\"]+)"?/);
+    if (propMatch && current) {
+      (current as any)[propMatch[1]] = propMatch[2];
+    }
+  }
+  return result;
+}
+
+export function loadSymbolphasen(): Record<string, Symbolphase> {
+  const file = path.resolve(__dirname, '../../config/symbolphasen.yaml');
+  const content = fs.readFileSync(file, 'utf8');
+  return parseSimpleYaml(content);
+}

--- a/packages/unifiedmandala-ui/hooks/useSymbolzeit.ts
+++ b/packages/unifiedmandala-ui/hooks/useSymbolzeit.ts
@@ -1,11 +1,7 @@
 import { useState, useEffect } from 'react';
+import { loadSymbolphasen } from '../../shared-utils';
 
-const SymbolzeitTabelle = {
-  morgen: { phase: "Initiation", farbe: "#B4E3F2" },
-  tag: { phase: "Aktivierung", farbe: "#E3F4D6" },
-  abend: { phase: "Integration", farbe: "#F7D9C4" },
-  nacht: { phase: "Reflexion", farbe: "#2C3E50" },
-};
+const SymbolzeitTabelle = loadSymbolphasen();
 
 export const useSymbolzeit = () => {
   const [symbolPhase, setSymbolPhase] = useState(SymbolzeitTabelle.tag);


### PR DESCRIPTION
## Summary
- add `config/symbolphasen.yaml` for phase data
- expose `loadSymbolphasen` util with simple YAML parser
- update `useSymbolzeit` hook to use YAML config
- prefix GPT responses with current Symbolzeit and log conversations
- document new utilities and modules in Handbuch
- mark related tasks completed in todo-sigil

## Testing
- `npm install`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6843621f55048322ab1e2ed45e62e6f4