### PR TITLE
Add codexbuild plans for repo split

### DIFF
--- a/codexbuild/aeon-fraktalurs.build.yaml
+++ b/codexbuild/aeon-fraktalurs.build.yaml
@@ -1,0 +1,8 @@
+name: aeon-fraktalurs
+purpose: Langzeit-GPT-Archiv
+features:
+  - SigillinChronik
+  - Embedding Speicher
+  - CREPMemoryWeaver
+integration:
+  - provides context to aeon-shell and sharedream-interface

--- a/codexbuild/aeon-genesisos.build.yaml
+++ b/codexbuild/aeon-genesisos.build.yaml
@@ -1,0 +1,9 @@
+name: aeon-genesisos
+purpose: CREP-Grundsystem
+modules:
+  - CREPContext
+  - CREPManager
+  - SymbolzeitModulator
+  - BackupManager
+integration:
+  - export library to aeon-shell and sharedream-interface

--- a/codexbuild/aeon-resoecho.build.yaml
+++ b/codexbuild/aeon-resoecho.build.yaml
@@ -1,0 +1,7 @@
+name: aeon-resoecho
+purpose: CREP-Zeitlinienarchiv
+features:
+  - MandalaTimeline
+  - Notfall-Rekontextualisierung
+integration:
+  - shares data with aeon-fraktalurs and sharedream-interface

--- a/codexbuild/aeon-shell.build.yaml
+++ b/codexbuild/aeon-shell.build.yaml
@@ -1,0 +1,10 @@
+name: aeon-shell
+purpose: Poetisches CLI
+features:
+  - chronopoem command
+  - sigil_invoke to export Sigillin
+  - cycle management via genesisos
+  - memory-daemon for .aeonvault
+integration:
+  - uses: aeon-genesisos
+  - uses: aeon-fraktalurs

--- a/codexbuild/overview.yaml
+++ b/codexbuild/overview.yaml
@@ -1,0 +1,20 @@
+phase: repo-split
+summary: |
+  Die Aufgaben aus docs/sigils/todo-sigil.yaml sind zu umfangreich f\xC3\xBCr ein einzelnes Repository.
+  Daher werden mehrere spezialisierte Repositories vorgeschlagen.
+repositories:
+  - name: unified-mandala
+    role: Monorepo-Orchestrator mit Basis-Paketen und CI.
+  - name: aeon-shell
+    role: Poetisches CLI f\xC3\xBCr Symbolzeit-Steuerung.
+  - name: aeon-genesisos
+    role: CREP-Engine und Zustandsverwaltung.
+  - name: aeon-fraktalurs
+    role: Langzeit-GPT-Archiv und Erinnerungsfeld.
+  - name: aeon-resoecho
+    role: Chronologisches CREP-Archiv und Timeline.
+  - name: sharedream-interface
+    role: Web-Frontend und Community-Portal.
+links:
+  workspace: pnpm-workspace.yaml
+  gpt-roles: codex/gpt-roles.yaml

--- a/codexbuild/sharedream-interface.build.yaml
+++ b/codexbuild/sharedream-interface.build.yaml
@@ -1,0 +1,9 @@
+name: sharedream-interface
+purpose: Web-Frontend
+features:
+  - MandalaMap Visualization
+  - SigillinLoader & Upload UI
+  - GPT-Bridge
+  - Deployment via Pages or Vercel
+integration:
+  - consumes aeon-genesisos, aeon-resoecho, aeon-fraktalurs

--- a/codexbuild/unified-mandala.build.yaml
+++ b/codexbuild/unified-mandala.build.yaml
@@ -1,0 +1,13 @@
+name: unified-mandala
+scope: monorepo
+focus:
+  - crep-engine
+  - gpt-bridges
+  - unifiedmandala-ui
+  - shared-utils
+steps:
+  - description: CREP-Engine erweitern (CREPContext, CREPManager, Tooltips)
+  - description: GPT-Synapse und Rollen festigen
+  - description: UI-Komponenten vervollst\xC3\xA4ndigen (MandalaMap, SigillinTimeline)
+  - description: Codex-Antwortsystem und SelfAudit weiterentwickeln
+  - description: CI f\xC3\xBCr Lint, Test, Docs vorbereiten


### PR DESCRIPTION
## Summary
- add overview for repository split and cross links
- add build plans for `aeon-shell`, `aeon-genesisos`, `aeon-fraktalurs`, `aeon-resoecho`, `sharedream-interface` and main repo

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436ba624a08322bdbd0a2da929d932