### PR TITLE
Implement CREP context and CI docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,4 @@ jobs:
       - run: pnpm --filter ./packages/genesis-sigillin-core run lint test build
       - run: pnpm --filter ./packages/gpt-bridges run lint test
       - run: pnpm --filter ./packages/cli-tools run lint test
+      - run: pnpm run docs:build

--- a/packages/gpt-bridges/GPTEventHub.ts
+++ b/packages/gpt-bridges/GPTEventHub.ts
@@ -1,2 +1,8 @@
-import mitt from 'mitt';
-export const GPTEventHub = mitt();
+import mitt, { Emitter } from 'mitt';
+
+type GPTEvents = {
+  response: { prompt: string; response: string };
+  [key: string]: any;
+};
+
+export const GPTEventHub: Emitter<GPTEvents> = mitt<GPTEvents>();

--- a/packages/gpt-bridges/aeon-gpt-synapse.ts
+++ b/packages/gpt-bridges/aeon-gpt-synapse.ts
@@ -1,13 +1,19 @@
+import { GPTRole } from './gptRoles';
+
 export interface GPTRequest {
-  role: "aeon" | "crep" | "poet";
+  role: GPTRole;
   input: string;
   context?: any;
 }
 
 import { getSymbolzeitPhase } from '../shared-utils/symbolzeitModulator';
 import { loadSymbolphasen } from '../shared-utils/loadSymbolphasen';
+import { isValidRole } from './gptRoles';
 
 export function sendToGPT(request: GPTRequest) {
+  if (!isValidRole(request.role)) {
+    throw new Error(`Unbekannte GPT-Rolle: ${request.role}`);
+  }
   const phaseId = getSymbolzeitPhase();
   const phases = loadSymbolphasen();
   const prefix = phases[phaseId]?.phase ? `[${phases[phaseId].phase}] ` : '';

--- a/packages/gpt-bridges/gptRoles.ts
+++ b/packages/gpt-bridges/gptRoles.ts
@@ -1,0 +1,9 @@
+export enum GPTRole {
+  AEON = 'aeon',
+  CREP = 'crep',
+  POET = 'poet',
+}
+
+export const isValidRole = (role: string): role is GPTRole =>
+  Object.values(GPTRole).includes(role as GPTRole);
+

--- a/packages/gpt-bridges/index.ts
+++ b/packages/gpt-bridges/index.ts
@@ -1,3 +1,4 @@
 export * from './GPTEventHub';
 export * from './aeon-gpt-synapse';
 export * from './GPTConversationLogger';
+export * from './gptRoles';

--- a/packages/unifiedmandala-ui/README.md
+++ b/packages/unifiedmandala-ui/README.md
@@ -9,6 +9,7 @@ React-Komponenten für das Mandala-Frontend.
 - **SigillinLoader** – Laden und Filtern von Sigillin-Dateien
 - **SigillinViewer** – Darstellung einzelner Sigillin-Daten
 - **SigillinMap** – Übersicht aller bekannten Sigillin
+- **MandalaMap** – einfache SVG-Karte der Mandala-Knoten
 - **SoforthilfeOverlay** – Kontextabhängige Hilfedialoge
 - **SymbolicWayfinder** – Navigations-Komponente für das Mandala
 - **AeonStoryMode** – Präsentationsmodus mit poetischen Sequenzen
@@ -19,6 +20,7 @@ React-Komponenten für das Mandala-Frontend.
 ## Hooks
 - **useSymbolzeit** – liefert aktuelle Symbolzeit-Phase
 - **useCREP** – Zugriff auf CREP-Historie und Trigger
+- **CREPContext** – stellt CREP-Daten via React Context bereit
 
 Zusätzlich stellt `shared-utils` die Funktion **getCREPPhaseColor** bereit,
 um CREP-Werte in Farbzustände zu übersetzen.

--- a/packages/unifiedmandala-ui/components/CREPTooltip.tsx
+++ b/packages/unifiedmandala-ui/components/CREPTooltip.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Tooltip } from 'react-tooltip'; // Annahme: react-tooltip als Abhängigkeit installiert
+import { Tooltip } from 'react-tooltip';
 
 interface CREPTooltipProps {
   label: string;
@@ -15,7 +15,7 @@ const CREPTooltip: React.FC<CREPTooltipProps> = ({ label, value }) => {
   };
 
   return (
-    <Tooltip content={`${descriptionMap[label]} Wert: ${value.toFixed(2)}`}>
+    <Tooltip content={`${descriptionMap[label]} Wert: ${value.toFixed(2)}`}> 
       <span className="crep-label">{label}: {value.toFixed(2)}</span>
     </Tooltip>
   );

--- a/packages/unifiedmandala-ui/components/MandalaMap.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaMap.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export interface MandalaNode {
+  id: string;
+  x: number;
+  y: number;
+  label?: string;
+}
+
+interface MandalaMapProps {
+  nodes: MandalaNode[];
+}
+
+const MandalaMap: React.FC<MandalaMapProps> = ({ nodes }) => (
+  <svg width={600} height={400} aria-label="Mandala Map">
+    {nodes.map(n => (
+      <g key={n.id} transform={`translate(${n.x},${n.y})`}>
+        <circle r={10} fill="#4a90e2" />
+        {n.label && (
+          <text x={0} y={-12} textAnchor="middle" fontSize="10">
+            {n.label}
+          </text>
+        )}
+      </g>
+    ))}
+  </svg>
+);
+
+export default MandalaMap;
+

--- a/packages/unifiedmandala-ui/contexts/CREPContext.tsx
+++ b/packages/unifiedmandala-ui/contexts/CREPContext.tsx
@@ -1,0 +1,53 @@
+import React, { createContext, useContext, useReducer, ReactNode } from 'react';
+import { CREPManager } from '../../crep-engine/CREPManager';
+import { CREPEvaluator } from '../../crep-engine/CREPEvaluator';
+import { CREPEntry } from '../../crep-engine/types';
+
+interface CREPState {
+  history: CREPEntry[];
+}
+
+type Action = { type: 'ADD'; entry: CREPEntry } | { type: 'RESET' };
+
+const crepManager = new CREPManager();
+const crepEvaluator = new CREPEvaluator(crepManager);
+
+const CREPContext = createContext<{
+  state: CREPState;
+  triggerCREP: (data: { C: number; R: number; E: number; P: number }) => void;
+}>({
+  state: { history: [] },
+  triggerCREP: () => {},
+});
+
+function crepReducer(state: CREPState, action: Action): CREPState {
+  switch (action.type) {
+    case 'ADD':
+      return { history: [...state.history, action.entry] };
+    case 'RESET':
+      return { history: [] };
+    default:
+      return state;
+  }
+}
+
+export const CREPProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [state, dispatch] = useReducer(crepReducer, {
+    history: crepManager.getCREPHistory(),
+  });
+
+  const triggerCREP = (data: { C: number; R: number; E: number; P: number }) => {
+    crepEvaluator.evaluateNewDataPoint(data);
+    const history = crepManager.getCREPHistory();
+    dispatch({ type: 'ADD', entry: history[history.length - 1] });
+  };
+
+  return (
+    <CREPContext.Provider value={{ state, triggerCREP }}>
+      {children}
+    </CREPContext.Provider>
+  );
+};
+
+export const useCREPContext = () => useContext(CREPContext);
+


### PR DESCRIPTION
## Summary
- extend GPT bridges with typed event hub and role checking
- add CREPContext and MandalaMap components
- fix CREPTooltip formatting
- document new components
- run docs generation in CI

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_6843734ddbf4832299f8f8c277f30897