### PR TITLE
Add codex instructions

### DIFF
--- a/codexinstructions.yaml
+++ b/codexinstructions.yaml
@@ -1,0 +1,7 @@
+# 🜂 codexinstructions.yaml
+workflow_steps:
+  - "codexwork.yaml öffnen und ausführen"
+  - "Nach unimplementierten Aufgaben oder TODO-Kommentaren suchen und in docs/sigils/todo-sigil.yaml ergänzen"
+  - "Fehlt diese Datei, alle offenen TODOs sammeln und als neue docs/sigils/todo-sigil.yaml anlegen"
+  - "Hinweise im Ordner repositorypflege beachten"
+  - "Während eines Commits möglichst viele TODOs abarbeiten und dokumentieren"


### PR DESCRIPTION
## Summary
- document repository steps in `codexinstructions.yaml`
- note that a new TODO file must be generated from open tasks if missing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684586e47ebc8322949544bb3278da3e