### PR TITLE
Update instructions and add repo TODO list

### DIFF
--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -1,0 +1,10 @@
+todos:
+  - id: todo-1
+    beschreibung: "Nukleon-Scanner als Analysetool implementieren und an CREP-Engine anbinden"
+    status: offen
+  - id: todo-2
+    beschreibung: "Fraktalkunst-Visualizer f\xC3\xBCr Sigillin-Daten in der UI integrieren"
+    status: offen
+  - id: todo-3
+    beschreibung: "Innovationsplanung-Modul auf Basis der conversations.json entwickeln"
+    status: offen

--- a/codexinstructions.yaml
+++ b/codexinstructions.yaml
@@ -5,3 +5,5 @@ workflow_steps:
   - "Fehlt diese Datei, alle offenen TODOs sammeln und als neue docs/sigils/todo-sigil.yaml anlegen"
   - "Hinweise im Ordner repositorypflege beachten"
   - "Während eines Commits möglichst viele TODOs abarbeiten und dokumentieren"
+  - "Programm und alle Funktionen laufen lassen und testen, Fehler beheben"
+  - "Aus dem Kontext des Repos und conversations.json unter Berücksichtigung der repoübergreifenden Gesamtarchitektur neue ToDos ableiten, überlegen wie du sie implementieren kannst und als neue ToDos in ToDo.yaml eintragen"


### PR DESCRIPTION
## Summary
- extend `codexinstructions.yaml` with new workflow steps
- add initial `ToDo.yaml` with tasks derived from conversations

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm run docs:build`
- `node scripts/update-todo-sigil.js`
- `node scripts/check-todo-sigil.js`
- `bash scripts/aeon.sh onboarding`


------
https://chatgpt.com/codex/tasks/task_e_6845a92f3edc8322806edd88b3dfb499