### PR TITLE
Update codex workflow and todo list

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-08, in der Zeit des Abend.
+Am 2025-06-09, in der Zeit des Morgen.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/codexwork.yaml
+++ b/codexwork.yaml
@@ -24,4 +24,5 @@ note: |
   maintain consistent handling of the conversation memory and Sigillin files.
   Beachte bei allem `repositorypflege/repository_map.yaml` als GenesisAeongesamtstruktur.
   Folge `codexinstructions.yaml`.
+  - erarbeite und Implementiere Testverfahren falls nicht vorhanden
   Beachte, dass `docs/sigils/conversations.json` aktualisiert wurde.

--- a/docs/sigils/todo-sigil.yaml
+++ b/docs/sigils/todo-sigil.yaml
@@ -433,3 +433,6 @@ aufgaben:
   - id: task-143
     beschreibung: "Merge-Skript für gesplittete conversation-Fragmente entwickeln"
     status: offen
+  - id: task-144
+    beschreibung: "Erarbeite und implementiere Testverfahren, falls noch nicht vorhanden"
+    status: offen


### PR DESCRIPTION
## Summary
- add instruction about implementing tests to codexwork
- track need to create test procedures in todo-sigil
- update chronopoem automatically via hook

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_6846b6eae6608322b57058abf6d85501