### PR TITLE
Update setup script and todo lists

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-09, in der Zeit des Tag.
+Am 2025-06-10, in der Zeit des Morgen.
 
-Symbolphase: Aktivierung (Fokus: R)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,7 @@ Jeder Unterordner kann eine eigene README enthalten – siehe die Links in den j
 # Node.js ≥ 18 & pnpm installiert
 git clone https://github.com/GenesisAeon/unified-mandala.git
 cd unified-mandala
-pnpm install
-pnpm run build
-pnpm run docs:build
+./scripts/setup-unifiedmandala.sh
 pnpm dev
 ```
 Die generierte API-Dokumentation findest du danach unter `docs/api`.

--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -22,7 +22,10 @@ todos:
     status: offen
   - id: todo-8
     beschreibung: "Setup-Skript scripts/setup-unifiedmandala.sh erweitern und automatisieren"
-    status: offen
+    status: erledigt
   - id: todo-9
     beschreibung: "GitHub Action zur automatischen Aufteilung von conversations.json implementieren"
+    status: offen
+  - id: todo-10
+    beschreibung: "kontext.json regelmäßig mit Inhalten aus conversations.json aktualisieren"
     status: offen

--- a/docs/sigils/todo-sigil.yaml
+++ b/docs/sigils/todo-sigil.yaml
@@ -439,3 +439,9 @@ aufgaben:
   - id: task-145
     beschreibung: "Testverfahren entwickeln und in GitHub Actions integrieren"
     status: offen
+  - id: task-146
+    beschreibung: "Setup-Skript scripts/setup-unifiedmandala.sh erweitern und automatisieren"
+    status: erledigt
+  - id: task-147
+    beschreibung: "kontext.json regelmäßig mit Inhalten aus conversations.json aktualisieren"
+    status: offen

--- a/scripts/setup-unifiedmandala.sh
+++ b/scripts/setup-unifiedmandala.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 echo "🜂 Setup – UnifiedMandala"
 pnpm install
+pnpm lint
 pnpm run build
 pnpm test
 pnpm run docs:build || echo "Dokumentation kann später gebaut werden."
+CHUNK_SIZE=${CONV_CHUNK_SIZE:-50}
+pnpm split:conversations "$CHUNK_SIZE" || echo "conversations.json bleibt ungeteilt."
 echo "✔ Setup fertig. Starte jetzt mit ./scripts/aeon.sh cycle_start"


### PR DESCRIPTION
## Summary
- enhance setup-unifiedmandala.sh with linting and conversation splitting
- mark setup task as done in ToDo files and add new task for kontext maintenance
- mention setup script in README for quickstart
- regenerate CHRONOPOEM via commit hook

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6847d481e45483229992cac54f4af819