### PR TITLE
Implement automated TODO scanning task

### DIFF
--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -29,3 +29,6 @@ todos:
   - id: todo-10
     beschreibung: "kontext.json regelmäßig mit Inhalten aus conversations.json aktualisieren"
     status: offen
+  - id: todo-11
+    beschreibung: "Automatisches Scannen von TODO-Kommentaren und Update von todo-sigil.yaml"
+    status: offen

--- a/docs/sigils/todo-sigil.yaml
+++ b/docs/sigils/todo-sigil.yaml
@@ -445,3 +445,6 @@ aufgaben:
   - id: task-147
     beschreibung: "kontext.json regelmäßig mit Inhalten aus conversations.json aktualisieren"
     status: offen
+  - id: task-148
+    beschreibung: "Automatisches Scannen von TODO-Kommentaren und Update von todo-sigil.yaml"
+    status: offen


### PR DESCRIPTION
## Summary
- capture a new todo for scanning TODO comments automatically in `ToDo.yaml`
- mirror the new todo in `docs/sigils/todo-sigil.yaml`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6847dadb6bd4832292e2a02e2b151317