### PR TITLE
Update todo lists and mark CI tasks

### DIFF
--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -19,7 +19,7 @@ todos:
     status: offen
   - id: todo-7
     beschreibung: "Testverfahren entwickeln und in GitHub Actions integrieren"
-    status: offen
+    status: erledigt
   - id: todo-8
     beschreibung: "Setup-Skript scripts/setup-unifiedmandala.sh erweitern und automatisieren"
     status: erledigt
@@ -31,4 +31,13 @@ todos:
     status: offen
   - id: todo-11
     beschreibung: "Automatisches Scannen von TODO-Kommentaren und Update von todo-sigil.yaml"
+    status: offen
+  - id: todo-12
+    beschreibung: "CI-Check zur Einhaltung von AI_POLICY.md in GitHub Actions einrichten"
+    status: offen
+  - id: todo-13
+    beschreibung: "Sigillin-Lint in CI integrieren"
+    status: offen
+  - id: todo-14
+    beschreibung: "Verarbeitung von conversations.json mit Fortschrittsdatei automatisieren"
     status: offen

--- a/docs/sigils/todo-sigil.yaml
+++ b/docs/sigils/todo-sigil.yaml
@@ -438,7 +438,7 @@ aufgaben:
     status: offen
   - id: task-145
     beschreibung: "Testverfahren entwickeln und in GitHub Actions integrieren"
-    status: offen
+    status: erledigt
   - id: task-146
     beschreibung: "Setup-Skript scripts/setup-unifiedmandala.sh erweitern und automatisieren"
     status: erledigt
@@ -447,4 +447,13 @@ aufgaben:
     status: offen
   - id: task-148
     beschreibung: "Automatisches Scannen von TODO-Kommentaren und Update von todo-sigil.yaml"
+    status: offen
+  - id: task-149
+    beschreibung: "CI-Check zur Einhaltung von AI_POLICY.md in GitHub Actions einrichten"
+    status: offen
+  - id: task-150
+    beschreibung: "Sigillin-Lint in CI integrieren"
+    status: offen
+  - id: task-151
+    beschreibung: "Verarbeitung von conversations.json mit Fortschrittsdatei automatisieren"
     status: offen


### PR DESCRIPTION
## Summary
- extend todo lists with CI policy and progress tasks
- mark existing test integration as complete

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm test`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6847e5d864d0832282cb5e38763a8288