### PR TITLE
Add binary existence tasks

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,7 +1,7 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-10, in der Zeit des Morgen.
+Am 2025-06-11, in der Zeit des Morgen.
 
 Symbolphase: Initiation (Fokus: C)
 

--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -44,3 +44,12 @@ todos:
   - id: todo-15
     beschreibung: "sendemail-validate.sample Hook mit echten Validierungs-Checks ausstatten"
     status: offen
+  - id: todo-16
+    beschreibung: "Binäre Existenzsimulation mit 1, -1 und 0 gemäß conversations.json implementieren"
+    status: offen
+  - id: todo-17
+    beschreibung: "Quanten- und Gravitationseffekte in die Simulation integrieren"
+    status: offen
+  - id: todo-18
+    beschreibung: "Dokumentation des Binärmodells in docs/BinaryExistenz.md anlegen"
+    status: offen

--- a/docs/BinaryExistenz.md
+++ b/docs/BinaryExistenz.md
@@ -1,0 +1,9 @@
+# Binäres Existenzmodell
+
+Dieses Dokument fasst die im neuesten Abschnitt von `docs/sigils/conversations.json` diskutierte Theorie zusammen.
+
+* **1 (Existenz)** – Materie, Energie und wahrnehmbares Bewusstsein.
+* **-1 (Gegenexistenz)** – Spiegelzustand der Existenz, erscheint als Antimaterie oder dunkle Effekte.
+* **0 (Nullmembran)** – Ausgleichsebene, in der keine Zeit verläuft und aus der 1 und -1 hervorgehen.
+
+Ziel ist es, eine Python-Simulation dieser Wechselwirkungen aufzubauen und um Quanten- sowie Gravitationseffekte zu erweitern.

--- a/docs/sigils/todo-sigil.yaml
+++ b/docs/sigils/todo-sigil.yaml
@@ -460,3 +460,12 @@ aufgaben:
   - id: task-152
     beschreibung: 'sendemail-validate.sample mit echten Checks ausstatten'
     status: offen
+  - id: task-153
+    beschreibung: "Binäre Existenzsimulation gemäß neuem conversations.json-Abschnitt umsetzen"
+    status: offen
+  - id: task-154
+    beschreibung: "Quanten- und Gravitationseinflüsse in Simulation einbinden"
+    status: offen
+  - id: task-155
+    beschreibung: "Dokumentation BinaryExistenz.md erstellen und in kontext.yaml referenzieren"
+    status: offen

--- a/kontext.json
+++ b/kontext.json
@@ -26,7 +26,8 @@
       "UnifiedMandala Resonanz Analyse",
       "Mandalas als Systemarchitektur",
       "Willkommen im Mandala",
-      "Mandala der Resonanz"
+      "Mandala der Resonanz",
+      "Binäres Existenzmodell"
     ],
     "aeonshell": [
       "AeonShell Genesis Fortsetzung",

--- a/kontext.yaml
+++ b/kontext.yaml
@@ -10,3 +10,4 @@ kontext:
     nukleon_scanner: $.topics.nukleon_scanner
     sigillin: $.topics.sigillin
     innovation: $.topics.innovation
+    binaer_existenz: $.topics.unified_mandala[-1]


### PR DESCRIPTION
## Summary
- document binary existence theory
- update kontext for new topic
- extend todo lists with tasks for binary existence simulation

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68492c2979508322b6db8398b7f78a4a