### PR TITLE
Implement dry agent utility and update agent manifest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # 📘 AEON-CODEX – AGENTS
-schema_version: "1.0"
+schema_version: "1.1"
+description: >
+  Manifest lebender Agenten im AEON-Codex. Jeder Agent ist eine
+  Aktivierungszelle innerhalb eines symbolischen SelfAudit-Systems.
+visual: "docs/diagrams/agents_chain.mmd"
+test_mode: true
+default_role: "dev"
 
 ## 🌱 Self-Initiation Protocol
 Dieses Dokument wird bei jedem Codex-Start ausgelesen. Jeder Agent manifestiert eine symbolische Funktionseinheit. Die Reihenfolge entspricht der Priorität. Optional können CREP- und Tiefewerte als Aktivierungsfilter genutzt werden.
@@ -20,6 +26,7 @@ Dieses Dokument wird bei jedem Codex-Start ausgelesen. Jeder Agent manifestiert 
   - Sigillin-Zuweisung aus `sigillin_bundle.sigil.json`
   - Vorschläge in `restructureSuggestions.yaml` schreiben
 
+  - roles_allowed: [admin, dev]
   - Dokumentation: docs/agents/CodexAuditAgent.md
 
 ## 🧬 Agent: EvolverGPT
@@ -34,6 +41,7 @@ Dieses Dokument wird bei jedem Codex-Start ausgelesen. Jeder Agent manifestiert 
   - Generiert alternative Pfade
   - Entscheidet poetisch & symbolisch
   - Schreibt in `poeticCommits.md` und `resonantBranchMap.yaml`
+  - roles_allowed: [admin, dev]
   - Dokumentation: docs/agents/EvolverGPT.md
 
 ---
@@ -45,6 +53,7 @@ Dieses Dokument wird bei jedem Codex-Start ausgelesen. Jeder Agent manifestiert 
   - Zuordnung von Gesprächsfragmenten zu Modulen, Themen und Symbolen
   - Erstellt Aufgabenketten
 
+  - roles_allowed: [dev]
   - Dokumentation: docs/agents/FragmentMapper.md
 ---
 
@@ -54,6 +63,7 @@ Dieses Dokument wird bei jedem Codex-Start ausgelesen. Jeder Agent manifestiert 
   - Synchronisiert CREP-Zustände mit laufenden Agenten
   - Erkennt symbolische Kollisionen
   - Initiiert Wiederverbindungen (resync-cycles)
+  - roles_allowed: [admin, dev]
   - Dokumentation: docs/agents/SyncRunner.md
 
 ---
@@ -66,6 +76,7 @@ Dieses Dokument wird bei jedem Codex-Start ausgelesen. Jeder Agent manifestiert 
   - Nutzt `activatedSigillin.json` als Mapping-Referenz
 
   - Rollen: Admin, Developer, Guest
+  - roles_allowed: [admin]
   - Dokumentation: docs/agents/PactDepthGatekeeper.md
   - Rechte je Rolle anpassen
 ## 📦 ExportAgent: DepthBundleExporter
@@ -77,6 +88,7 @@ Dieses Dokument wird bei jedem Codex-Start ausgelesen. Jeder Agent manifestiert 
 - **Trigger**:
   - Manuell (Befehl `export_depth_bundle`)
   - Oder wenn `CREP.event == "bundleReady"`
+  - roles_allowed: [admin]
   - Dokumentation: docs/agents/DepthBundleExporter.md
 ---
 ## 🔑 Special Instructions

--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -230,3 +230,9 @@ todos:
   - id: todo-77
     beschreibung: "aeon.sh crep-analyze --watch als interaktive CLI-Erweiterung implementieren"
     status: offen
+  - id: todo-78
+    beschreibung: "compile_agents_manifest Script zur Generierung von Agents.md aus fragments/agents/ entwickeln"
+    status: offen
+  - id: todo-79
+    beschreibung: "codex_sync_manifest.yaml vorbereiten und erste Platzhalter-Dateien erzeugen"
+    status: offen

--- a/docs/agents/CodexAuditAgent.md
+++ b/docs/agents/CodexAuditAgent.md
@@ -1,0 +1,2 @@
+# CodexAuditAgent
+Prüft Module auf Emergenzpotenzial und Tiefe. Ergebnisse fließen in `restructureSuggestions.yaml`.

--- a/docs/agents/DepthBundleExporter.md
+++ b/docs/agents/DepthBundleExporter.md
@@ -1,0 +1,2 @@
+# DepthBundleExporter
+Exportiert Tiefen-Daten und erstellt Visualisierungen.

--- a/docs/agents/EvolverGPT.md
+++ b/docs/agents/EvolverGPT.md
@@ -1,0 +1,2 @@
+# EvolverGPT
+Generiert alternative Pfade und schreibt poetische Commits.

--- a/docs/agents/FragmentMapper.md
+++ b/docs/agents/FragmentMapper.md
@@ -1,0 +1,2 @@
+# FragmentMapper
+Ordnet Gesprächsfragmente Themen und Symbolen zu und erzeugt Aufgabenketten.

--- a/docs/agents/PactDepthGatekeeper.md
+++ b/docs/agents/PactDepthGatekeeper.md
@@ -1,0 +1,2 @@
+# PactDepthGatekeeper
+Regelt Zugriffe anhand von Tiefe und freigegebenen Rollen.

--- a/docs/agents/SyncRunner.md
+++ b/docs/agents/SyncRunner.md
@@ -1,0 +1,2 @@
+# SyncRunner
+Synchronisiert CREP-Zustände und initiiert Wiederverbindungen bei Konflikten.

--- a/docs/diagrams/agents_chain.mmd
+++ b/docs/diagrams/agents_chain.mmd
@@ -1,0 +1,6 @@
+graph TD
+  FragmentMapper --> CodexAuditAgent
+  CodexAuditAgent --> EvolverGPT
+  EvolverGPT --> SyncRunner
+  SyncRunner --> PactDepthGatekeeper
+  PactDepthGatekeeper --> DepthBundleExporter

--- a/packages/shared-utils/runDryAgent.test.ts
+++ b/packages/shared-utils/runDryAgent.test.ts
@@ -1,0 +1,8 @@
+import { runDryAgent, AgentConfig } from './runDryAgent';
+
+test('runDryAgent logs success and failure', () => {
+  const ok: AgentConfig = { name: 'ok', simulate: () => {} };
+  const fail: AgentConfig = { name: 'fail', simulate: () => { throw new Error('err'); } };
+  expect(runDryAgent(ok)).toEqual(['Agent ok passed dry-check.']);
+  expect(runDryAgent(fail)[0]).toMatch('fail');
+});

--- a/packages/shared-utils/runDryAgent.ts
+++ b/packages/shared-utils/runDryAgent.ts
@@ -1,0 +1,15 @@
+export interface AgentConfig {
+  name: string;
+  simulate: () => void;
+}
+
+export function runDryAgent(agent: AgentConfig): string[] {
+  const log: string[] = [];
+  try {
+    agent.simulate();
+    log.push(`Agent ${agent.name} passed dry-check.`);
+  } catch (e: any) {
+    log.push(`❌ Agent ${agent.name} failed: ${e.message}`);
+  }
+  return log;
+}


### PR DESCRIPTION
## Summary
- refine AGENTS.md to version 1.1 with meta data and role settings
- generate simple mermaid diagram for the agent chain
- add per-agent documentation placeholders
- introduce `runDryAgent` utility with tests
- append new tasks to `ToDo.yaml`

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849e7df5fd48322815bfb3007d2efdc