### PR TITLE
Add CodexNavigatorAgent skeleton

### DIFF
--- a/packages/agents/CodexNavigatorAgent.ts
+++ b/packages/agents/CodexNavigatorAgent.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+export interface NavigatorState {
+  phase: string;
+  resonanzpfad: Array<{ task: string; antwort: string }>;
+}
+
+export class CodexNavigatorAgent {
+  private instruction: any;
+  private agents: string;
+  private work: any;
+  public state: NavigatorState = { phase: 'init', resonanzpfad: [] };
+
+  constructor(private codexDir: string) {
+    this.instruction = this.readYAML('codexinstructions.yaml');
+    this.agents = this.readMarkdown('AGENTS.md');
+    this.work = this.readYAML('codexwork.yaml');
+  }
+
+  private readYAML(filename: string): any {
+    const file = path.join(this.codexDir, filename);
+    const content = fs.readFileSync(file, 'utf-8');
+    return yaml.load(content);
+  }
+
+  private readMarkdown(filename: string): string {
+    const file = path.join(this.codexDir, filename);
+    return fs.readFileSync(file, 'utf-8');
+  }
+
+  public explore(): void {
+    const tasks = Array.isArray(this.work.tasks) ? this.work.tasks : [];
+    for (const task of tasks) {
+      const result = this.processTask(task);
+      this.state.resonanzpfad.push(result);
+      this.logResult(result);
+    }
+  }
+
+  private processTask(task: any): { task: any; antwort: string } {
+    return {
+      task,
+      antwort: `Resonanz aus Phase ${this.state.phase}`
+    };
+  }
+
+  private logResult(result: { task: any; antwort: string }): void {
+    console.log(`\uD83C\uDF00 ${JSON.stringify(result.task)} \u2192 ${result.antwort}`);
+  }
+}

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -1,0 +1,5 @@
+# Agents Package
+
+Dieses Verzeichnis bündelt verschiedene Agenten des Unified Mandala Projekts. 
+Der `CodexNavigatorAgent` dient als Ausgangspunkt und verarbeitet Aufgaben aus
+`codexwork.yaml`.

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -1,0 +1,1 @@
+export * from './CodexNavigatorAgent';


### PR DESCRIPTION
## Summary
- introduce `packages/agents` package
- add initial `CodexNavigatorAgent` implementation
- export agent in new index and document it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851a3970d4c8322a1e59bd57c59820c