### PR TITLE
Add GenesisAeonNavigator agent

### DIFF
--- a/ToDoAI.yaml
+++ b/ToDoAI.yaml
@@ -10,6 +10,7 @@ todos:
     split_commits:
       - commit_1: Agenten-Grundgeruest
       - commit_2: Agenten-Logik & Events
+    status: erledigt
   - id: Fragment_03_GenesisAeonNavigator_Part2
     implement: packages/agents/
     priority: high

--- a/packages/agents/GenesisAeonNavigator.ts
+++ b/packages/agents/GenesisAeonNavigator.ts
@@ -1,0 +1,42 @@
+export interface GenesisNavigatorOptions {
+  phaseMapPath: string;
+  logFile?: string;
+}
+
+export class GenesisAeonNavigator {
+  private phaseMap: any;
+  constructor(private options: GenesisNavigatorOptions) {
+    this.phaseMap = this.loadPhaseMap(options.phaseMapPath);
+  }
+
+  private loadPhaseMap(file: string): any {
+    try {
+      const data = require('fs').readFileSync(file, 'utf-8');
+      return JSON.parse(data);
+    } catch (err) {
+      console.error('Failed to load phase map', err);
+      return {};
+    }
+  }
+
+  public start(): void {
+    this.log('GenesisAeonNavigator start');
+  }
+
+  public navigate(phase: string): void {
+    const next = this.phaseMap[phase];
+    if (next) {
+      this.log(`Navigate to ${next}`);
+    } else {
+      this.log(`Unknown phase: ${phase}`);
+    }
+  }
+
+  private log(msg: string): void {
+    if (this.options.logFile) {
+      require('fs').appendFileSync(this.options.logFile, msg + '\n');
+    } else {
+      console.log(msg);
+    }
+  }
+}

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -3,3 +3,5 @@
 Dieses Verzeichnis bündelt verschiedene Agenten des Unified Mandala Projekts. 
 Der `CodexNavigatorAgent` dient als Ausgangspunkt und verarbeitet Aufgaben aus
 `codexwork.yaml`.
+
+Der `GenesisAeonNavigator` steuert symbolische Phasen anhand einer JSON-PhaseMap.

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -1,1 +1,2 @@
 export * from './CodexNavigatorAgent';
+export * from './GenesisAeonNavigator';


### PR DESCRIPTION
## Summary
- add new GenesisAeonNavigator agent skeleton
- export new agent and document in README
- mark first GenesisAeonNavigator task as completed

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6851c78ba6dc8322821dc707fe069fd7