### PR TITLE
Implement KoKreation init agent

### DIFF
--- a/ToDoAI.yaml
+++ b/ToDoAI.yaml
@@ -27,6 +27,7 @@ todos:
     implement: packages/agents/
     priority: high
     next_commit: true
+    status: erledigt
     split_commits:
       - commit_1: Ko-Kreation Grundstein
       - commit_2: Resonanzinitialisierung

--- a/packages/agents/KoKreationInitAgent.test.ts
+++ b/packages/agents/KoKreationInitAgent.test.ts
@@ -1,0 +1,20 @@
+import { KoKreationInitAgent } from './KoKreationInitAgent';
+import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
+
+describe('KoKreationInitAgent', () => {
+  beforeEach(() => {
+    jest.spyOn(GPTEventHub, 'emit');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('initializes and logs message', () => {
+    const agent = new KoKreationInitAgent();
+    agent.init('start');
+    expect(agent.isInitialized()).toBe(true);
+    expect(agent.getLog()).toContain('start');
+    expect((GPTEventHub.emit as jest.Mock).mock.calls[0]).toEqual(['kocreation:init', 'start']);
+  });
+});

--- a/packages/agents/KoKreationInitAgent.ts
+++ b/packages/agents/KoKreationInitAgent.ts
@@ -1,0 +1,22 @@
+import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
+
+export class KoKreationInitAgent {
+  private initialized = false;
+  private log: string[] = [];
+
+  constructor(private hub = GPTEventHub) {}
+
+  init(message: string): void {
+    this.initialized = true;
+    this.log.push(message);
+    this.hub.emit('kocreation:init', message);
+  }
+
+  getLog(): string[] {
+    return this.log;
+  }
+
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+}

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -1,2 +1,3 @@
 export * from './CodexNavigatorAgent';
 export * from './GenesisAeonNavigator';
+export * from './KoKreationInitAgent';


### PR DESCRIPTION
## Summary
- add `KoKreationInitAgent` with event emission
- export the new agent
- add unit test
- mark `Fragment_06_KoKreation_Init` as erledigt

## Testing
- `pnpm install --ignore-scripts`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6851cb62fcd8832291415420c77a1d64