### PR TITLE
Implement resonanz agents

### DIFF
--- a/packages/agents/AeonKIResonanzAgent.test.ts
+++ b/packages/agents/AeonKIResonanzAgent.test.ts
@@ -1,0 +1,11 @@
+import { AeonKIResonanzAgent } from './AeonKIResonanzAgent';
+
+describe('AeonKIResonanzAgent', () => {
+  it('logs messages and emits event', () => {
+    const events: any[] = [];
+    const agent = new AeonKIResonanzAgent((e, p) => events.push([e, p]));
+    agent.start('hello');
+    expect(agent.getLog()).toContain('hello');
+    expect(events).toEqual([['aeon:resonanz', 'hello']]);
+  });
+});

--- a/packages/agents/AeonKIResonanzAgent.ts
+++ b/packages/agents/AeonKIResonanzAgent.ts
@@ -1,0 +1,14 @@
+export class AeonKIResonanzAgent {
+  private resonanzLog: string[] = [];
+
+  constructor(private emit: (event: string, payload: any) => void = () => {}) {}
+
+  start(message: string): void {
+    this.resonanzLog.push(message);
+    this.emit('aeon:resonanz', message);
+  }
+
+  getLog(): string[] {
+    return this.resonanzLog;
+  }
+}

--- a/packages/agents/CodexProjectInitAgent.test.ts
+++ b/packages/agents/CodexProjectInitAgent.test.ts
@@ -1,0 +1,10 @@
+import { CodexProjectInitAgent } from './CodexProjectInitAgent';
+
+describe('CodexProjectInitAgent', () => {
+  it('adds and lists projects', () => {
+    const agent = new CodexProjectInitAgent();
+    agent.addProject('alpha');
+    agent.addProject('beta');
+    expect(agent.list()).toEqual(['alpha', 'beta']);
+  });
+});

--- a/packages/agents/CodexProjectInitAgent.ts
+++ b/packages/agents/CodexProjectInitAgent.ts
@@ -1,0 +1,11 @@
+export class CodexProjectInitAgent {
+  private projects: string[] = [];
+
+  addProject(name: string): void {
+    this.projects.push(name);
+  }
+
+  list(): string[] {
+    return this.projects;
+  }
+}

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -1,3 +1,5 @@
 export * from './CodexNavigatorAgent';
 export * from './GenesisAeonNavigator';
 export * from './KoKreationInitAgent';
+export * from './AeonKIResonanzAgent';
+export * from './CodexProjectInitAgent';


### PR DESCRIPTION
## Summary
- add AeonKIResonanzAgent for emitting resonanz events
- add CodexProjectInitAgent to track project names
- export new agents
- add unit tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6851d1792acc8322bc77c6f18924b9fe