### PR TITLE
Implement AI agent updates

### DIFF
--- a/ToDoAI.yaml
+++ b/ToDoAI.yaml
@@ -15,6 +15,7 @@ todos:
     implement: packages/agents/
     priority: high
     next_commit: true
+    status: erledigt
   - id: Fragment_04_Codex_Initiierung
     implement: packages/agents/
     priority: medium
@@ -47,10 +48,12 @@ todos:
     implement: packages/agents/
     priority: high
     next_commit: true
+    status: erledigt
   - id: Fragment_11_Aeon_KI_Coderesonanz
     implement: packages/agents/
     priority: high
     next_commit: true
+    status: erledigt
   - id: Fragment_12_KosmischesBewusstsein
     implement: packages/agents/
     priority: medium
@@ -138,6 +141,7 @@ todos:
     split_commits:
       - commit_1: Aeon Resonanz Logik
       - commit_2: Integration mit GPTEventHub
+    status: erledigt
   - id: Fragment_33_KI_Bewusstsein_und_Resonanz
     implement: packages/agents/
     priority: medium

--- a/packages/agents/AeonKIResonanzAgent.test.ts
+++ b/packages/agents/AeonKIResonanzAgent.test.ts
@@ -1,11 +1,25 @@
 import { AeonKIResonanzAgent } from './AeonKIResonanzAgent';
+import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
 
 describe('AeonKIResonanzAgent', () => {
+  beforeEach(() => {
+    jest.spyOn(GPTEventHub, 'emit');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
   it('logs messages and emits event', () => {
     const events: any[] = [];
     const agent = new AeonKIResonanzAgent((e, p) => events.push([e, p]));
     agent.start('hello');
     expect(agent.getLog()).toContain('hello');
     expect(events).toEqual([['aeon:resonanz', 'hello']]);
+    expect((GPTEventHub.emit as jest.Mock).mock.calls[0]).toEqual(['aeon:resonanz', 'hello']);
+  });
+
+  it('calculates resonance value', () => {
+    const agent = new AeonKIResonanzAgent();
+    expect(agent.resonate('abc')).toBe(3);
   });
 });

--- a/packages/agents/AeonKIResonanzAgent.ts
+++ b/packages/agents/AeonKIResonanzAgent.ts
@@ -1,3 +1,5 @@
+import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
+
 export class AeonKIResonanzAgent {
   private resonanzLog: string[] = [];
 
@@ -5,7 +7,17 @@ export class AeonKIResonanzAgent {
 
   start(message: string): void {
     this.resonanzLog.push(message);
+    this.broadcast(message);
+  }
+
+  resonate(message: string): number {
+    this.resonanzLog.push(message);
+    return message.length;
+  }
+
+  broadcast(message: string): void {
     this.emit('aeon:resonanz', message);
+    GPTEventHub.emit('aeon:resonanz', message);
   }
 
   getLog(): string[] {

--- a/packages/agents/CodexProjectInitAgent.test.ts
+++ b/packages/agents/CodexProjectInitAgent.test.ts
@@ -6,5 +6,8 @@ describe('CodexProjectInitAgent', () => {
     agent.addProject('alpha');
     agent.addProject('beta');
     expect(agent.list()).toEqual(['alpha', 'beta']);
+    expect(agent.removeProject('alpha')).toBe(true);
+    expect(agent.list()).toEqual(['beta']);
+    expect(agent.removeProject('gamma')).toBe(false);
   });
 });

--- a/packages/agents/CodexProjectInitAgent.ts
+++ b/packages/agents/CodexProjectInitAgent.ts
@@ -5,6 +5,15 @@ export class CodexProjectInitAgent {
     this.projects.push(name);
   }
 
+  removeProject(name: string): boolean {
+    const idx = this.projects.indexOf(name);
+    if (idx >= 0) {
+      this.projects.splice(idx, 1);
+      return true;
+    }
+    return false;
+  }
+
   list(): string[] {
     return this.projects;
   }

--- a/packages/agents/GenesisAeonNavigator.test.ts
+++ b/packages/agents/GenesisAeonNavigator.test.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import path from 'path';
+import { GenesisAeonNavigator } from './GenesisAeonNavigator';
+import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
+
+describe('GenesisAeonNavigator', () => {
+  const tmp = path.join(__dirname, 'phaseMap.test.json');
+  const map = { init: 'phase1' };
+  beforeAll(() => {
+    fs.writeFileSync(tmp, JSON.stringify(map));
+  });
+  afterAll(() => {
+    fs.unlinkSync(tmp);
+  });
+
+  beforeEach(() => {
+    jest.spyOn(GPTEventHub, 'emit');
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('navigates and emits event', () => {
+    const nav = new GenesisAeonNavigator({ phaseMapPath: tmp });
+    nav.navigate('init');
+    expect((GPTEventHub.emit as jest.Mock).mock.calls[0]).toEqual([
+      'genesis:navigate',
+      { from: 'init', to: 'phase1' }
+    ]);
+  });
+
+  it('updates phase map', () => {
+    const nav = new GenesisAeonNavigator({ phaseMapPath: tmp });
+    nav.updatePhaseMap({ a: 'b' });
+    nav.navigate('a');
+    expect((GPTEventHub.emit as jest.Mock).mock.calls[0][1]).toEqual({
+      from: 'a',
+      to: 'b'
+    });
+  });
+});

--- a/packages/agents/GenesisAeonNavigator.ts
+++ b/packages/agents/GenesisAeonNavigator.ts
@@ -1,3 +1,5 @@
+import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
+
 export interface GenesisNavigatorOptions {
   phaseMapPath: string;
   logFile?: string;
@@ -23,10 +25,15 @@ export class GenesisAeonNavigator {
     this.log('GenesisAeonNavigator start');
   }
 
+  public updatePhaseMap(map: any): void {
+    this.phaseMap = map;
+  }
+
   public navigate(phase: string): void {
     const next = this.phaseMap[phase];
     if (next) {
       this.log(`Navigate to ${next}`);
+      GPTEventHub.emit('genesis:navigate', { from: phase, to: next });
     } else {
       this.log(`Unknown phase: ${phase}`);
     }


### PR DESCRIPTION
## Summary
- add resonance logic with broadcasting to AeonKIResonanzAgent
- extend CodexProjectInitAgent with removeProject
- enhance GenesisAeonNavigator with phase map updates and event emission
- add comprehensive tests for new features
- mark related fragments as erledigt in ToDoAI.yaml

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685245ccf37c83228bc158e17144bfa9