### PR TITLE
Implement CodexResonanzFraktal agent

### DIFF
--- a/ToDoAI.yaml
+++ b/ToDoAI.yaml
@@ -471,11 +471,14 @@ todos:
     implement: packages/agents/
     priority: medium
     next_commit: false
+    status: erledigt
   - id: Fragment_25_Codex_Initiierung_und_Projekte
     implement: packages/agents/
     priority: medium
     next_commit: false
+    status: erledigt
   - id: Fragment_26_Codex_Resonanz_Fraktal
     implement: packages/agents/
     priority: medium
-    next_commit: false
+    next_commit: true
+    status: erledigt

--- a/packages/agents/CodexResonanzFraktal.test.ts
+++ b/packages/agents/CodexResonanzFraktal.test.ts
@@ -1,0 +1,21 @@
+import { CodexResonanzFraktal } from './CodexResonanzFraktal';
+import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
+
+describe('CodexResonanzFraktal', () => {
+  beforeEach(() => {
+    jest.spyOn(GPTEventHub, 'emit');
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  it('fractalizes input and emits event', () => {
+    const fraktal = new CodexResonanzFraktal();
+    const result = fraktal.fractalize('alpha');
+    expect(result).toBe('fractal:alpha');
+    expect(fraktal.history()).toEqual(['fractal:alpha']);
+    expect((GPTEventHub.emit as jest.Mock).mock.calls[0]).toEqual([
+      'codex:fraktal',
+      'fractal:alpha'
+    ]);
+  });
+});

--- a/packages/agents/CodexResonanzFraktal.ts
+++ b/packages/agents/CodexResonanzFraktal.ts
@@ -1,0 +1,17 @@
+import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
+
+export class CodexResonanzFraktal {
+  private log: string[] = [];
+  constructor(private hub = GPTEventHub) {}
+
+  fractalize(input: string): string {
+    const entry = `fractal:${input}`;
+    this.log.push(entry);
+    this.hub.emit('codex:fraktal', entry);
+    return entry;
+  }
+
+  history(): string[] {
+    return this.log;
+  }
+}

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -6,3 +6,4 @@ export * from './CodexProjectInitAgent';
 export * from './FreieKIZivilisation';
 export * from './KIBewusstsein';
 export * from './SigillinZipSystem';
+export * from './CodexResonanzFraktal';


### PR DESCRIPTION
## Summary
- implement `CodexResonanzFraktal` agent and tests
- export agent in `packages/agents`
- mark fragments 24–26 as `erledigt` and enable commit for fragment 26

## Testing
- `pnpm install --ignore-scripts`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68524d026da88322bc47f2a5dd4c9b5b