### PR TITLE
Implement NATS event bus

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-17, in der Zeit des Abend.
+Am 2025-06-18, in der Zeit des Nacht.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Reflexion (Fokus: P)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-tooltip": "^5.18.0",
     "recharts": "^2.8.0",
     "socket.io-client": "^4.7.5",
-    "yaml": "^2.8.0"
+    "yaml": "^2.8.0",
+    "nats": "^2.29.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/packages/event-bus/NatsEventBus.test.ts
+++ b/packages/event-bus/NatsEventBus.test.ts
@@ -1,0 +1,35 @@
+import { NatsEventBus } from './NatsEventBus';
+import { Subjects } from './subjects';
+import { connect } from 'nats';
+
+jest.mock('nats', () => {
+  const publish = jest.fn();
+  const subscribe = jest.fn(() => ({
+    [Symbol.asyncIterator]: async function* () {},
+  }));
+  const close = jest.fn();
+  const sc = { encode: (v: string) => Buffer.from(v), decode: (b: Uint8Array) => Buffer.from(b).toString() };
+  return {
+    connect: jest.fn(() => Promise.resolve({ publish, subscribe, close })),
+    StringCodec: jest.fn(() => sc),
+  };
+});
+
+const mockConnect = connect as jest.Mock;
+
+describe('NatsEventBus', () => {
+  beforeEach(() => {
+    mockConnect.mockClear();
+  });
+
+  it('connects with default url', async () => {
+    const bus = new NatsEventBus();
+    await bus.connect();
+    expect(mockConnect).toHaveBeenCalledWith({ servers: 'nats://localhost:4222' });
+  });
+
+  it('throws when publishing without connection', async () => {
+    const bus = new NatsEventBus();
+    await expect(bus.publish(Subjects.CREP_UPDATE, { a: 1 })).rejects.toThrow('Not connected');
+  });
+});

--- a/packages/event-bus/NatsEventBus.ts
+++ b/packages/event-bus/NatsEventBus.ts
@@ -1,0 +1,32 @@
+import { connect, NatsConnection, StringCodec, Subscription } from 'nats';
+import { Subjects } from './subjects';
+
+export class NatsEventBus {
+  private nc?: NatsConnection;
+  private sc = StringCodec();
+
+  async connect(url = 'nats://localhost:4222'): Promise<void> {
+    this.nc = await connect({ servers: url });
+  }
+
+  async publish(subject: Subjects, payload: unknown): Promise<void> {
+    if (!this.nc) throw new Error('Not connected');
+    const data = this.sc.encode(JSON.stringify(payload));
+    this.nc.publish(subject, data);
+  }
+
+  subscribe(subject: Subjects, handler: (data: unknown) => void): Subscription {
+    if (!this.nc) throw new Error('Not connected');
+    const sub = this.nc.subscribe(subject);
+    (async () => {
+      for await (const msg of sub) {
+        handler(JSON.parse(this.sc.decode(msg.data)));
+      }
+    })();
+    return sub;
+  }
+
+  async close(): Promise<void> {
+    await this.nc?.close();
+  }
+}

--- a/packages/event-bus/index.ts
+++ b/packages/event-bus/index.ts
@@ -1,0 +1,2 @@
+export * from './NatsEventBus';
+export * from './subjects';

--- a/packages/event-bus/subjects.ts
+++ b/packages/event-bus/subjects.ts
@@ -1,0 +1,4 @@
+export enum Subjects {
+  CREP_UPDATE = 'crep.update',
+  AGENT_HEARTBEAT = 'agent.heartbeat',
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       mitt:
         specifier: ^3.0.0
         version: 3.0.1
+      nats:
+        specifier: ^2.29.3
+        version: 2.29.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1597,8 +1600,16 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  nats@2.29.3:
+    resolution: {integrity: sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA==}
+    engines: {node: '>= 14.0.0'}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  nkeys.js@1.1.0:
+    resolution: {integrity: sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==}
+    engines: {node: '>=10.0.0'}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -1969,6 +1980,9 @@ packages:
         optional: true
       '@swc/wasm':
         optional: true
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
@@ -3996,7 +4010,15 @@ snapshots:
 
   ms@2.1.3: {}
 
+  nats@2.29.3:
+    dependencies:
+      nkeys.js: 1.1.0
+
   natural-compare@1.4.0: {}
+
+  nkeys.js@1.1.0:
+    dependencies:
+      tweetnacl: 1.0.3
 
   node-int64@0.4.0: {}
 
@@ -4352,6 +4374,8 @@ snapshots:
       typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  tweetnacl@1.0.3: {}
 
   type-detect@4.0.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,5 +9,6 @@ packages:
   - 'packages/aeon-genesisos'
   - 'packages/aeon-fraktalurs'
   - 'packages/aeon-resoecho'
+  - 'packages/event-bus'
   - 'packages/sharedream-interface'
   - 'apps/*'


### PR DESCRIPTION
## Summary
- introduce `NatsEventBus` with enum based subjects
- include tests for connection and error handling
- document update from automatic Chronopoem hook

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68532d2858f08322a37da06bffc365e9