### PR TITLE
Implement MetaScore API and UI

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1,0 +1,8 @@
+[
+  {
+    "commit": "Add MetaScore API and UI",
+    "path": "apps/sharedream-interface",
+    "task": "Provide /api/meta-scores endpoint and display component",
+    "test": "apps/sharedream-interface/hooks/useMetaScores.test.ts"
+  }
+]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1,0 +1,4 @@
+- commit: Add MetaScore API and UI
+  path: apps/sharedream-interface
+  task: Provide /api/meta-scores endpoint and display component
+  test: apps/sharedream-interface/hooks/useMetaScores.test.ts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,0 +1,6 @@
+{
+  "lastCommit": "MetaScore API and UI",
+  "fractalStep": "implementiert und getestet",
+  "openBranches": [],
+  "mergeConflicts": []
+}

--- a/apps/sharedream-interface/README.md
+++ b/apps/sharedream-interface/README.md
@@ -1,3 +1,5 @@
 # Sharedream Interface
 
 React-Frontend mit GPT-Anbindung. Siehe [GenesisMandala](https://example.com) für die Gesamtübersicht.
+
+Dieses Interface nutzt nun ein /api/meta-scores Endpoint für Metadaten.

--- a/apps/sharedream-interface/components/MetaScoreDisplay.tsx
+++ b/apps/sharedream-interface/components/MetaScoreDisplay.tsx
@@ -1,0 +1,15 @@
+import { useMetaScores } from '../hooks/useMetaScores';
+
+export default function MetaScoreDisplay() {
+  const scores = useMetaScores();
+
+  if (!scores.length) return <div>Keine Meta-Scores verfügbar.</div>;
+
+  return (
+    <ul>
+      {scores.map((s) => (
+        <li key={s.id}>{s.id}: {s.value}</li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/sharedream-interface/hooks/useMetaScores.test.ts
+++ b/apps/sharedream-interface/hooks/useMetaScores.test.ts
@@ -1,0 +1,18 @@
+import { renderHook, act } from '@testing-library/react';
+import { useMetaScores } from './useMetaScores';
+
+beforeEach(() => {
+  (global as any).fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve({ scores: [{ id: 't', value: 0.5 }] }) })
+  );
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('loads meta scores', async () => {
+  const { result } = renderHook(() => useMetaScores());
+  await act(async () => {});
+  expect(result.current[0]).toEqual({ id: 't', value: 0.5 });
+});

--- a/apps/sharedream-interface/hooks/useMetaScores.ts
+++ b/apps/sharedream-interface/hooks/useMetaScores.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+export interface MetaScore { id: string; value: number; }
+
+export function useMetaScores() {
+  const [scores, setScores] = useState<MetaScore[]>([]);
+
+  useEffect(() => {
+    fetch('/api/meta-scores')
+      .then((res) => res.json())
+      .then((data) => setScores(data.scores || []))
+      .catch((err) => {
+        console.error('Fehler beim Laden der Meta-Scores:', err);
+      });
+  }, []);
+
+  return scores;
+}

--- a/apps/sharedream-interface/pages/api/meta-scores.ts
+++ b/apps/sharedream-interface/pages/api/meta-scores.ts
@@ -1,0 +1,6 @@
+export default function handler(req: any, res: any) {
+  res.status(200).json({ scores: [
+    { id: 'meta1', value: 0.75 },
+    { id: 'meta2', value: 0.82 }
+  ]});
+}

--- a/apps/sharedream-interface/pages/meta.tsx
+++ b/apps/sharedream-interface/pages/meta.tsx
@@ -1,0 +1,10 @@
+import MetaScoreDisplay from '../components/MetaScoreDisplay';
+
+export default function MetaScoresPage() {
+  return (
+    <div>
+      <h1>Meta-Scores</h1>
+      <MetaScoreDisplay />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/api/meta-scores` route for meta score data
- introduce `useMetaScores` hook and `MetaScoreDisplay` component
- add `meta` page to display scores
- document new API in Sharedream Interface README
- create advanced ToDo and progress records
- test `useMetaScores` hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854757209f08322b637c0f41dd89ae9