### PR TITLE
Add MetaScoreDisplay Storybook entry

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "MetaScore API and UI",
-  "fractalStep": "implementiert und getestet",
+  "lastCommit": "Add MetaScoreDisplay story",
+  "fractalStep": "dokumentiert",
   "openBranches": [],
   "mergeConflicts": []
 }

--- a/apps/sharedream-interface/README.md
+++ b/apps/sharedream-interface/README.md
@@ -3,3 +3,4 @@
 React-Frontend mit GPT-Anbindung. Siehe [GenesisMandala](https://example.com) für die Gesamtübersicht.
 
 Dieses Interface nutzt nun ein /api/meta-scores Endpoint für Metadaten.
+Eine Storybook-Story f\u00fcr MetaScoreDisplay findet sich unter components/MetaScoreDisplay.stories.tsx.

--- a/apps/sharedream-interface/components/MetaScoreDisplay.stories.tsx
+++ b/apps/sharedream-interface/components/MetaScoreDisplay.stories.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import MetaScoreDisplay from './MetaScoreDisplay';
+
+export default {
+  title: 'Sharedream/MetaScoreDisplay',
+  component: MetaScoreDisplay,
+};
+
+export const Default = () => <MetaScoreDisplay />;


### PR DESCRIPTION
## Summary
- add a Storybook story for the MetaScoreDisplay component
- document the story location in the Sharedream Interface README
- update advancedprogress.json to mark documentation step

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68547814dbfc83228a48dc11170961bf