### PR TITLE
Add MetaScoreChart component

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-18, in der Zeit des Nacht.
+Am 2025-06-19, in der Zeit des Abend.
 
-Symbolphase: Reflexion (Fokus: P)
+Symbolphase: Integration (Fokus: E)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -10,5 +10,17 @@
     "path": "apps/sharedream-interface/components",
     "task": "Storybook entry for MetaScoreDisplay",
     "test": "apps/sharedream-interface/hooks/useMetaScores.test.ts"
+  },
+  {
+    "commit": "Add MetaScoreChart",
+    "path": "apps/sharedream-interface/components",
+    "task": "Visualize meta scores via Recharts",
+    "test": "apps/sharedream-interface/components/MetaScoreChart.test.tsx"
+  },
+  {
+    "commit": "Self-Check meta score layer",
+    "path": "apps/sharedream-interface",
+    "task": "Verify UI, API and tests in sync",
+    "test": "apps/sharedream-interface/components/MetaScoreChart.test.tsx"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6,3 +6,11 @@
   path: apps/sharedream-interface/components
   task: Storybook entry for MetaScoreDisplay
   test: apps/sharedream-interface/hooks/useMetaScores.test.ts
+- commit: Add MetaScoreChart
+  path: apps/sharedream-interface/components
+  task: Visualize meta scores via Recharts
+  test: apps/sharedream-interface/components/MetaScoreChart.test.tsx
+- commit: Self-Check meta score layer
+  path: apps/sharedream-interface
+  task: Verify UI, API and tests in sync
+  test: apps/sharedream-interface/components/MetaScoreChart.test.tsx

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "Add MetaScoreDisplay story",
-  "fractalStep": "getestet",
+  "lastCommit": "Add MetaScoreChart component",
+  "fractalStep": "implementiert und getestet",
   "openBranches": [],
   "mergeConflicts": []
 }

--- a/apps/sharedream-interface/README.md
+++ b/apps/sharedream-interface/README.md
@@ -4,3 +4,4 @@ React-Frontend mit GPT-Anbindung. Siehe [GenesisMandala](https://example.com) f�
 
 Dieses Interface nutzt nun ein /api/meta-scores Endpoint für Metadaten.
 Eine Storybook-Story f\u00fcr MetaScoreDisplay findet sich unter components/MetaScoreDisplay.stories.tsx.
+Eine Story für MetaScoreChart befindet sich unter components/MetaScoreChart.stories.tsx.

--- a/apps/sharedream-interface/components/MetaScoreChart.stories.tsx
+++ b/apps/sharedream-interface/components/MetaScoreChart.stories.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import MetaScoreChart from './MetaScoreChart';
+
+export default {
+  title: 'Sharedream/MetaScoreChart',
+  component: MetaScoreChart,
+};
+
+export const Default = () => <MetaScoreChart />;

--- a/apps/sharedream-interface/components/MetaScoreChart.test.tsx
+++ b/apps/sharedream-interface/components/MetaScoreChart.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MetaScoreChart from './MetaScoreChart';
+
+jest.mock('../hooks/useMetaScores', () => ({
+  useMetaScores: () => [
+    { id: 'a', value: 0.4 },
+    { id: 'b', value: 0.7 },
+  ],
+}));
+
+it('renders chart with meta score data', () => {
+  render(<MetaScoreChart />);
+  // expect svg to be in the document
+  expect(screen.getByLabelText('MetaScore Chart')).toBeInTheDocument();
+});

--- a/apps/sharedream-interface/components/MetaScoreChart.tsx
+++ b/apps/sharedream-interface/components/MetaScoreChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
+import { useMetaScores } from '../hooks/useMetaScores';
+
+export default function MetaScoreChart() {
+  const scores = useMetaScores();
+
+  if (!scores.length) {
+    return <div>Keine Meta-Scores verfügbar.</div>;
+  }
+
+  return (
+    <LineChart width={400} height={200} data={scores} aria-label="MetaScore Chart">
+      <CartesianGrid stroke="#ccc" />
+      <XAxis dataKey="id" />
+      <YAxis domain={[0, 1]} />
+      <Tooltip />
+      <Line type="monotone" dataKey="value" stroke="#8884d8" />
+    </LineChart>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `MetaScoreChart` component with tests and story
- document new story location
- log tasks and progress for fractal cycle
- update Chronopoem

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68547cc2de8c8322a507f0311bbee094