### PR TITLE
Add API test for meta scores

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -22,5 +22,11 @@
     "path": "apps/sharedream-interface",
     "task": "Verify UI, API and tests in sync",
     "test": "apps/sharedream-interface/components/MetaScoreChart.test.tsx"
+  },
+  {
+    "commit": "Add meta-scores API test",
+    "path": "apps/sharedream-interface/pages/api",
+    "task": "Ensure meta-scores endpoint returns correct data",
+    "test": "apps/sharedream-interface/pages/api/meta-scores.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -14,3 +14,7 @@
   path: apps/sharedream-interface
   task: Verify UI, API and tests in sync
   test: apps/sharedream-interface/components/MetaScoreChart.test.tsx
+- commit: Add meta-scores API test
+  path: apps/sharedream-interface/pages/api
+  task: Ensure meta-scores endpoint returns correct data
+  test: apps/sharedream-interface/pages/api/meta-scores.test.ts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "Add MetaScoreChart component",
-  "fractalStep": "implementiert und getestet",
+  "lastCommit": "Add meta-scores API test",
+  "fractalStep": "self-check durchgefuehrt",
   "openBranches": [],
   "mergeConflicts": []
 }

--- a/apps/sharedream-interface/README.md
+++ b/apps/sharedream-interface/README.md
@@ -3,5 +3,6 @@
 React-Frontend mit GPT-Anbindung. Siehe [GenesisMandala](https://example.com) für die Gesamtübersicht.
 
 Dieses Interface nutzt nun ein /api/meta-scores Endpoint für Metadaten.
-Eine Storybook-Story f\u00fcr MetaScoreDisplay findet sich unter components/MetaScoreDisplay.stories.tsx.
+Eine Storybook-Story für MetaScoreDisplay findet sich unter components/MetaScoreDisplay.stories.tsx.
 Eine Story für MetaScoreChart befindet sich unter components/MetaScoreChart.stories.tsx.
+Tests für Hooks und API liegen unter `apps/sharedream-interface/hooks` und `pages/api`.

--- a/apps/sharedream-interface/pages/api/meta-scores.test.ts
+++ b/apps/sharedream-interface/pages/api/meta-scores.test.ts
@@ -1,0 +1,19 @@
+/** @jest-environment node */
+import handler from './meta-scores';
+
+test('returns meta scores', () => {
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  const req = {} as any;
+  const res = { status } as any;
+
+  handler(req, res);
+
+  expect(status).toHaveBeenCalledWith(200);
+  expect(json).toHaveBeenCalledWith({
+    scores: [
+      { id: 'meta1', value: 0.75 },
+      { id: 'meta2', value: 0.82 },
+    ],
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for `/api/meta-scores` endpoint
- note test locations in Sharedream interface README
- update `advancedToDo` lists with API test task
- update `advancedprogress.json` for new fractal step

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68547e4f89188322b1ecbbac23396e26