### PR TITLE
Add error handling for meta score fetch

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -28,5 +28,11 @@
     "path": "apps/sharedream-interface/pages/api",
     "task": "Ensure meta-scores endpoint returns correct data",
     "test": "apps/sharedream-interface/pages/api/meta-scores.test.ts"
+  },
+  {
+    "commit": "Handle fetch errors in useMetaScores",
+    "path": "apps/sharedream-interface/hooks",
+    "task": "Return error state when meta-score fetch fails and update components",
+    "test": "apps/sharedream-interface/hooks/useMetaScores.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -18,3 +18,7 @@
   path: apps/sharedream-interface/pages/api
   task: Ensure meta-scores endpoint returns correct data
   test: apps/sharedream-interface/pages/api/meta-scores.test.ts
+- commit: Handle fetch errors in useMetaScores
+  path: apps/sharedream-interface/hooks
+  task: Return error state when meta-score fetch fails and update components
+  test: apps/sharedream-interface/hooks/useMetaScores.test.ts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "Add meta-scores API test",
-  "fractalStep": "self-check durchgefuehrt",
+  "lastCommit": "Handle fetch errors in useMetaScores",
+  "fractalStep": "implementiert und getestet",
   "openBranches": [],
   "mergeConflicts": []
 }

--- a/apps/sharedream-interface/README.md
+++ b/apps/sharedream-interface/README.md
@@ -6,3 +6,4 @@ Dieses Interface nutzt nun ein /api/meta-scores Endpoint für Metadaten.
 Eine Storybook-Story für MetaScoreDisplay findet sich unter components/MetaScoreDisplay.stories.tsx.
 Eine Story für MetaScoreChart befindet sich unter components/MetaScoreChart.stories.tsx.
 Tests für Hooks und API liegen unter `apps/sharedream-interface/hooks` und `pages/api`.
+Die Hook `useMetaScores` liefert nun einen Fehlerstatus, falls der API-Aufruf fehlschlägt.

--- a/apps/sharedream-interface/components/MetaScoreChart.test.tsx
+++ b/apps/sharedream-interface/components/MetaScoreChart.test.tsx
@@ -4,10 +4,13 @@ import '@testing-library/jest-dom';
 import MetaScoreChart from './MetaScoreChart';
 
 jest.mock('../hooks/useMetaScores', () => ({
-  useMetaScores: () => [
-    { id: 'a', value: 0.4 },
-    { id: 'b', value: 0.7 },
-  ],
+  useMetaScores: () => ({
+    scores: [
+      { id: 'a', value: 0.4 },
+      { id: 'b', value: 0.7 },
+    ],
+    error: null,
+  }),
 }));
 
 it('renders chart with meta score data', () => {

--- a/apps/sharedream-interface/components/MetaScoreChart.tsx
+++ b/apps/sharedream-interface/components/MetaScoreChart.tsx
@@ -3,7 +3,11 @@ import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts'
 import { useMetaScores } from '../hooks/useMetaScores';
 
 export default function MetaScoreChart() {
-  const scores = useMetaScores();
+  const { scores, error } = useMetaScores();
+
+  if (error) {
+    return <div>{error}</div>;
+  }
 
   if (!scores.length) {
     return <div>Keine Meta-Scores verfügbar.</div>;

--- a/apps/sharedream-interface/components/MetaScoreDisplay.tsx
+++ b/apps/sharedream-interface/components/MetaScoreDisplay.tsx
@@ -1,8 +1,9 @@
 import { useMetaScores } from '../hooks/useMetaScores';
 
 export default function MetaScoreDisplay() {
-  const scores = useMetaScores();
+  const { scores, error } = useMetaScores();
 
+  if (error) return <div>{error}</div>;
   if (!scores.length) return <div>Keine Meta-Scores verfügbar.</div>;
 
   return (

--- a/apps/sharedream-interface/hooks/useMetaScores.test.ts
+++ b/apps/sharedream-interface/hooks/useMetaScores.test.ts
@@ -14,5 +14,14 @@ afterEach(() => {
 test('loads meta scores', async () => {
   const { result } = renderHook(() => useMetaScores());
   await act(async () => {});
-  expect(result.current[0]).toEqual({ id: 't', value: 0.5 });
+  expect(result.current.scores[0]).toEqual({ id: 't', value: 0.5 });
+  expect(result.current.error).toBeNull();
+});
+
+test('handles fetch error', async () => {
+  (global as any).fetch = jest.fn(() => Promise.reject('fail'));
+  const { result } = renderHook(() => useMetaScores());
+  await act(async () => {});
+  expect(result.current.error).toBe('Fehler beim Laden der Meta-Scores');
+  expect(result.current.scores).toEqual([]);
 });

--- a/apps/sharedream-interface/hooks/useMetaScores.ts
+++ b/apps/sharedream-interface/hooks/useMetaScores.ts
@@ -4,6 +4,7 @@ export interface MetaScore { id: string; value: number; }
 
 export function useMetaScores() {
   const [scores, setScores] = useState<MetaScore[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     fetch('/api/meta-scores')
@@ -11,8 +12,9 @@ export function useMetaScores() {
       .then((data) => setScores(data.scores || []))
       .catch((err) => {
         console.error('Fehler beim Laden der Meta-Scores:', err);
+        setError('Fehler beim Laden der Meta-Scores');
       });
   }, []);
 
-  return scores;
+  return { scores, error };
 }


### PR DESCRIPTION
## Summary
- document tasks and progress for new feature
- handle fetch errors in `useMetaScores`
- display error state in UI components
- update related tests and docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685482988978832287f05912a81b0ad3