### PR TITLE
Add meta score layer self-check

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -34,5 +34,11 @@
     "path": "apps/sharedream-interface/hooks",
     "task": "Return error state when meta-score fetch fails and update components",
     "test": "apps/sharedream-interface/hooks/useMetaScores.test.ts"
+  },
+  {
+    "commit": "Add meta score layer self-check",
+    "path": "scripts",
+    "task": "Verify meta score layer files and endpoint",
+    "test": "scripts/check-meta-score-layer.js"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -22,3 +22,7 @@
   path: apps/sharedream-interface/hooks
   task: Return error state when meta-score fetch fails and update components
   test: apps/sharedream-interface/hooks/useMetaScores.test.ts
+- commit: Add meta score layer self-check
+  path: scripts
+  task: Verify meta score layer files and endpoint
+  test: scripts/check-meta-score-layer.js

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Handle fetch errors in useMetaScores",
+  "lastCommit": "Add meta score layer self-check",
   "fractalStep": "implementiert und getestet",
   "openBranches": [],
   "mergeConflicts": []

--- a/scripts/check-meta-score-layer.js
+++ b/scripts/check-meta-score-layer.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+
+const requiredFiles = [
+  'apps/sharedream-interface/hooks/useMetaScores.ts',
+  'apps/sharedream-interface/hooks/useMetaScores.test.ts',
+  'apps/sharedream-interface/pages/api/meta-scores.ts',
+  'apps/sharedream-interface/pages/api/meta-scores.test.ts',
+  'apps/sharedream-interface/components/MetaScoreChart.tsx',
+  'apps/sharedream-interface/components/MetaScoreChart.test.tsx',
+  'apps/sharedream-interface/components/MetaScoreChart.stories.tsx',
+  'apps/sharedream-interface/components/MetaScoreDisplay.tsx',
+  'apps/sharedream-interface/components/MetaScoreDisplay.stories.tsx'
+];
+
+function checkFiles() {
+  let allPresent = true;
+  for (const file of requiredFiles) {
+    const exists = fs.existsSync(file);
+    console.log(`${file}: ${exists ? 'OK' : 'FEHLT'}`);
+    if (!exists) allPresent = false;
+  }
+  return allPresent;
+}
+
+function checkHookEndpoint() {
+  const hookPath = 'apps/sharedream-interface/hooks/useMetaScores.ts';
+  const content = fs.readFileSync(hookPath, 'utf8');
+  const usesEndpoint = content.includes('/api/meta-scores');
+  console.log(`useMetaScores fetches /api/meta-scores: ${usesEndpoint ? 'OK' : 'FEHLT'}`);
+  return usesEndpoint;
+}
+
+if (require.main === module) {
+  const ok = checkFiles() && checkHookEndpoint();
+  if (!ok) {
+    console.error('Meta score layer is inconsistent');
+    process.exitCode = 1;
+  }
+}
+
+module.exports = { checkFiles, checkHookEndpoint };
+


### PR DESCRIPTION
## Summary
- add script `check-meta-score-layer.js` to verify files and endpoint
- log new step in advancedprogress.json
- track new meta score layer self-check in advancedToDo files

## Testing
- `node scripts/check-meta-score-layer.js`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6854846c7c8883228fdbfd705276c5ee