### PR TITLE
Add advanced conversation anchor parser

### DIFF
--- a/packages/shared-utils/advancedConversation.test.ts
+++ b/packages/shared-utils/advancedConversation.test.ts
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+import { extractMessagesAfterAnchor } from './advancedConversation';
+
+describe('extractMessagesAfterAnchor', () => {
+  const tmp = path.join(__dirname, '__tmp_anchor.json');
+  beforeAll(() => {
+    const conv = [{
+      id: 'c1',
+      mapping: {
+        root: { id: 'root', message: { id: 'm1', author: { role: 'user' }, create_time: 1, content: { parts: ['Hallo'] } }, parent: null, children: ['a'] },
+        a: { id: 'a', message: { id: 'm2', author: { role: 'user' }, create_time: 2, content: { parts: ['siehe codex-sigil.yaml'] } }, parent: 'root', children: ['b'] },
+        b: { id: 'b', message: { id: 'm3', author: { role: 'assistant' }, create_time: 3, content: { parts: ['task 1'] } }, parent: 'a', children: [] }
+      }
+    }];
+    fs.writeFileSync(tmp, JSON.stringify(conv), 'utf8');
+  });
+  afterAll(() => { fs.unlinkSync(tmp); });
+
+  it('extracts messages after anchor', () => {
+    const msgs = extractMessagesAfterAnchor(tmp, 'codex-sigil.yaml');
+    expect(msgs).toEqual(['task 1']);
+  });
+});

--- a/packages/shared-utils/advancedConversation.ts
+++ b/packages/shared-utils/advancedConversation.ts
@@ -1,0 +1,34 @@
+import { loadConversations } from './conversationAnalyzer';
+
+/**
+ * Extracts message contents after the first occurrence of an anchor string.
+ * @param filePath Path to conversations JSON array.
+ * @param anchor Anchor text to search for (case-insensitive).
+ */
+export function extractMessagesAfterAnchor(filePath: string, anchor: string): string[] {
+  const convs = loadConversations(filePath);
+  const anchorRe = new RegExp(anchor, 'i');
+  const collected: string[] = [];
+
+  for (const conv of convs) {
+    const nodes = Object.values(conv.mapping)
+      .filter(n => n.message)
+      .sort((a, b) => ((a as any).message?.create_time || 0) - ((b as any).message?.create_time || 0));
+    let anchorFound = false;
+    for (const node of nodes) {
+      const parts = (node as any).message?.content?.parts || [];
+      const text = parts.join('\n');
+      if (!anchorFound) {
+        if (anchorRe.test(text)) {
+          anchorFound = true;
+        }
+        continue;
+      }
+      if (anchorFound && text.trim() !== '') {
+        collected.push(text.trim());
+      }
+    }
+  }
+
+  return collected;
+}

--- a/packages/shared-utils/index.ts
+++ b/packages/shared-utils/index.ts
@@ -14,3 +14,4 @@ export * from "./SymbolicForecaster";
 export * from './symbolzeitModulator';
 export * from './loadSymbolphasen';
 export * from './conversationAnalyzer';
+export * from './advancedConversation';


### PR DESCRIPTION
## Summary
- add helper to extract conversation messages after a custom anchor
- test the new utility
- export the helper for use by scripts

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68548a75e2448322846c000f28fd042c