### PR TITLE
Implement parsing script for advanced conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,5 @@ gespeichert. Nutzen Sie die Helferskripte aus `packages/shared-utils`
 (`jsonFragmenter.*`), um daraus ToDos für `advancedToDo.yaml` und
 `advancedToDo.json` zu extrahieren.
 
+Nutze `node scripts/parse-advanced-conversations.js` um Gesprächs-TODOs aus dem Datensatz zu filtern.
+

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
   "lastCommit": "Parse advanced conversations",
-  "fractalStep": "dokumentiert",
+  "fractalStep": "implementiert und getestet",
   "openBranches": [],
   "mergeConflicts": []
 }

--- a/scripts/parse-advanced-conversations.js
+++ b/scripts/parse-advanced-conversations.js
@@ -1,0 +1,11 @@
+const path = require('path');
+const { grepJsonArrayFile } = require('../packages/shared-utils/jsonFragmenter');
+
+const file = path.join(__dirname, '../docs/sigils/advancedconversations.json');
+const dest = path.join(__dirname, '../docs/sigils/advancedconversations');
+const keyword = process.argv[2] || 'TODO';
+const regex = new RegExp(keyword, 'i');
+
+const matches = grepJsonArrayFile(file, dest, regex);
+console.log(`Parsed ${matches.length} fragments containing '${keyword}'. Output: ${dest}`);
+


### PR DESCRIPTION
## Summary
- add `parse-advanced-conversations.js` to filter TODOs from `advancedconversations.json`
- document the new helper script in the README
- mark fractal cycle step as implemented and tested

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68548d67fb50832297bdf65cf4b8b425