### PR TITLE
Implement TODO extraction script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "prepare": "husky install",
     "split:conversations": "node scripts/split-conversations.js",
     "grep:conversations": "node scripts/filter-conversations.js",
-    "analyze:conversations": "node scripts/analyze-conversations.js"
+    "analyze:conversations": "node scripts/analyze-conversations.js",
+    "update:advanced-todo": "node scripts/update-advanced-todo.js"
   },
   "dependencies": {
     "ajv": "^8.0.0",

--- a/packages/shared-utils/advancedTodoUpdater.js
+++ b/packages/shared-utils/advancedTodoUpdater.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const YAML = require('yaml');
+const { extractTodosFromConversations } = require('./conversationAnalyzer');
+
+function updateAdvancedTodo(convFile, yamlFile, jsonFile) {
+  const todos = extractTodosFromConversations(convFile);
+  const entries = Array.from(new Set(todos)).map(t => ({
+    commit: t,
+    path: '',
+    task: t,
+    test: ''
+  }));
+
+  const loadYaml = f => {
+    if (fs.existsSync(f)) {
+      const data = YAML.parse(fs.readFileSync(f, 'utf8'));
+      return Array.isArray(data) ? data : [];
+    }
+    return [];
+  };
+  const loadJson = f => {
+    if (fs.existsSync(f)) {
+      return JSON.parse(fs.readFileSync(f, 'utf8'));
+    }
+    return [];
+  };
+  const merge = (existing, add) => {
+    const known = new Set(existing.map(e => e.commit));
+    for (const e of add) {
+      if (!known.has(e.commit)) {
+        existing.push(e);
+        known.add(e.commit);
+      }
+    }
+    return existing;
+  };
+  const yamlData = merge(loadYaml(yamlFile), entries);
+  const jsonData = merge(loadJson(jsonFile), entries);
+  fs.writeFileSync(yamlFile, YAML.stringify(yamlData));
+  fs.writeFileSync(jsonFile, JSON.stringify(jsonData, null, 2));
+  return entries;
+}
+module.exports = { updateAdvancedTodo };

--- a/packages/shared-utils/advancedTodoUpdater.test.ts
+++ b/packages/shared-utils/advancedTodoUpdater.test.ts
@@ -1,0 +1,33 @@
+/** @jest-environment node */
+import fs from 'fs';
+import path from 'path';
+import { updateAdvancedTodo } from './advancedTodoUpdater';
+
+describe('updateAdvancedTodo', () => {
+  const tmp = path.join(__dirname, '__todo_tmp__');
+  const conv = path.join(tmp, 'conv.json');
+  const yml = path.join(tmp, 'todo.yaml');
+  const json = path.join(tmp, 'todo.json');
+
+  beforeAll(() => {
+    if (!fs.existsSync(tmp)) fs.mkdirSync(tmp);
+    const data = [
+      { id: 'c1', mapping: { root: { message: { content: { parts: ['Test'] } } }, node2: { message: { content: { parts: ['// TODO: first task'] } } } } },
+      { id: 'c2', mapping: { root: { message: { content: { parts: ['# TODO second task'] } } } } }
+    ];
+    fs.writeFileSync(conv, JSON.stringify(data), 'utf8');
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('extracts todos and writes files', () => {
+    const entries = updateAdvancedTodo(conv, yml, json);
+    expect(entries.length).toBe(2);
+    const yamlOut = fs.readFileSync(yml, 'utf8');
+    const jsonOut = JSON.parse(fs.readFileSync(json, 'utf8'));
+    expect(yamlOut).toContain('first task');
+    expect(jsonOut[0].task).toBe('first task');
+  });
+});

--- a/packages/shared-utils/advancedTodoUpdater.ts
+++ b/packages/shared-utils/advancedTodoUpdater.ts
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import YAML from 'yaml';
+import path from 'path';
+import { extractTodosFromConversations } from './conversationAnalyzer';
+
+export interface AdvancedTodoEntry {
+  commit: string;
+  path: string;
+  task: string;
+  test: string;
+}
+
+export function updateAdvancedTodo(convFile: string, yamlFile: string, jsonFile: string): AdvancedTodoEntry[] {
+  const todos = extractTodosFromConversations(convFile);
+  const entries: AdvancedTodoEntry[] = Array.from(new Set(todos)).map(t => ({
+    commit: t,
+    path: '',
+    task: t,
+    test: ''
+  }));
+
+  const loadYaml = (f: string): AdvancedTodoEntry[] => {
+    if (fs.existsSync(f)) {
+      const data = YAML.parse(fs.readFileSync(f, 'utf8'));
+      return Array.isArray(data) ? data : [];
+    }
+    return [];
+  };
+  const loadJson = (f: string): AdvancedTodoEntry[] => {
+    if (fs.existsSync(f)) {
+      return JSON.parse(fs.readFileSync(f, 'utf8'));
+    }
+    return [];
+  };
+
+  const merge = (existing: AdvancedTodoEntry[], add: AdvancedTodoEntry[]) => {
+    const known = new Set(existing.map(e => e.commit));
+    for (const e of add) {
+      if (!known.has(e.commit)) {
+        existing.push(e);
+        known.add(e.commit);
+      }
+    }
+    return existing;
+  };
+
+  const yamlData = merge(loadYaml(yamlFile), entries);
+  const jsonData = merge(loadJson(jsonFile), entries);
+
+  fs.writeFileSync(yamlFile, YAML.stringify(yamlData));
+  fs.writeFileSync(jsonFile, JSON.stringify(jsonData, null, 2));
+  return entries;
+}

--- a/packages/shared-utils/conversationAnalyzer.js
+++ b/packages/shared-utils/conversationAnalyzer.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+
+function loadConversations(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function analyzeConversations(filePath) {
+  const convs = loadConversations(filePath);
+  const stats = { conversationCount: convs.length, messageCount: 0, authorCounts: {} };
+  for (const conv of convs) {
+    for (const node of Object.values(conv.mapping)) {
+      const msg = node.message;
+      const content = msg?.content?.parts?.[0];
+      if (content && content !== '') {
+        stats.messageCount++;
+        const role = msg?.author?.role || 'unknown';
+        stats.authorCounts[role] = (stats.authorCounts[role] || 0) + 1;
+      }
+    }
+  }
+  return stats;
+}
+
+function extractTodosFromConversations(filePath) {
+  const convs = loadConversations(filePath);
+  const todos = [];
+  const regex = /TODO[:]?\s*(.*)/i;
+  for (const conv of convs) {
+    for (const node of Object.values(conv.mapping)) {
+      const msg = node.message;
+      if (!msg) continue;
+      const parts = msg.content?.parts || [];
+      for (const part of parts) {
+        const m = regex.exec(part);
+        if (m) todos.push(m[1].trim());
+      }
+    }
+  }
+  return todos;
+}
+
+module.exports = { loadConversations, analyzeConversations, extractTodosFromConversations };

--- a/scripts/update-advanced-todo.js
+++ b/scripts/update-advanced-todo.js
@@ -1,0 +1,14 @@
+const path = require('path');
+let updateAdvancedTodo;
+try {
+  ({ updateAdvancedTodo } = require('../dist/shared-utils/advancedTodoUpdater.js'));
+} catch {
+  ({ updateAdvancedTodo } = require('../packages/shared-utils/advancedTodoUpdater'));
+}
+
+const convFile = path.join(__dirname, '../docs/sigils/advancedconversations.json');
+const yamlFile = path.join(__dirname, '../advancedToDo.yaml');
+const jsonFile = path.join(__dirname, '../advancedToDo.json');
+
+const entries = updateAdvancedTodo(convFile, yamlFile, jsonFile);
+console.log(`advancedToDo updated with ${entries.length} tasks.`);


### PR DESCRIPTION
## Summary
- add `update:advanced-todo` script in package.json
- implement `advancedTodoUpdater` utility and tests
- export compiled JS helper for runtime use
- add Node script `update-advanced-todo.js` to parse conversations

## Testing
- `npm test`
- `node scripts/update-advanced-todo.js`

------
https://chatgpt.com/codex/tasks/task_e_685494c81fb08322ad314196671ddd62