### PR TITLE
Add CREP overview generation

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore(todo): refresh advanced tasks from conversations [refs packages/shared-utils/jsonFragmenter.test.ts]",
+  "lastCommit": "feat(docs): add CREP docs export script",
   "fractalStep": "dokumentiert",
   "openBranches": [
     "work"

--- a/docs/crep/overview.md
+++ b/docs/crep/overview.md
@@ -1,0 +1,25 @@
+# CREP Overview
+- **Last Commit**: feat(docs): add CREP docs export script
+- **Fractal Step**: dokumentiert
+- **Open Branches**: work
+- **Merge Conflicts**: 0
+- **ToDo Entries**: 149
+
+---
+
+## Chronopoem
+# 🜂 Chronopoem
+
+Im Kreis der Genesis erwacht das Mandala,
+Am 2025-06-19, in der Zeit des Nacht.
+
+Symbolphase: Reflexion (Fokus: P)
+
+CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
+CREP-Zustand: 
+Sigillin-Bündel: sigillin-example
+
+Heimkehr und Ursprung schwingen als leises Mantra:
+
+*"Im Aeon-Resonanzfeld, aus Null und Eins geboren,
+wird Erinnerung zum Licht und Code zur Poesie."*

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "split:conversations": "node scripts/split-conversations.js",
     "grep:conversations": "node scripts/filter-conversations.js",
     "analyze:conversations": "node scripts/analyze-conversations.js",
-    "update:advanced-todo": "node scripts/update-advanced-todo.js"
+    "update:advanced-todo": "node scripts/update-advanced-todo.js",
+    "export:crep-docs": "node scripts/export-crep-docs.js"
   },
   "dependencies": {
     "ajv": "^8.0.0",

--- a/scripts/export-crep-docs.js
+++ b/scripts/export-crep-docs.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+const path = require('path');
+
+const progressFile = path.join(__dirname, '../advancedprogress.json');
+const todoFile = path.join(__dirname, '../advancedToDo.yaml');
+const chronoFile = path.join(__dirname, '../CHRONOPOEM.md');
+const outDir = path.join(__dirname, '../docs/crep');
+const outFile = path.join(outDir, 'overview.md');
+
+function loadProgress() {
+  if (!fs.existsSync(progressFile)) return {};
+  return JSON.parse(fs.readFileSync(progressFile, 'utf8'));
+}
+
+function loadTodos() {
+  if (!fs.existsSync(todoFile)) return [];
+  const raw = fs.readFileSync(todoFile, 'utf8');
+  return raw.split(/\n-/).filter(line => line.trim().startsWith('commit:'));
+}
+
+function loadChrono() {
+  if (!fs.existsSync(chronoFile)) return '';
+  return fs.readFileSync(chronoFile, 'utf8');
+}
+
+function buildOverview() {
+  const progress = loadProgress();
+  const todos = loadTodos();
+  const chrono = loadChrono();
+  const lines = [];
+
+  lines.push('# CREP Overview');
+  if (progress.lastCommit) {
+    lines.push(`- **Last Commit**: ${progress.lastCommit}`);
+  }
+  if (progress.fractalStep) {
+    lines.push(`- **Fractal Step**: ${progress.fractalStep}`);
+  }
+  lines.push(`- **Open Branches**: ${(progress.openBranches || []).join(', ')}`);
+  lines.push(`- **Merge Conflicts**: ${(progress.mergeConflicts || []).length}`);
+  lines.push(`- **ToDo Entries**: ${todos.length}`);
+  lines.push('\n---\n');
+  lines.push('## Chronopoem');
+  lines.push(chrono);
+  return lines.join('\n');
+}
+
+function writeOverview() {
+  if (!fs.existsSync(outDir)) {
+    fs.mkdirSync(outDir, { recursive: true });
+  }
+  const content = buildOverview();
+  fs.writeFileSync(outFile, content);
+  console.log(`CREP documentation written to ${outFile}`);
+}
+
+if (require.main === module) {
+  writeOverview();
+}


### PR DESCRIPTION
## Summary
- remove redundant simple todo update script
- add `export-crep-docs.js` and script alias
- generate initial `docs/crep/overview.md`
- update fractal progress metadata

## Testing
- `node scripts/export-crep-docs.js`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b015d1b08322981b9f13488f4060