### PR TITLE
Add TriggerArchive and PoeticReactorAgent

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-19, in der Zeit des Nacht.
+Am 2025-06-20, in der Zeit des Morgen.
 
-Symbolphase: Reflexion (Fokus: P)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/packages/agents/PoeticReactorAgent.test.ts
+++ b/packages/agents/PoeticReactorAgent.test.ts
@@ -1,0 +1,14 @@
+import { PoeticReactorAgent } from './PoeticReactorAgent';
+
+describe('PoeticReactorAgent', () => {
+  it('returns haiku when CREP threshold exceeded', () => {
+    const agent = new PoeticReactorAgent(50);
+    const haiku = agent.observe(60);
+    expect(haiku).toBeTruthy();
+  });
+
+  it('returns null below threshold', () => {
+    const agent = new PoeticReactorAgent(70);
+    expect(agent.observe(40)).toBeNull();
+  });
+});

--- a/packages/agents/PoeticReactorAgent.ts
+++ b/packages/agents/PoeticReactorAgent.ts
@@ -1,0 +1,20 @@
+export class PoeticReactorAgent {
+  private haikus: string[] = [
+    'Silent dawn arrives',
+    'Waves whisper to ancient stones',
+    'Dreams echo in light'
+  ];
+
+  constructor(private threshold = 80) {}
+
+  observe(crepValue: number): string | null {
+    if (crepValue >= this.threshold) {
+      return this.generateHaiku();
+    }
+    return null;
+  }
+
+  private generateHaiku(): string {
+    return this.haikus[Math.floor(Math.random() * this.haikus.length)];
+  }
+}

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -7,3 +7,4 @@ export * from './FreieKIZivilisation';
 export * from './KIBewusstsein';
 export * from './SigillinZipSystem';
 export * from './CodexResonanzFraktal';
+export * from './PoeticReactorAgent';

--- a/packages/core/TriggerArchive.test.ts
+++ b/packages/core/TriggerArchive.test.ts
@@ -1,0 +1,18 @@
+import { TriggerArchive, useTriggerArchive } from './TriggerArchive';
+import { renderHook, act } from '@testing-library/react';
+
+describe('TriggerArchive', () => {
+  it('records triggers and exposes latest entries', () => {
+    TriggerArchive.record('alpha');
+    TriggerArchive.record('beta');
+    expect(TriggerArchive.latest(2).map(t => t.label)).toEqual(['alpha', 'beta']);
+  });
+
+  it('useTriggerArchive hook updates when adding trigger', () => {
+    const { result } = renderHook(() => useTriggerArchive());
+    act(() => {
+      result.current.addTrigger('gamma');
+    });
+    expect(result.current.triggers.some((t: { label: string }) => t.label === 'gamma')).toBe(true);
+  });
+});

--- a/packages/core/TriggerArchive.ts
+++ b/packages/core/TriggerArchive.ts
@@ -1,0 +1,29 @@
+export interface TriggerEntry {
+  label: string;
+  timestamp: string;
+}
+
+export class TriggerArchive {
+  private static archive: TriggerEntry[] = [];
+
+  static record(label: string): void {
+    this.archive.push({ label, timestamp: new Date().toISOString() });
+  }
+
+  static latest(n = 10): TriggerEntry[] {
+    return this.archive.slice(-n);
+  }
+}
+
+import { useState } from 'react';
+
+export function useTriggerArchive() {
+  const [triggers, setTriggers] = useState<TriggerEntry[]>(TriggerArchive.latest());
+
+  const addTrigger = (label: string) => {
+    TriggerArchive.record(label);
+    setTriggers([...TriggerArchive.latest()]);
+  };
+
+  return { triggers, addTrigger };
+}


### PR DESCRIPTION
## Summary
- add `TriggerArchive` utilities with React hook
- implement `PoeticReactorAgent` for haiku reactions
- export new agent
- update Chronopoem via hooks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854b7817d40832284edaaf9ce8bf7b8