### PR TITLE
Implement conversation todo extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ dist
 docs/sigils/conversations/
 docs/sigils/code-archive/
 package-lock.json
+docs/sigils/todo-from-convos.yaml

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ node scripts/self-analyze.js          # zeigt Repository-Statistiken
 node scripts/check-todo-sigil.js      # prüft erledigte Aufgaben
 node scripts/mark-fragment.js ID      # zeichnet bearbeitete Conversation-Fragmente
 node scripts/analyze-conversations.js # wertet conversations.json aus
+node scripts/generate-todo-from-convos.js # erzeugt todo-from-convos.yaml aus advancedconversations.json
 node scripts/repotool-convo.js       # schnelle Auswertung und Progress-Update
 node scripts/update-advancedprogress.js dokumentiert # Fortschrittsdatei aktualisieren
 ```

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "feat(docs): add CREP docs export script",
-  "fractalStep": "dokumentiert",
+  "lastCommit": "feat(utils): add conversation todo extractor",
+  "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],

--- a/packages/shared-utils/conversationAnalyzer.test.ts
+++ b/packages/shared-utils/conversationAnalyzer.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { analyzeConversations, extractTodosFromConversations } from './conversationAnalyzer';
+import { analyzeConversations, extractTodosFromConversations, extractImplicitTodosFromConversations } from './conversationAnalyzer';
 
 describe('conversationAnalyzer', () => {
   const sample = path.join(__dirname, 'sample-conv.json');
@@ -27,5 +27,23 @@ describe('conversationAnalyzer', () => {
   it('extracts TODOs', () => {
     const todos = extractTodosFromConversations(sample);
     expect(todos).toEqual(['teste']);
+  });
+
+  it('extracts implicit todos', () => {
+    const file = path.join(__dirname, 'implicit.json');
+    const data = [
+      {
+        id: 'b',
+        mapping: {
+          root: {
+            message: { id: 'm2', author: { role: 'user' }, content: { parts: ['Wir sollten mehr Tests schreiben.'] } }
+          }
+        }
+      }
+    ];
+    fs.writeFileSync(file, JSON.stringify(data), 'utf8');
+    const todos = extractImplicitTodosFromConversations(file);
+    expect(todos).toEqual(['mehr Tests schreiben']);
+    fs.unlinkSync(file);
   });
 });

--- a/packages/shared-utils/conversationAnalyzer.ts
+++ b/packages/shared-utils/conversationAnalyzer.ts
@@ -63,3 +63,38 @@ export function extractTodosFromConversations(filePath: string): string[] {
   }
   return todos;
 }
+
+export function extractImplicitTodosFromConversations(filePath: string): string[] {
+  const convs = loadConversations(filePath);
+  const todos: string[] = [];
+  const patterns = [
+    /TODO[:]?\s*(.*)/i,
+    /wir\s+sollten\s+([^\.\n]+)/i,
+    /k\u00F6nnten\s+wir\s+([^\.\n]+)/i,
+    /sollten\s+wir\s+([^\.\n]+)/i,
+    /lass\s+uns\s+([^\.\n]+)/i,
+    /wollen\s+wir\s+([^\.\n]+)/i
+  ];
+
+  for (const conv of convs) {
+    for (const node of Object.values(conv.mapping)) {
+      const msg = node.message;
+      if (!msg) continue;
+      const parts = msg.content?.parts || [];
+      for (const part of parts) {
+        if (typeof part !== 'string') continue;
+        for (const line of part.split(/\n+/)) {
+          for (const re of patterns) {
+            const m = re.exec(line);
+            if (m) {
+              const text = m[1].split(/[\n\.]/)[0].trim();
+              if (text) todos.push(text);
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+  return Array.from(new Set(todos));
+}

--- a/scripts/generate-todo-from-convos.js
+++ b/scripts/generate-todo-from-convos.js
@@ -1,0 +1,31 @@
+const path = require('path');
+let { extractImplicitTodosFromConversations } = (() => {
+  try {
+    return require('../dist/shared-utils/conversationAnalyzer.js');
+  } catch {
+    return require('../packages/shared-utils/conversationAnalyzer');
+  }
+})();
+let { createTodoSigil } = (() => {
+  try {
+    return require('../dist/shared-utils/todoSigilGenerator.js');
+  } catch {
+    return require('../packages/shared-utils/todoSigilGenerator');
+  }
+})();
+const fs = require('fs');
+
+function generateTodoFromConvos(sourcePath = path.join(__dirname, '../docs/sigils/advancedconversations.json')) {
+  const outPath = path.join(__dirname, '../docs/sigils/todo-from-convos.yaml');
+  const tasks = extractImplicitTodosFromConversations(path.resolve(sourcePath)).map(t => ({ text: t, done: false }));
+  const yaml = createTodoSigil(tasks, { id: 'aeon:todo-from-convos', titel: 'Konversations ToDos', symbolzeit: 'tag' });
+  fs.writeFileSync(outPath, yaml);
+  console.log(`todo-from-convos.yaml generated from ${path.basename(sourcePath)}`);
+}
+
+if (require.main === module) {
+  const src = process.argv[2];
+  generateTodoFromConvos(src);
+}
+
+module.exports = { generateTodoFromConvos };


### PR DESCRIPTION
## Summary
- add `extractImplicitTodosFromConversations` util
- test new util in `conversationAnalyzer.test.ts`
- provide `generate-todo-from-convos.js` script for converting conversations to todo sigils
- document new script in README
- update progress log

## Testing
- `pnpm lint` *(fails: Cannot find module 'react')*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685530226d30832293f7c950f3fa74b7