### PR TITLE
Implement SigillinParser and update progress

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat(utils): add conversation todo extractor",
+  "lastCommit": "feat(sigillin-core): add SigillinParser",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"

--- a/packages/genesis-sigillin-core/SigillinParser.test.ts
+++ b/packages/genesis-sigillin-core/SigillinParser.test.ts
@@ -1,0 +1,17 @@
+/** @jest-environment node */
+import { gzipSync } from 'zlib';
+import YAML from 'yaml';
+import { SigillinParser } from './SigillinParser';
+import { generateSigillinMetaSignatur } from './SigillinMetaSignatur';
+
+describe('SigillinParser', () => {
+  it('parses YAML header from zipped buffer and returns signature', () => {
+    const header = { id: 'a1', type: 'poetic-root', status: 'draft' };
+    const yamlStr = YAML.stringify(header);
+    const zipped = gzipSync(Buffer.from(yamlStr, 'utf-8'));
+
+    const { header: parsed, signature } = SigillinParser(zipped);
+    expect(parsed).toEqual(header);
+    expect(signature).toBe(generateSigillinMetaSignatur(header));
+  });
+});

--- a/packages/genesis-sigillin-core/SigillinParser.ts
+++ b/packages/genesis-sigillin-core/SigillinParser.ts
@@ -1,0 +1,18 @@
+import { unzipSync } from 'zlib';
+import YAML from 'yaml';
+import { generateSigillinMetaSignatur } from './SigillinMetaSignatur';
+
+export interface ParsedSigillin {
+  header: any;
+  signature: string;
+}
+
+/**
+ * Parses a compressed YAML buffer and returns the header object and its signature.
+ */
+export function SigillinParser(zipBuffer: Buffer): ParsedSigillin {
+  const yamlContent = unzipSync(zipBuffer).toString('utf-8');
+  const header = YAML.parse(yamlContent);
+  const signature = generateSigillinMetaSignatur(header);
+  return { header, signature };
+}

--- a/packages/shared-utils/conversationAnalyzer.js
+++ b/packages/shared-utils/conversationAnalyzer.js
@@ -40,4 +40,44 @@ function extractTodosFromConversations(filePath) {
   return todos;
 }
 
-module.exports = { loadConversations, analyzeConversations, extractTodosFromConversations };
+function extractImplicitTodosFromConversations(filePath) {
+  const convs = loadConversations(filePath);
+  const todos = [];
+  const patterns = [
+    /TODO[:]?\s*(.*)/i,
+    /wir\s+sollten\s+([^\.\n]+)/i,
+    /k\u00F6nnten\s+wir\s+([^\.\n]+)/i,
+    /sollten\s+wir\s+([^\.\n]+)/i,
+    /lass\s+uns\s+([^\.\n]+)/i,
+    /wollen\s+wir\s+([^\.\n]+)/i
+  ];
+  for (const conv of convs) {
+    for (const node of Object.values(conv.mapping)) {
+      const msg = node.message;
+      if (!msg)
+        continue;
+      const parts = msg.content?.parts || [];
+      for (const part of parts) {
+        for (const line of part.split(/\n+/)) {
+          for (const re of patterns) {
+            const m = re.exec(line);
+            if (m) {
+              const text = m[1].split(/[\n\.]/)[0].trim();
+              if (text)
+                todos.push(text);
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+  return Array.from(new Set(todos));
+}
+
+module.exports = {
+  loadConversations,
+  analyzeConversations,
+  extractTodosFromConversations,
+  extractImplicitTodosFromConversations
+};


### PR DESCRIPTION
## Summary
- add `SigillinParser` for reading zipped YAML headers
- add accompanying tests
- export implicit todo function in conversation analyzer
- update `advancedprogress.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685542db1c908322b19e93fbbd11593a