### PR TITLE
Implement AeonMemory and AgentHeatmap

### DIFF
--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2411,29 +2411,29 @@
 - commit: Dispatch Befehl nutzt REST/gRPC Client
   path: apps/cli-tools
   task: dispatchCmd ruft REST/gRPC Client für Task-Dispatch auf
-  test: TODO
+  test: packages/cli-tools/dispatchCmd.test.ts
 - commit: Implement SigillinParser
   path: packages/genesis-sigillin-core
   task: YAML-Header aus ZIP-Mem lesen und Sigillin-Signatur erzeugen
-  test: TODO
+  test: packages/genesis-sigillin-core/SigillinParser.test.ts
 - commit: Implement ResonanzNavigator
   path: packages/aeon-genesisos
   task: Zustände anhand Sigillin-Signatur aktualisieren
-  test: TODO
+  test: packages/aeon-genesisos/ResonanzNavigator.test.ts
 - commit: Add TriggerArchive utilities
   path: packages/core
   task: TriggerArchive und useTriggerArchive hook bereitstellen
-  test: TODO
+  test: packages/core/TriggerArchive.test.ts
 - commit: Add PoeticReactorAgent
   path: packages/agents
   task: Agent generiert Haikus bei hohen CREP-Werten
-  test: TODO
+  test: packages/agents/PoeticReactorAgent.test.ts
 - commit: Create AgentHeatmap dashboard
   path: packages/unifiedmandala-ui
   task: useAgentActivity Hook und AgentHeatmap Komponente implementieren
-  test: TODO
+  test: packages/unifiedmandala-ui/components/AgentHeatmap.test.tsx
 - commit: Introduce AeonMemory
   path: packages/core
   task: Speichert erledigte Tasks in mandala-chronik.yaml und stellt useAeonMemory
     bereit
-  test: TODO
+  test: packages/core/AeonMemory.test.ts

--- a/packages/aeon-genesisos/ResonanzNavigator.test.ts
+++ b/packages/aeon-genesisos/ResonanzNavigator.test.ts
@@ -1,0 +1,11 @@
+import { gzipSync } from 'zlib';
+import YAML from 'yaml';
+import { ResonanzNavigator } from './ResonanzNavigator';
+
+it('updates current signature from zipped sigillin', () => {
+  const yaml = YAML.stringify({ id: 't1' });
+  const zip = gzipSync(Buffer.from(yaml));
+  const nav = new ResonanzNavigator();
+  nav.update(zip);
+  expect(nav.current()).toBeDefined();
+});

--- a/packages/aeon-genesisos/ResonanzNavigator.ts
+++ b/packages/aeon-genesisos/ResonanzNavigator.ts
@@ -1,0 +1,14 @@
+import { SigillinParser } from '../genesis-sigillin-core/SigillinParser';
+
+export class ResonanzNavigator {
+  private signatures: string[] = [];
+
+  update(zip: Buffer): void {
+    const { signature } = SigillinParser(zip);
+    this.signatures.push(signature);
+  }
+
+  current(): string | undefined {
+    return this.signatures[this.signatures.length - 1];
+  }
+}

--- a/packages/cli-tools/dispatchCmd.test.ts
+++ b/packages/cli-tools/dispatchCmd.test.ts
@@ -1,0 +1,20 @@
+import https from 'https';
+import { dispatchCmd } from './dispatchCmd';
+
+jest.mock('https', () => ({
+  request: jest.fn((_url: string, _opts: any, cb: any) => {
+    cb({ statusCode: 200 });
+    return { write: jest.fn(), end: jest.fn(), on: jest.fn() };
+  }),
+}));
+
+const mockRequest = https.request as jest.Mock;
+
+test('dispatchCmd posts task to endpoint', async () => {
+  await dispatchCmd('demo', 'https://api.test/dispatch');
+  expect(mockRequest).toHaveBeenCalledWith(
+    'https://api.test/dispatch',
+    expect.objectContaining({ method: 'POST' }),
+    expect.any(Function)
+  );
+});

--- a/packages/cli-tools/dispatchCmd.ts
+++ b/packages/cli-tools/dispatchCmd.ts
@@ -1,0 +1,13 @@
+import https from 'https';
+
+export function dispatchCmd(task: string, endpoint = 'https://localhost:3000/dispatch'): Promise<number> {
+  const data = JSON.stringify({ task });
+  return new Promise((resolve, reject) => {
+    const req = https.request(endpoint, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Content-Length': data.length } }, res => {
+      resolve(res.statusCode ?? 0);
+    });
+    req.on('error', reject);
+    req.write(data);
+    req.end();
+  });
+}

--- a/packages/core/AeonMemory.test.ts
+++ b/packages/core/AeonMemory.test.ts
@@ -1,0 +1,28 @@
+import fs from 'fs';
+import path from 'path';
+import { renderHook, act } from '@testing-library/react';
+import { AeonMemory, useAeonMemory } from './AeonMemory';
+
+const CHRONIK = path.resolve('mandala-chronik.yaml');
+
+describe('AeonMemory', () => {
+  beforeEach(() => {
+    if (fs.existsSync(CHRONIK)) fs.unlinkSync(CHRONIK);
+  });
+
+  it('records tasks to yaml file', () => {
+    const entry = AeonMemory.record('test-task');
+    expect(fs.existsSync(CHRONIK)).toBe(true);
+    const content = fs.readFileSync(CHRONIK, 'utf-8');
+    expect(content).toContain('test-task');
+    expect(entry.description).toBe('test-task');
+  });
+
+  it('useAeonMemory hook adds entry', () => {
+    const { result } = renderHook(() => useAeonMemory());
+    act(() => {
+      result.current.remember('hook-task');
+    });
+    expect(result.current.entries[0].description).toBe('hook-task');
+  });
+});

--- a/packages/core/AeonMemory.ts
+++ b/packages/core/AeonMemory.ts
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import path from 'path';
+import YAML from 'yaml';
+import { useEffect, useState } from 'react';
+
+const CHRONIK_PATH = path.resolve('mandala-chronik.yaml');
+
+export interface MemoryEntry {
+  id: string;
+  timestamp: string;
+  description: string;
+}
+
+export class AeonMemory {
+  private static entries: MemoryEntry[] = [];
+
+  static load(): void {
+    if (fs.existsSync(CHRONIK_PATH)) {
+      const parsed = YAML.parse(fs.readFileSync(CHRONIK_PATH, 'utf-8'));
+      this.entries = Array.isArray(parsed) ? parsed : [];
+    }
+  }
+
+  static record(description: string): MemoryEntry {
+    const entry: MemoryEntry = {
+      id: `${Date.now()}`,
+      timestamp: new Date().toISOString(),
+      description,
+    };
+    this.entries.push(entry);
+    fs.writeFileSync(CHRONIK_PATH, YAML.stringify(this.entries), 'utf-8');
+    return entry;
+  }
+
+  static latest(n = 10): MemoryEntry[] {
+    return [...this.entries].slice(-n).reverse();
+  }
+}
+
+export function useAeonMemory() {
+  const [entries, setEntries] = useState<MemoryEntry[]>([]);
+
+  useEffect(() => {
+    AeonMemory.load();
+    setEntries(AeonMemory.latest());
+  }, []);
+
+  const remember = (desc: string) => {
+    const entry = AeonMemory.record(desc);
+    setEntries([entry, ...entries]);
+  };
+
+  return { entries, remember };
+}

--- a/packages/unifiedmandala-ui/components/AgentHeatmap.stories.tsx
+++ b/packages/unifiedmandala-ui/components/AgentHeatmap.stories.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import AgentHeatmap from './AgentHeatmap';
+
+export default {
+  title: 'UnifiedMandala/AgentHeatmap',
+  component: AgentHeatmap,
+};
+
+export const Basic = () => <AgentHeatmap />;

--- a/packages/unifiedmandala-ui/components/AgentHeatmap.test.tsx
+++ b/packages/unifiedmandala-ui/components/AgentHeatmap.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AgentHeatmap from './AgentHeatmap';
+import { GPTEventHub } from '../../gpt-bridges/GPTEventHub';
+
+test('renders incoming agent events', () => {
+  render(<AgentHeatmap />);
+  act(() => {
+    GPTEventHub.emit('agentActivity', { id: 'AgentY', timestamp: 'now' });
+  });
+  expect(screen.getByText('AgentY')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/AgentHeatmap.tsx
+++ b/packages/unifiedmandala-ui/components/AgentHeatmap.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useAgentActivity } from '../hooks/useAgentActivity';
+
+const AgentHeatmap: React.FC = () => {
+  const activities = useAgentActivity();
+  return (
+    <section aria-label="Agent Heatmap">
+      <h3>Agent Activity</h3>
+      <ul>
+        {activities.slice(-5).map((a, i) => (
+          <li key={i}>{a.id}</li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default AgentHeatmap;

--- a/packages/unifiedmandala-ui/hooks/useAgentActivity.test.ts
+++ b/packages/unifiedmandala-ui/hooks/useAgentActivity.test.ts
@@ -1,0 +1,11 @@
+import { renderHook, act } from '@testing-library/react';
+import { useAgentActivity } from './useAgentActivity';
+import { GPTEventHub } from '../../gpt-bridges/GPTEventHub';
+
+test('collects agent activity events', () => {
+  const { result } = renderHook(() => useAgentActivity());
+  act(() => {
+    GPTEventHub.emit('agentActivity', { id: 'AgentX', timestamp: '2023-01-01' });
+  });
+  expect(result.current[0].id).toBe('AgentX');
+});

--- a/packages/unifiedmandala-ui/hooks/useAgentActivity.ts
+++ b/packages/unifiedmandala-ui/hooks/useAgentActivity.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { GPTEventHub } from '../../gpt-bridges/GPTEventHub';
+
+export interface AgentActivity {
+  id: string;
+  timestamp: string;
+}
+
+export function useAgentActivity() {
+  const [activities, setActivities] = useState<AgentActivity[]>([]);
+
+  useEffect(() => {
+    const handler = (data: AgentActivity) => {
+      setActivities(a => [...a.slice(-49), data]);
+    };
+    GPTEventHub.on('agentActivity', handler);
+    return () => {
+      GPTEventHub.off('agentActivity', handler);
+    };
+  }, []);
+
+  return activities;
+}


### PR DESCRIPTION
## Summary
- mark completed tasks in `advancedToDo.yaml`
- add dispatchCmd utility
- create ResonanzNavigator core module
- implement AeonMemory store and React hook
- add AgentHeatmap UI component and hook
- include matching tests and stories

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685545b3454083229f4b1fa7a3bca518