### PR TITLE
Implement advanced ToDo items

### DIFF
--- a/docs/diagrams/architecture.svg
+++ b/docs/diagrams/architecture.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+  <rect x="10" y="10" width="180" height="80" fill="#eee" stroke="#333" />
+  <text x="100" y="55" text-anchor="middle" font-size="14">Architecture</text>
+</svg>

--- a/docs/glossar-genesis.md
+++ b/docs/glossar-genesis.md
@@ -1,0 +1,7 @@
+# Glossar Genesis
+
+| Begriff | Bedeutung |
+|--------|-----------|
+| Archetyp | Symbolische Grundfigur im Mandala |
+| Sigillin | Verschlüsselter Marker für CREP-Zustände |
+| Resonanz | Wechselwirkung von Symbol und Handlung |

--- a/docs/symbols.md
+++ b/docs/symbols.md
@@ -1,0 +1,8 @@
+# Grundsymbole
+
+| Symbol | Bedeutung |
+|-------|-----------|
+| 🜂 | Feuer |
+| 🜁 | Luft |
+| 🜃 | Erde |
+| 🜄 | Wasser |

--- a/packages/aeon-genesisos/aeonCompiler.ts
+++ b/packages/aeon-genesisos/aeonCompiler.ts
@@ -1,0 +1,8 @@
+export function aeonCompiler(state: string): string {
+  const map: Record<string, string> = {
+    'β': 'γ',
+    'γ': 'δ',
+    'α': 'β',
+  };
+  return map[state] || state;
+}

--- a/packages/crep-engine/CREPRating.test.ts
+++ b/packages/crep-engine/CREPRating.test.ts
@@ -1,0 +1,13 @@
+import { rateCREP } from './CREPRating';
+
+test('rates high values as high', () => {
+  expect(rateCREP({C:5,R:5,E:5,P:5})).toBe('high');
+});
+
+test('rates medium values', () => {
+  expect(rateCREP({C:3,R:3,E:3,P:2})).toBe('medium');
+});
+
+test('rates low values', () => {
+  expect(rateCREP({C:1,R:1,E:1,P:1})).toBe('low');
+});

--- a/packages/crep-engine/CREPRating.ts
+++ b/packages/crep-engine/CREPRating.ts
@@ -1,0 +1,8 @@
+export interface CREPEntry { C:number; R:number; E:number; P:number; }
+
+export function rateCREP({C, R, E, P}: CREPEntry): 'low' | 'medium' | 'high' {
+  const total = C + R + E + P;
+  if (total >= 20) return 'high';
+  if (total >= 10) return 'medium';
+  return 'low';
+}

--- a/packages/unifiedmandala-ui/components/Resonanzfeld.test.tsx
+++ b/packages/unifiedmandala-ui/components/Resonanzfeld.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Resonanzfeld from './Resonanzfeld';
+
+test('renders message', () => {
+  render(<Resonanzfeld message="Hallo" />);
+  expect(screen.getByLabelText('Resonanzfeld')).toHaveTextContent('Hallo');
+});

--- a/packages/unifiedmandala-ui/components/Resonanzfeld.tsx
+++ b/packages/unifiedmandala-ui/components/Resonanzfeld.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface ResonanzfeldProps {
+  message: string;
+}
+
+const Resonanzfeld: React.FC<ResonanzfeldProps> = ({ message }) => (
+  <div aria-label="Resonanzfeld">{message}</div>
+);
+
+export default Resonanzfeld;

--- a/packages/unifiedmandala-ui/components/SymbolLogin.test.tsx
+++ b/packages/unifiedmandala-ui/components/SymbolLogin.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SymbolLogin from './SymbolLogin';
+
+test('submits entered symbol', () => {
+  const submit = jest.fn();
+  render(<SymbolLogin onSubmit={submit} />);
+  fireEvent.change(screen.getByLabelText('Symbol-Login'), { target: { value: '🜂' } });
+  fireEvent.click(screen.getByRole('button', { name: /start/i }));
+  expect(submit).toHaveBeenCalledWith('🜂');
+});

--- a/packages/unifiedmandala-ui/components/SymbolLogin.tsx
+++ b/packages/unifiedmandala-ui/components/SymbolLogin.tsx
@@ -1,0 +1,17 @@
+import React, { useState } from 'react';
+
+interface SymbolLoginProps {
+  onSubmit?: (symbol: string) => void;
+}
+
+const SymbolLogin: React.FC<SymbolLoginProps> = ({ onSubmit }) => {
+  const [value, setValue] = useState('');
+  return (
+    <form onSubmit={e => { e.preventDefault(); onSubmit?.(value); }}>
+      <input aria-label="Symbol-Login" value={value} onChange={e => setValue(e.target.value)} />
+      <button type="submit">Start</button>
+    </form>
+  );
+};
+
+export default SymbolLogin;

--- a/packages/unifiedmandala-ui/data/sigillinMap.json
+++ b/packages/unifiedmandala-ui/data/sigillinMap.json
@@ -1,0 +1,3 @@
+{
+  "fields": ["id", "symbol", "meaning"]
+}


### PR DESCRIPTION
## Summary
- add new glossary and symbols docs
- sketch aeonCompiler, CREPRating, SymbolLogin and Resonanzfeld modules
- include tests for new components and rating helper
- add placeholder architecture diagram and sigillin map

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68554be67a548322a8089af59d08ea42