### PR TITLE
Add conversation analysis package and update sigil map

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-20, in der Zeit des Morgen.
+Am 2025-06-20, in der Zeit des Tag.
 
-Symbolphase: Initiation (Fokus: C)
+Symbolphase: Aktivierung (Fokus: R)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/packages/conversation-analysis/CREPConversationScanner.test.ts
+++ b/packages/conversation-analysis/CREPConversationScanner.test.ts
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import { scanConversations } from './CREPConversationScanner';
+
+test('counts conversation entries', () => {
+  const tmp = 'tmp-convos.json';
+  fs.writeFileSync(tmp, JSON.stringify([{text:'a'}, {text:'b'}, {text:'c'}]));
+  const report = scanConversations(tmp);
+  fs.unlinkSync(tmp);
+  expect(report.total).toBe(3);
+});

--- a/packages/conversation-analysis/CREPConversationScanner.ts
+++ b/packages/conversation-analysis/CREPConversationScanner.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+
+export interface CREPConvoReport {
+  total: number;
+}
+
+export function scanConversations(file = 'docs/sigils/conversations.json'): CREPConvoReport {
+  const raw = fs.readFileSync(file, 'utf-8');
+  const data = JSON.parse(raw);
+  return { total: Array.isArray(data) ? data.length : 0 };
+}
+
+if (require.main === module) {
+  const report = scanConversations(process.argv[2]);
+  fs.writeFileSync('CREPConvoReport.json', JSON.stringify(report, null, 2));
+}

--- a/packages/conversation-analysis/ChronoPoemExtractor.ts
+++ b/packages/conversation-analysis/ChronoPoemExtractor.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+
+export function extractChronoPoem(input = 'docs/sigils/conversations.json', output = 'CHRONOPOEM_TIMELINE.md') {
+  const raw = fs.readFileSync(input, 'utf-8');
+  const data = JSON.parse(raw);
+  const lines = (Array.isArray(data) ? data : []).map((item: any) => {
+    const time = item.timestamp || item.date || '';
+    const title = item.title || item.text || '';
+    return `- ${time}: ${title}`;
+  });
+  fs.writeFileSync(output, lines.join('\n'));
+}
+
+if (require.main === module) {
+  extractChronoPoem(process.argv[2], process.argv[3]);
+}

--- a/packages/conversation-analysis/README.md
+++ b/packages/conversation-analysis/README.md
@@ -1,0 +1,7 @@
+# Conversation Analysis
+
+This package contains utilities for scanning conversation logs and extracting data for the Unified Mandala project.
+
+- **CREPConversationScanner** generates a simple report counting conversation entries.
+- **ChronoPoemExtractor** creates a timeline markdown file from conversations.
+- **generate-todo-from-convos** collects todo hints into `todo-sigil.yaml`.

--- a/packages/conversation-analysis/generate-todo-from-convos.ts
+++ b/packages/conversation-analysis/generate-todo-from-convos.ts
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import yaml from 'yaml';
+
+export interface TodoItem {
+  id: string;
+  beschreibung: string;
+  status: string;
+}
+
+export function generateTodos(input = 'docs/sigils/conversations.json', output = 'todo-sigil.yaml') {
+  const raw = fs.readFileSync(input, 'utf-8');
+  const data = JSON.parse(raw);
+  const todos: TodoItem[] = [];
+  (Array.isArray(data) ? data : []).forEach((item: any) => {
+    const text: string = item.text || '';
+    if (/wir sollten|TODO/i.test(text)) {
+      todos.push({ id: `todo-${todos.length + 1}`, beschreibung: text.trim(), status: 'offen' });
+    }
+  });
+  fs.writeFileSync(output, yaml.stringify(todos));
+}
+
+if (require.main === module) {
+  generateTodos(process.argv[2], process.argv[3]);
+}

--- a/packages/conversation-analysis/index.ts
+++ b/packages/conversation-analysis/index.ts
@@ -1,0 +1,3 @@
+export const name = 'conversation-analysis';
+export * from './CREPConversationScanner';
+export * from './ChronoPoemExtractor';

--- a/packages/unifiedmandala-ui/data/sigillinMap.json
+++ b/packages/unifiedmandala-ui/data/sigillinMap.json
@@ -1,3 +1,7 @@
 {
-  "fields": ["id", "symbol", "meaning"]
+  "fields": ["id", "symbol", "meaning"],
+  "data": [
+    { "id": "sun", "symbol": "\uD83C\uDF1E", "meaning": "fire" },
+    { "id": "water", "symbol": "\uD83C\uDF0A", "meaning": "water" }
+  ]
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,4 +11,5 @@ packages:
   - 'packages/aeon-resoecho'
   - 'packages/event-bus'
   - 'packages/sharedream-interface'
+  - 'packages/conversation-analysis'
   - 'apps/*'


### PR DESCRIPTION
## Summary
- add `conversation-analysis` package with utilities for scanning conversations and extracting chronopoem timelines
- generate ToDo suggestions from conversations
- expand `sigillinMap.json` with sample entries
- include the new package in `pnpm-workspace.yaml`
- update CHRONOPOEM after commit hook

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685557b7669483228f6e4def704381c3