### PR TITLE
Implement CREP sync utilities

### DIFF
--- a/ci/sigillin-lint-and-validate.sh
+++ b/ci/sigillin-lint-and-validate.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+ROOT_DIR=$(dirname "$0")/..
+SCHEMA="$ROOT_DIR/packages/genesis-sigillin-core/schemas/sigillin.schema.json"
+EXIT=0
+for file in "$ROOT_DIR"/docs/sigils/*.yaml; do
+  [ -e "$file" ] || continue
+  echo "Validating $file"
+  node - <<NODE || EXIT=1
+const fs = require('fs');
+const Ajv = require('ajv');
+const addFormats = require('ajv-formats');
+const yaml = require('yaml');
+const schema = require('$SCHEMA');
+const ajv = new Ajv();
+addFormats(ajv);
+const validate = ajv.compile(schema);
+const data = yaml.parse(fs.readFileSync('$file', 'utf8'));
+if (!validate(data)) { console.error(validate.errors); process.exit(1); }
+NODE
+done
+if [ $EXIT -eq 0 ]; then
+  echo "All sigillins valid"
+else
+  echo "Validation failed"
+  exit 1
+fi

--- a/docs/MandalaIndex.yaml
+++ b/docs/MandalaIndex.yaml
@@ -1,0 +1,8 @@
+components:
+  aeon-genesisos: packages/aeon-genesisos
+  crep-engine: packages/crep-engine
+  gpt-bridges: packages/gpt-bridges
+  unifiedmandala-ui: packages/unifiedmandala-ui
+  cli-tools: packages/cli-tools
+  event-bus: packages/event-bus
+  genesis-sigillin-core: packages/genesis-sigillin-core

--- a/packages/crep-engine/CREPMultiSync.test.ts
+++ b/packages/crep-engine/CREPMultiSync.test.ts
@@ -1,0 +1,30 @@
+import { CREPMultiSync } from './CREPMultiSync';
+import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
+import { io as ioClient, Socket } from 'socket.io-client';
+
+jest.mock('socket.io-client');
+const mockIo = ioClient as unknown as jest.Mock;
+
+it('emits crep sync events from socket', () => {
+  const handlers: Record<string, (d: any) => void> = {};
+  const socket = { on: jest.fn((ev, cb) => { handlers[ev] = cb; }), emit: jest.fn(), disconnect: jest.fn() } as unknown as Socket;
+  mockIo.mockReturnValue(socket);
+  jest.spyOn(GPTEventHub, 'emit');
+
+  const sync = new CREPMultiSync();
+  sync.connect('ws://test');
+  handlers['crep-update']({ C: 1 });
+
+  expect(GPTEventHub.emit).toHaveBeenCalledWith('crep:sync', { C: 1 });
+});
+
+it('sends updates via socket', () => {
+  const socket = { on: jest.fn(), emit: jest.fn(), disconnect: jest.fn() } as unknown as Socket;
+  mockIo.mockReturnValue(socket);
+
+  const sync = new CREPMultiSync();
+  sync.connect();
+  sync.sendUpdate({ C: 2 });
+
+  expect(socket.emit).toHaveBeenCalledWith('crep-update', { C: 2 });
+});

--- a/packages/crep-engine/CREPMultiSync.ts
+++ b/packages/crep-engine/CREPMultiSync.ts
@@ -1,0 +1,21 @@
+import { io, Socket } from 'socket.io-client';
+import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
+
+export class CREPMultiSync {
+  private socket?: Socket;
+
+  connect(url = 'ws://localhost:4000') {
+    this.socket = io(url);
+    this.socket.on('crep-update', data => {
+      GPTEventHub.emit('crep:sync', data);
+    });
+  }
+
+  sendUpdate(data: unknown) {
+    this.socket?.emit('crep-update', data);
+  }
+
+  disconnect() {
+    this.socket?.disconnect();
+  }
+}

--- a/packages/genesis-sigillin-core/SigillinSuggestionEngine.ts
+++ b/packages/genesis-sigillin-core/SigillinSuggestionEngine.ts
@@ -2,6 +2,11 @@ import { SigillinGenerator } from './SigillinGenerator';
 
 export function suggestSigillins(peaks: number[]): string[] {
   return peaks.map((_, i) =>
-    SigillinGenerator(`suggestion-${i+1}`, 'suggestion', 'draft', 'engine').id
+    SigillinGenerator(
+      `suggestion-${i + 1}`,
+      'crep-trigger',
+      'draft',
+      'engine'
+    ).id
   );
 }


### PR DESCRIPTION
## Summary
- add MandalaIndex for component mapping
- add sigillin validation script for CI
- implement CREPMultiSync websocket helper
- fix SigillinSuggestionEngine type mismatch
- test CREPMultiSync behavior

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685565a7cc8883228523ca9c3d499b4b