### PR TITLE
Implement CollaborativeEditor module

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -899,4 +899,11 @@
     "task": "Speichert erledigte Tasks in mandala-chronik.yaml und stellt useAeonMemory bereit",
     "test": "packages/core/AeonMemory.test.ts"
   }
+  ,
+  {
+    "commit": "Implement CollaborativeEditor",
+    "path": "packages/collab-editor",
+    "task": "Texteditor mit Federation-Routes für Sync",
+    "test": "packages/collab-editor/CollaborativeEditor.test.ts"
+  }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2437,6 +2437,10 @@
   task: Speichert erledigte Tasks in mandala-chronik.yaml und stellt useAeonMemory
     bereit
   test: packages/core/AeonMemory.test.ts
+- commit: Implement CollaborativeEditor
+  path: packages/collab-editor
+  task: Texteditor mit Federation-Routes für Sync
+  test: packages/collab-editor/CollaborativeEditor.test.ts
 Prüfe regelmäßig, ob die Datenquellen (z.B. /api/meta-scores) und die Dashboard-Komponenten konsistent und aktuell die Layer-Konfiguration abbilden. Bei jedem Commit: Test-/Doku-Referenz ergänzen!
 Neue Aufgaben laut advancedconversations.json:
 - AestheticsLayer und EthicsLayer umsetzen.

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat(layers): add AestheticsLayer and EthicsLayer",
+  "lastCommit": "feat(collab): add CollaborativeEditor module",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"

--- a/packages/collab-editor/CollaborativeEditor.test.ts
+++ b/packages/collab-editor/CollaborativeEditor.test.ts
@@ -1,0 +1,16 @@
+import { CollaborativeEditor } from './CollaborativeEditor';
+import * as routes from './federationRoutes';
+
+test('applyLocalChange updates content', () => {
+  const editor = new CollaborativeEditor();
+  editor.applyLocalChange('hello');
+  expect(editor.getContent()).toBe('hello');
+});
+
+test('applyLocalChange triggers federation update', () => {
+  const spy = jest.spyOn(routes, 'sendUpdate').mockImplementation(() => {});
+  const editor = new CollaborativeEditor('https://remote/sync');
+  editor.applyLocalChange('world');
+  expect(spy).toHaveBeenCalledWith('https://remote/sync', 'world');
+  spy.mockRestore();
+});

--- a/packages/collab-editor/CollaborativeEditor.ts
+++ b/packages/collab-editor/CollaborativeEditor.ts
@@ -1,0 +1,28 @@
+import { EventEmitter } from 'events';
+import { sendUpdate } from './federationRoutes';
+
+export class CollaborativeEditor extends EventEmitter {
+  private content = '';
+
+  constructor(private endpoint?: string) {
+    super();
+    this.on('update', (text: string) => {
+      if (this.endpoint) {
+        sendUpdate(this.endpoint, text);
+      }
+    });
+  }
+
+  applyLocalChange(text: string): void {
+    this.content = text;
+    this.emit('update', this.content);
+  }
+
+  applyRemoteChange(text: string): void {
+    this.content = text;
+  }
+
+  getContent(): string {
+    return this.content;
+  }
+}

--- a/packages/collab-editor/federationRoutes.ts
+++ b/packages/collab-editor/federationRoutes.ts
@@ -1,0 +1,12 @@
+import https from 'https';
+
+export function sendUpdate(endpoint: string, content: string): void {
+  const data = JSON.stringify({ content });
+  const req = https.request(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Content-Length': data.length }
+  });
+  req.on('error', () => {});
+  req.write(data);
+  req.end();
+}

--- a/packages/collab-editor/index.ts
+++ b/packages/collab-editor/index.ts
@@ -1,0 +1,2 @@
+export * from './CollaborativeEditor';
+export * from './federationRoutes';

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,4 +12,5 @@ packages:
   - 'packages/event-bus'
   - 'packages/sharedream-interface'
   - 'packages/conversation-analysis'
+  - 'packages/collab-editor'
   - 'apps/*'


### PR DESCRIPTION
## Summary
- add a CollaborativeEditor with Federation routes
- test the new editor
- register new package in workspace
- track new task in advancedToDo files
- update progress log

## Testing
- `pnpm install`
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68557c55379c8322abbffe68cbd96af9