### PR TITLE
Add RestClient util and update docs

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-20, in der Zeit des Tag.
+Am 2025-06-20, in der Zeit des Abend.
 
-Symbolphase: Aktivierung (Fokus: R)
+Symbolphase: Integration (Fokus: E)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -63,6 +63,7 @@ console.log(sigil.id); // hello
 - `SymbolicForecaster` – Berechnet die nächste Symbolzeitphase.
 - `CREPWirkungstracker` – Protokolliert Effekte von CREP-Einträgen.
 - `loadSymbolphasen` – liest die Symbolphasen-Definition aus `config/symbolphasen.yaml`.
+- `RestClient` – einfacher HTTP/HTTPS-Client für Tests und Skripte.
 
 ### core
 - `AeonMemory` – Persistiert Aufgaben in `mandala-chronik.yaml`.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ packages/
   ├── tts                  # Sprachsynthese
   ├── universum-simulationen # Simulationsmodule
   └── shared-utils              # Hilfsfunktionen für alle Pakete
+      └── RestClient.ts         # einfacher REST-Helper
 scripts/
   ├── aeon.sh                   # Poetisches Bash-CLI für Mandala-Steuerung
   ├── setup-unifiedmandala.sh   # Installer & Initialisierung

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -63,7 +63,8 @@
     "commit": "call your REST/gRPC client",
     "path": "",
     "task": "call your REST/gRPC client",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "implement",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -60,6 +60,7 @@
   path: ""
   task: call your REST/gRPC client
   test: ""
+  status: done
 - commit: implement
   path: ""
   task: implement

--- a/packages/shared-utils/RestClient.test.ts
+++ b/packages/shared-utils/RestClient.test.ts
@@ -1,0 +1,13 @@
+import { callRest } from './RestClient';
+import http from 'http';
+
+it('performs a GET request to a local server', async () => {
+  const server = http.createServer((_, res) => {
+    res.end('ok');
+  });
+  await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+  const { port } = server.address() as any;
+  const data = await callRest(`http://localhost:${port}`);
+  server.close();
+  expect(data).toBe('ok');
+});

--- a/packages/shared-utils/RestClient.ts
+++ b/packages/shared-utils/RestClient.ts
@@ -1,0 +1,18 @@
+import http from 'http';
+import https from 'https';
+
+function getModule(url: string) {
+  return url.startsWith('https') ? https : http;
+}
+
+export function callRest(url: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    getModule(url)
+      .get(url, (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+      })
+      .on('error', reject);
+  });
+}

--- a/packages/shared-utils/index.ts
+++ b/packages/shared-utils/index.ts
@@ -15,3 +15,4 @@ export * from './symbolzeitModulator';
 export * from './loadSymbolphasen';
 export * from './conversationAnalyzer';
 export * from './advancedConversation';
+export * from './RestClient';


### PR DESCRIPTION
## Summary
- add `RestClient` helper in shared-utils
- document new util in README and Handbuch
- update advanced tasks to mark REST client todo done
- include generated chronopoem entry

## Testing
- `pnpm install`
- `pnpm exec jest`

------
https://chatgpt.com/codex/tasks/task_e_6855aaa256508322a9f06c3146c5924a