### PR TITLE
Add website YAML script and update docs

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -205,6 +205,8 @@ packages/
   └── codex-navigator-agent     # Parser für Codex-Instruktionen
 codex/                    # Codex-Workflows und Sigillin-Dateien
 codexbuild/               # Build-Skripte und Deploy-Hilfen
+ci/                      # Test- und Pipeline-Konfigurationen
+config/                  # Zentrale YAML- und Env-Dateien
 repositorypflege/         # Pflegekonzepte und Repository-Mapping
 apps/
   └── sharedream-interface      # Web-Schnittstelle & Sync

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ packages/
   └── codex-navigator-agent     # Parser für Codex-Instruktionen
 codex/                    # Codex-Workflows und Sigillin-Dateien
 codexbuild/               # Build-Skripte und Deploy-Hilfen
+ci/                      # Test- und Pipeline-Konfigurationen
+config/                  # Zentrale YAML- und Env-Dateien
 repositorypflege/         # Pflegekonzepte und Repository-Mapping
 apps/
   └── sharedream-interface      # Web-Schnittstelle & Sync

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -953,11 +953,29 @@
     "path": ".github/workflows",
     "task": "Periodischer Lern-Agent per Action ausfuehren",
     "test": ".github/workflows/MetaLearnerAgent.test.ts"
-  }
-  ,{
+  },
+  {
     "commit": "Implement MandalaCoreLicense",
     "path": "packages/shared-utils",
     "task": "Lizenzmodell verwalten",
     "test": "packages/shared-utils/MandalaCoreLicense.test.ts"
+  },
+  {
+    "commit": "Create AeonKIResonanzAgent",
+    "path": "packages/agents",
+    "task": "Agent analysiert Resonanzdaten aus conversations",
+    "test": "packages/agents/AeonKIResonanzAgent.test.ts"
+  },
+  {
+    "commit": "Implement KIBewusstseinAgent",
+    "path": "packages/agents",
+    "task": "Modul zur Bewusstseins- und Resonanzbewertung",
+    "test": "packages/agents/KIBewusstsein.test.ts"
+  },
+  {
+    "commit": "Extend NucleonScanner for v0.6 analysis",
+    "path": "packages/crep-engine",
+    "task": "Phi-Profil dynamisch berechnen und loggen",
+    "test": "packages/crep-engine/NucleonScanner.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2524,3 +2524,18 @@ status: done
   task: Lizenzmodell verwalten
   test: packages/shared-utils/MandalaCoreLicense.test.ts
   status: done
+- commit: Create AeonKIResonanzAgent
+  path: packages/agents
+  task: Agent analysiert Resonanzdaten aus conversations
+  test: packages/agents/AeonKIResonanzAgent.test.ts
+  status: open
+- commit: Implement KIBewusstseinAgent
+  path: packages/agents
+  task: Modul zur Bewusstseins- und Resonanzbewertung
+  test: packages/agents/KIBewusstsein.test.ts
+  status: open
+- commit: Extend NucleonScanner for v0.6 analysis
+  path: packages/crep-engine
+  task: Phi-Profil dynamisch berechnen und loggen
+  test: packages/crep-engine/NucleonScanner.test.ts
+  status: open

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "js-yaml": "^4.1.0",
     "mitt": "^3.0.0",
     "nats": "^2.29.3",
+    "node-fetch": "2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-tooltip": "^5.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       nats:
         specifier: ^2.29.3
         version: 2.29.3
+      node-fetch:
+        specifier: '2'
+        version: 2.7.0
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1629,6 +1632,15 @@ packages:
     resolution: {integrity: sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==}
     engines: {node: '>=10.0.0'}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
@@ -1957,6 +1969,9 @@ packages:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
@@ -2058,6 +2073,9 @@ packages:
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -2073,6 +2091,9 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4046,6 +4067,10 @@ snapshots:
     dependencies:
       tweetnacl: 1.0.3
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-int64@0.4.0: {}
 
   node-releases@2.0.19: {}
@@ -4359,6 +4384,8 @@ snapshots:
     dependencies:
       tldts: 6.1.86
 
+  tr46@0.0.3: {}
+
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
@@ -4464,6 +4491,8 @@ snapshots:
     dependencies:
       makeerror: 1.0.12
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@7.0.0: {}
 
   whatwg-encoding@3.1.1:
@@ -4476,6 +4505,11 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:

--- a/scripts/website-to-yaml.js
+++ b/scripts/website-to-yaml.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const yaml = require('js-yaml');
+const fetch = require('node-fetch');
+
+async function main() {
+  const target = process.argv[2];
+  if (!target) {
+    console.error('Usage: node website-to-yaml.js <url-or-file>');
+    process.exit(1);
+  }
+  let text;
+  if (/^https?:/.test(target)) {
+    const res = await fetch(target);
+    if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+    text = await res.text();
+  } else {
+    text = fs.readFileSync(target, 'utf8');
+  }
+  const data = { source: target, content: text };
+  const out = yaml.dump(data);
+  fs.writeFileSync('codex/website.yaml', out, 'utf8');
+  console.log('Saved to codex/website.yaml');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/website-to-yaml.test.ts
+++ b/scripts/website-to-yaml.test.ts
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import { execSync } from 'child_process';
+
+test('website to yaml generates file', () => {
+  fs.writeFileSync('test.html', '<h1>Test</h1>');
+  execSync('node scripts/website-to-yaml.js test.html');
+  const out = fs.readFileSync('codex/website.yaml', 'utf8');
+  expect(out).toContain('Test');
+  fs.unlinkSync('test.html');
+});


### PR DESCRIPTION
## Summary
- add script to convert website content to YAML
- test the new script
- reference `ci/` and `config/` folders in README and Handbuch
- add new tasks for resonance agents and scanner upgrades in advancedToDo files

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6855c5a72fc08322b1823b42115d3783