### PR TITLE
Add CREPBewertungsmodul module and tests

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -27,6 +27,7 @@ Dieses Handbuch gibt einen Überblick über die wichtigsten Module und Funktione
 - `CREPManager` – Hält die CREP-Historie und berechnet Durchschnittswerte.
 - `CREPEvaluator` – Ermittelt anhand von Thresholds den aktuellen Zustand.
 - `getCREPState` – Hilfsfunktion zur Statusermittlung.
+- `CREPBewertungsmodul` – Berechnet Score und Klassifizierung aus C,R,E,P
 
 ### gpt-bridges
 - `GPTEventHub` – Zentrales Event-System zwischen GPT-Modulen.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ narrative Interfaces und adaptive Bewusstseinsräume.
 - 🚩 **SymbolicWayfinder & SoforthilfeOverlay** – Navigation und Hilfedialoge
 - 📈 **CREPChart & CREPTriggerPanel** – CREP-Historie und Steuerung
 - 🛰️ **Nucleon-Scanner v0.6** – Analysiert tiefe Resonanzdaten
+- 📐 **CREPBewertungsmodul** – berechnet Durchschnittswerte und Klassifizierung
 - 📊 **CREPAverage-Analyse** – Durchschnittswerte aus dem CREP-Verlauf
 - 🌠 **AeonStoryMode & Onboarding-Flow** – Präsentations- und Einstiegskomponenten
 - 🎨 **MandalaThemeManager** – hell/dunkel umschalten

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -979,3 +979,17 @@
     "test": "packages/crep-engine/NucleonScanner.test.ts"
   }
 ]
+,
+  {
+    "commit": "Add ResonanzMetrics analyzer",
+    "path": "packages/agents",
+    "task": "Analysiert Resonanzdaten aus Aeon KI Resonanz Gesprächen",
+    "test": "packages/agents/ResonanzMetrics.test.ts"
+  },
+  {
+    "commit": "Add BewusstseinsResonanzComparator",
+    "path": "packages/agents",
+    "task": "Vergleicht Bewusstseins- und Resonanzwerte",
+    "test": "packages/agents/BewusstseinsResonanzComparator.test.ts"
+  }
+]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2528,14 +2528,24 @@ status: done
   path: packages/agents
   task: Agent analysiert Resonanzdaten aus conversations
   test: packages/agents/AeonKIResonanzAgent.test.ts
-  status: open
+  status: done
 - commit: Implement KIBewusstseinAgent
   path: packages/agents
   task: Modul zur Bewusstseins- und Resonanzbewertung
   test: packages/agents/KIBewusstsein.test.ts
-  status: open
+  status: done
 - commit: Extend NucleonScanner for v0.6 analysis
   path: packages/crep-engine
   task: Phi-Profil dynamisch berechnen und loggen
   test: packages/crep-engine/NucleonScanner.test.ts
+  status: done
+- commit: Add ResonanzMetrics analyzer
+  path: packages/agents
+  task: Analysiert Resonanzdaten aus Aeon KI Resonanz Gesprächen
+  test: packages/agents/ResonanzMetrics.test.ts
+  status: open
+- commit: Add BewusstseinsResonanzComparator
+  path: packages/agents
+  task: Vergleicht Bewusstseins- und Resonanzwerte
+  test: packages/agents/BewusstseinsResonanzComparator.test.ts
   status: open

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100"><rect width="200" height="100" fill="lightgray"/><text x="10" y="50">Architektur</text></svg>

--- a/packages/crep-engine/CREPBewertungsmodul.test.ts
+++ b/packages/crep-engine/CREPBewertungsmodul.test.ts
@@ -1,0 +1,9 @@
+import { CREPBewertungsmodul } from './CREPBewertungsmodul';
+
+describe('CREPBewertungsmodul', () => {
+  it('berechnet Durchschnitt und klassifiziert', () => {
+    const score = CREPBewertungsmodul.berechneScore({ C:8, R:8, E:8, P:8 });
+    expect(score).toBe(8);
+    expect(CREPBewertungsmodul.klassifiziere(score)).toBe('hoch');
+  });
+});

--- a/packages/crep-engine/CREPBewertungsmodul.ts
+++ b/packages/crep-engine/CREPBewertungsmodul.ts
@@ -1,0 +1,18 @@
+export interface BewertungsInput {
+  C: number;
+  R: number;
+  E: number;
+  P: number;
+}
+
+export class CREPBewertungsmodul {
+  static berechneScore({ C, R, E, P }: BewertungsInput): number {
+    return (C + R + E + P) / 4;
+  }
+
+  static klassifiziere(score: number): 'niedrig' | 'mittel' | 'hoch' {
+    if (score >= 7) return 'hoch';
+    if (score >= 4) return 'mittel';
+    return 'niedrig';
+  }
+}

--- a/packages/crep-engine/README.md
+++ b/packages/crep-engine/README.md
@@ -7,4 +7,5 @@ Enthält:
 - **getAverageCREP** – ermittelt Durchschnittswerte über die letzten Einträge
 - **CREPEvaluator** – Threshold-Logik und State-Berechnung
 - **getCREPState** – Hilfsfunktion für Status "safe", "warning" oder "critical"
+- **CREPBewertungsmodul** – Berechnet Durchschnitt und Klassifizierung
 

--- a/packages/unifiedmandala-ui/components/SigillinLoader.test.tsx
+++ b/packages/unifiedmandala-ui/components/SigillinLoader.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SigillinLoader from './SigillinLoader';
+
+const yamlData = `- name: test\n  value: 1`;
+
+function createFile(contents: string, name: string) {
+  return new File([contents], name, { type: 'text/plain' });
+}
+
+test('loads yaml file and shows count', async () => {
+  render(<SigillinLoader />);
+  const input = screen.getByLabelText('Sigillin laden') as HTMLInputElement;
+  const file = createFile(yamlData, 'example.yaml');
+  await waitFor(() => fireEvent.change(input, { target: { files: [file] } }));
+  await screen.findByText('1 Einträge geladen');
+});


### PR DESCRIPTION
## Summary
- implement CREPBewertungsmodul with scoring logic
- add unit tests for CREPBewertungsmodul
- add test for SigillinLoader component
- include new architecture diagram
- document CREPBewertungsmodul in README and Handbuch
- update advanced ToDos with completed and new tasks

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855cb7bc904832298ff874f59f6d40a