### PR TITLE
Implement ResonanzMetrics and comparator

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -81,6 +81,13 @@ console.log(sigil.id); // hello
 ### agents
 - `PoeticReactorAgent` – Generiert Haikus bei hohen CREP-Werten.
 - `GenesisAeonNavigator` – Schaltet Phasen anhand Sigillin frei.
+- `AeonKIResonanzAgent` – Sendet Resonanzereignisse an den GPTEventHub.
+- `KIBewusstsein` – Bewertet Symbiosepfade und Zielharmonie.
+- `SigillinZipSystem` – Packt und entpackt Sigillin-Bundles.
+- `CodexNavigatorAgent` – Liest Anweisungen aus `codexwork.yaml`.
+- `CodexProjectInitAgent` – Initialisiert neue Projektpfade.
+- `ResonanzMetrics` – Berechnet Durchschnitts- und Maximalwerte aus Resonanzdaten.
+- `BewusstseinsResonanzComparator` – Vergleicht Bewusstseins- und Resonanzwerte.
 
 ### collab-editor
 - `CollaborativeEditor` – Federated Texteditor mit Remote-Sync.

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -984,12 +984,14 @@
     "commit": "Add ResonanzMetrics analyzer",
     "path": "packages/agents",
     "task": "Analysiert Resonanzdaten aus Aeon KI Resonanz Gesprächen",
-    "test": "packages/agents/ResonanzMetrics.test.ts"
+    "test": "packages/agents/ResonanzMetrics.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add BewusstseinsResonanzComparator",
     "path": "packages/agents",
     "task": "Vergleicht Bewusstseins- und Resonanzwerte",
-    "test": "packages/agents/BewusstseinsResonanzComparator.test.ts"
+    "test": "packages/agents/BewusstseinsResonanzComparator.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2543,9 +2543,9 @@ status: done
   path: packages/agents
   task: Analysiert Resonanzdaten aus Aeon KI Resonanz Gesprächen
   test: packages/agents/ResonanzMetrics.test.ts
-  status: open
+  status: done
 - commit: Add BewusstseinsResonanzComparator
   path: packages/agents
   task: Vergleicht Bewusstseins- und Resonanzwerte
   test: packages/agents/BewusstseinsResonanzComparator.test.ts
-  status: open
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: implement GPT synapse and extend sigillin nodes",
+  "lastCommit": "feat: add ResonanzMetrics analyzer and comparator",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"

--- a/packages/agents/BewusstseinsResonanzComparator.test.ts
+++ b/packages/agents/BewusstseinsResonanzComparator.test.ts
@@ -1,0 +1,10 @@
+import { BewusstseinsResonanzComparator } from './BewusstseinsResonanzComparator';
+
+describe('BewusstseinsResonanzComparator', () => {
+  it('compares values correctly', () => {
+    const comp = new BewusstseinsResonanzComparator();
+    expect(comp.compare(5, 7)).toContain('übersteigt');
+    expect(comp.compare(7, 5)).toContain('über Resonanz');
+    expect(comp.compare(5, 5)).toContain('Gleichgewicht');
+  });
+});

--- a/packages/agents/BewusstseinsResonanzComparator.ts
+++ b/packages/agents/BewusstseinsResonanzComparator.ts
@@ -1,0 +1,11 @@
+export class BewusstseinsResonanzComparator {
+  compare(bewusstsein: number, resonanz: number): string {
+    if (resonanz > bewusstsein) {
+      return 'Resonanz übersteigt Bewusstsein';
+    }
+    if (resonanz < bewusstsein) {
+      return 'Bewusstsein über Resonanz';
+    }
+    return 'Resonanz und Bewusstsein im Gleichgewicht';
+  }
+}

--- a/packages/agents/ResonanzMetrics.test.ts
+++ b/packages/agents/ResonanzMetrics.test.ts
@@ -1,0 +1,11 @@
+import { ResonanzMetrics } from './ResonanzMetrics';
+
+describe('ResonanzMetrics', () => {
+  it('calculates average and max', () => {
+    const metrics = new ResonanzMetrics();
+    metrics.addSample(3);
+    metrics.addSample(7);
+    expect(metrics.average()).toBe(5);
+    expect(metrics.max()).toBe(7);
+  });
+});

--- a/packages/agents/ResonanzMetrics.ts
+++ b/packages/agents/ResonanzMetrics.ts
@@ -1,0 +1,17 @@
+export class ResonanzMetrics {
+  private samples: number[] = [];
+
+  addSample(value: number): void {
+    this.samples.push(value);
+  }
+
+  average(): number {
+    if (this.samples.length === 0) return 0;
+    const sum = this.samples.reduce((a, b) => a + b, 0);
+    return sum / this.samples.length;
+  }
+
+  max(): number {
+    return this.samples.length ? Math.max(...this.samples) : 0;
+  }
+}

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -8,3 +8,5 @@ export * from './KIBewusstsein';
 export * from './SigillinZipSystem';
 export * from './CodexResonanzFraktal';
 export * from './PoeticReactorAgent';
+export * from './ResonanzMetrics';
+export * from './BewusstseinsResonanzComparator';


### PR DESCRIPTION
## Summary
- add new ResonanzMetrics analyzer module
- add BewusstseinsResonanzComparator module
- export new modules
- mark tasks as done in advancedToDo files
- document new agents in Handbuch
- update progress record

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6855e3e607bc8322b3b8073c0e199cf6