### PR TITLE
Add new analysis tasks & document repo map

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -366,3 +366,4 @@ Weitere Beispiele und GIF-Demos findest du im [Wiki](https://github.com/GenesisA
 Ein SVG-Beispiel liegt unter [`docs/assets/unified-mandala.svg`](docs/assets/unified-mandala.svg).
 
 Das `CHRONOPOEM.md` entsteht automatisch – und kann bei jedem Commit erneuert werden.
+\nDie detaillierte Struktur aller Module, Utilities und Skripte findest du in [repositorypflege/repository_map.yaml](repositorypflege/repository_map.yaml).

--- a/README.md
+++ b/README.md
@@ -233,3 +233,4 @@ gespeichert. Nutzen Sie die Helferskripte aus `packages/shared-utils`
 
 Nutze `node scripts/parse-advanced-conversations.js` um Gesprächs-TODOs aus dem Datensatz zu filtern.
 
+\nDie komplette Ordnerstruktur samt Modulen, Utils und Skripten ist in [repositorypflege/repository_map.yaml](repositorypflege/repository_map.yaml) dokumentiert.

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -977,9 +977,7 @@
     "path": "packages/crep-engine",
     "task": "Phi-Profil dynamisch berechnen und loggen",
     "test": "packages/crep-engine/NucleonScanner.test.ts"
-  }
-]
-,
+  },
   {
     "commit": "Add ResonanzMetrics analyzer",
     "path": "packages/agents",
@@ -993,5 +991,26 @@
     "task": "Vergleicht Bewusstseins- und Resonanzwerte",
     "test": "packages/agents/BewusstseinsResonanzComparator.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Implement AeonKIResonanzAnalyzer",
+    "path": "packages/agents",
+    "task": "Analyse conversation logs for resonant patterns from Aeon KI Resonanz",
+    "test": "packages/agents/AeonKIResonanzAnalyzer.test.ts",
+    "status": "geplant"
+  },
+  {
+    "commit": "Add KIBewusstseinResonanzMonitor",
+    "path": "packages/agents",
+    "task": "Monitor Bewusstsein und Resonanzmetriken",
+    "test": "packages/agents/KIBewusstseinResonanzMonitor.test.ts",
+    "status": "geplant"
+  },
+  {
+    "commit": "Expand NucleonScanner conversation import for v0.6",
+    "path": "packages/crep-engine",
+    "task": "Parse Nukleon-Scanner v0.6 Analyse Transkripte",
+    "test": "packages/crep-engine/NucleonScannerConversation.test.ts",
+    "status": "geplant"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2547,3 +2547,18 @@ status: done
   task: Vergleicht Bewusstseins- und Resonanzwerte
   test: packages/agents/BewusstseinsResonanzComparator.test.ts
   status: done
+- commit: Implement AeonKIResonanzAnalyzer
+  path: packages/agents
+  task: Analyse conversation logs for resonant patterns from Aeon KI Resonanz
+  test: packages/agents/AeonKIResonanzAnalyzer.test.ts
+  status: geplant
+- commit: Add KIBewusstseinResonanzMonitor
+  path: packages/agents
+  task: Monitor Bewusstsein und Resonanzmetriken
+  test: packages/agents/KIBewusstseinResonanzMonitor.test.ts
+  status: geplant
+- commit: Expand NucleonScanner conversation import for v0.6
+  path: packages/crep-engine
+  task: Parse Nukleon-Scanner v0.6 Analyse Transkripte
+  test: packages/crep-engine/NucleonScannerConversation.test.ts
+  status: geplant


### PR DESCRIPTION
## Summary
- link repository map in README and Handbuch
- append new analysis tasks for Aeon KI Resonanz, KI Bewusstsein und Resonanz and Nucleon-Scanner conversations
- fix trailing syntax in `advancedToDo.json`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6855ec2ccc708322898bd571f47e2f2b