### PR TITLE
Add CREP info modal and resonance analyzers

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -281,6 +281,7 @@ codex/                    # Codex-Workflows und Sigillin-Dateien
 codexbuild/               # Build-Skripte und Deploy-Hilfen
 ci/                      # Test- und Pipeline-Konfigurationen
 config/                  # Zentrale YAML- und Env-Dateien
+  └── interfaces.yaml       # API-Endpunkte der Plattform
 repositorypflege/         # Pflegekonzepte und Repository-Mapping
 apps/
   └── sharedream-interface      # Web-Schnittstelle & Sync

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ codex/                    # Codex-Workflows und Sigillin-Dateien
 codexbuild/               # Build-Skripte und Deploy-Hilfen
 ci/                      # Test- und Pipeline-Konfigurationen
 config/                  # Zentrale YAML- und Env-Dateien
+  └── interfaces.yaml       # API-Endpunkte der Plattform
 repositorypflege/         # Pflegekonzepte und Repository-Mapping
 apps/
   └── sharedream-interface      # Web-Schnittstelle & Sync

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -997,14 +997,14 @@
     "path": "packages/agents",
     "task": "Analyse conversation logs for resonant patterns from Aeon KI Resonanz",
     "test": "packages/agents/AeonKIResonanzAnalyzer.test.ts",
-    "status": "geplant"
+    "status": "done"
   },
   {
     "commit": "Add KIBewusstseinResonanzMonitor",
     "path": "packages/agents",
     "task": "Monitor Bewusstsein und Resonanzmetriken",
     "test": "packages/agents/KIBewusstseinResonanzMonitor.test.ts",
-    "status": "geplant"
+    "status": "done"
   },
   {
     "commit": "Expand NucleonScanner conversation import for v0.6",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2551,12 +2551,12 @@ status: done
   path: packages/agents
   task: Analyse conversation logs for resonant patterns from Aeon KI Resonanz
   test: packages/agents/AeonKIResonanzAnalyzer.test.ts
-  status: geplant
+  status: done
 - commit: Add KIBewusstseinResonanzMonitor
   path: packages/agents
   task: Monitor Bewusstsein und Resonanzmetriken
   test: packages/agents/KIBewusstseinResonanzMonitor.test.ts
-  status: geplant
+  status: done
 - commit: Expand NucleonScanner conversation import for v0.6
   path: packages/crep-engine
   task: Parse Nukleon-Scanner v0.6 Analyse Transkripte

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add ResonanzMetrics analyzer and comparator",
+  "lastCommit": "feat: add resonance monitor and analyzer",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"

--- a/config/interfaces.yaml
+++ b/config/interfaces.yaml
@@ -1,0 +1,10 @@
+apis:
+  AeonShellAPI:
+    description: Shell-Kommandos zur Steuerung von Mandala-Instanzen
+    endpoint: /api/aeon-shell
+  GenesisPublicDocsAPI:
+    description: Zugriff auf öffentliche Genesis-Dokumentation
+    endpoint: /api/docs
+  SigillinValidatorAPI:
+    description: Validierung von Sigillin-Dateien
+    endpoint: /api/sigillin/validate

--- a/packages/agents/AeonKIResonanzAnalyzer.test.ts
+++ b/packages/agents/AeonKIResonanzAnalyzer.test.ts
@@ -1,0 +1,7 @@
+import { AeonKIResonanzAnalyzer } from './AeonKIResonanzAnalyzer';
+
+test('counts resonance messages', () => {
+  const analyzer = new AeonKIResonanzAnalyzer();
+  const result = analyzer.analyze(['Resonanz steigt', 'kein match', 'resonanz ton']);
+  expect(result.resonanceCount).toBe(2);
+});

--- a/packages/agents/AeonKIResonanzAnalyzer.ts
+++ b/packages/agents/AeonKIResonanzAnalyzer.ts
@@ -1,0 +1,6 @@
+export class AeonKIResonanzAnalyzer {
+  analyze(logs: string[]): { resonanceCount: number } {
+    const resonanceCount = logs.filter(msg => /resonanz/i.test(msg)).length;
+    return { resonanceCount };
+  }
+}

--- a/packages/agents/KIBewusstseinResonanzMonitor.test.ts
+++ b/packages/agents/KIBewusstseinResonanzMonitor.test.ts
@@ -1,0 +1,9 @@
+import { KIBewusstseinResonanzMonitor } from './KIBewusstseinResonanzMonitor';
+
+test('records and computes averages', () => {
+  const mon = new KIBewusstseinResonanzMonitor();
+  mon.record(5, 7);
+  mon.record(6, 6);
+  expect(mon.latest()).toEqual({ bewusstsein: 6, resonanz: 6 });
+  expect(mon.averageDifference()).toBeCloseTo((2 + 0) / 2);
+});

--- a/packages/agents/KIBewusstseinResonanzMonitor.ts
+++ b/packages/agents/KIBewusstseinResonanzMonitor.ts
@@ -1,0 +1,19 @@
+export interface Metrics { bewusstsein: number; resonanz: number }
+
+export class KIBewusstseinResonanzMonitor {
+  history: Metrics[] = [];
+
+  record(bewusstsein: number, resonanz: number): void {
+    this.history.push({ bewusstsein, resonanz });
+  }
+
+  latest(): Metrics | null {
+    return this.history[this.history.length - 1] || null;
+  }
+
+  averageDifference(): number {
+    if (this.history.length === 0) return 0;
+    const sum = this.history.reduce((a, b) => a + (b.resonanz - b.bewusstsein), 0);
+    return sum / this.history.length;
+  }
+}

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -10,3 +10,5 @@ export * from './CodexResonanzFraktal';
 export * from './PoeticReactorAgent';
 export * from './ResonanzMetrics';
 export * from './BewusstseinsResonanzComparator';
+export * from './AeonKIResonanzAnalyzer';
+export * from './KIBewusstseinResonanzMonitor';

--- a/packages/unifiedmandala-ui/README.md
+++ b/packages/unifiedmandala-ui/README.md
@@ -6,6 +6,7 @@ React-Komponenten für das Mandala-Frontend.
 - **MandalaNetworkView** – D3-Netzwerk aller Sigillin-Knoten
 - **CREPChart** – Visualisierung der CREP-Historie
 - **CREPTriggerPanel** – Anzeige und Steuerung von CREP-Events
+- **CREPInfoModal** – Erklärungsdialog für CREP-Werte
 - **SigillinLoader** – Laden und Filtern von Sigillin-Dateien
 - **SigillinViewer** – Darstellung einzelner Sigillin-Daten
 - **SigillinMap** – Übersicht aller bekannten Sigillin

--- a/packages/unifiedmandala-ui/components/CREPInfoModal.test.tsx
+++ b/packages/unifiedmandala-ui/components/CREPInfoModal.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CREPInfoModal from './CREPInfoModal';
+
+test('renders modal content and closes', () => {
+  const onClose = jest.fn();
+  render(<CREPInfoModal open={true} onClose={onClose} />);
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Schließen'));
+  expect(onClose).toHaveBeenCalled();
+});

--- a/packages/unifiedmandala-ui/components/CREPInfoModal.tsx
+++ b/packages/unifiedmandala-ui/components/CREPInfoModal.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface CREPInfoModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const descriptions = {
+  C: 'Coherence – Klarheit der Verbindungen.',
+  R: 'Resonance – Mitschwingen und Kommunikation.',
+  E: 'Emergence – Neues entsteht spontan.',
+  P: 'Poetics – Tiefere symbolische Bedeutung.'
+};
+
+const CREPInfoModal: React.FC<CREPInfoModalProps> = ({ open, onClose }) => {
+  if (!open) return null;
+  return (
+    <div role="dialog" aria-modal="true" className="crep-info-modal">
+      <h2>CREP-Werte</h2>
+      <ul>
+        {Object.entries(descriptions).map(([key, text]) => (
+          <li key={key}><strong>{key}</strong>: {text}</li>
+        ))}
+      </ul>
+      <button onClick={onClose}>Schließen</button>
+    </div>
+  );
+};
+
+export default CREPInfoModal;


### PR DESCRIPTION
## Summary
- add `interfaces.yaml` config listing API endpoints
- document new API config in README and Handbuch
- extend UI docs with **CREPInfoModal** component
- implement CREPInfoModal React component with tests
- add AeonKIResonanzAnalyzer and KIBewusstseinResonanzMonitor utilities
- export new agents and mark related advanced ToDo items as done
- update progress log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855f28485d08322b0344581ef292054