### PR TITLE
Implement transcript import for NucleonScanner

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1011,6 +1011,34 @@
     "path": "packages/crep-engine",
     "task": "Parse Nukleon-Scanner v0.6 Analyse Transkripte",
     "test": "packages/crep-engine/NucleonScannerConversation.test.ts",
+    "status": "done"
+  },
+  {
+    "commit": "Implement ConversationTodoExtractor",
+    "path": "packages/agents",
+    "task": "Extract tasks from conversation logs based on key phrases",
+    "test": "packages/agents/ConversationTodoExtractor.test.ts",
+    "status": "geplant"
+  },
+  {
+    "commit": "Link CREP scores with todo priority",
+    "path": "packages/crep-engine",
+    "task": "Prioritize extracted ToDos via CREP evaluation",
+    "test": "packages/crep-engine/TodoPriority.test.ts",
+    "status": "geplant"
+  },
+  {
+    "commit": "Calendar integration for high priority todos",
+    "path": "packages/crep-engine",
+    "task": "Export high priority ToDos to calendar via CREPCalendarSync",
+    "test": "packages/crep-engine/CalendarSync.test.ts",
+    "status": "geplant"
+  },
+  {
+    "commit": "Admin metrics dashboard",
+    "path": "apps/sharedream-interface",
+    "task": "Display average CREP, Sigillin adoption, open high priority todos",
+    "test": "apps/sharedream-interface/AdminMetrics.test.ts",
     "status": "geplant"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -61,6 +61,26 @@
   task: call your REST/gRPC client
   test: ""
   status: done
+- commit: Implement ConversationTodoExtractor
+  path: packages/agents
+  task: Extract tasks from conversation logs based on key phrases
+  test: packages/agents/ConversationTodoExtractor.test.ts
+  status: geplant
+- commit: Link CREP scores with todo priority
+  path: packages/crep-engine
+  task: Prioritize extracted ToDos via CREP evaluation
+  test: packages/crep-engine/TodoPriority.test.ts
+  status: geplant
+- commit: Calendar integration for high priority todos
+  path: packages/crep-engine
+  task: Export high priority ToDos to calendar via CREPCalendarSync
+  test: packages/crep-engine/CalendarSync.test.ts
+  status: geplant
+- commit: Admin metrics dashboard
+  path: apps/sharedream-interface
+  task: Display average CREP, Sigillin adoption, open high priority todos
+  test: apps/sharedream-interface/AdminMetrics.test.ts
+  status: geplant
 - commit: implement
   path: ""
   task: implement
@@ -2561,4 +2581,4 @@ status: done
   path: packages/crep-engine
   task: Parse Nukleon-Scanner v0.6 Analyse Transkripte
   test: packages/crep-engine/NucleonScannerConversation.test.ts
-  status: geplant
+  status: done

--- a/packages/crep-engine/NucleonScanner.ts
+++ b/packages/crep-engine/NucleonScanner.ts
@@ -6,6 +6,17 @@ export interface PhiProfile {
 export class NucleonScanner {
   history: PhiProfile[] = [];
 
+  importFromTranscript(transcript: string) {
+    const regex = /phi[:=]\s*(\d+(?:\.\d+)?)/gi;
+    let match;
+    while ((match = regex.exec(transcript)) !== null) {
+      const value = parseFloat(match[1]);
+      if (!isNaN(value)) {
+        this.logPhi(value);
+      }
+    }
+  }
+
   logPhi(phi: number) {
     this.history.push({ phi, timestamp: Date.now() });
   }

--- a/packages/crep-engine/NucleonScannerConversation.test.ts
+++ b/packages/crep-engine/NucleonScannerConversation.test.ts
@@ -1,0 +1,13 @@
+import { NucleonScanner } from './NucleonScanner';
+
+describe('NucleonScanner conversation import', () => {
+  it('parses phi values from transcript', () => {
+    const ns = new NucleonScanner();
+    const transcript = `line one phi: 0.4\nnext phi=0.9`;
+    ns.importFromTranscript(transcript);
+    expect(ns.history.length).toBe(2);
+    expect(ns.history[0].phi).toBeCloseTo(0.4);
+    expect(ns.history[1].phi).toBeCloseTo(0.9);
+    expect(ns.averagePhi()).toBeCloseTo(0.65);
+  });
+});


### PR DESCRIPTION
## Summary
- extend `NucleonScanner` with a transcript parser
- add test for transcript import
- mark NucleonScanner task as done and list new tasks from conversations

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f5a0dbd8832281ae99b413396338