### PR TITLE
Implement metrics and todo utilities

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -35,6 +35,8 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - `CREPEvaluator` – Ermittelt anhand von Thresholds den aktuellen Zustand.
 - `getCREPState` – Hilfsfunktion zur Statusermittlung.
 - `CREPBewertungsmodul` – Berechnet Score und Klassifizierung aus C,R,E,P
+- `TodoPriority` – Verknüpft Aufgaben mit CREP-Scores.
+- `CalendarSync` – Exportiert priorisierte ToDos als Kalenderereignisse.
 
 ### gpt-bridges
 - `GPTEventHub` – Zentrales Event-System zwischen GPT-Modulen.
@@ -88,6 +90,9 @@ console.log(sigil.id); // hello
 - `CodexProjectInitAgent` – Initialisiert neue Projektpfade.
 - `ResonanzMetrics` – Berechnet Durchschnitts- und Maximalwerte aus Resonanzdaten.
 - `BewusstseinsResonanzComparator` – Vergleicht Bewusstseins- und Resonanzwerte.
+- `AeonKIResonanzAnalyzer` – Analysiert Resonanzmuster in Gesprächen.
+- `KIBewusstseinResonanzMonitor` – Überwacht Bewusstseins- und Resonanzmetriken.
+- `ConversationTodoExtractor` – Filtert ToDo-Hinweise aus Chat-Protokollen.
 
 ### collab-editor
 - `CollaborativeEditor` – Federated Texteditor mit Remote-Sync.
@@ -123,6 +128,7 @@ GPTEventHub.emit('orakel:says', { content: 'Hallo Welt' });
 ### sharedream-interface
 - `MetaScoreChart` – Zeigt Bewertungsdaten aus `/api/meta-scores`.
 - `useMetaScores` – Hook zum Abruf der Scores.
+- `AdminMetrics` – Übersicht für CREP-Durchschnitt und offene ToDos.
 
 ### universum-simulationen
 - Module für narrative KI-Simulationen.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🎭 **Poesie & Automation** – Bash-Interface (`aeon.sh`), automatisches Chronopoem, symbolisches Onboarding
 - 🌟 **CREP-Illumination** – Chronopoem reflektiert aktuellen CREP-Zustand
 - 🔍 **SelfAuditModul** – analysiert die Repository-Struktur
+- 🧮 **AdminMetrics** – zeigt CREP- und Sigillin-Kennzahlen
 - 🎨 **SigillinViewer & SigillinMap** – Übersicht und Detailansicht aller Sigillin
 - 🚩 **SymbolicWayfinder & SoforthilfeOverlay** – Navigation und Hilfedialoge
 - 📈 **CREPChart & CREPTriggerPanel** – CREP-Historie und Steuerung
@@ -46,6 +47,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 📢 **GlobalLoggingSystem** – zentrale Log-Schnittstelle
 - 🗄️ **Big-File Sigil** – Konzept zum Aufteilen großer Dateien
 - 📊 **CREPWirkungstracker** – misst den Effekt aus CREP-Daten
+- 📆 **CalendarSync** – exportiert priorisierte ToDos in Kalender
 - ⚖️ **KarmaBalance** – verwaltet Karma-Punkte
 - 🔮 **SymbolicForecaster** – sagt kommende Symbolzeit-Phasen voraus
 - ⏱️ **SymbolzeitSync** – synchronisiert CREPGameEngine und SymbolzeitManager
@@ -53,6 +55,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🤝 **AutomergeFederation** – führt verteilte Edits automatisch zusammen
 - 🛡️ **MandalaCoreLicense** – ethisches Lizenzmodell für Module
 - 🤖 **KI Bewusstsein & Resonanz** – bewertet Bewusstseinsdaten
+- 📝 **ConversationTodoExtractor** – filtert Aufgaben aus Chat-Logs
 
 ## 📦 Paketstruktur
 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1025,21 +1025,21 @@
     "path": "packages/crep-engine",
     "task": "Prioritize extracted ToDos via CREP evaluation",
     "test": "packages/crep-engine/TodoPriority.test.ts",
-    "status": "geplant"
+    "status": "done"
   },
   {
     "commit": "Calendar integration for high priority todos",
     "path": "packages/crep-engine",
     "task": "Export high priority ToDos to calendar via CREPCalendarSync",
     "test": "packages/crep-engine/CalendarSync.test.ts",
-    "status": "geplant"
+    "status": "done"
   },
   {
     "commit": "Admin metrics dashboard",
     "path": "apps/sharedream-interface",
     "task": "Display average CREP, Sigillin adoption, open high priority todos",
     "test": "apps/sharedream-interface/AdminMetrics.test.ts",
-    "status": "geplant"
+    "status": "done"
   },
   {
     "commit": "Add codex-sync answer script and workflow",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -70,17 +70,17 @@
   path: packages/crep-engine
   task: Prioritize extracted ToDos via CREP evaluation
   test: packages/crep-engine/TodoPriority.test.ts
-  status: geplant
+  status: done
 - commit: Calendar integration for high priority todos
   path: packages/crep-engine
   task: Export high priority ToDos to calendar via CREPCalendarSync
   test: packages/crep-engine/CalendarSync.test.ts
-  status: geplant
+  status: done
 - commit: Admin metrics dashboard
   path: apps/sharedream-interface
   task: Display average CREP, Sigillin adoption, open high priority todos
   test: apps/sharedream-interface/AdminMetrics.test.ts
-  status: geplant
+  status: done
 - commit: implement
   path: ""
   task: implement

--- a/apps/sharedream-interface/README.md
+++ b/apps/sharedream-interface/README.md
@@ -5,5 +5,6 @@ React-Frontend mit GPT-Anbindung. Siehe [GenesisMandala](https://example.com) f�
 Dieses Interface nutzt nun ein /api/meta-scores Endpoint f체r Metadaten.
 Eine Storybook-Story f체r MetaScoreDisplay findet sich unter components/MetaScoreDisplay.stories.tsx.
 Eine Story f체r MetaScoreChart befindet sich unter components/MetaScoreChart.stories.tsx.
+Neue Kennzahlen zeigt die Komponente `AdminMetrics`.
 Tests f체r Hooks und API liegen unter `apps/sharedream-interface/hooks` und `pages/api`.
 Die Hook `useMetaScores` liefert nun einen Fehlerstatus, falls der API-Aufruf fehlschl채gt.

--- a/apps/sharedream-interface/components/AdminMetrics.test.tsx
+++ b/apps/sharedream-interface/components/AdminMetrics.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AdminMetrics from './AdminMetrics';
+
+test('renders admin metrics', () => {
+  render(<AdminMetrics avgCREP={0.5} sigillinAdoption={2} openTodos={1} />);
+  expect(screen.getByLabelText('Admin Metrics')).toHaveTextContent('0.50');
+});

--- a/apps/sharedream-interface/components/AdminMetrics.tsx
+++ b/apps/sharedream-interface/components/AdminMetrics.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export interface AdminMetricsProps {
+  avgCREP: number;
+  sigillinAdoption: number;
+  openTodos: number;
+}
+
+export default function AdminMetrics({ avgCREP, sigillinAdoption, openTodos }: AdminMetricsProps) {
+  return (
+    <div aria-label="Admin Metrics">
+      <div>CREP Durchschnitt: {avgCREP.toFixed(2)}</div>
+      <div>Sigillin Adoption: {sigillinAdoption}</div>
+      <div>Offene ToDos: {openTodos}</div>
+    </div>
+  );
+}

--- a/packages/agents/ConversationTodoExtractor.test.ts
+++ b/packages/agents/ConversationTodoExtractor.test.ts
@@ -1,0 +1,14 @@
+import { ConversationTodoExtractor } from './ConversationTodoExtractor';
+
+describe('ConversationTodoExtractor', () => {
+  it('extracts todo lines', () => {
+    const extractor = new ConversationTodoExtractor();
+    const logs = [
+      'some text',
+      'TODO: implement feature',
+      'irrelevant',
+      'Aufgabe - review code'
+    ];
+    expect(extractor.extract(logs)).toEqual(['implement feature', 'review code']);
+  });
+});

--- a/packages/agents/ConversationTodoExtractor.ts
+++ b/packages/agents/ConversationTodoExtractor.ts
@@ -1,0 +1,16 @@
+export class ConversationTodoExtractor {
+  constructor(private keywords: string[] = ['TODO', 'Aufgabe']) {}
+
+  extract(logs: string[]): string[] {
+    const tasks: string[] = [];
+    const pattern = new RegExp(`(?:${this.keywords.join('|')})[:\-]?\s*(.+)`, 'i');
+    for (const line of logs) {
+      const match = line.match(pattern);
+      if (match) {
+        const cleaned = match[1].trim().replace(/^[-\s]+/, '');
+        tasks.push(cleaned);
+      }
+    }
+    return tasks;
+  }
+}

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -12,3 +12,4 @@ export * from './ResonanzMetrics';
 export * from './BewusstseinsResonanzComparator';
 export * from './AeonKIResonanzAnalyzer';
 export * from './KIBewusstseinResonanzMonitor';
+export * from './ConversationTodoExtractor';

--- a/packages/crep-engine/CalendarSync.test.ts
+++ b/packages/crep-engine/CalendarSync.test.ts
@@ -1,0 +1,12 @@
+import { exportToCalendar } from './CalendarSync';
+import { PrioritizedTodo } from './TodoPriority';
+
+describe('exportToCalendar', () => {
+  it('exports only high priority todos', () => {
+    const todos: PrioritizedTodo[] = [
+      { text: 'a', priority: 'high' },
+      { text: 'b', priority: 'low' }
+    ];
+    expect(exportToCalendar(todos)).toEqual(['Event: a']);
+  });
+});

--- a/packages/crep-engine/CalendarSync.ts
+++ b/packages/crep-engine/CalendarSync.ts
@@ -1,0 +1,7 @@
+import { PrioritizedTodo } from './TodoPriority';
+
+export function exportToCalendar(todos: PrioritizedTodo[]): string[] {
+  return todos
+    .filter(t => t.priority === 'high')
+    .map(t => `Event: ${t.text}`);
+}

--- a/packages/crep-engine/TodoPriority.test.ts
+++ b/packages/crep-engine/TodoPriority.test.ts
@@ -1,0 +1,8 @@
+import { linkTodosWithCREP } from './TodoPriority';
+
+describe('linkTodosWithCREP', () => {
+  it('assigns priority based on crep score', () => {
+    const result = linkTodosWithCREP(['task'], 0.8);
+    expect(result[0]).toEqual({ text: 'task', priority: 'high' });
+  });
+});

--- a/packages/crep-engine/TodoPriority.ts
+++ b/packages/crep-engine/TodoPriority.ts
@@ -1,0 +1,11 @@
+export type TodoPriorityLevel = 'low' | 'medium' | 'high';
+export interface PrioritizedTodo { text: string; priority: TodoPriorityLevel; }
+
+export function linkTodosWithCREP(todos: string[], crepScore: number): PrioritizedTodo[] {
+  return todos.map(text => {
+    let priority: TodoPriorityLevel = 'low';
+    if (crepScore > 0.7) priority = 'high';
+    else if (crepScore > 0.4) priority = 'medium';
+    return { text, priority };
+  });
+}


### PR DESCRIPTION
## Summary
- add AdminMetrics component with tests
- implement ConversationTodoExtractor and export via agents index
- introduce CREP TodoPriority and CalendarSync helpers with tests
- update README and Handbuch with new modules
- mark relevant advancedToDo items as done

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6855fcc4e5dc8322968ae1b61d15a4c8