### PR TITLE
Update advanced task lists and docs

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -374,4 +374,7 @@ Weitere Beispiele und GIF-Demos findest du im [Wiki](https://github.com/GenesisA
 Ein SVG-Beispiel liegt unter [`docs/assets/unified-mandala.svg`](docs/assets/unified-mandala.svg).
 
 Das `CHRONOPOEM.md` entsteht automatisch – und kann bei jedem Commit erneuert werden.
+- **Module**: liegen unter `packages/` nach Funktion sortiert
+- **Utils**: gebündelt in `packages/shared-utils/`
+- **Scripts**: hilfreiche Automationen unter `scripts/`
 \nDie detaillierte Struktur aller Module, Utilities und Skripte findest du in [repositorypflege/repository_map.yaml](repositorypflege/repository_map.yaml).

--- a/README.md
+++ b/README.md
@@ -238,4 +238,8 @@ gespeichert. Nutzen Sie die Helferskripte aus `packages/shared-utils`
 
 Nutze `node scripts/parse-advanced-conversations.js` um Gesprächs-TODOs aus dem Datensatz zu filtern.
 
+- **Module**: unter `packages/` gegliedert in Agents, Core und mehr
+- **Utils**: zentrale Helfer liegen in `packages/shared-utils/`
+- **Scripts**: Automatisierungs- und CI-Skripte finden sich im `scripts/` Verzeichnis
+
 \nDie komplette Ordnerstruktur samt Modulen, Utils und Skripten ist in [repositorypflege/repository_map.yaml](repositorypflege/repository_map.yaml) dokumentiert.

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1048,4 +1048,35 @@
     "test": ".github/workflows/codex-sync.yml",
     "status": "done"
   }
+  ,{
+    "commit": "Implement MetaScoreComposer aggregation",
+    "path": "packages/agents",
+    "task": "Aggregate multi-layer scores with conflict detection",
+    "test": "packages/agents/__tests__/MetaScoreComposer.spec.ts",
+    "status": "geplant"
+  },{
+    "commit": "Create MetaScoreChart component",
+    "path": "packages/unifiedmandala-ui/components",
+    "task": "Visualize MetaScore data with animations and tooltips",
+    "test": "packages/unifiedmandala-ui/__tests__/MetaScoreChart.test.tsx",
+    "status": "geplant"
+  },{
+    "commit": "Add federation routes and SyncStatus UI",
+    "path": "packages/core/routes",
+    "task": "Provide push/pull API and sync status indicator",
+    "test": "packages/unifiedmandala-ui/__tests__/SyncStatus.test.tsx",
+    "status": "geplant"
+  },{
+    "commit": "Setup mTLS scripts and Kong JWT gateway",
+    "path": "scripts",
+    "task": "Provide certificate generation and JWT API gateway config",
+    "test": "scripts/security-ci.test.ts",
+    "status": "geplant"
+  },{
+    "commit": "Integrate OpenTelemetry metrics and Storybook CI",
+    "path": "packages/core",
+    "task": "Add tracing setup and deploy Storybook via GitHub Actions",
+    "test": "ci/storybook-ci.test.ts",
+    "status": "geplant"
+  }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2587,3 +2587,28 @@ status: done
   task: Codex-Antwortsystem für Vorschläge implementieren
   test: .github/workflows/codex-sync.yml
   status: done
+- commit: Implement MetaScoreComposer aggregation
+  path: packages/agents
+  task: Aggregate multi-layer scores with conflict detection
+  test: packages/agents/__tests__/MetaScoreComposer.spec.ts
+  status: geplant
+- commit: Create MetaScoreChart component
+  path: packages/unifiedmandala-ui/components
+  task: Visualize MetaScore data with animations and tooltips
+  test: packages/unifiedmandala-ui/__tests__/MetaScoreChart.test.tsx
+  status: geplant
+- commit: Add federation routes and SyncStatus UI
+  path: packages/core/routes
+  task: Provide push/pull API and sync status indicator
+  test: packages/unifiedmandala-ui/__tests__/SyncStatus.test.tsx
+  status: geplant
+- commit: Setup mTLS scripts and Kong JWT gateway
+  path: scripts
+  task: Provide certificate generation and JWT API gateway config
+  test: scripts/security-ci.test.ts
+  status: geplant
+- commit: Integrate OpenTelemetry metrics and Storybook CI
+  path: packages/core
+  task: Add tracing setup and deploy Storybook via GitHub Actions
+  test: ci/storybook-ci.test.ts
+  status: geplant


### PR DESCRIPTION
## Summary
- append new planning tasks extracted from conversations
- document module, utils and scripts directories in docs

## Testing
- `pnpm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685670a2375c8322a3f05486839a85c6