### PR TITLE
Add GoAgent and docs

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -94,6 +94,7 @@ console.log(sigil.id); // hello
 - `KIBewusstseinResonanzMonitor` – Überwacht Bewusstseins- und Resonanzmetriken.
 - `ConversationTodoExtractor` – Filtert ToDo-Hinweise aus Chat-Protokollen.
 - `MetaScoreComposer` – Aggregiert mehrere Score-Layer.
+- `GoAgent` – Liest advancedToDo-Dateien und listet offene Tasks.
 
 ### collab-editor
 - `CollaborativeEditor` – Federated Texteditor mit Remote-Sync.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🤖 **KI Bewusstsein & Resonanz** – bewertet Bewusstseinsdaten
 - 📝 **ConversationTodoExtractor** – filtert Aufgaben aus Chat-Logs
 - 🎛️ **MetaScoreComposer** – aggregiert Score-Layer
+- 🕹️ **GoAgent** – liest advancedToDo-Dateien und listet offene Tasks
 - 📊 **MetaScoreChart** & **SyncStatus** – UI für MetaScores und Sync-Stände
 
 ## 📦 Paketstruktur

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1303,3 +1303,6 @@ Sobald die Core-Stabilität steht, schieben wir die funkelnden Extras ins Mandal
 
     LangChain-Adapter & Sigil-Generator-Service
 
+
+{"commit": "Implement GoAgent", "path": "packages/agents", "task": "Liest advancedToDo-Dateien und listet offene Tasks", "test": "packages/agents/GoAgent.test.ts", "status": "done"}
+]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2612,4 +2612,8 @@ status: done
   task: Add tracing setup and deploy Storybook via GitHub Actions
   test: ci/storybook-ci.test.ts
   status: done
-Highprior: Pläne für Implementierung GO-Agent aus advancedToDo.json Repokonform ausarbeiten und implementiern
+- commit: Implement GoAgent
+  path: packages/agents
+  task: Liest advancedToDo-Dateien und listet offene Tasks
+  test: packages/agents/GoAgent.test.ts
+  status: done

--- a/packages/agents/GoAgent.test.ts
+++ b/packages/agents/GoAgent.test.ts
@@ -1,0 +1,9 @@
+import { GoAgent } from './GoAgent';
+
+describe('GoAgent', () => {
+  it('loads tasks and filters pending ones', () => {
+    const agent = new GoAgent('.');
+    expect(Array.isArray(agent.jsonTasks)).toBe(true);
+    expect(agent.pending()).toEqual(agent.jsonTasks.filter(t => t.status !== 'done'));
+  });
+});

--- a/packages/agents/GoAgent.ts
+++ b/packages/agents/GoAgent.ts
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+export interface GoTask {
+  commit: string;
+  path: string;
+  task: string;
+  test?: string;
+  status?: string;
+}
+
+export class GoAgent {
+  jsonTasks: GoTask[] = [];
+  yamlTasks: GoTask[] = [];
+
+  constructor(private repoDir: string) {
+    this.jsonTasks = this.readJSON('advancedToDo.json');
+    this.yamlTasks = this.readYAML('advancedToDo.yaml');
+  }
+
+  private readJSON(file: string): GoTask[] {
+    try {
+      const data = fs.readFileSync(`${this.repoDir}/${file}`, 'utf-8');
+      return JSON.parse(data);
+    } catch {
+      return [];
+    }
+  }
+
+  private readYAML(file: string): GoTask[] {
+    try {
+      const data = fs.readFileSync(`${this.repoDir}/${file}`, 'utf-8');
+      const doc = yaml.load(data);
+      return Array.isArray(doc) ? (doc as GoTask[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  pending(): GoTask[] {
+    return this.jsonTasks.filter(t => t.status !== 'done');
+  }
+}

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -3,5 +3,6 @@
 Dieses Verzeichnis bündelt verschiedene Agenten des Unified Mandala Projekts. 
 Der `CodexNavigatorAgent` dient als Ausgangspunkt und verarbeitet Aufgaben aus
 `codexwork.yaml`.
+Der `GoAgent` liest advancedToDo-Dateien und gibt offene Aufgaben aus.
 
 Der `GenesisAeonNavigator` steuert symbolische Phasen anhand einer JSON-PhaseMap.

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -14,3 +14,4 @@ export * from './AeonKIResonanzAnalyzer';
 export * from './KIBewusstseinResonanzMonitor';
 export * from './ConversationTodoExtractor';
 export * from './MetaScoreComposer';
+export * from './GoAgent';


### PR DESCRIPTION
## Summary
- implement a simple GoAgent to parse advancedToDo files
- document the new agent in README and Handbuch
- register GoAgent in agents package
- append GoAgent tasks in advancedToDo lists

## Testing
- `npx jest` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569f2785f0832291cda44bb467d5ef