### PR TITLE
Update roadmap refs and add sigillin map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,5 @@ docs/sigils/conversations/
 docs/sigils/code-archive/
 package-lock.json
 docs/sigils/todo-from-convos.yaml
+codex/website.yaml
+mandala-chronik.yaml

--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-21, in der Zeit des Morgen.
+Am 2025-06-21, in der Zeit des Tag.
 
-Symbolphase: Initiation (Fokus: C)
+Symbolphase: Aktivierung (Fokus: R)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -383,3 +383,4 @@ Das `CHRONOPOEM.md` entsteht automatisch – und kann bei jedem Commit erneuert 
 - **Utils**: gebündelt in `packages/shared-utils/`
 - **Scripts**: hilfreiche Automationen unter `scripts/`
 \nDie detaillierte Struktur aller Module, Utilities und Skripte findest du in [repositorypflege/repository_map.yaml](repositorypflege/repository_map.yaml).
+Einen Ausblick auf kommende Schritte liefert [codex/codex-roadmap.yaml](codex/codex-roadmap.yaml).

--- a/README.md
+++ b/README.md
@@ -248,3 +248,4 @@ Nutze `node scripts/parse-advanced-conversations.js` um Gesprächs-TODOs aus dem
 - **Scripts**: Automatisierungs- und CI-Skripte finden sich im `scripts/` Verzeichnis
 
 \nDie komplette Ordnerstruktur samt Modulen, Utils und Skripten ist in [repositorypflege/repository_map.yaml](repositorypflege/repository_map.yaml) dokumentiert.
+Weitere geplante Entwicklungsschritte findest du in [codex/codex-roadmap.yaml](codex/codex-roadmap.yaml).

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1305,4 +1305,6 @@ Sobald die Core-Stabilität steht, schieben wir die funkelnden Extras ins Mandal
 
 
 {"commit": "Implement GoAgent", "path": "packages/agents", "task": "Liest advancedToDo-Dateien und listet offene Tasks", "test": "packages/agents/GoAgent.test.ts", "status": "done"}
+,{"commit": "Create codex-roadmap.yaml", "path": "codex/codex-roadmap.yaml", "task": "Zentrale Datei fuer Codex-Workflows anlegen", "test": "", "status": "done"}
+,{"commit": "Add sigillinMap.json", "path": "config/sigillinMap.json", "task": "Mapping-Datei fuer Sigillin-Felder vorbereiten", "test": "", "status": "done"}
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2617,3 +2617,13 @@ status: done
   task: Liest advancedToDo-Dateien und listet offene Tasks
   test: packages/agents/GoAgent.test.ts
   status: done
+- commit: Create codex-roadmap.yaml
+  path: codex/codex-roadmap.yaml
+  task: Zentrale Datei fuer Codex-Workflows anlegen
+  test: ""
+  status: done
+- commit: Add sigillinMap.json
+  path: config/sigillinMap.json
+  task: Mapping-Datei fuer Sigillin-Felder vorbereiten
+  test: ""
+  status: done

--- a/config/sigillinMap.json
+++ b/config/sigillinMap.json
@@ -1,0 +1,6 @@
+{
+  "symbol_a": "🜂",
+  "symbol_b": "🜁",
+  "symbol_c": "🜃",
+  "symbol_d": "🜄"
+}

--- a/packages/core/routes/federation.ts
+++ b/packages/core/routes/federation.ts
@@ -1,17 +1,15 @@
 import mitt from 'mitt';
 
 const bus = mitt();
+let last: any;
 
 export function push(data: any) {
+  last = data;
   bus.emit('push', data);
 }
 
 export function pull() {
-  let result: any;
-  bus.on('push', (d) => {
-    result = d;
-  });
-  return result;
+  return last;
 }
 
 export default { push, pull };

--- a/packages/unifiedmandala-ui/hooks/useMetaScores.test.ts
+++ b/packages/unifiedmandala-ui/hooks/useMetaScores.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { useMetaScores } from './useMetaScores';
 
@@ -9,7 +9,7 @@ beforeEach(() => {
 });
 
 test('fetches meta scores', async () => {
-  const { result, waitForNextUpdate } = renderHook(() => useMetaScores('/test'));
-  await waitForNextUpdate();
+  const { result } = renderHook(() => useMetaScores('/test'));
+  await waitFor(() => expect(result.current.length).toBeGreaterThan(0));
   expect(result.current[0].layer).toBe('x');
 });


### PR DESCRIPTION
## Summary
- reference `codex-roadmap.yaml` in docs
- create `config/sigillinMap.json`
- fix federation route state handling
- update unit tests accordingly
- record tasks in advanced TODO files

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6856a4e372b883228e1849c4e0f33954