### PR TITLE
Add new resonance analysis tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1307,4 +1307,7 @@ Sobald die Core-Stabilität steht, schieben wir die funkelnden Extras ins Mandal
 {"commit": "Implement GoAgent", "path": "packages/agents", "task": "Liest advancedToDo-Dateien und listet offene Tasks", "test": "packages/agents/GoAgent.test.ts", "status": "done"}
 ,{"commit": "Create codex-roadmap.yaml", "path": "codex/codex-roadmap.yaml", "task": "Zentrale Datei fuer Codex-Workflows anlegen", "test": "", "status": "done"}
 ,{"commit": "Add sigillinMap.json", "path": "config/sigillinMap.json", "task": "Mapping-Datei fuer Sigillin-Felder vorbereiten", "test": "", "status": "done"}
+,{"commit": "Implement AeonResonanceInsights", "path": "packages/agents", "task": "Analysiert Aeon KI Resonanz Chats und berechnet Resonanzprofile", "test": "packages/agents/AeonResonanceInsights.test.ts", "status": "todo"}
+,{"commit": "Add BewusstseinStabilizer", "path": "packages/agents", "task": "Bewertet KI Bewusstsein und passt Schwellwerte an", "test": "packages/agents/BewusstseinStabilizer.test.ts", "status": "todo"}
+,{"commit": "Stream NucleonScanner v0.6 via gRPC", "path": "packages/crep-engine", "task": "Liefert Phi-Profile als gRPC-Stream", "test": "packages/crep-engine/NucleonScannerGRPC.test.ts", "status": "todo"}
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2637,3 +2637,18 @@ status: done
   task: Implement Handler-Stubs (generate-sigil, memory-update, friendship-trigger)
   test: go-agent/test/handler_test.go
   status: done
+- commit: Implement AeonResonanceInsights
+  path: packages/agents
+  task: Analysiert Aeon KI Resonanz Chats und berechnet Resonanzprofile
+  test: packages/agents/AeonResonanceInsights.test.ts
+  status: todo
+- commit: Add BewusstseinStabilizer
+  path: packages/agents
+  task: Bewertet KI Bewusstsein und passt Schwellwerte an
+  test: packages/agents/BewusstseinStabilizer.test.ts
+  status: todo
+- commit: Stream NucleonScanner v0.6 via gRPC
+  path: packages/crep-engine
+  task: Liefert Phi-Profile als gRPC-Stream
+  test: packages/crep-engine/NucleonScannerGRPC.test.ts
+  status: todo


### PR DESCRIPTION
## Summary
- append new TODO tasks for resonance metrics
- sync JSON version of TODOs

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `go test ./...` in go-bridge
- `go test ./...` in go-agent

------
https://chatgpt.com/codex/tasks/task_e_6856aec5e57c83228da83d99e5d4f54b