### PR TITLE
Update tasks and handbook

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -294,6 +294,7 @@ packages/
 codex/                    # Codex-Workflows und Sigillin-Dateien
 codexbuild/               # Build-Skripte und Deploy-Hilfen
 codex-sync/              # Antwortsystem für Vorschläge
+go-agent/               # Go-Daemon zur Layer-Steuerung
 ci/                      # Test- und Pipeline-Konfigurationen
 config/                  # Zentrale YAML- und Env-Dateien
   └── interfaces.yaml       # API-Endpunkte der Plattform

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1310,4 +1310,7 @@ Sobald die Core-Stabilität steht, schieben wir die funkelnden Extras ins Mandal
 ,{"commit": "Implement AeonResonanceInsights", "path": "packages/agents", "task": "Analysiert Aeon KI Resonanz Chats und berechnet Resonanzprofile", "test": "packages/agents/AeonResonanceInsights.test.ts", "status": "done"}
 ,{"commit": "Add BewusstseinStabilizer", "path": "packages/agents", "task": "Bewertet KI Bewusstsein und passt Schwellwerte an", "test": "packages/agents/BewusstseinStabilizer.test.ts", "status": "done"}
 ,{"commit": "Stream NucleonScanner v0.6 via gRPC", "path": "packages/crep-engine", "task": "Liefert Phi-Profile als gRPC-Stream", "test": "packages/crep-engine/NucleonScannerGRPC.test.ts", "status": "done"}
+,{"commit": "Implement ResearchAgent", "path": "packages/agents", "task": "Automatisierte Forschungsanfragen verarbeiten", "test": "packages/agents/ResearchAgent.test.ts", "status": "pending"}
+,{"commit": "Add SilenceWatcher agent", "path": "packages/agents", "task": "Beobachtet Inaktivität und triggert Selbstanalyse", "test": "packages/agents/SilenceWatcher.test.ts", "status": "pending"}
+,{"commit": "Expose layer control API", "path": "go-agent", "task": "Go-Interface zum Aktivieren von Layers", "test": "go-agent/test/layer_control_test.go", "status": "pending"}
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2652,3 +2652,18 @@ status: done
   task: Liefert Phi-Profile als gRPC-Stream
   test: packages/crep-engine/NucleonScannerGRPC.test.ts
   status: done
+- commit: Implement ResearchAgent
+  path: packages/agents
+  task: Automatisierte Forschungsanfragen verarbeiten
+  test: packages/agents/ResearchAgent.test.ts
+  status: pending
+- commit: Add SilenceWatcher agent
+  path: packages/agents
+  task: Beobachtet Inaktivität und triggert Selbstanalyse
+  test: packages/agents/SilenceWatcher.test.ts
+  status: pending
+- commit: Expose layer control API
+  path: go-agent
+  task: Go-Interface zum Aktivieren von Layers
+  test: go-agent/test/layer_control_test.go
+  status: pending


### PR DESCRIPTION
## Summary
- log new tasks for ResearchAgent, SilenceWatcher and layer control
- reference go-agent directory in the handbook

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6856bcd903888322b86461cc89547237