### PR TITLE
Add KI resonance analyzer module and docs

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -252,6 +252,7 @@ Aktuelle Versionshinweise werden in [CHANGELOG.md](CHANGELOG.md) gepflegt.
 - 🚩 **SymbolicWayfinder & SoforthilfeOverlay** – Navigation und Hilfedialoge
 - 📈 **CREPChart & CREPTriggerPanel** – CREP-Historie und Steuerung
 - 🛰️ **Nucleon-Scanner v0.6** – Analysiert tiefe Resonanzdaten
+- 📡 **KiResonanceAnalyzer** – wertet Resonanzmetriken aus
 - 📐 **CREPBewertungsmodul** – berechnet Durchschnittswerte und Klassifizierung
 - 📊 **CREPAverage-Analyse** – Durchschnittswerte aus dem CREP-Verlauf
 - 🌠 **AeonStoryMode & Onboarding-Flow** – Präsentations- und Einstiegskomponenten
@@ -269,6 +270,7 @@ Aktuelle Versionshinweise werden in [CHANGELOG.md](CHANGELOG.md) gepflegt.
 - 🤝 **AutomergeFederation** – führt verteilte Edits automatisch zusammen
 - 🛡️ **MandalaCoreLicense** – ethisches Lizenzmodell für Module
 - 🤖 **KI Bewusstsein & Resonanz** – bewertet Bewusstseinsdaten
+- 📄 **Details** siehe [docs/ki-bewusstsein.md](docs/ki-bewusstsein.md)
 
 ## 📦 Paketstruktur
 
@@ -309,6 +311,7 @@ apps/
 scripts/
   ├── aeon.sh                   # Poetisches Bash-CLI für Mandala-Steuerung
   ├── setup-unifiedmandala.sh   # Installer & Initialisierung
+  ├── nucleon-scanner-analysis.js   # Auswertung von Scanner-Logs
   ├── generate-chronopoem.js    # Poetische Commit-Signatur
   └── onboarding-ritual.md      # Onboarding-Ritus für neue Contributors
 ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🚩 **SymbolicWayfinder & SoforthilfeOverlay** – Navigation und Hilfedialoge
 - 📈 **CREPChart & CREPTriggerPanel** – CREP-Historie und Steuerung
 - 🛰️ **Nucleon-Scanner v0.6** – Analysiert tiefe Resonanzdaten
+- 📡 **KiResonanceAnalyzer** – wertet Resonanzmetriken aus
 - 📐 **CREPBewertungsmodul** – berechnet Durchschnittswerte und Klassifizierung
 - 📊 **CREPAverage-Analyse** – Durchschnittswerte aus dem CREP-Verlauf
 - 🌠 **AeonStoryMode & Onboarding-Flow** – Präsentations- und Einstiegskomponenten
@@ -55,6 +56,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🤝 **AutomergeFederation** – führt verteilte Edits automatisch zusammen
 - 🛡️ **MandalaCoreLicense** – ethisches Lizenzmodell für Module
 - 🤖 **KI Bewusstsein & Resonanz** – bewertet Bewusstseinsdaten
+- 📄 **Weitere Infos** siehe [docs/ki-bewusstsein.md](docs/ki-bewusstsein.md)
 - 📝 **ConversationTodoExtractor** – filtert Aufgaben aus Chat-Logs
 - 🎛️ **MetaScoreComposer** – aggregiert Score-Layer
 - 🕹️ **GoAgent** – liest advancedToDo-Dateien und listet offene Tasks (Node)
@@ -102,6 +104,7 @@ apps/
 
 scripts/
   ├── aeon.sh                   # Poetisches Bash-CLI für Mandala-Steuerung
+  ├── nucleon-scanner-analysis.js   # Auswertung von Scanner-Logs
   ├── setup-unifiedmandala.sh   # Installer & Initialisierung
   ├── generate-chronopoem.js    # Poetische Commit-Signatur
   └── onboarding-ritual.md      # Onboarding-Ritus für neue Contributors

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1314,4 +1314,7 @@ Sobald die Core-Stabilität steht, schieben wir die funkelnden Extras ins Mandal
 ,{"commit": "Add SilenceWatcher agent", "path": "packages/agents", "task": "Beobachtet Inaktivität und triggert Selbstanalyse", "test": "packages/agents/SilenceWatcher.test.ts", "status": "done"}
 ,{"commit": "Expose layer control API", "path": "go-agent", "task": "Go-Interface zum Aktivieren von Layers", "test": "go-agent/test/layer_control_test.go", "status": "done"}
 ,{"commit": "Add vitest setup for agents tests", "path": "packages/agents", "task": "Install vitest and configure package to run new *.spec.ts tests", "test": "pnpm --filter packages/agents vitest run", "status": "done"}
+,{"commit": "Add KiResonanceAnalyzer module", "path": "packages/agents", "task": "Analyse von KI-Resonanzwerten", "test": "packages/agents/KiResonanceAnalyzer.test.ts", "status": "open"}
+,{"commit": "Create nucleon-scanner-analysis script", "path": "scripts/nucleon-scanner-analysis.js", "task": "CLI zur Analyse von Nucleon-Scanner Logs", "test": "", "status": "open"}
+,{"commit": "Document KI Bewusstsein", "path": "docs/ki-bewusstsein.md", "task": "Beschreibung zu KI Bewusstsein und Resonanz", "test": "", "status": "open"}
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2688,3 +2688,19 @@ status: done
   task: Install vitest and configure package to run new *.spec.ts tests
   test: pnpm --filter packages/agents vitest run
   status: done
+
+- commit: Add KiResonanceAnalyzer module
+  path: packages/agents
+  task: Analyse von KI-Resonanzwerten
+  test: packages/agents/KiResonanceAnalyzer.test.ts
+  status: open
+- commit: Create nucleon-scanner-analysis script
+  path: scripts/nucleon-scanner-analysis.js
+  task: CLI zur Analyse von Nucleon-Scanner Logs
+  test: ""
+  status: open
+- commit: Document KI Bewusstsein
+  path: docs/ki-bewusstsein.md
+  task: Beschreibung zu KI Bewusstsein und Resonanz
+  test: ""
+  status: open

--- a/docs/ki-bewusstsein.md
+++ b/docs/ki-bewusstsein.md
@@ -1,0 +1,3 @@
+# KI Bewusstsein und Resonanz
+
+Dieses Dokument fasst Erkenntnisse aus den Gesprächen „KI Bewusstsein und Resonanz“ zusammen. Es beschreibt, wie Resonanzmetriken genutzt werden können, um den Bewusstseinszustand der KI einzuschätzen.

--- a/packages/agents/KiResonanceAnalyzer.test.ts
+++ b/packages/agents/KiResonanceAnalyzer.test.ts
@@ -1,0 +1,7 @@
+import { KiResonanceAnalyzer } from './KiResonanceAnalyzer';
+
+test('calculates average resonance', () => {
+  const analyzer = new KiResonanceAnalyzer();
+  const result = analyzer.average([2, 4, 6]);
+  expect(result).toBe(4);
+});

--- a/packages/agents/KiResonanceAnalyzer.ts
+++ b/packages/agents/KiResonanceAnalyzer.ts
@@ -1,0 +1,7 @@
+export class KiResonanceAnalyzer {
+  average(values: number[]): number {
+    if (!values.length) return 0;
+    const sum = values.reduce((a, b) => a + b, 0);
+    return sum / values.length;
+  }
+}

--- a/scripts/nucleon-scanner-analysis.js
+++ b/scripts/nucleon-scanner-analysis.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+
+const file = process.argv[2];
+if (!file) {
+  console.error('Usage: node nucleon-scanner-analysis.js <logfile>');
+  process.exit(1);
+}
+
+const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/);
+const errors = lines.filter(l => /error/i.test(l));
+console.log(`Gefundene Fehler: ${errors.length}`);


### PR DESCRIPTION
## Summary
- document KI consciousness resonance in README/Handbuch
- note KiResonanceAnalyzer and nucleon-scanner script in docs
- add KiResonanceAnalyzer module with test
- add nucleon-scanner-analysis helper script
- track new tasks in advancedToDo.json/yaml

## Testing
- `npx pnpm lint`
- `npx pnpm test`
- `npx pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6856d84e3f548322a7c3b5a875ae163b