### PR TITLE
Add UploadYamlForm component

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -101,6 +101,7 @@ console.log(sigil.id); // hello
 - `withCircuit` – CircuitBreaker-Helfer für Agenten.
 - `healthz.ts` & `metaScores.ts` – API-Routen.
 - `Dashboard` – Anzeige der MetaScore-Daten.
+- `UploadYamlForm` – wandelt hochgeladene Dateien in YAML um
 - `ResonanzpfadAgent` – komplexe Analyse & Archetypenlogik (`packages/agents/ResonanzpfadAgent.ts`).
 - `AutoDocGeneration` – wandelt README & JSDoc in HTML/PDF (`packages/crep-engine/autoDocGeneration.ts`).
 - `HexaAgentSystem` – Kombiniert sechs Agenten für Resonanz- und Bewusstseinsauswertung.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🛡️ **withCircuit** – CircuitBreaker Wrapper für Agenten-Calls
 - 🩺 **healthz.ts** & **metaScores.ts** – API-Routen
 - 🖥️ **Dashboard** – zeigt MetaScoreChart per Hook
+- 📄 **UploadYamlForm** – wandelt hochgeladene Dateien in YAML um
 - 🌀 **ResonanzpfadAgent** – komplexe Analyse & Archetypenlogik (`packages/agents/ResonanzpfadAgent.ts`)
 - 📚 **AutoDocGeneration** – wandelt README & JSDoc in HTML/PDF (`packages/crep-engine/autoDocGeneration.ts`)
 - 🔗 **Hexa-AgentSystem** – verbindet sechs Agenten für Resonanz- und Bewusstseinsanalyse

--- a/packages/unifiedmandala-ui/components/UploadYamlForm.test.tsx
+++ b/packages/unifiedmandala-ui/components/UploadYamlForm.test.tsx
@@ -1,0 +1,21 @@
+import { render, fireEvent } from '@testing-library/react';
+import UploadYamlForm from './UploadYamlForm';
+
+class MockFileReader {
+  result: string | ArrayBuffer | null = null;
+  onload: ((e: ProgressEvent<FileReader>) => any) | null = null;
+  readAsText(_file: Blob) {
+    this.result = 'hello';
+    if (this.onload) this.onload({} as ProgressEvent<FileReader>);
+  }
+}
+
+test('converts uploaded file to yaml', () => {
+  (global as any).FileReader = MockFileReader as any;
+  const file = new File(['hello'], 'test.txt', { type: 'text/plain' });
+  const { getByTestId } = render(<UploadYamlForm />);
+  const input = getByTestId('file-input') as HTMLInputElement;
+  fireEvent.change(input, { target: { files: [file] } });
+  const output = getByTestId('yaml-output') as HTMLTextAreaElement;
+  expect(output.value).toContain('hello');
+});

--- a/packages/unifiedmandala-ui/components/UploadYamlForm.tsx
+++ b/packages/unifiedmandala-ui/components/UploadYamlForm.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import yaml from 'js-yaml';
+
+export default function UploadYamlForm() {
+  const [yamlOut, setYamlOut] = useState('');
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = reader.result as string;
+      const data = { source: file.name, content: text };
+      setYamlOut(yaml.dump(data));
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <div>
+      <input type="file" onChange={handleFile} data-testid="file-input" />
+      {yamlOut && (
+        <textarea value={yamlOut} readOnly data-testid="yaml-output" />
+      )}
+    </div>
+  );
+}

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -1,2 +1,3 @@
 export * from './components/MetaScoreChart';
 export * from './hooks/useMetaScores';
+export { default as UploadYamlForm } from './components/UploadYamlForm';


### PR DESCRIPTION
## Summary
- add `UploadYamlForm` React component with FileReader
- export `UploadYamlForm` from UI package
- document new component in README and Handbuch
- add unit test for UploadYamlForm

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_685708c116a48322b373f29342c92ec1