### PR TITLE
Add mobile breakpoint hook

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -157,6 +157,7 @@ GPTEventHub.emit('orakel:says', { content: 'Hallo Welt' });
 - `SigillinLoader` – Lädt Sigillin-Dateien und filtert Einträge.
 - `SelfAuditModul` – Zeigt Kennzahlen aus `selfAnalyzer`.
 - `useSymbolzeit` – liest Symbolphasen aus der YAML und steuert Farben dynamisch.
+- `useBreakpoint` – erkennt mobile Ansichten für responsive Layouts.
 
 
 Weitere Module sind in Arbeit.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 📚 **AutoDocGeneration** – wandelt README & JSDoc in HTML/PDF (`packages/crep-engine/autoDocGeneration.ts`)
 - 🔗 **Hexa-AgentSystem** – verbindet sechs Agenten für Resonanz- und Bewusstseinsanalyse
 - 🧠 **AdvancedHexaAgent** – erweitert das Hexa-System um Research- und SilenceWatcher-Agenten
+- 📱 **useBreakpoint Hook** – erkennt mobile Ansichten für responsive UI
 
 ## 📦 Paketstruktur
 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1140,6 +1140,13 @@
     "status": "done"
   },
   {
+    "commit": "Implement useBreakpoint hook",
+    "path": "packages/unifiedmandala-ui/hooks/useBreakpoint.ts",
+    "task": "MobileOptimization for responsive design",
+    "test": "packages/unifiedmandala-ui/hooks/useBreakpoint.test.ts",
+    "status": "done"
+  },
+  {
     "commit": "Implement ResonanzpfadAgent analysis",
     "path": "packages/agents/ResonanzpfadAgent.ts",
     "task": "komplexe Analyse, Kontextverarbeitung und Archetypenlogik",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2754,3 +2754,8 @@ status: done
   task: Render MetaScoreChart via hook
   test: ""
   status: done
+- commit: Implement useBreakpoint hook
+  path: packages/unifiedmandala-ui/hooks/useBreakpoint.ts
+  task: MobileOptimization for responsive design
+  test: packages/unifiedmandala-ui/hooks/useBreakpoint.test.ts
+  status: done

--- a/packages/unifiedmandala-ui/hooks/useBreakpoint.test.ts
+++ b/packages/unifiedmandala-ui/hooks/useBreakpoint.test.ts
@@ -1,0 +1,14 @@
+import { renderHook, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useBreakpoint } from './useBreakpoint';
+
+test('detects mobile breakpoint', () => {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 400 });
+  const { result } = renderHook(() => useBreakpoint(500));
+  expect(result.current).toBe(true);
+  act(() => {
+    window.innerWidth = 600;
+    window.dispatchEvent(new Event('resize'));
+  });
+  expect(result.current).toBe(false);
+});

--- a/packages/unifiedmandala-ui/hooks/useBreakpoint.ts
+++ b/packages/unifiedmandala-ui/hooks/useBreakpoint.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+export function useBreakpoint(threshold: number = 768): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= threshold);
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [threshold]);
+
+  return isMobile;
+}


### PR DESCRIPTION
## Summary
- add `useBreakpoint` hook to detect mobile viewports
- test the hook with React Testing Library
- document hook in README and Handbuch
- update advancedToDo lists with completed MobileOptimization task

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68570c4ada6883229ef451f9990b2697