### PR TITLE
Implement CREP feedback modules and docs update

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -159,6 +159,10 @@ GPTEventHub.emit('orakel:says', { content: 'Hallo Welt' });
 - `SelfAuditModul` – Zeigt Kennzahlen aus `selfAnalyzer`.
 - `useSymbolzeit` – liest Symbolphasen aus der YAML und steuert Farben dynamisch.
 - `useBreakpoint` – erkennt mobile Ansichten für responsive Layouts.
+- `CREPFeedbackLoop` – erzeugt automatische Feedback-Aufgaben aus Snapshot-Daten.
+- `SigillinOnDemandGenerator` – CLI-Modul für spontane Sigillin-Templates.
+- `CREPToDoPrioritizer` – stuft Aufgaben nach Emergenz ein.
+- `CREPConvoHeatmap` – React-Komponente zur Visualisierung von CREP-Schwankungen.
 
 
 Weitere Module sind in Arbeit.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🔗 **Hexa-AgentSystem** – verbindet sechs Agenten für Resonanz- und Bewusstseinsanalyse
 - 🧠 **AdvancedHexaAgent** – erweitert das Hexa-System um Research- und SilenceWatcher-Agenten
 - 📱 **useBreakpoint Hook** – erkennt mobile Ansichten für responsive UI
+- 🔁 **CREPFeedbackLoop** – erstellt Micro-Feedback-Aufgaben aus CREP-Snapshots (`packages/crep-automation/CREPFeedbackLoop.ts`)
+- 🌀 **SigillinOnDemandGenerator** – generiert Sigillin-Templates per CLI (`packages/cli-tools/SigillinOnDemandGenerator.ts`)
+- 📊 **CREPToDoPrioritizer** – priorisiert ToDos nach aktueller Emergenz (`packages/crep-automation/CREPToDoPrioritizer.ts`)
+- 🔥 **CREPConvoHeatmap** – zeigt Schwankungen im CREP-Verlauf (`apps/sharedream-interface/components/CREPConvoHeatmap.tsx`)
 
 ## 📦 Paketstruktur
 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1159,5 +1159,33 @@
     "task": "README und JSDoc zu HTML/PDF umwandeln",
     "test": "packages/crep-engine/autoDocGeneration.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add CREPFeedbackLoop module",
+    "path": "packages/crep-automation/CREPFeedbackLoop.ts",
+    "task": "Generate micro-feedback tasks from snapshots",
+    "test": "packages/crep-automation/CREPFeedbackLoop.test.ts",
+    "status": "done"
+  },
+  {
+    "commit": "Add SigillinOnDemandGenerator CLI",
+    "path": "packages/cli-tools/SigillinOnDemandGenerator.ts",
+    "task": "Generate sigillin templates via CLI",
+    "test": "packages/cli-tools/SigillinOnDemandGenerator.test.ts",
+    "status": "done"
+  },
+  {
+    "commit": "Add CREPToDoPrioritizer",
+    "path": "packages/crep-automation/CREPToDoPrioritizer.ts",
+    "task": "Prioritize todos using CREP trends",
+    "test": "packages/crep-automation/CREPToDoPrioritizer.test.ts",
+    "status": "done"
+  },
+  {
+    "commit": "Add CREPConvoHeatmap component",
+    "path": "apps/sharedream-interface/components/CREPConvoHeatmap.tsx",
+    "task": "Visualize CREP fluctuations as heatmap",
+    "test": "apps/sharedream-interface/components/CREPConvoHeatmap.test.tsx",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2759,3 +2759,23 @@ status: done
   task: MobileOptimization for responsive design
   test: packages/unifiedmandala-ui/hooks/useBreakpoint.test.ts
   status: done
+- commit: Add CREPFeedbackLoop module
+  path: packages/crep-automation/CREPFeedbackLoop.ts
+  task: Generate micro-feedback tasks from snapshots
+  test: packages/crep-automation/CREPFeedbackLoop.test.ts
+  status: done
+- commit: Add SigillinOnDemandGenerator CLI
+  path: packages/cli-tools/SigillinOnDemandGenerator.ts
+  task: Generate sigillin templates via CLI
+  test: packages/cli-tools/SigillinOnDemandGenerator.test.ts
+  status: done
+- commit: Add CREPToDoPrioritizer
+  path: packages/crep-automation/CREPToDoPrioritizer.ts
+  task: Prioritize todos using CREP trends
+  test: packages/crep-automation/CREPToDoPrioritizer.test.ts
+  status: done
+- commit: Add CREPConvoHeatmap component
+  path: apps/sharedream-interface/components/CREPConvoHeatmap.tsx
+  task: Visualize CREP fluctuations as heatmap
+  test: apps/sharedream-interface/components/CREPConvoHeatmap.test.tsx
+  status: done

--- a/apps/sharedream-interface/components/CREPConvoHeatmap.test.tsx
+++ b/apps/sharedream-interface/components/CREPConvoHeatmap.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CREPConvoHeatmap from './CREPConvoHeatmap';
+
+test('renders svg heatmap', () => {
+  render(<CREPConvoHeatmap data={[{ time: 't1', value: 0.5 }]} />);
+  expect(screen.getByLabelText('CREP Heatmap')).toBeInTheDocument();
+});

--- a/apps/sharedream-interface/components/CREPConvoHeatmap.tsx
+++ b/apps/sharedream-interface/components/CREPConvoHeatmap.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export interface HeatmapPoint { time: string; value: number; }
+
+export default function CREPConvoHeatmap({ data }: { data: HeatmapPoint[] }) {
+  return (
+    <svg aria-label="CREP Heatmap" width={200} height={100}>
+      {data.map((d, i) => (
+        <rect
+          key={i}
+          x={i * 10}
+          y={100 - d.value * 100}
+          width={8}
+          height={d.value * 100}
+          fill="blue"
+        />
+      ))}
+    </svg>
+  );
+}

--- a/packages/cli-tools/SigillinOnDemandGenerator.test.ts
+++ b/packages/cli-tools/SigillinOnDemandGenerator.test.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import { generateSigillin, saveSigillin } from './SigillinOnDemandGenerator';
+
+test('generates sigillin template', () => {
+  const t = generateSigillin('hello');
+  expect(t.phrase).toBe('hello');
+  expect(t.id).toHaveLength(8);
+});
+
+test('saves sigillin file', () => {
+  const file = 'sigillin-test.json';
+  const sig = generateSigillin('hello');
+  saveSigillin(sig, file);
+  expect(fs.existsSync(file)).toBe(true);
+  fs.unlinkSync(file);
+});

--- a/packages/cli-tools/SigillinOnDemandGenerator.ts
+++ b/packages/cli-tools/SigillinOnDemandGenerator.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+function randomId() {
+  return Math.random().toString(36).substring(2, 10);
+}
+
+export interface SigillinTemplate {
+  id: string;
+  phrase: string;
+}
+
+export function generateSigillin(phrase: string): SigillinTemplate {
+  return { id: randomId(), phrase };
+}
+
+export function saveSigillin(template: SigillinTemplate, file: string): void {
+  fs.writeFileSync(file, JSON.stringify(template, null, 2), 'utf-8');
+}

--- a/packages/crep-automation/CREPFeedbackLoop.test.ts
+++ b/packages/crep-automation/CREPFeedbackLoop.test.ts
@@ -1,0 +1,15 @@
+import fs from 'fs';
+import { generateFeedbackTasks, scheduleFeedback } from './CREPFeedbackLoop';
+
+test('generates tasks from snapshot', () => {
+  const tasks = generateFeedbackTasks({ R: -1, E: -1 });
+  expect(tasks).toContain('Team-Check-in');
+  expect(tasks).toContain('Dokumentation aktualisieren');
+});
+
+test('writes scheduled tasks file', () => {
+  const file = 'test-scheduled.json';
+  scheduleFeedback({ R: -1, E: -1 }, file);
+  expect(fs.existsSync(file)).toBe(true);
+  fs.unlinkSync(file);
+});

--- a/packages/crep-automation/CREPFeedbackLoop.ts
+++ b/packages/crep-automation/CREPFeedbackLoop.ts
@@ -1,0 +1,18 @@
+import fs from 'fs';
+
+export interface CREPSnapshot {
+  R: number;
+  E: number;
+}
+
+export function generateFeedbackTasks(snapshot: CREPSnapshot): string[] {
+  const tasks: string[] = [];
+  if (snapshot.E < 0) tasks.push('Team-Check-in');
+  if (snapshot.R < 0) tasks.push('Dokumentation aktualisieren');
+  return tasks;
+}
+
+export function scheduleFeedback(snapshot: CREPSnapshot, file = 'scheduled-tasks.json'): void {
+  const tasks = generateFeedbackTasks(snapshot);
+  fs.writeFileSync(file, JSON.stringify(tasks, null, 2), 'utf-8');
+}

--- a/packages/crep-automation/CREPToDoPrioritizer.test.ts
+++ b/packages/crep-automation/CREPToDoPrioritizer.test.ts
@@ -1,0 +1,11 @@
+import { prioritizeTodos } from './CREPToDoPrioritizer';
+
+test('prioritizes high when E positive', () => {
+  const result = prioritizeTodos([{ text: 'x' }], { E: 1 });
+  expect(result[0].priority).toBe('high');
+});
+
+test('prioritizes low when E negative', () => {
+  const result = prioritizeTodos([{ text: 'x' }], { E: -1 });
+  expect(result[0].priority).toBe('low');
+});

--- a/packages/crep-automation/CREPToDoPrioritizer.ts
+++ b/packages/crep-automation/CREPToDoPrioritizer.ts
@@ -1,0 +1,10 @@
+export interface CREPTrend { E: number; }
+export interface TodoItem { text: string; }
+export interface PrioritizedItem extends TodoItem { priority: 'high' | 'low'; }
+
+export function prioritizeTodos(todos: TodoItem[], trend: CREPTrend): PrioritizedItem[] {
+  return todos.map(t => ({
+    text: t.text,
+    priority: trend.E > 0 ? 'high' : 'low'
+  }));
+}


### PR DESCRIPTION
## Summary
- add new automation modules: CREPFeedbackLoop, CREPToDoPrioritizer and SigillinOnDemandGenerator
- add CREPConvoHeatmap component
- document new utilities in README and Handbuch
- log completed tasks in advancedToDo files
- all tests pass

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68571877dad0832282e32ab8e1aa7f21