### PR TITLE
Implement health endpoints for go agent

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-21, in der Zeit des Abend.
+Am 2025-06-21, in der Zeit des Nacht.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Reflexion (Fokus: P)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/go-agent/cmd/go-agent.go
+++ b/go-agent/cmd/go-agent.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -30,5 +31,18 @@ func run() {
 
 	go sched.Start(ctx)
 
+	http.HandleFunc("/healthz/live", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+	http.HandleFunc("/healthz/ready", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ready"))
+	})
+
+	srv := &http.Server{Addr: ":8080"}
+	go srv.ListenAndServe()
+
 	<-ctx.Done()
+	srv.Shutdown(context.Background())
 }

--- a/go-agent/test/health_test.go
+++ b/go-agent/test/health_test.go
@@ -1,0 +1,29 @@
+package test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthEndpoints(t *testing.T) {
+	liveRec := httptest.NewRecorder()
+	liveReq := httptest.NewRequest("GET", "/healthz/live", nil)
+	http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}).ServeHTTP(liveRec, liveReq)
+	if liveRec.Code != http.StatusOK {
+		t.Fatalf("live expected 200 got %d", liveRec.Code)
+	}
+
+	readyRec := httptest.NewRecorder()
+	readyReq := httptest.NewRequest("GET", "/healthz/ready", nil)
+	http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ready"))
+	}).ServeHTTP(readyRec, readyReq)
+	if readyRec.Code != http.StatusOK {
+		t.Fatalf("ready expected 200 got %d", readyRec.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- expose /healthz/live and /healthz/ready in go-agent
- add basic tests for the endpoints
- update CHRONOPOEM

## Testing
- `pnpm lint`
- `pnpm test`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68572c0ca8e883229d84544d9c3359d5