### PR TITLE
Add Community Onboarding guide

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-21, in der Zeit des Abend.
+Am 2025-06-21, in der Zeit des Nacht.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Reflexion (Fokus: P)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -6,6 +6,7 @@ Dieses Handbuch gibt einen Überblick über die wichtigsten Module und Funktione
 > 1. Lies [scripts/onboarding-ritual.md](scripts/onboarding-ritual.md)
 > 2. Starte `./scripts/aeon.sh onboarding`
 > 3. Erkunde das [CHRONOPOEM.md](CHRONOPOEM.md)
+> 4. Lies den [Community Onboarding Guide](docs/CommunityOnboarding.md)
 
 Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 Das Pendant zum Genesis ZIPMEM ist die Datei `advancedconversations.json`.

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Siehe `/LICENSES/` für vollständige Texte & Attribution.
 *Bring dein Licht ins Mandala – jede Linie zählt.*
 
 Du möchtest beitragen? Bitte lies zuerst die [CONTRIBUTING.md](CONTRIBUTING.md) und [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) – sie enthalten unseren Community-Standard, den Review-Prozess und Branch-Workflow.
+Ein kompakter Einstieg findet sich im [Community Onboarding Guide](docs/CommunityOnboarding.md).
 
 Deine Idee, deine Story, dein Sigillin sind willkommen! Jeder Pull Request ist eine neue Linie im Mandala.
 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1447,12 +1447,6 @@
     "test": "openapi-validate"
   },
   {
-    "commit": "Write Community Onboarding Guide",
-    "path": "docs/CommunityOnboarding.md",
-    "task": "Provide quickstart steps and CLI usage",
-    "test": "markdownlint"
-  },
-  {
     "commit": "Create MobileImpactDashboard for React Native",
     "path": "apps/socialgood-mobile/MobileImpactDashboard.tsx",
     "task": "Implement mobile friendly dashboard component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2951,10 +2951,6 @@ status: done
   path: docs/api/friendship-socialgood.yaml
   task: "Write OpenAPI schema for region and socialgood endpoints"
   test: "openapi-validate"
-- commit: "Write Community Onboarding Guide"
-  path: docs/CommunityOnboarding.md
-  task: "Provide quickstart steps and CLI usage"
-  test: "markdownlint"
 - commit: "Create MobileImpactDashboard for React Native"
   path: apps/socialgood-mobile/MobileImpactDashboard.tsx
   task: "Implement mobile friendly dashboard component"

--- a/docs/CommunityOnboarding.md
+++ b/docs/CommunityOnboarding.md
@@ -1,0 +1,23 @@
+# Community Onboarding Guide
+
+Dieses Dokument erleichtert neuen Mitwirkenden den Einstieg in UnifiedMandala.
+
+## Schnellstart
+
+1. Repository klonen und Abhängigkeiten installieren:
+   ```bash
+   git clone https://github.com/GenesisAeon/unified-mandala.git
+   cd unified-mandala
+   ./scripts/setup-unifiedmandala.sh
+   pnpm dev
+   ```
+2. Überblick über wichtige CLI-Befehle verschaffen:
+   ```bash
+   ./scripts/aeon.sh help         # zeigt alle poetischen und technischen Befehle
+   ./scripts/aeon.sh onboarding   # präsentiert den Onboarding-Ritus
+   ./scripts/aeon.sh cycle_start  # startet einen lokalen Mandala-Zyklus
+   pnpm test                      # führt Unit- und UI-Tests aus
+   pnpm docs:auto                 # generiert TypeDoc-API-Dokumentation
+   ```
+
+Weitere Hinweise zu Modulen und Ordnerstruktur findest du im [Handbuch](Handbuch.md).


### PR DESCRIPTION
## Summary
- add CommunityOnboarding guide under docs
- reference new onboarding doc in README and Handbuch
- update advancedToDo files
- regenerate CHRONOPOEM

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68572c0ca8e883229d84544d9c3359d5