### PR TITLE
Add PoeticToDoSynth tool and schema validator

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -200,6 +200,7 @@ Weitere Module sind in Arbeit.
 | `node scripts/parse-advanced-conversations.js` | Parst `advancedconversations.json` |
 | `node scripts/analyze-conversations.js` | Analysiert Gespräche |
 | `node scripts/generate-todo-from-convos.js` | Erstellt ToDo-Datei aus Convos |
+| `node tools/PoeticToDoSynth.ts` | Extrahiert poetische Aufgaben aus Symbolfluss |
 | `node scripts/export-crep-docs.js` | Exportiert CREP-Daten |
 | `node scripts/update-advanced-todo.js` | Aktualisiert Advanced-ToDo-Liste |
 | `node scripts/update-advancedprogress.js` | Dokumentiert Fortschritt |
@@ -211,6 +212,7 @@ Weitere Module sind in Arbeit.
 | `node scripts/mark-fragment.js` | Markiert bearbeitete Fragmente |
 | `node scripts/self-analyze.js` | Zeigt Repository-Statistiken |
 | `node scripts/scan-todo-comments.js` | Scannt TODO-Kommentare |
+| `./scripts/validate-schemas.sh` | Validiert JSON- und YAML-Dateien |
 | `node scripts/repotool-convo.js` | Schnelle Auswertung & Progress-Update |
 | `node scripts/website-to-yaml.js` | Wandelt Webseite in YAML um |
 | `node scripts/symbolzeit-runner.js` | Läuft Symbolzeit-Cronjob |
@@ -339,6 +341,7 @@ scripts/
 
 Jeder Unterordner kann eine eigene README enthalten – siehe die Links in den jeweiligen Verzeichnissen.
 Utilities liegen in `packages/shared-utils/`, weitere Module findest du ebenfalls unter `packages/`.
+Kleine Hilfsskripte liegen unter `tools/`.
 
 ## 💻 Schnellstart
 
@@ -385,6 +388,7 @@ npm run dev   # oder: yarn dev
 | `node scripts/parse-advanced-conversations.js` | Parst `advancedconversations.json` |
 | `node scripts/analyze-conversations.js` | Analysiert Gespräche |
 | `node scripts/generate-todo-from-convos.js` | Erstellt ToDo-Datei aus Convos |
+| `node tools/PoeticToDoSynth.ts` | Extrahiert poetische Aufgaben aus Symbolfluss |
 | `node scripts/export-crep-docs.js` | Exportiert CREP-Daten |
 | `node scripts/update-advanced-todo.js` | Aktualisiert Advanced-ToDo-Liste |
 | `node scripts/update-advancedprogress.js` | Dokumentiert Fortschritt |
@@ -396,6 +400,7 @@ npm run dev   # oder: yarn dev
 | `node scripts/mark-fragment.js` | Markiert bearbeitete Fragmente |
 | `node scripts/self-analyze.js` | Zeigt Repository-Statistiken |
 | `node scripts/scan-todo-comments.js` | Scannt TODO-Kommentare |
+| `./scripts/validate-schemas.sh` | Validiert JSON- und YAML-Dateien |
 | `node scripts/repotool-convo.js` | Schnelle Auswertung & Progress-Update |
 | `node scripts/website-to-yaml.js` | Wandelt Webseite in YAML um |
 | `node scripts/symbolzeit-runner.js` | Läuft Symbolzeit-Cronjob |

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ packages/
   │   ├── pkg/policy        # Policy Enforcement Stubs
   │   └── pkg/hooks         # Event Hook Publisher
   └── codex-navigator-agent     # Parser für Codex-Instruktionen
+tools/                    # Kleine Helferskripte & Generatoren
 codex/                    # Codex-Workflows und Sigillin-Dateien
 codexbuild/               # Build-Skripte und Deploy-Hilfen
 codex-sync/              # Antwortsystem für Vorschläge
@@ -129,6 +130,7 @@ scripts/
 
 Jeder Unterordner kann eine eigene README enthalten – siehe die Links in den jeweiligen Verzeichnissen.
 Utilities liegen in `packages/shared-utils/`, weitere Module findest du ebenfalls unter `packages/`.
+Kleine Hilfsskripte liegen unter `tools/`.
 
 ## 💻 Schnellstart
 
@@ -175,6 +177,7 @@ npm run dev   # oder: yarn dev
 | `node scripts/parse-advanced-conversations.js` | Parst `advancedconversations.json` |
 | `node scripts/analyze-conversations.js` | Analysiert Gespräche |
 | `node scripts/generate-todo-from-convos.js` | Erstellt ToDo-Datei aus Convos |
+| `node tools/PoeticToDoSynth.ts` | Extrahiert poetische Aufgaben aus Symbolfluss |
 | `node scripts/export-crep-docs.js` | Exportiert CREP-Daten |
 | `node scripts/update-advanced-todo.js` | Aktualisiert Advanced-ToDo-Liste |
 | `node scripts/update-advancedprogress.js` | Dokumentiert Fortschritt |
@@ -186,6 +189,7 @@ npm run dev   # oder: yarn dev
 | `node scripts/mark-fragment.js` | Markiert bearbeitete Fragmente |
 | `node scripts/self-analyze.js` | Zeigt Repository-Statistiken |
 | `node scripts/scan-todo-comments.js` | Scannt TODO-Kommentare |
+| `./scripts/validate-schemas.sh` | Validiert JSON- und YAML-Dateien |
 | `node scripts/repotool-convo.js` | Schnelle Auswertung & Progress-Update |
 | `node scripts/website-to-yaml.js` | Wandelt Webseite in YAML um |
 | `node scripts/symbolzeit-runner.js` | Läuft Symbolzeit-Cronjob |

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -315,8 +315,9 @@
   {
     "commit": "Synth.ts**        | GPT-basiertes ToDo-Generieren aus Symbolfluss          | `./tools/PoeticToDoSynth.ts` |",
     "path": "",
-    "task": "Synth.ts**        | GPT-basiertes ToDo-Generieren aus Symbolfluss          | `./tools/PoeticToDoSynth.ts` |",
-    "test": ""
+  "task": "Synth.ts**        | GPT-basiertes ToDo-Generieren aus Symbolfluss          | `./tools/PoeticToDoSynth.ts` |",
+  "test": "",
+  "status": "done"
   },
   {
     "commit": "- & Dashboard-Komponenten",
@@ -1378,7 +1379,8 @@
     "commit": "Add schema validation hook script",
     "path": "scripts/validate-schemas.sh",
     "task": "Validate JSON and YAML files in CI",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Add sigil trigger script",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -549,12 +549,14 @@
   path: ""
   task: s, `README.md`, `Dockerfile`, Handbuch, etc.),
   test: ""
+  status: done
 - commit: Synth.ts**        | GPT-basiertes ToDo-Generieren aus
     Symbolfluss          | `./tools/PoeticToDoSynth.ts` |
   path: ""
   task: Synth.ts**        | GPT-basiertes ToDo-Generieren aus
     Symbolfluss          | `./tools/PoeticToDoSynth.ts` |
   test: ""
+  status: done
 - commit: "- & Dashboard-Komponenten"
   path: ""
   task: "- & Dashboard-Komponenten"
@@ -2907,6 +2909,7 @@ status: done
   path: scripts/validate-schemas.sh
   task: Validate JSON and YAML files in CI
   test: ""
+  status: done
 - commit: Add sigil trigger script
   path: services/sigil-trigger/trigger.sh
   task: Watch files and generate sigils on change

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "scaffold sim-domain and art modules",
-  "fractalStep": "scaffold-sim-domain-art",
+  "lastCommit": "added PoeticToDoSynth and schema validator",
+  "fractalStep": "docs-update",
   "openBranches": [
     "work"
   ],

--- a/scripts/validate-schemas.sh
+++ b/scripts/validate-schemas.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+fail=0
+printf "Validating JSON files...\n"
+for f in $(git ls-files '*.json'); do
+  node -e "const fs=require('fs');JSON.parse(fs.readFileSync('$f','utf8'));" 2>/dev/null || { echo "Invalid JSON: $f"; fail=1; }
+done
+printf "Validating YAML files...\n"
+for f in $(git ls-files '*.yaml' '*.yml'); do
+  node -e "const yaml=require('js-yaml');const fs=require('fs');yaml.load(fs.readFileSync('$f','utf8'));" 2>/dev/null || { echo "Invalid YAML: $f"; fail=1; }
+done
+if [ $fail -ne 0 ]; then
+  echo "Schema validation failed" >&2
+  exit 1
+fi
+echo "All schemas valid"

--- a/tools/PoeticToDoSynth.ts
+++ b/tools/PoeticToDoSynth.ts
@@ -1,0 +1,22 @@
+import path from 'path';
+import fs from 'fs';
+import { extractImplicitTodosFromConversations } from '../packages/shared-utils/conversationAnalyzer';
+import { createTodoSigil } from '../packages/shared-utils/todoSigilGenerator';
+
+export function synthFromSymbolflow(sourcePath: string, outPath: string) {
+  const todos = extractImplicitTodosFromConversations(path.resolve(sourcePath));
+  const items = todos.map(t => ({ text: t, done: false }));
+  const yaml = createTodoSigil(items, {
+    id: 'aeon:poetic-todo',
+    titel: 'Poetische Aufgaben',
+    symbolzeit: 'tag'
+  });
+  fs.writeFileSync(outPath, yaml);
+  console.log(`Poetic todo sigil written to ${outPath}`);
+}
+
+if (require.main === module) {
+  const src = process.argv[2] || path.join(__dirname, '../docs/sigils/advancedconversations.json');
+  const out = process.argv[3] || path.join(__dirname, '../docs/sigils/poetic-todo.yaml');
+  synthFromSymbolflow(src, out);
+}


### PR DESCRIPTION
## Summary
- add PoeticToDoSynth helper under `tools/`
- add `scripts/validate-schemas.sh` for basic schema checks
- reference new tools in README and Handbuch
- mark related tasks as done
- update progress file

## Testing
- `pnpm lint` *(fails: cannot find React types)*
- `pnpm test` *(fails: jest not found)*
- `pnpm test:agents` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573dc356d88322814398ec9826a33e