### PR TITLE
Add Socialgood dashboard components and API spec

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-21, in der Zeit des Nacht.
+Am 2025-06-22, in der Zeit des Morgen.
 
-Symbolphase: Reflexion (Fokus: P)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -165,6 +165,10 @@ GPTEventHub.emit('orakel:says', { content: 'Hallo Welt' });
 - `SigillinOnDemandGenerator` – CLI-Modul für spontane Sigillin-Templates.
 - `CREPToDoPrioritizer` – stuft Aufgaben nach Emergenz ein.
 - `CREPConvoHeatmap` – React-Komponente zur Visualisierung von CREP-Schwankungen.
+- `ImpactDashboard` – Dashboard mit MandalaNetworkView und AgentHeatmap.
+- `CustomRegionGallery` – Galerieansicht für Regionen.
+- `ProjectListView` – Listenansicht für Social-Good-Projekte.
+- `MobileImpactDashboard` – mobile Variante auf Basis von React Native.
 
 
 Weitere Module sind in Arbeit.
@@ -353,6 +357,7 @@ cd unified-mandala
 pnpm dev
 ```
 Die generierte API-Dokumentation findest du danach unter `docs/api`.
+Die OpenAPI-Spezifikation für Friendship & SocialGood liegt unter `docs/api/friendship-socialgood.yaml`.
 
 Für `npm` oder `yarn` nutze alternativ:
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🩺 **healthz.ts** & **metaScores.ts** – API-Routen
 - 🖥️ **Dashboard** – zeigt MetaScoreChart per Hook
 - 📄 **UploadYamlForm** – wandelt hochgeladene Dateien in YAML um
+- 📊 **ImpactDashboard** – kombiniert MandalaNetworkView und AgentHeatmap
+- 📱 **MobileImpactDashboard** – mobile Variante des Dashboards
+- 📑 **Friendship & SocialGood API** – siehe `docs/api/friendship-socialgood.yaml`
 - 🌀 **ResonanzpfadAgent** – komplexe Analyse & Archetypenlogik (`packages/agents/ResonanzpfadAgent.ts`)
 - 📚 **AutoDocGeneration** – wandelt README & JSDoc in HTML/PDF (`packages/crep-engine/autoDocGeneration.ts`)
 - 🔗 **Hexa-AgentSystem** – verbindet sechs Agenten für Resonanz- und Bewusstseinsanalyse

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -315,9 +315,9 @@
   {
     "commit": "Synth.ts**        | GPT-basiertes ToDo-Generieren aus Symbolfluss          | `./tools/PoeticToDoSynth.ts` |",
     "path": "",
-  "task": "Synth.ts**        | GPT-basiertes ToDo-Generieren aus Symbolfluss          | `./tools/PoeticToDoSynth.ts` |",
-  "test": "",
-  "status": "done"
+    "task": "Synth.ts**        | GPT-basiertes ToDo-Generieren aus Symbolfluss          | `./tools/PoeticToDoSynth.ts` |",
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "- & Dashboard-Komponenten",
@@ -1395,33 +1395,33 @@
     "test": ""
   },
   {
-  "commit": "Add policy enforcement stub",
-  "path": "pkg/policy/enforcer.go",
-  "task": "Load policy.yaml and check consent",
-  "test": "",
-  "status": "done"
-},
-{
-  "commit": "Add event hook publisher",
-  "path": "pkg/hooks/publisher.go",
-  "task": "Publish NATS events from payload template",
-  "test": "",
-  "status": "done"
-},
-{
-  "commit": "Add event hook workflow test",
-  "path": "test/event_hook_test.go",
-  "task": "Test NATS publish via event hooks",
-  "test": "",
-  "status": "done"
-},
-{
-  "commit": "Update mock data generator",
-  "path": "scripts/mock-data.go",
-  "task": "Generate new fields eventHook and fractalHash",
-  "test": "",
-  "status": "done"
-},
+    "commit": "Add policy enforcement stub",
+    "path": "pkg/policy/enforcer.go",
+    "task": "Load policy.yaml and check consent",
+    "test": "",
+    "status": "done"
+  },
+  {
+    "commit": "Add event hook publisher",
+    "path": "pkg/hooks/publisher.go",
+    "task": "Publish NATS events from payload template",
+    "test": "",
+    "status": "done"
+  },
+  {
+    "commit": "Add event hook workflow test",
+    "path": "test/event_hook_test.go",
+    "task": "Test NATS publish via event hooks",
+    "test": "",
+    "status": "done"
+  },
+  {
+    "commit": "Update mock data generator",
+    "path": "scripts/mock-data.go",
+    "task": "Generate new fields eventHook and fractalHash",
+    "test": "",
+    "status": "done"
+  },
   {
     "commit": "Update shared schema utilities",
     "path": "shared-utils/schema",
@@ -1438,27 +1438,31 @@
     "commit": "Implement ImpactDashboard component with MandalaNetworkView",
     "path": "apps/socialgood-ui/src/components/ImpactDashboard.tsx",
     "task": "Create React component for Impact Dashboard and heatmap",
-    "test": "jest"
+    "test": "jest",
+    "status": "done"
   },
   {
     "commit": "Add ProjectListView and CustomRegionGallery components",
     "path": "apps/socialgood-ui/src/components",
     "task": "Build UI for project list and custom region gallery",
-    "test": "jest"
+    "test": "jest",
+    "status": "done"
   },
   {
     "commit": "Add Friendship & SocialGood API Swagger spec",
     "path": "docs/api/friendship-socialgood.yaml",
     "task": "Write OpenAPI schema for region and socialgood endpoints",
-    "test": "openapi-validate"
+    "test": "openapi-validate",
+    "status": "done"
   },
   {
     "commit": "Create MobileImpactDashboard for React Native",
     "path": "apps/socialgood-mobile/MobileImpactDashboard.tsx",
     "task": "Implement mobile friendly dashboard component",
-    "test": "jest"
-  }
-  ,{
+    "test": "jest",
+    "status": "done"
+  },
+  {
     "commit": "Add Go-Bridge scaffold with CLI and REST client",
     "path": "go-bridge/",
     "task": "Initial Go interface scaffold, models and docs",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2950,18 +2950,22 @@ status: done
   path: apps/socialgood-ui/src/components/ImpactDashboard.tsx
   task: "Create React component for Impact Dashboard and heatmap"
   test: "jest"
+  status: done
 - commit: "Add ProjectListView and CustomRegionGallery components"
   path: apps/socialgood-ui/src/components
   task: "Build UI for project list and custom region gallery"
   test: "jest"
+  status: done
 - commit: "Add Friendship & SocialGood API Swagger spec"
   path: docs/api/friendship-socialgood.yaml
   task: "Write OpenAPI schema for region and socialgood endpoints"
   test: "openapi-validate"
+  status: done
 - commit: "Create MobileImpactDashboard for React Native"
   path: apps/socialgood-mobile/MobileImpactDashboard.tsx
   task: "Implement mobile friendly dashboard component"
   test: "jest"
+  status: done
 - commit: "Add Go-Bridge scaffold with CLI and REST client"
   path: go-bridge/
   task: Initial Go interface scaffold, models and docs

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Add Go-Bridge scaffold with CLI and REST client",
+  "lastCommit": "Implement ImpactDashboard component with MandalaNetworkView",
   "fractalStep": "docs-update",
   "openBranches": [
     "work"

--- a/apps/socialgood-mobile/MobileImpactDashboard.test.tsx
+++ b/apps/socialgood-mobile/MobileImpactDashboard.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+jest.mock('../socialgood-ui/src/components/ImpactDashboard', () => () => <div aria-label="mock-impact" />);
+import MobileImpactDashboard from './MobileImpactDashboard';
+
+test('renders mobile dashboard', () => {
+  render(<MobileImpactDashboard />);
+  expect(screen.getByLabelText('Mobile Impact Dashboard')).toBeInTheDocument();
+});

--- a/apps/socialgood-mobile/MobileImpactDashboard.tsx
+++ b/apps/socialgood-mobile/MobileImpactDashboard.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ImpactDashboard from '../socialgood-ui/src/components/ImpactDashboard';
+
+const MobileImpactDashboard: React.FC = () => (
+  <div aria-label="Mobile Impact Dashboard">
+    <ImpactDashboard />
+  </div>
+);
+
+export default MobileImpactDashboard;

--- a/apps/socialgood-ui/src/components/CustomRegionGallery.test.tsx
+++ b/apps/socialgood-ui/src/components/CustomRegionGallery.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CustomRegionGallery from './CustomRegionGallery';
+
+test('renders regions', () => {
+  render(<CustomRegionGallery regions={['X', 'Y']} />);
+  expect(screen.getByLabelText('Region Gallery')).toHaveTextContent('X');
+  expect(screen.getByLabelText('Region Gallery')).toHaveTextContent('Y');
+});

--- a/apps/socialgood-ui/src/components/CustomRegionGallery.tsx
+++ b/apps/socialgood-ui/src/components/CustomRegionGallery.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface CustomRegionGalleryProps {
+  regions?: string[];
+}
+
+const CustomRegionGallery: React.FC<CustomRegionGalleryProps> = ({ regions = [] }) => (
+  <div aria-label="Region Gallery">
+    {regions.map((r) => (
+      <div key={r}>{r}</div>
+    ))}
+  </div>
+);
+
+export default CustomRegionGallery;

--- a/apps/socialgood-ui/src/components/ImpactDashboard.test.tsx
+++ b/apps/socialgood-ui/src/components/ImpactDashboard.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+jest.mock('../../../../packages/unifiedmandala-ui/components/MandalaNetworkView', () => () => <svg aria-label="mock-network" />);
+jest.mock('../../../../packages/unifiedmandala-ui/components/AgentHeatmap', () => () => <div aria-label="mock-heatmap" />);
+import ImpactDashboard from './ImpactDashboard';
+
+test('renders network view and heatmap', () => {
+  render(<ImpactDashboard />);
+  expect(screen.getByLabelText('Impact Dashboard')).toBeInTheDocument();
+});

--- a/apps/socialgood-ui/src/components/ImpactDashboard.tsx
+++ b/apps/socialgood-ui/src/components/ImpactDashboard.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import MandalaNetworkView from '../../../../packages/unifiedmandala-ui/components/MandalaNetworkView';
+import AgentHeatmap from '../../../../packages/unifiedmandala-ui/components/AgentHeatmap';
+
+const ImpactDashboard: React.FC = () => (
+  <section aria-label="Impact Dashboard">
+    <MandalaNetworkView />
+    <AgentHeatmap />
+  </section>
+);
+
+export default ImpactDashboard;

--- a/apps/socialgood-ui/src/components/ProjectListView.test.tsx
+++ b/apps/socialgood-ui/src/components/ProjectListView.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ProjectListView from './ProjectListView';
+
+test('renders provided projects', () => {
+  render(<ProjectListView projects={['A', 'B']} />);
+  expect(screen.getByLabelText('Project List')).toHaveTextContent('A');
+  expect(screen.getByLabelText('Project List')).toHaveTextContent('B');
+});

--- a/apps/socialgood-ui/src/components/ProjectListView.tsx
+++ b/apps/socialgood-ui/src/components/ProjectListView.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface ProjectListViewProps {
+  projects?: string[];
+}
+
+const ProjectListView: React.FC<ProjectListViewProps> = ({ projects = [] }) => (
+  <ul aria-label="Project List">
+    {projects.map((p) => (
+      <li key={p}>{p}</li>
+    ))}
+  </ul>
+);
+
+export default ProjectListView;

--- a/docs/api/friendship-socialgood.yaml
+++ b/docs/api/friendship-socialgood.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: Friendship & SocialGood API
+  version: 1.0.0
+paths:
+  /regions:
+    get:
+      summary: List regions
+      responses:
+        '200':
+          description: List of regions
+  /socialgood:
+    get:
+      summary: List social good projects
+      responses:
+        '200':
+          description: List of projects


### PR DESCRIPTION
## Summary
- introduce ImpactDashboard with MandalaNetworkView and AgentHeatmap
- add ProjectListView and CustomRegionGallery components
- provide MobileImpactDashboard for React Native
- document Friendship & SocialGood API in docs/api
- reference new modules in README and Handbuch
- mark related tasks done in advancedToDo files
- update progress log
- update CHRONOPOEM

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6857c7a0f27883228f695c4c09f8b2d5