### PR TITLE
Add sigil trigger service

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -322,6 +322,7 @@ packages/
   ├── shared-utils              # Hilfsfunktionen für alle Pakete
   │   └── RestClient.ts         # einfacher REST-Helper
   ├── services/vector-indexer   # Embedding generator service
+  ├── services/sigil-trigger    # Beobachtet Sigillin-Änderungen
   └── codex-navigator-agent     # Parser für Codex-Instruktionen
 codex/                    # Codex-Workflows und Sigillin-Dateien
 codexbuild/               # Build-Skripte und Deploy-Hilfen

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ packages/
   │   ├── pkg/policy        # Policy Enforcement Stubs
   │   └── pkg/hooks         # Event Hook Publisher
   ├── services/vector-indexer # Embedding generator service
+  ├── services/sigil-trigger  # Beobachtet Sigillin-Änderungen
   └── codex-navigator-agent     # Parser für Codex-Instruktionen
 tools/                    # Kleine Helferskripte & Generatoren
 codex/                    # Codex-Workflows und Sigillin-Dateien

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1386,7 +1386,8 @@
     "commit": "Add sigil trigger script",
     "path": "services/sigil-trigger/trigger.sh",
     "task": "Watch files and generate sigils on change",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Add vector indexer service",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2914,6 +2914,7 @@ status: done
   path: services/sigil-trigger/trigger.sh
   task: Watch files and generate sigils on change
   test: ""
+  status: done
 - commit: Add vector indexer service
   path: services/vector-indexer/indexer.go
   task: Create embeddings and push to external DB

--- a/services/sigil-trigger/README.md
+++ b/services/sigil-trigger/README.md
@@ -1,0 +1,6 @@
+# Sigil Trigger Service
+
+This utility watches the `docs/sigils` directory for changes to `*.sigil.json` files.
+Whenever a sigil file is updated, it regenerates the sigil relation graph using `sigillin-cli.js`.
+
+Run `./trigger.sh` from the repository root. `inotifywait` must be available on the system.

--- a/services/sigil-trigger/trigger.sh
+++ b/services/sigil-trigger/trigger.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+WATCH_DIR=${1:-docs/sigils}
+CMD="node packages/cli-tools/sigillin-cli.js graph --json"
+
+echo "Watching $WATCH_DIR for sigil changes..."
+
+inotifywait -m -e close_write,create,delete "$WATCH_DIR" | while read -r path action file; do
+  if [[ "$file" == *.sigil.json ]]; then
+    echo "[sigil-trigger] $file changed -> regenerate graph"
+    $CMD >/dev/null 2>&1 || echo "failed to run sigillin-cli"
+  fi
+done


### PR DESCRIPTION
## Summary
- add `sigil-trigger` service with `trigger.sh`
- document new service in README and Handbuch
- mark `sigil trigger script` task as done in advancedToDo lists

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_6857dab99fec8322a8e9ecce743df4f7