### PR TITLE
Add CREP test harness UI component

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -275,6 +275,7 @@ Aktuelle Versionshinweise werden in [CHANGELOG.md](CHANGELOG.md) gepflegt.
 - 🎨 **SigillinViewer & SigillinMap** – Übersicht und Detailansicht aller Sigillin
 - 🚩 **SymbolicWayfinder & SoforthilfeOverlay** – Navigation und Hilfedialoge
 - 📈 **CREPChart & CREPTriggerPanel** – CREP-Historie und Steuerung
+- 🧪 **CREPTestHarness** – UI zum Durchspielen von CREP-Werten
 - 🛰️ **Nucleon-Scanner v0.6** – Analysiert tiefe Resonanzdaten
 - 📡 **KiResonanceAnalyzer** – wertet Resonanzmetriken aus
 - 📐 **CREPBewertungsmodul** – berechnet Durchschnittswerte und Klassifizierung

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🎨 **SigillinViewer & SigillinMap** – Übersicht und Detailansicht aller Sigillin
 - 🚩 **SymbolicWayfinder & SoforthilfeOverlay** – Navigation und Hilfedialoge
 - 📈 **CREPChart & CREPTriggerPanel** – CREP-Historie und Steuerung
+- 🧪 **CREPTestHarness** – UI zum Durchspielen von CREP-Werten
 - 🛰️ **Nucleon-Scanner v0.6** – Analysiert tiefe Resonanzdaten
 - 📡 **KiResonanceAnalyzer** – wertet Resonanzmetriken aus
 - 📐 **CREPBewertungsmodul** – berechnet Durchschnittswerte und Klassifizierung

--- a/packages/unifiedmandala-ui/components/CREPTestHarness.test.tsx
+++ b/packages/unifiedmandala-ui/components/CREPTestHarness.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CREPTestHarness from './CREPTestHarness';
+
+jest.mock('./CREPTriggerPanel', () => ({ __esModule: true, default: () => <div>trigger</div> }));
+jest.mock('./CREPChart', () => ({ __esModule: true, default: () => <div>chart</div> }));
+
+it('renders trigger panel and chart', () => {
+  render(<CREPTestHarness />);
+  expect(screen.getByText('trigger')).toBeInTheDocument();
+  expect(screen.getByText('chart')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/CREPTestHarness.tsx
+++ b/packages/unifiedmandala-ui/components/CREPTestHarness.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useCREP } from '../hooks/useCREP';
+import CREPTriggerPanel from './CREPTriggerPanel';
+import CREPChart from './CREPChart';
+
+const DEMO_TRIGGERS = [
+  { label: 'Low', data: { C: 1, R: 1, E: 1, P: 1 } },
+  { label: 'Medium', data: { C: 5, R: 5, E: 5, P: 5 } },
+  { label: 'High', data: { C: 9, R: 9, E: 9, P: 9 } },
+];
+
+const CREPTestHarness: React.FC = () => {
+  const { history } = useCREP();
+  return (
+    <div aria-label="CREP Test Harness">
+      <CREPTriggerPanel availableTriggers={DEMO_TRIGGERS} />
+      <CREPChart history={history} />
+    </div>
+  );
+};
+
+export default CREPTestHarness;

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -1,3 +1,4 @@
 export * from './components/MetaScoreChart';
 export * from './hooks/useMetaScores';
 export { default as UploadYamlForm } from './components/UploadYamlForm';
+export { default as CREPTestHarness } from './components/CREPTestHarness';


### PR DESCRIPTION
## Summary
- add `CREPTestHarness` React component and tests
- export new component in `unifiedmandala-ui` package
- document component in README and Handbuch

## Testing
- `pnpm test`
- `pnpm test:agents`

------
https://chatgpt.com/codex/tasks/task_e_6857ebe0ef4c832294916698173cac99