### PR TITLE
Implement CREPPlayEngine component

### DIFF
--- a/packages/unifiedmandala-ui/components/CREPPlayEngine.test.tsx
+++ b/packages/unifiedmandala-ui/components/CREPPlayEngine.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CREPPlayEngine from './CREPPlayEngine';
+
+jest.mock('../hooks/useCREP', () => ({
+  useCREP: () => ({ triggerCREP: jest.fn() })
+}));
+
+describe('CREPPlayEngine', () => {
+  it('triggers CREP with selected values', () => {
+    const trigger = jest.fn();
+    (require('../hooks/useCREP') as any).useCREP = () => ({ triggerCREP: trigger });
+    render(<CREPPlayEngine />);
+    fireEvent.change(screen.getAllByRole('slider')[0], { target: { value: '7' } });
+    fireEvent.click(screen.getByText('Trigger'));
+    expect(trigger).toHaveBeenCalledWith(expect.objectContaining({ C: 7 }));
+  });
+});

--- a/packages/unifiedmandala-ui/components/CREPPlayEngine.tsx
+++ b/packages/unifiedmandala-ui/components/CREPPlayEngine.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { useCREP } from '../hooks/useCREP';
+
+const CREPPlayEngine: React.FC = () => {
+  const { triggerCREP } = useCREP();
+  const [values, setValues] = useState({ C: 5, R: 5, E: 5, P: 5 });
+
+  const handleChange = (key: 'C' | 'R' | 'E' | 'P') => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValues({ ...values, [key]: Number(e.target.value) });
+  };
+
+  const handleSubmit = () => {
+    triggerCREP(values);
+  };
+
+  return (
+    <div aria-label="CREP Play Engine">
+      {(['C','R','E','P'] as const).map(key => (
+        <label key={key}>
+          {key}: <input type="range" min="0" max="10" value={values[key]} onChange={handleChange(key)} />
+        </label>
+      ))}
+      <button onClick={handleSubmit}>Trigger</button>
+    </div>
+  );
+};
+
+export default CREPPlayEngine;

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -2,3 +2,4 @@ export * from './components/MetaScoreChart';
 export * from './hooks/useMetaScores';
 export { default as UploadYamlForm } from './components/UploadYamlForm';
 export { default as CREPTestHarness } from './components/CREPTestHarness';
+export { default as CREPPlayEngine } from './components/CREPPlayEngine';


### PR DESCRIPTION
## Summary
- add new `CREPPlayEngine` React component with simple sliders
- add corresponding test
- export the component from `unifiedmandala-ui`

## Testing
- `npx jest packages/unifiedmandala-ui/components/CREPPlayEngine.test.tsx --runInBand` *(fails: jest missing)*

------
https://chatgpt.com/codex/tasks/task_e_6857eef8d8948322ae4332ad5371a0d8