### PR TITLE
Add nukleon utils and update docs

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-22, in der Zeit des Morgen.
+Am 2025-06-22, in der Zeit des Tag.
 
-Symbolphase: Initiation (Fokus: C)
+Symbolphase: Aktivierung (Fokus: R)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -169,6 +169,10 @@ GPTEventHub.emit('orakel:says', { content: 'Hallo Welt' });
 - `CustomRegionGallery` – Galerieansicht für Regionen.
 - `ProjectListView` – Listenansicht für Social-Good-Projekte.
 - `MobileImpactDashboard` – mobile Variante auf Basis von React Native.
+- `ConvoMemoryBridge` – extrahiert Gesprächsstrukturen und CREP-Signaturen.
+- `MemorySonifier` – übersetzt Memory-Zustände in Klänge.
+- `UniversePulseSimulator` – simuliert emergente Zustände.
+- `ToDoWeaver` – erzeugt YAML-Aufgaben aus CREP-Clustern.
 
 
 Weitere Module sind in Arbeit.
@@ -319,6 +323,8 @@ packages/
   ├── crep-automation      # CREP-bezogene Automationen
   ├── tts                  # Sprachsynthese
   ├── universum-simulationen # Simulationsmodule
+  ├── nukleon-scanner        # Extrahiert Gesprächsstrukturen
+  ├── nukleon-sonifier       # Sonifiziert Memory-Zustände
   ├── sim-domain          # Domänenspezifische Simulationen
   ├── art                 # Sonification & AI-Art
   ├── shared-utils              # Hilfsfunktionen für alle Pakete

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🌀 **SigillinOnDemandGenerator** – generiert Sigillin-Templates per CLI (`packages/cli-tools/SigillinOnDemandGenerator.ts`)
 - 📊 **CREPToDoPrioritizer** – priorisiert ToDos nach aktueller Emergenz (`packages/crep-automation/CREPToDoPrioritizer.ts`)
 - 🔥 **CREPConvoHeatmap** – zeigt Schwankungen im CREP-Verlauf (`apps/sharedream-interface/components/CREPConvoHeatmap.tsx`)
+- 🛰️ **ConvoMemoryBridge** – extrahiert Gesprächsstruktur & CREP-Signaturen (`packages/nukleon-scanner/ConvoMemoryBridge.ts`)
+- 🎶 **MemorySonifier** – übersetzt Memory-Zustände in Klänge (`packages/nukleon-sonifier/MemorySonifier.ts`)
+- 🔮 **UniversePulseSimulator** – simuliert emergente Zustände (`packages/universum-simulationen/UniversePulseSimulator.ts`)
+- 🕸️ **ToDoWeaver** – generiert YAML-Aufgaben aus CREP-Clustern (`packages/cli-tools/ToDoWeaver.ts`)
 
 ## 📦 Paketstruktur
 
@@ -104,6 +108,8 @@ packages/
   ├── crep-automation      # CREP-bezogene Automationen
   ├── tts                  # Sprachsynthese
   ├── universum-simulationen # Simulationsmodule
+  ├── nukleon-scanner        # Extrahiert Gesprächsstrukturen
+  ├── nukleon-sonifier       # Sonifiziert Memory-Zustände
   ├── sim-domain          # Domänenspezifische Simulationen
   ├── art                 # Sonification & AI-Art
   ├── shared-utils              # Hilfsfunktionen für alle Pakete

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1478,5 +1478,33 @@
     "task": "Combine advancedToDo and progress update",
     "test": "",
     "status": "done"
+  },
+  {
+    "commit": "Add ConvoMemoryBridge module",
+    "path": "packages/nukleon-scanner/ConvoMemoryBridge.ts",
+    "task": "Extract conversation structure and CREP signatures",
+    "test": "jest",
+    "status": "done"
+  },
+  {
+    "commit": "Add MemorySonifier utility",
+    "path": "packages/nukleon-sonifier/MemorySonifier.ts",
+    "task": "Map memory weights to tone labels",
+    "test": "jest",
+    "status": "done"
+  },
+  {
+    "commit": "Add ToDoWeaver CLI",
+    "path": "packages/cli-tools/ToDoWeaver.ts",
+    "task": "Generate todo.yaml from CREP clusters",
+    "test": "jest",
+    "status": "done"
+  },
+  {
+    "commit": "Add UniversePulseSimulator",
+    "path": "packages/universum-simulationen/UniversePulseSimulator.ts",
+    "task": "Simulate emergent pulse steps",
+    "test": "jest",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2979,3 +2979,23 @@ status: done
   task: Combine advancedToDo and progress update
   test: ""
   status: done
+- commit: "Add ConvoMemoryBridge module"
+  path: packages/nukleon-scanner/ConvoMemoryBridge.ts
+  task: Extract conversation structure and CREP signatures
+  test: jest
+  status: done
+- commit: "Add MemorySonifier utility"
+  path: packages/nukleon-sonifier/MemorySonifier.ts
+  task: Map memory weights to tone labels
+  test: jest
+  status: done
+- commit: "Add ToDoWeaver CLI"
+  path: packages/cli-tools/ToDoWeaver.ts
+  task: Generate todo.yaml from CREP clusters
+  test: jest
+  status: done
+- commit: "Add UniversePulseSimulator"
+  path: packages/universum-simulationen/UniversePulseSimulator.ts
+  task: Simulate emergent pulse steps
+  test: jest
+  status: done

--- a/packages/cli-tools/ToDoWeaver.test.ts
+++ b/packages/cli-tools/ToDoWeaver.test.ts
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import { weaveTodos } from './ToDoWeaver';
+
+test('weaveTodos writes yaml file', () => {
+  const tmp = 'tmp_todo.yaml';
+  weaveTodos(['a','b'], tmp);
+  const content = fs.readFileSync(tmp, 'utf8');
+  expect(content).toContain('task-0');
+  fs.unlinkSync(tmp);
+});

--- a/packages/cli-tools/ToDoWeaver.ts
+++ b/packages/cli-tools/ToDoWeaver.ts
@@ -1,0 +1,9 @@
+import fs from 'fs';
+
+/**
+ * Weaves a list of cluster strings into a simple YAML todo file.
+ */
+export function weaveTodos(clusters: string[], output = 'todo.yaml') {
+  const yamlLines = clusters.map((c, i) => `- id: task-${i}\n  text: ${c}`);
+  fs.writeFileSync(output, yamlLines.join('\n'));
+}

--- a/packages/nukleon-scanner/ConvoMemoryBridge.test.ts
+++ b/packages/nukleon-scanner/ConvoMemoryBridge.test.ts
@@ -1,0 +1,7 @@
+import { extractConvoMemory } from './ConvoMemoryBridge';
+
+test('extractConvoMemory returns text and signature', () => {
+  const res = extractConvoMemory('hello world');
+  expect(res.text).toBe('hello world');
+  expect(res.crepSignature).toHaveProperty('coherence');
+});

--- a/packages/nukleon-scanner/ConvoMemoryBridge.ts
+++ b/packages/nukleon-scanner/ConvoMemoryBridge.ts
@@ -1,0 +1,26 @@
+export interface ConvoMemory {
+  text: string;
+  crepSignature: {
+    coherence: number;
+    resonance: number;
+    emergence: number;
+    poetics: number;
+  };
+}
+
+/**
+ * Extracts a simple conversation memory and returns a pseudo CREP signature.
+ */
+export function extractConvoMemory(conversation: string): ConvoMemory {
+  const text = conversation.replace(/\n+/g, ' ').trim();
+  const len = text.length || 1;
+  return {
+    text,
+    crepSignature: {
+      coherence: Math.min(10, len % 10),
+      resonance: Math.min(10, (len >> 1) % 10),
+      emergence: Math.min(10, (len >> 2) % 10),
+      poetics: Math.min(10, (len >> 3) % 10)
+    }
+  };
+}

--- a/packages/nukleon-scanner/index.ts
+++ b/packages/nukleon-scanner/index.ts
@@ -1,0 +1,1 @@
+export * from './ConvoMemoryBridge';

--- a/packages/nukleon-sonifier/MemorySonifier.test.ts
+++ b/packages/nukleon-sonifier/MemorySonifier.test.ts
@@ -1,0 +1,7 @@
+import { memoryToTone } from './MemorySonifier';
+
+test('memoryToTone maps weight to tone', () => {
+  expect(memoryToTone(0.8)).toBe('high');
+  expect(memoryToTone(0.5)).toBe('mid');
+  expect(memoryToTone(0.1)).toBe('low');
+});

--- a/packages/nukleon-sonifier/MemorySonifier.ts
+++ b/packages/nukleon-sonifier/MemorySonifier.ts
@@ -1,0 +1,6 @@
+/** Simple mapping from memory weight to a symbolic tone name */
+export function memoryToTone(weight: number): string {
+  if (weight > 0.7) return 'high';
+  if (weight > 0.3) return 'mid';
+  return 'low';
+}

--- a/packages/nukleon-sonifier/index.ts
+++ b/packages/nukleon-sonifier/index.ts
@@ -1,0 +1,1 @@
+export * from './MemorySonifier';

--- a/packages/universum-simulationen/UniversePulseSimulator.test.ts
+++ b/packages/universum-simulationen/UniversePulseSimulator.test.ts
@@ -1,0 +1,7 @@
+import { simulatePulse } from './UniversePulseSimulator';
+
+test('simulatePulse returns array of numbers', () => {
+  const res = simulatePulse(0, 3);
+  expect(res.length).toBe(3);
+  expect(typeof res[0]).toBe('number');
+});

--- a/packages/universum-simulationen/UniversePulseSimulator.ts
+++ b/packages/universum-simulationen/UniversePulseSimulator.ts
@@ -1,0 +1,12 @@
+/**
+ * Simple sine based pulse simulation for emergent values.
+ */
+export function simulatePulse(start: number, steps: number): number[] {
+  const values: number[] = [];
+  let v = start;
+  for (let i = 0; i < steps; i++) {
+    v = Math.sin(v + i / 10);
+    values.push(v);
+  }
+  return values;
+}

--- a/packages/universum-simulationen/index.ts
+++ b/packages/universum-simulationen/index.ts
@@ -1,0 +1,1 @@
+export * from './UniversePulseSimulator';


### PR DESCRIPTION
## Summary
- implement new nukleon packages (`nukleon-scanner`, `nukleon-sonifier`)
- add `ToDoWeaver` CLI and `UniversePulseSimulator`
- document new modules in README and Handbuch
- update advancedToDo lists
- keep CHRONOPOEM in sync

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6857f4a243448322915ad69986ec3a65