### PR TITLE
Add next sigil generator script

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -225,6 +225,7 @@ Weitere Module sind in Arbeit.
 | `node scripts/repotool-convo.js` | Schnelle Auswertung & Progress-Update |
 | `node scripts/website-to-yaml.js` | Wandelt Webseite in YAML um |
 | `node scripts/symbolzeit-runner.js` | Läuft Symbolzeit-Cronjob |
+| `node scripts/generate-next-sigil.js` | Erstellt Folgesigil nach Zyklus |
 | `./scripts/setup-mtls.sh` | Erstellt Testzertifikate |
 | `./scripts/setup-kong-jwt.sh` | Konfiguriert JWT Gateway |
 | `node packages/cli-tools/sigillin-cli.js convert beispiel.yaml` | YAML ↔ JSON-Konvertierung |

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ npm run dev   # oder: yarn dev
 | `node scripts/repotool-convo.js` | Schnelle Auswertung & Progress-Update |
 | `node scripts/website-to-yaml.js` | Wandelt Webseite in YAML um |
 | `node scripts/symbolzeit-runner.js` | Läuft Symbolzeit-Cronjob |
+| `node scripts/generate-next-sigil.js` | Erstellt Folgesigil nach Zyklus |
 | `node packages/cli-tools/sigillin-cli.js convert beispiel.yaml` | YAML ↔ JSON-Konvertierung |
 | `./scripts/setup-mtls.sh` | Erstellt Testzertifikate |
 | `./scripts/setup-kong-jwt.sh` | Konfiguriert JWT Gateway |

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1506,5 +1506,12 @@
     "task": "Simulate emergent pulse steps",
     "test": "jest",
     "status": "done"
+  },
+  {
+    "commit": "Add next-sigil generation script",
+    "path": "scripts/generate-next-sigil.js",
+    "task": "Create follow-up sigil file after each cycle",
+    "test": "",
+    "status": "todo"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2999,3 +2999,8 @@ status: done
   task: Simulate emergent pulse steps
   test: jest
   status: done
+- commit: "Add next-sigil generation script"
+  path: scripts/generate-next-sigil.js
+  task: Create follow-up sigil file after each cycle
+  test: ""
+  status: todo

--- a/docs/sigils/2025-06-22-next-sigil.yaml
+++ b/docs/sigils/2025-06-22-next-sigil.yaml
@@ -1,0 +1,21 @@
+# Auto-generated sigil
+anchor: unifiedmandala-advanced-2025-06-22
+description: Dieses Sigil ist der rekursive Anker für fortschrittliche Entwicklung, Test und Verknüpfung
+  aller hier beschriebenen Module, Patterns, UIs und CI/CD-Prozesse.
+updated_from: unifiedmandala-advanced
+update_time: 2025-06-22
+instructions:
+  - Extrahiere für jede Sprint-Welle (MetaScore, Collaboration, Federation, MetaLearner, Security, UI) jeweils:
+  -       * Die vollständigen, jeweils neuesten Code- und Config-Komponenten
+  -       * Alle relevanten Tests und Storybook-Stories
+  - Erzeuge daraus:
+  -       * advancedToDo.json: Liste von Commits, jedem Commit zugeordnet sind
+  -         (a) betroffener Modul/Pfad
+  -         (b) Task-Beschreibung
+  -         (c) Referenz auf zugehörigen Test/Story/Doku
+  -       * advancedToDo.yaml: Spiegelstruktur, zur manuellen Review/Verlinkung
+  -       * advancedprogress.json: Dokumentiert Status, Merge-Konflikte, offene Branches, Fraktal-Zyklus ("ToDo extrahieren, dokumentieren, implementieren …")
+  - Ordne für jeden Entwicklungsschritt den Sprint, die Responsible und ggf. die Abhängigkeiten zu.
+  - Füge einen Self-Check-Task je Zyklus hinzu ("Sind die Layer/Tests/Stories synchron und aktuell?").
+  - Verweise explizit auf das MetaScoreChart-API/Frontend, damit UI und Backend immer konsistent gehalten werden.
+  - 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "analyze:conversations": "node scripts/analyze-conversations.js",
     "update:advanced-todo": "node scripts/update-advanced-todo.js",
     "export:crep-docs": "node scripts/export-crep-docs.js",
-    "symbolzeit:run": "node scripts/symbolzeit-runner.js"
+    "symbolzeit:run": "node scripts/symbolzeit-runner.js",
+    "generate:next-sigil": "node scripts/generate-next-sigil.js"
   },
   "dependencies": {
     "ajv": "^8.0.0",

--- a/scripts/generate-next-sigil.js
+++ b/scripts/generate-next-sigil.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const sigilPath = path.join(__dirname, '../codex-sigil.yaml');
+const text = fs.readFileSync(sigilPath, 'utf8');
+const anchorMatch = text.match(/^anchor:\s*(.+)$/m);
+const descMatch = text.match(/description:\s*>\n([\s\S]*?)\n(?:instructions:|$)/);
+const instructionsMatch = text.match(/instructions:\n([\s\S]*?)(?:\n\w|$)/);
+
+const baseAnchor = anchorMatch ? anchorMatch[1].trim() : 'unifiedmandala';
+const description = descMatch ? descMatch[1].trim() : '';
+const instructions = instructionsMatch ? instructionsMatch[1].split('\n').map(l => l.replace(/^\s*-\s*/, '')) : [];
+
+const timestamp = new Date().toISOString().slice(0, 10);
+const nextSigil = {
+  anchor: `${baseAnchor}-${timestamp}`,
+  description,
+  updated_from: baseAnchor,
+  update_time: timestamp,
+  instructions,
+};
+
+function yamlString(obj) {
+  return Object.entries(obj)
+    .map(([k, v]) => {
+      if (Array.isArray(v)) return `${k}:\n${v.map(i => `  - ${i}`).join('\n')}`;
+      return `${k}: ${v}`;
+    })
+    .join('\n');
+}
+
+const outDir = path.join(__dirname, '../docs/sigils');
+if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+const outFile = path.join(outDir, `${timestamp}-next-sigil.yaml`);
+fs.writeFileSync(outFile, `# Auto-generated sigil\n${yamlString(nextSigil)}\n`);
+console.log(`New sigil written to ${outFile}`);


### PR DESCRIPTION
## Summary
- generate follow-up sigils via `generate-next-sigil.js`
- document new script in README and Handbuch
- register script in advancedToDo files
- wire script into package.json
- produce first generated sigil example

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_685804241b2c8322819ae9fd6f0747ef