### PR TITLE
Implement Symbolzeit orchestrator

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -21,6 +21,7 @@ Pitch-Beispiele für Events sind unter `docs/pitch/` abgelegt.
 ## Packages
 
 ### aeon-shell
+  ├── SymbolzeitOrchestrator.ts    # Ereignissteuerung für Symbolzeit
 - `index.ts` – Exportiert den Paketnamen.
 - `symbolzeit.ts` – Liefert die aktuelle Symbolzeit-Phase.
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ packages/
   ├── gpt-bridges               # Mitt-basierter EventHub für GPT-Module
   ├── cli-tools                 # CLI: sigillin-cli, export-doc, Archivierung
   ├── aeon-shell                # Symbolzeit & CLI-Trigger
+  ├── SymbolzeitOrchestrator.ts    # Ereignissteuerung für Symbolzeit
   ├── aeon-genesisos            # Basis-Engine & CREP-Matrix
   ├── aeon-fraktalurs           # GPT-Kontextarchiv
   ├── aeon-resoecho             # CREP-Zeitlinienarchiv

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1541,5 +1541,12 @@
     "task": "Compute relationship metrics",
     "test": "services/memorymesh/relationship-meter/index.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add SymbolzeitOrchestrator module",
+    "path": "packages/aeon-shell/SymbolzeitOrchestrator.ts",
+    "task": "Emit phaseChange events based on symbolzeit",
+    "test": "packages/aeon-shell/SymbolzeitOrchestrator.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3024,3 +3024,8 @@ status: done
   task: Compute relationship metrics
   test: services/memorymesh/relationship-meter/index.test.ts
   status: done
+- commit: "Add SymbolzeitOrchestrator module"
+  path: packages/aeon-shell/SymbolzeitOrchestrator.ts
+  task: Emit phaseChange events based on symbolzeit
+  test: packages/aeon-shell/SymbolzeitOrchestrator.test.ts
+  status: done

--- a/packages/aeon-shell/SymbolzeitOrchestrator.test.ts
+++ b/packages/aeon-shell/SymbolzeitOrchestrator.test.ts
@@ -1,0 +1,32 @@
+import { SymbolzeitOrchestrator } from './SymbolzeitOrchestrator';
+import { getSymbolzeitPhase } from '../shared-utils/symbolzeitModulator';
+
+jest.mock('../shared-utils/symbolzeitModulator');
+
+const mockedGetPhase = getSymbolzeitPhase as jest.MockedFunction<typeof getSymbolzeitPhase>;
+
+describe('SymbolzeitOrchestrator', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockedGetPhase.mockReturnValue('morgen');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetAllMocks();
+  });
+
+  it('emits phaseChange when phase updates', () => {
+    const orchestrator = new SymbolzeitOrchestrator(1000);
+    const handler = jest.fn();
+    orchestrator.on('phaseChange', handler);
+    orchestrator.start();
+
+    mockedGetPhase.mockReturnValue('tag');
+    jest.advanceTimersByTime(1000);
+
+    expect(handler).toHaveBeenCalledWith({ phase: 'tag' });
+
+    orchestrator.stop();
+  });
+});

--- a/packages/aeon-shell/SymbolzeitOrchestrator.ts
+++ b/packages/aeon-shell/SymbolzeitOrchestrator.ts
@@ -1,0 +1,37 @@
+import mitt, { Emitter } from 'mitt';
+import { getSymbolzeitPhase } from '../shared-utils/symbolzeitModulator';
+
+export type SymbolzeitEvents = {
+  phaseChange: { phase: string };
+};
+
+export class SymbolzeitOrchestrator {
+  private emitter: Emitter<SymbolzeitEvents> = mitt<SymbolzeitEvents>();
+  private currentPhase: string = getSymbolzeitPhase();
+  private timer?: NodeJS.Timeout;
+
+  constructor(private intervalMs = 60000) {}
+
+  start() {
+    this.checkPhase();
+    this.timer = setInterval(() => this.checkPhase(), this.intervalMs);
+  }
+
+  stop() {
+    if (this.timer) clearInterval(this.timer);
+  }
+
+  on<E extends keyof SymbolzeitEvents>(event: E, handler: (data: SymbolzeitEvents[E]) => void) {
+    this.emitter.on(event, handler);
+  }
+
+  private checkPhase() {
+    const next = getSymbolzeitPhase();
+    if (next !== this.currentPhase) {
+      this.currentPhase = next;
+      this.emitter.emit('phaseChange', { phase: next });
+    }
+  }
+}
+
+export default SymbolzeitOrchestrator;

--- a/packages/aeon-shell/index.ts
+++ b/packages/aeon-shell/index.ts
@@ -1,1 +1,3 @@
 export const name = 'aeon-shell';
+export { SYMBOLZEIT } from './symbolzeit';
+export { SymbolzeitOrchestrator } from './SymbolzeitOrchestrator';


### PR DESCRIPTION
## Summary
- add SymbolzeitOrchestrator utility and test
- expose orchestrator via aeon-shell index
- reference orchestrator in README and Handbuch
- record task completion in advancedToDo files
- regenerate CHRONOPOEM

## Testing
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_68580ef8836483229fbfb4a6d89ba2ef