### PR TITLE
Add chem, mind, sonifier docs & new Sigillin validator

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -178,6 +178,7 @@ GPTEventHub.emit('orakel:says', { content: 'Hallo Welt' });
 
 Weitere Module sind in Arbeit.
 
+Eine Pipeline-Demonstration findest du in [docs/POC-run-guide.md](docs/POC-run-guide.md).
 ## Tools und Skripte
 ### Häufige Probleme
 - `pnpm dev` startet nicht → Node-Version prüfen, `pnpm install` erneut ausführen.
@@ -229,6 +230,7 @@ Weitere Module sind in Arbeit.
 | `node scripts/generate-next-sigil.js` | Erstellt Folgesigil nach Zyklus |
 | `./scripts/setup-mtls.sh` | Erstellt Testzertifikate |
 | `./scripts/setup-kong-jwt.sh` | Konfiguriert JWT Gateway |
+| `node packages/cli-tools/SigillinValidator.ts <file>` | Validiert eine Sigillin-Datei |
 | `node packages/cli-tools/sigillin-cli.js convert beispiel.yaml` | YAML ↔ JSON-Konvertierung |
 | `node packages/cli-tools/sigillin-cli.js todo-sigil` | Erzeugt todo-sigil aus Aufgabenlisten |
 | `node packages/cli-tools/sigillin-cli.js grep-conversations TODO` | Filtert Conversations nach Keyword |
@@ -328,6 +330,9 @@ packages/
   ├── nukleon-scanner        # Extrahiert Gesprächsstrukturen
   ├── nukleon-sonifier       # Sonifiziert Memory-Zustände
   ├── sim-domain          # Domänenspezifische Simulationen
+  ├── pkg/chem             # Reaction kinetics simulation
+  ├── pkg/mind             # Hybrid symbolic & neural agents
+  ├── pkg/sonifier         # CREP-to-MIDI music generator
   ├── art                 # Sonification & AI-Art
   ├── shared-utils              # Hilfsfunktionen für alle Pakete
   │   └── RestClient.ts         # einfacher REST-Helper

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ packages/
   ├── nukleon-scanner        # Extrahiert Gesprächsstrukturen
   ├── nukleon-sonifier       # Sonifiziert Memory-Zustände
   ├── sim-domain          # Domänenspezifische Simulationen
+  ├── pkg/chem             # Reaction kinetics simulation
+  ├── pkg/mind             # Hybrid symbolic & neural agents
+  ├── pkg/sonifier         # CREP-to-MIDI music generator
   ├── art                 # Sonification & AI-Art
   ├── shared-utils              # Hilfsfunktionen für alle Pakete
   │   └── RestClient.ts         # einfacher REST-Helper
@@ -227,6 +230,7 @@ npm run dev   # oder: yarn dev
 
 
 Weitere Beispiele und GIF-Demos findest du im [Wiki](https://github.com/GenesisAeon/unified-mandala/wiki).
+Weitere Infos zur Pipeline findest du in [docs/POC-run-guide.md](docs/POC-run-guide.md).
 Ein SVG-Beispiel liegt unter [`docs/assets/unified-mandala.svg`](docs/assets/unified-mandala.svg).
 
 Das `CHRONOPOEM.md` entsteht automatisch – und kann bei jedem Commit erneuert werden.

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1548,5 +1548,12 @@
     "task": "Emit phaseChange events based on symbolzeit",
     "test": "packages/aeon-shell/SymbolzeitOrchestrator.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add SigillinValidator CLI",
+    "path": "packages/cli-tools/SigillinValidator.ts",
+    "task": "Validate sigil files via Ajv",
+    "test": "",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3029,3 +3029,8 @@ status: done
   task: Emit phaseChange events based on symbolzeit
   test: packages/aeon-shell/SymbolzeitOrchestrator.test.ts
   status: done
+- commit: Add SigillinValidator CLI
+  path: packages/cli-tools/SigillinValidator.ts
+  task: Validate sigil files via Ajv
+  test: ''
+  status: done

--- a/docs/POC-run-guide.md
+++ b/docs/POC-run-guide.md
@@ -1,0 +1,36 @@
+# POC Run: Bio-Sim → Sonification → AI Art
+
+## Overview
+Demonstrate the pipeline from scientific simulation through music and image generation in a single workflow.
+
+### Steps
+1. **Run Bio Simulation**
+   ```bash
+   bio-sim-service --config genome-sim.yaml --output genome-run.jsonl
+   ```
+2. **Compute CREP Scores**
+   ```bash
+   crep-scanner --input genome-run.jsonl --output crep-scores.json
+   ```
+3. **Sonify CREP Timeline**
+   ```bash
+   sonify-run --input crep-scores.json --model melody --output fractal-symphony.mid
+   ```
+4. **Generate AI Image**
+   ```bash
+   curl -X POST https://api.unifiedmandala.org/art/generate \
+     -d '{"prompt":"A fractal symphony of DNA, watercolor style","steps":50}' \
+     -H 'Content-Type: application/json'
+   ```
+
+## GIF Storyboard
+
+| Frame | Scene              | Description                                                            | Duration |
+| ----- | ------------------ | ---------------------------------------------------------------------- | -------- |
+| 1     | Bio Simulation log | Terminal shows `genome-run.jsonl` being produced                       | 3s       |
+| 2     | CREP Scoring       | Heatmap timeline for CREP scores appears                               | 4s       |
+| 3     | Sonification       | MIDI notation scrolls with audio icon                                  | 4s       |
+| 4     | Image Generation   | Progress bar then reveal of AI-generated fractal-DNA watercolor image  | 4s       |
+| 5     | Sigil Creation     | Dashboard flashes new Sigil card with `fractalHash` and artifact links | 3s       |
+
+*Use animated overlays: arrows, labels like “CREP → Melody”, “Genomes → Art”.*

--- a/packages/cli-tools/README.md
+++ b/packages/cli-tools/README.md
@@ -7,3 +7,4 @@ Sammlung von Befehlen zur Arbeit mit Sigillin- und CREP-Daten.
 - **sigillin-archive.js** – Erstellt poetisches Archiv aller Sigillin-Dateien
 - **sigillin-cli.js todo-sigil** – erzeugt `docs/sigils/todo-sigil.yaml` aus Aufgabenlisten
 
+- **SigillinValidator.ts** – Prüft eine Sigillin-Datei gegen das Schema

--- a/packages/cli-tools/SigillinValidator.ts
+++ b/packages/cli-tools/SigillinValidator.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import Ajv from 'ajv';
+import YAML from 'yaml';
+import path from 'path';
+import schema from '../genesis-sigillin-core/schemas/sigillin.schema.json';
+
+export function validateSigil(filePath: string): boolean {
+  const ajv = new Ajv();
+  const validate = ajv.compile(schema);
+  const content = fs.readFileSync(filePath, 'utf8');
+  const data = filePath.endsWith('.yaml') || filePath.endsWith('.yml')
+    ? YAML.parse(content)
+    : JSON.parse(content);
+  const valid = validate(data);
+  if (!valid) {
+    console.error(validate.errors);
+  }
+  return !!valid;
+}
+
+if (require.main === module) {
+  const file = process.argv[2];
+  if (!file) {
+    console.error('Usage: ts-node SigillinValidator.ts <file>');
+    process.exit(1);
+  }
+  const abs = path.resolve(file);
+  if (validateSigil(abs)) {
+    console.log('Sigillin-Datei gültig.');
+  } else {
+    process.exit(1);
+  }
+}

--- a/pkg/chem/kinetics/README.md
+++ b/pkg/chem/kinetics/README.md
@@ -1,0 +1,72 @@
+# Chemistry Simulation: Kinetics & Molecule Module
+
+This module provides tools for simulating chemical reaction kinetics and molecular structures.
+
+## Features
+- Reaction equation parser and ODE-based kinetics solver
+- Molecule graph representation (atoms & bonds)
+- Export results to JSON and YAML
+- REST & gRPC service endpoints
+
+## Installation
+```bash
+# From project root
+go get github.com/GenesisAeon/unifiedmandala/pkg/chem/kinetics
+```
+
+## Usage Example (Go)
+```go
+import "github.com/GenesisAeon/unifiedmandala/pkg/chem/kinetics"
+
+func main() {
+  config := kinetics.ReactionConfig{
+    Equations: []string{"A + B -> C : 0.1"},
+    Duration:  100,
+    StepSize:  0.1,
+  }
+  result, err := kinetics.SimulateReaction(config)
+  if err != nil { panic(err) }
+  kinetics.SaveYAML(result, "reaction-output.yaml")
+}
+```
+
+## API Documentation
+
+### gRPC Service: `ChemistryService`
+```protobuf
+service ChemistryService {
+  rpc ComputeReaction (ReactionConfig) returns (ReactionResult);
+}
+```
+
+### REST Bridge (`chem-sim-engine/swagger.yaml`)
+```yaml
+paths:
+  /chem/kinetics/simulate:
+    post:
+      summary: Compute reaction kinetics
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReactionConfig'
+      responses:
+        '200':
+          description: ReactionResult JSON
+components:
+  schemas:
+    ReactionConfig:
+      type: object
+      required: [equations, duration, stepSize]
+      properties:
+        equations:
+          type: array
+          items: { type: string }
+        duration: { type: number }
+        stepSize: { type: number }
+    ReactionResult:
+      type: object
+      properties:
+        timeSeries: { type: array, items: { type: object } }
+        finalConcentrations: { type: object }
+```

--- a/pkg/mind/hybrid/README.md
+++ b/pkg/mind/hybrid/README.md
@@ -1,0 +1,67 @@
+# Mind Simulation: Hybrid Symbolic & Neural Agents
+
+This module implements cognitive agents combining symbolic logic and neural networks.
+
+## Features
+- Production-rule engine for symbolic reasoning
+- Simple MLP networks for perception modules
+- Hybrid execution pipeline with context switching
+- CLI & gRPC interface
+
+## Installation
+```bash
+go get github.com/GenesisAeon/unifiedmandala/pkg/mind/hybrid
+```
+
+## Usage Example (Go)
+```go
+import "github.com/GenesisAeon/unifiedmandala/pkg/mind/hybrid"
+
+func main() {
+  config := hybrid.AgentConfig{
+    SymbolicRules: "rules.conf",
+    NeuralModel:   "models/mind-net.onnx",
+  }
+  agent := hybrid.NewAgent(config)
+  thought, err := agent.StepThought("What is the meaning of the fractal?")
+  if err != nil { panic(err) }
+  fmt.Println("Agent thought:", thought)
+}
+```
+
+## API Documentation
+
+### gRPC Service: `MindService`
+```protobuf
+service MindService {
+  rpc LoadMind (MindConfig) returns (MindState);
+  rpc StepThought (ThoughtRequest) returns (ThoughtResponse);
+}
+```
+
+### REST Bridge (`mind-engine/swagger.yaml`)
+```yaml
+paths:
+  /mind/step:
+    post:
+      summary: Evaluate one thought step
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ThoughtRequest'
+      responses:
+        '200':
+          description: ThoughtResponse JSON
+components:
+  schemas:
+    ThoughtRequest:
+      type: object
+      required: [input]
+      properties:
+        input: { type: string }
+    ThoughtResponse:
+      type: object
+      properties:
+        output: { type: string }
+```

--- a/pkg/sonifier/melody/README.md
+++ b/pkg/sonifier/melody/README.md
@@ -1,0 +1,58 @@
+# Sonifier: CREP-to-MIDI Music Generator
+
+This module converts CREP timelines and simulation events into musical compositions.
+
+## Features
+- Map CREP metrics to melody parameters
+- Generate MIDI files or play live via WebAudio
+- Configurable scales, tempos, and instruments
+- CLI & REST endpoints
+
+## Installation
+```bash
+go get github.com/GenesisAeon/unifiedmandala/pkg/sonifier/melody
+```
+
+## Usage Example (CLI)
+```bash
+sonify-run \
+  --input events.jsonl \
+  --model melody \
+  --scale major \
+  --tempo 120 \
+  --output mandala.mid
+```
+
+## API Documentation
+
+### REST Bridge (`sonifier-service/swagger.yaml`)
+```yaml
+paths:
+  /sonify:
+    post:
+      summary: Generate MIDI from events
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SonifyRequest'
+      responses:
+        '201':
+          description: MIDI file location
+components:
+  schemas:
+    SonifyRequest:
+      type: object
+      required: [inputPath, model]
+      properties:
+        inputPath: { type: string }
+        model:
+          type: string
+          enum: [melody, harmony, rhythm]
+        scale: { type: string }
+        tempo: { type: integer }
+    SonifyResponse:
+      type: object
+      properties:
+        url: { type: string }
+```


### PR DESCRIPTION
## Summary
- document chemistry, mind agent and sonifier packages
- include POC run guide for demo pipeline
- add SigillinValidator CLI example
- reference new docs in main README and Handbuch
- update advanced todo lists

## Testing
- `pnpm test` *(fails: jest not found)*
- `pnpm vitest run` *(fails: command not found)*
- `pnpm lint` *(fails: missing dependencies)*
- `node scripts/generate-chronopoem.js` *(fails: cannot find module 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6858121337f88322bc824fcfea7fd5e7