### PR TITLE
Add CodeAgent scaffolding

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -333,6 +333,7 @@ packages/
   ├── pkg/chem             # Reaction kinetics simulation
   ├── pkg/mind             # Hybrid symbolic & neural agents
   ├── pkg/sonifier         # CREP-to-MIDI music generator
+  ├── pkg/codeagent        # Language-specific code agents
   ├── art                 # Sonification & AI-Art
   ├── shared-utils              # Hilfsfunktionen für alle Pakete
   │   └── RestClient.ts         # einfacher REST-Helper

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ packages/
   ├── pkg/chem             # Reaction kinetics simulation
   ├── pkg/mind             # Hybrid symbolic & neural agents
   ├── pkg/sonifier         # CREP-to-MIDI music generator
+  ├── pkg/codeagent        # Language-specific code agents
   ├── art                 # Sonification & AI-Art
   ├── shared-utils              # Hilfsfunktionen für alle Pakete
   │   └── RestClient.ts         # einfacher REST-Helper

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1555,5 +1555,23 @@
     "task": "Validate sigil files via Ajv",
     "test": "",
     "status": "done"
+  },
+  {
+    "commit": "Add CodeAgent scaffolding",
+    "path": "pkg/codeagent",
+    "task": "Skeleton for language agents and CLI",
+    "test": ""
+  },
+  {
+    "commit": "Add C-Tutor skeleton",
+    "path": "apps/c-tutor",
+    "task": "Interactive C learning tool placeholder",
+    "test": ""
+  },
+  {
+    "commit": "Add JavaHamster AI skeleton",
+    "path": "apps/java-hamster-ai",
+    "task": "Gamified C learning pendant",
+    "test": ""
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3034,3 +3034,15 @@ status: done
   task: Validate sigil files via Ajv
   test: ''
   status: done
+- commit: "Add CodeAgent scaffolding"
+  path: pkg/codeagent
+  task: Skeleton for language agents and CLI
+  test: ''
+- commit: "Add C-Tutor skeleton"
+  path: apps/c-tutor
+  task: Interactive C learning tool placeholder
+  test: ''
+- commit: "Add JavaHamster AI skeleton"
+  path: apps/java-hamster-ai
+  task: Gamified C learning pendant
+  test: ''

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Add MemoryMesh scaffolding and next-sigil generation",
+  "lastCommit": "Add CodeAgent scaffolding",
   "fractalStep": "implementation",
   "openBranches": [
     "work"

--- a/apps/c-tutor/README.md
+++ b/apps/c-tutor/README.md
@@ -1,0 +1,3 @@
+# C-Tutor
+
+CLI and web tool guiding learners through C programming levels.

--- a/apps/c-tutor/cli.js
+++ b/apps/c-tutor/cli.js
@@ -1,0 +1,1 @@
+#!/usr/bin/env node\nconsole.log("c-tutor placeholder");

--- a/apps/java-hamster-ai/README.md
+++ b/apps/java-hamster-ai/README.md
@@ -1,0 +1,3 @@
+# JavaHamster AI
+
+Gamified learning tool with GPT-powered coaching.

--- a/apps/java-hamster-ai/cli.js
+++ b/apps/java-hamster-ai/cli.js
@@ -1,0 +1,1 @@
+#!/usr/bin/env node\nconsole.log("java-hamster-ai placeholder");

--- a/cmd/mandala-codeagent.go
+++ b/cmd/mandala-codeagent.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("mandala-codeagent placeholder")
+}

--- a/docs/tutorials/use-our-ai-and-sigil.md
+++ b/docs/tutorials/use-our-ai-and-sigil.md
@@ -1,0 +1,3 @@
+# Use our AI & Sigil
+
+This tutorial demonstrates combining AI modules with Sigil workflows.

--- a/pkg/codeagent/bash_agent/README.md
+++ b/pkg/codeagent/bash_agent/README.md
@@ -1,0 +1,3 @@
+# Bash Agent
+
+Skeleton for bash_agent.

--- a/pkg/codeagent/c_agent/README.md
+++ b/pkg/codeagent/c_agent/README.md
@@ -1,0 +1,3 @@
+# C Agent
+
+Skeleton for c_agent.

--- a/pkg/codeagent/go_agent/README.md
+++ b/pkg/codeagent/go_agent/README.md
@@ -1,0 +1,3 @@
+# Go Agent
+
+Skeleton for go_agent.

--- a/pkg/codeagent/java_agent/README.md
+++ b/pkg/codeagent/java_agent/README.md
@@ -1,0 +1,3 @@
+# Java Agent
+
+Skeleton for java_agent.

--- a/pkg/codeagent/python_agent/README.md
+++ b/pkg/codeagent/python_agent/README.md
@@ -1,0 +1,3 @@
+# Python Agent
+
+Skeleton for python_agent.

--- a/pkg/codeagent/rust_agent/README.md
+++ b/pkg/codeagent/rust_agent/README.md
@@ -1,0 +1,3 @@
+# Rust Agent
+
+Skeleton for rust_agent.

--- a/pkg/codeagent/ts_agent/README.md
+++ b/pkg/codeagent/ts_agent/README.md
@@ -1,0 +1,3 @@
+# Ts Agent
+
+Skeleton for ts_agent.


### PR DESCRIPTION
## Summary
- add placeholder CodeAgent modules
- stub out C-Tutor and JavaHamster AI apps
- basic CLI `mandala-codeagent.go`
- add tutorial skeleton
- update README and Handbuch
- log tasks in advancedToDo and progress

## Testing
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_68581481793c8322b1dbbee17b8aa101