### PR TITLE
Implement new CREP utilities and UI hook

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -114,6 +114,13 @@ console.log(sigil.id); // hello
 - `AdvancedHexaAgent` – Erweiterte Analyse mit Research- und SilenceWatcher-Agenten.
 - `go-bridge` – Golang-Client für REST/gRPC/NATS Kommunikation.
 
+- `WeightedDispatcher` – verteilt Aufgaben nach Priorität (`packages/agents/WeightedDispatcher.ts`)
+- `patternReactivator` – reaktiviert schwache Erinnerungen (`packages/agents/patternReactivator.ts`)
+- `ReplayController` – spielt Memory-Einträge periodisch ab (`packages/agents/ReplayController.ts`)
+- `useEventGlow` – React-Hook zur Event-Hervorhebung (`packages/unifiedmandala-ui/hooks/useEventGlow.ts`)
+- `silenceWatcher` – meldet Stille an den GPTEventHub (`packages/agents/silenceWatcher.ts`)
+- `aggregateCREP` – berechnet Durchschnittswerte (`packages/crep-engine/aggregateCREP.ts`)
+- `CREPMusicGenerator` – generiert BPM aus CREP (`packages/crep-engine/CREPMusicGenerator.ts`)
 ### collab-editor
 - `CollaborativeEditor` – Federated Texteditor mit Remote-Sync.
 - `AutomergeFederation` – Verbindet lokale und entfernte Änderungen.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🔮 **UniversePulseSimulator** – simuliert emergente Zustände (`packages/universum-simulationen/UniversePulseSimulator.ts`)
 - 🕸️ **ToDoWeaver** – generiert YAML-Aufgaben aus CREP-Clustern (`packages/cli-tools/ToDoWeaver.ts`)
 
+- 📊 **WeightedDispatcher** – verteilt Tasks nach Priorität (`packages/agents/WeightedDispatcher.ts`)
+- 🔄 **patternReactivator** – reaktiviert schwache Muster (`packages/agents/patternReactivator.ts`)
+- ⏪ **ReplayController** – spielt Memory-Einträge periodisch ab (`packages/agents/ReplayController.ts`)
+- ✨ **useEventGlow** – Hook für Event-Hervorhebung (`packages/unifiedmandala-ui/hooks/useEventGlow.ts`)
+- 🤫 **silenceWatcher** – meldet Stille im EventHub (`packages/agents/silenceWatcher.ts`)
+- 🎚️ **aggregateCREP** – mittelt CREP-Werte (`packages/crep-engine/aggregateCREP.ts`)
+- 🎵 **CREPMusicGenerator** – erzeugt BPM aus CREP (`packages/crep-engine/CREPMusicGenerator.ts`)
 ## 📦 Paketstruktur
 
 ```bash

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1573,5 +1573,47 @@
     "path": "apps/java-hamster-ai",
     "task": "Gamified C learning pendant",
     "test": ""
+  },
+  {
+    "commit": "Add WeightedDispatcher",
+    "path": "packages/agents/WeightedDispatcher.ts",
+    "task": "Priority based dispatching",
+    "test": "packages/agents/WeightedDispatcher.test.ts"
+  },
+  {
+    "commit": "Add patternReactivator",
+    "path": "packages/agents/patternReactivator.ts",
+    "task": "Reactivate low CREP patterns",
+    "test": "packages/agents/patternReactivator.test.ts"
+  },
+  {
+    "commit": "Add ReplayController",
+    "path": "packages/agents/ReplayController.ts",
+    "task": "Replay memory entries",
+    "test": "packages/agents/ReplayController.test.ts"
+  },
+  {
+    "commit": "Add useEventGlow hook",
+    "path": "packages/unifiedmandala-ui/hooks/useEventGlow.ts",
+    "task": "UI glow effect for events",
+    "test": "packages/unifiedmandala-ui/hooks/useEventGlow.test.ts"
+  },
+  {
+    "commit": "Add silenceWatcher util",
+    "path": "packages/agents/silenceWatcher.ts",
+    "task": "Emit message on inactivity",
+    "test": "packages/agents/silenceWatcher.test.ts"
+  },
+  {
+    "commit": "Add aggregateCREP util",
+    "path": "packages/crep-engine/aggregateCREP.ts",
+    "task": "Average CREP entries",
+    "test": "packages/crep-engine/aggregateCREP.test.ts"
+  },
+  {
+    "commit": "Add CREPMusicGenerator",
+    "path": "packages/crep-engine/CREPMusicGenerator.ts",
+    "task": "Generate BPM from CREP",
+    "test": "packages/crep-engine/CREPMusicGenerator.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3046,3 +3046,31 @@ status: done
   path: apps/java-hamster-ai
   task: Gamified C learning pendant
   test: ''
+- commit: Add WeightedDispatcher
+  path: packages/agents/WeightedDispatcher.ts
+  task: Priority based dispatching
+  test: packages/agents/WeightedDispatcher.test.ts
+- commit: Add patternReactivator
+  path: packages/agents/patternReactivator.ts
+  task: Reactivate low CREP patterns
+  test: packages/agents/patternReactivator.test.ts
+- commit: Add ReplayController
+  path: packages/agents/ReplayController.ts
+  task: Replay memory entries
+  test: packages/agents/ReplayController.test.ts
+- commit: Add useEventGlow hook
+  path: packages/unifiedmandala-ui/hooks/useEventGlow.ts
+  task: UI glow effect for events
+  test: packages/unifiedmandala-ui/hooks/useEventGlow.test.ts
+- commit: Add silenceWatcher util
+  path: packages/agents/silenceWatcher.ts
+  task: Emit message on inactivity
+  test: packages/agents/silenceWatcher.test.ts
+- commit: Add aggregateCREP util
+  path: packages/crep-engine/aggregateCREP.ts
+  task: Average CREP entries
+  test: packages/crep-engine/aggregateCREP.test.ts
+- commit: Add CREPMusicGenerator
+  path: packages/crep-engine/CREPMusicGenerator.ts
+  task: Generate BPM from CREP
+  test: packages/crep-engine/CREPMusicGenerator.test.ts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,8 +1,6 @@
 {
-  "lastCommit": "Add CodeAgent scaffolding",
+  "lastCommit": "Add CREPMusicGenerator",
   "fractalStep": "implementation",
-  "openBranches": [
-    "work"
-  ],
+  "openBranches": ["work"],
   "mergeConflicts": []
 }

--- a/packages/agents/ReplayController.test.ts
+++ b/packages/agents/ReplayController.test.ts
@@ -1,0 +1,13 @@
+import { ReplayController } from './ReplayController';
+import { AeonMemory } from '../core/AeonMemory';
+
+test('logs replay message', () => {
+  jest.useFakeTimers();
+  console.log = jest.fn();
+  AeonMemory.record('x', { task: { id: 't1', description: 'd' } });
+  const c = new ReplayController(1000);
+  c.start();
+  jest.advanceTimersByTime(1000);
+  expect((console.log as jest.Mock).mock.calls[0][0]).toContain('t1');
+  jest.useRealTimers();
+});

--- a/packages/agents/ReplayController.ts
+++ b/packages/agents/ReplayController.ts
@@ -1,0 +1,11 @@
+import { AeonMemory } from '../core/AeonMemory';
+
+export class ReplayController {
+  constructor(private intervalMs = 5000) {}
+  public start() {
+    setInterval(() => {
+      const entry = AeonMemory.all()[0];
+      if (entry) console.log(`🔁 Replaying ${entry.task?.id}`);
+    }, this.intervalMs);
+  }
+}

--- a/packages/agents/WeightedDispatcher.test.ts
+++ b/packages/agents/WeightedDispatcher.test.ts
@@ -1,0 +1,13 @@
+import { WeightedDispatcher } from './WeightedDispatcher';
+import { Agent, Task } from '../core/interfaces';
+
+test('dispatches agents by priority', async () => {
+  const calls: string[] = [];
+  const agents: Agent[] = [
+    { id: 'a', layer: 'L', priority: 1, handle: async (t: Task) => { calls.push('a'); } } as any,
+    { id: 'b', layer: 'L', priority: 5, handle: async (t: Task) => { calls.push('b'); } } as any,
+  ];
+  const d = new WeightedDispatcher(agents);
+  await d.dispatch({ id: '1', description: 'x' });
+  expect(calls).toEqual(['b', 'a']);
+});

--- a/packages/agents/WeightedDispatcher.ts
+++ b/packages/agents/WeightedDispatcher.ts
@@ -1,0 +1,10 @@
+import { Agent, Task } from '../core/interfaces';
+
+export class WeightedDispatcher {
+  constructor(private agents: Agent[]) {}
+
+  async dispatch(task: Task) {
+    const sorted = this.agents.sort((a, b) => ((b as any).priority || 0) - ((a as any).priority || 0));
+    for (const agent of sorted) await agent.handle(task);
+  }
+}

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -38,3 +38,7 @@ export * from './MetaComposerAgent';
 export * from './AeonEchoMirrorAgent';
 export * from './CommonsAgent';
 export * from './ResonanzpfadAgent';
+export * from './WeightedDispatcher';
+export * from './patternReactivator';
+export * from './ReplayController';
+export * from './silenceWatcher';

--- a/packages/agents/patternReactivator.test.ts
+++ b/packages/agents/patternReactivator.test.ts
@@ -1,0 +1,12 @@
+import { patternReactivator } from './patternReactivator';
+import { AeonMemory } from '../core/AeonMemory';
+import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
+
+test('emits reactivate for low crep score', () => {
+  const spy = jest.fn();
+  GPTEventHub.on('task:reactivate', spy);
+  AeonMemory.record('t', { crepScore: 0.2, task: { id: '1', description: 'd' } });
+  patternReactivator();
+  expect(spy).toHaveBeenCalled();
+  GPTEventHub.off('task:reactivate', spy);
+});

--- a/packages/agents/patternReactivator.ts
+++ b/packages/agents/patternReactivator.ts
@@ -1,0 +1,11 @@
+import { AeonMemory } from '../core/AeonMemory';
+import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
+
+export function patternReactivator() {
+  const top = AeonMemory.top(5);
+  top.forEach(e => {
+    if ((e.crepScore ?? 1) < 0.3 && e.task) {
+      GPTEventHub.emit('task:reactivate', e.task);
+    }
+  });
+}

--- a/packages/agents/silenceWatcher.test.ts
+++ b/packages/agents/silenceWatcher.test.ts
@@ -1,0 +1,13 @@
+import { silenceWatcher } from './silenceWatcher';
+import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
+
+test('emits orakel message on silence', () => {
+  jest.useFakeTimers();
+  const spy = jest.fn();
+  GPTEventHub.on('orakel:says', spy);
+  silenceWatcher(1000);
+  jest.advanceTimersByTime(1500);
+  expect(spy).toHaveBeenCalled();
+  jest.useRealTimers();
+  GPTEventHub.off('orakel:says', spy);
+});

--- a/packages/agents/silenceWatcher.ts
+++ b/packages/agents/silenceWatcher.ts
@@ -1,0 +1,11 @@
+import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
+
+export function silenceWatcher(thresholdMs = 15000) {
+  let last = Date.now();
+  GPTEventHub.on("*", () => { last = Date.now(); });
+  setInterval(() => {
+    if (Date.now() - last > thresholdMs) {
+      GPTEventHub.emit('orakel:says', { text: '… Stille spricht lauter als Worte.' });
+    }
+  }, thresholdMs / 2);
+}

--- a/packages/core/AdaptiveThreshold.test.ts
+++ b/packages/core/AdaptiveThreshold.test.ts
@@ -1,0 +1,11 @@
+import { AdaptiveThreshold } from './AdaptiveThreshold';
+
+test('computes adaptive threshold', () => {
+  const th = new AdaptiveThreshold(3, 1);
+  th.push(1);
+  th.push(2);
+  th.push(3);
+  const t = th.getThreshold();
+  expect(typeof t).toBe('number');
+  expect(t).toBeGreaterThan(0);
+});

--- a/packages/core/AdaptiveThreshold.ts
+++ b/packages/core/AdaptiveThreshold.ts
@@ -1,18 +1,17 @@
 export class AdaptiveThreshold {
-  private value: number;
-  private readonly min: number;
-  private readonly max: number;
-  constructor(initial = 0.5, min = 0.1, max = 0.9) {
-    this.value = initial;
-    this.min = min;
-    this.max = max;
+  constructor(private windowSize = 10, private k = 1.0) {}
+  private history: number[] = [];
+
+  push(value: number) {
+    this.history.push(value);
+    if (this.history.length > this.windowSize) this.history.shift();
   }
-  update(feedback: number) {
-    this.value += feedback;
-    if (this.value > this.max) this.value = this.max;
-    if (this.value < this.min) this.value = this.min;
-  }
-  get threshold() {
-    return this.value;
+
+  getThreshold(): number {
+    const vals = [...this.history];
+    const mean = vals.reduce((a, b) => a + b, 0) / vals.length;
+    const variance = vals.reduce((a, b) => a + (b - mean) ** 2, 0) / vals.length;
+    const std = Math.sqrt(variance);
+    return mean + std * this.k;
   }
 }

--- a/packages/core/AeonMemory.ts
+++ b/packages/core/AeonMemory.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import YAML from 'yaml';
 import { useEffect, useState } from 'react';
+import { Task } from './interfaces';
 
 const CHRONIK_PATH = path.resolve('mandala-chronik.yaml');
 
@@ -9,6 +10,8 @@ export interface MemoryEntry {
   id: string;
   timestamp: string;
   description: string;
+  task?: Task;
+  crepScore?: number;
 }
 
 export class AeonMemory {
@@ -21,11 +24,12 @@ export class AeonMemory {
     }
   }
 
-  static record(description: string): MemoryEntry {
+  static record(description: string, extra: Partial<MemoryEntry> = {}): MemoryEntry {
     const entry: MemoryEntry = {
       id: `${Date.now()}`,
       timestamp: new Date().toISOString(),
       description,
+      ...extra
     };
     this.entries.push(entry);
     fs.writeFileSync(CHRONIK_PATH, YAML.stringify(this.entries), 'utf-8');
@@ -34,6 +38,16 @@ export class AeonMemory {
 
   static latest(n = 10): MemoryEntry[] {
     return [...this.entries].slice(-n).reverse();
+  }
+
+  static top(n = 5): MemoryEntry[] {
+    return [...this.entries]
+      .sort((a, b) => (b.crepScore || 0) - (a.crepScore || 0))
+      .slice(0, n);
+  }
+
+  static all(): MemoryEntry[] {
+    return [...this.entries];
   }
 }
 
@@ -45,8 +59,8 @@ export function useAeonMemory() {
     setEntries(AeonMemory.latest());
   }, []);
 
-  const remember = (desc: string) => {
-    const entry = AeonMemory.record(desc);
+  const remember = (desc: string, extra?: Partial<MemoryEntry>) => {
+    const entry = AeonMemory.record(desc, extra);
     setEntries([entry, ...entries]);
   };
 

--- a/packages/core/DebounceManager.test.ts
+++ b/packages/core/DebounceManager.test.ts
@@ -1,0 +1,11 @@
+import { DebounceManager } from './DebounceManager';
+
+test('enforces wait time between fires', () => {
+  jest.useFakeTimers();
+  const dm = new DebounceManager(1000);
+  expect(dm.canFire()).toBe(true);
+  expect(dm.canFire()).toBe(false);
+  jest.advanceTimersByTime(1000);
+  expect(dm.canFire()).toBe(true);
+  jest.useRealTimers();
+});

--- a/packages/core/DebounceManager.ts
+++ b/packages/core/DebounceManager.ts
@@ -1,14 +1,10 @@
 export class DebounceManager {
-  private timers: Map<string, NodeJS.Timeout> = new Map();
-  constructor(private delay = 300) {}
-  run(key: string, fn: () => void) {
-    if (this.timers.has(key)) clearTimeout(this.timers.get(key));
-    this.timers.set(
-      key,
-      setTimeout(() => {
-        this.timers.delete(key);
-        fn();
-      }, this.delay)
-    );
+  private last: number = 0;
+  constructor(private waitMs = 300) {}
+  canFire(): boolean {
+    const now = Date.now();
+    if (now - this.last < this.waitMs) return false;
+    this.last = now;
+    return true;
   }
 }

--- a/packages/crep-engine/CREPMusicGenerator.test.ts
+++ b/packages/crep-engine/CREPMusicGenerator.test.ts
@@ -1,0 +1,9 @@
+import { CREPMusicGenerator } from './CREPMusicGenerator';
+
+const generator = new CREPMusicGenerator();
+console.log = jest.fn();
+
+test('plays music with bpm from C score', () => {
+  generator.play([{ C: 0.5, R: 0, E: 0, P: 0, timestamp: new Date() }] as any);
+  expect((console.log as jest.Mock).mock.calls[0][0]).toContain('BPM');
+});

--- a/packages/crep-engine/CREPMusicGenerator.ts
+++ b/packages/crep-engine/CREPMusicGenerator.ts
@@ -1,0 +1,9 @@
+import { aggregateCREP } from './aggregateCREP';
+import { CREPEntry } from './types';
+
+export class CREPMusicGenerator {
+  play(entries: CREPEntry[]) {
+    const { C } = aggregateCREP(entries);
+    console.log(`🎵 Playing at BPM ${Math.round(C * 100)}`);
+  }
+}

--- a/packages/crep-engine/aggregateCREP.test.ts
+++ b/packages/crep-engine/aggregateCREP.test.ts
@@ -1,0 +1,14 @@
+import { aggregateCREP } from './aggregateCREP';
+
+const sample = [
+  { C: 1, R: 1, E: 1, P: 1, timestamp: new Date() },
+  { C: 3, R: 3, E: 3, P: 3, timestamp: new Date() }
+];
+
+test('averages crep entries', () => {
+  const result = aggregateCREP(sample as any);
+  expect(result.C).toBe(2);
+  expect(result.R).toBe(2);
+  expect(result.E).toBe(2);
+  expect(result.P).toBe(2);
+});

--- a/packages/crep-engine/aggregateCREP.ts
+++ b/packages/crep-engine/aggregateCREP.ts
@@ -1,0 +1,17 @@
+import { CREPEntry } from './types';
+
+export function aggregateCREP(entries: CREPEntry[]) {
+  const sum = entries.reduce((acc, e) => ({
+    C: acc.C + e.C,
+    R: acc.R + e.R,
+    E: acc.E + e.E,
+    P: acc.P + e.P
+  }), { C: 0, R: 0, E: 0, P: 0 });
+  const len = entries.length || 1;
+  return {
+    C: sum.C / len,
+    R: sum.R / len,
+    E: sum.E / len,
+    P: sum.P / len
+  };
+}

--- a/packages/unifiedmandala-ui/hooks/useEventGlow.test.ts
+++ b/packages/unifiedmandala-ui/hooks/useEventGlow.test.ts
@@ -1,0 +1,11 @@
+import { renderHook, act } from '@testing-library/react';
+import { useEventGlow } from './useEventGlow';
+import { GPTEventHub } from '../../gpt-bridges/GPTEventHub';
+
+test('toggles glow on event', () => {
+  const { result } = renderHook(() => useEventGlow('ping'));
+  act(() => {
+    GPTEventHub.emit('ping');
+  });
+  expect(result.current).toBe(true);
+});

--- a/packages/unifiedmandala-ui/hooks/useEventGlow.ts
+++ b/packages/unifiedmandala-ui/hooks/useEventGlow.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+import { GPTEventHub } from '../../gpt-bridges/GPTEventHub';
+
+export function useEventGlow(eventType: string) {
+  const [glow, setGlow] = useState(false);
+  useEffect(() => {
+    const handler = () => {
+      setGlow(true);
+      setTimeout(() => setGlow(false), 1000);
+    };
+    GPTEventHub.on(eventType, handler);
+    return () => GPTEventHub.off(eventType, handler);
+  }, [eventType]);
+  return glow;
+}


### PR DESCRIPTION
## Summary
- add adaptive threshold and debounce helpers
- implement weighted dispatcher and replay logic
- include event glow hook and silence watcher utility
- provide CREP aggregation and music generator
- document new modules in README and Handbuch
- update advancedToDo lists and progress
- add comprehensive tests

## Testing
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_685818038234832288624b332cb04e90