### PR TITLE
Add Greek agent docs and new advanced tasks

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -119,6 +119,9 @@ console.log(sigil.id); // hello
 - `ReplayController` – spielt Memory-Einträge periodisch ab (`packages/agents/ReplayController.ts`)
 - `useEventGlow` – React-Hook zur Event-Hervorhebung (`packages/unifiedmandala-ui/hooks/useEventGlow.ts`)
 - `silenceWatcher` – meldet Stille an den GPTEventHub (`packages/agents/silenceWatcher.ts`)
+- `ArchetypeDecoderAgent` – erkennt Archetypen in Task-Beschreibungen (`packages/agents/ArchetypeDecoderAgent.ts`)
+- `SigillinInterpreterAgent` – extrahiert Sigillin aus Text (`packages/agents/SigillinInterpreterAgent.ts`)
+- `ChronoPoemGeneratorAgent` – erzeugt poetische Chrono-Zeilen (`packages/agents/ChronoPoemGeneratorAgent.ts`)
 - `aggregateCREP` – berechnet Durchschnittswerte (`packages/crep-engine/aggregateCREP.ts`)
 - `CREPMusicGenerator` – generiert BPM aus CREP (`packages/crep-engine/CREPMusicGenerator.ts`)
 ### collab-editor

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - ⏪ **ReplayController** – spielt Memory-Einträge periodisch ab (`packages/agents/ReplayController.ts`)
 - ✨ **useEventGlow** – Hook für Event-Hervorhebung (`packages/unifiedmandala-ui/hooks/useEventGlow.ts`)
 - 🤫 **silenceWatcher** – meldet Stille im EventHub (`packages/agents/silenceWatcher.ts`)
+- 🔥 **ArchetypeDecoderAgent** – extrahiert Archetypen aus Beschreibungen (`packages/agents/ArchetypeDecoderAgent.ts`)
+- 🔮 **SigillinInterpreterAgent** – erkennt Sigillin-Symbole (`packages/agents/SigillinInterpreterAgent.ts`)
+- 📝 **ChronoPoemGeneratorAgent** – generiert poetische Zeilen (`packages/agents/ChronoPoemGeneratorAgent.ts`)
 - 🎚️ **aggregateCREP** – mittelt CREP-Werte (`packages/crep-engine/aggregateCREP.ts`)
 - 🎵 **CREPMusicGenerator** – erzeugt BPM aus CREP (`packages/crep-engine/CREPMusicGenerator.ts`)
 ## 📦 Paketstruktur

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1616,4 +1616,8 @@
     "task": "Generate BPM from CREP",
     "test": "packages/crep-engine/CREPMusicGenerator.test.ts"
   }
+,
+  {"commit": "Add Go-Agent watcher", "path": "go-agent/internal/watchers/advancedtodo.go", "task": "Monitor advancedToDo via NATS or polling", "test": "go-agent/test/advancedtodo_test.go"},
+  {"commit": "Add POC Run Guide", "path": "docs/demo/POC-Run-Guide.md", "task": "Document POC run with GIF storyboard", "test": ""},
+  {"commit": "Validate Swagger Docs", "path": "docs/swagger/README.md", "task": "API endpoint validation", "test": ""}
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3074,3 +3074,15 @@ status: done
   path: packages/crep-engine/CREPMusicGenerator.ts
   task: Generate BPM from CREP
   test: packages/crep-engine/CREPMusicGenerator.test.ts
+- commit: Add Go-Agent watcher
+  path: go-agent/internal/watchers/advancedtodo.go
+  task: Monitor advancedToDo via NATS or polling
+  test: go-agent/test/advancedtodo_test.go
+- commit: Add POC Run Guide
+  path: docs/demo/POC-Run-Guide.md
+  task: Document POC run with GIF storyboard
+  test: ""
+- commit: Validate Swagger Docs
+  path: docs/swagger/README.md
+  task: API endpoint validation
+  test: ""


### PR DESCRIPTION
## Summary
- document ArchetypeDecoderAgent, SigillinInterpreterAgent and ChronoPoemGeneratorAgent
- extend advancedToDo files with tasks from advanced conversations

## Testing
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_68581d1dbf7c8322a28e2aec75f9f2d8