### PR TITLE
Implement ResonanzPoetik module

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -122,6 +122,7 @@ console.log(sigil.id); // hello
 - `ArchetypeDecoderAgent` – erkennt Archetypen in Task-Beschreibungen (`packages/agents/ArchetypeDecoderAgent.ts`)
 - `SigillinInterpreterAgent` – extrahiert Sigillin aus Text (`packages/agents/SigillinInterpreterAgent.ts`)
 - `ChronoPoemGeneratorAgent` – erzeugt poetische Chrono-Zeilen (`packages/agents/ChronoPoemGeneratorAgent.ts`)
+- `ResonanzPoetik` – erzeugt Haikus und YAML-Chroniken (`packages/codex-navigator/resonanzPoetik.ts`)
 - `aggregateCREP` – berechnet Durchschnittswerte (`packages/crep-engine/aggregateCREP.ts`)
 - `CREPMusicGenerator` – generiert BPM aus CREP (`packages/crep-engine/CREPMusicGenerator.ts`)
 ### collab-editor
@@ -350,6 +351,7 @@ packages/
   ├── services/vector-indexer   # Embedding generator service
   ├── services/sigil-trigger    # Beobachtet Sigillin-Änderungen
   ├── services/memorymesh       # Region-Archive und Reflexionsdienste
+  ├── codex-navigator        # Haiku-Generator und Chronik-Exporter
   └── codex-navigator-agent     # Parser für Codex-Instruktionen
 codex/                    # Codex-Workflows und Sigillin-Dateien
 codexbuild/               # Build-Skripte und Deploy-Hilfen

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🔥 **ArchetypeDecoderAgent** – extrahiert Archetypen aus Beschreibungen (`packages/agents/ArchetypeDecoderAgent.ts`)
 - 🔮 **SigillinInterpreterAgent** – erkennt Sigillin-Symbole (`packages/agents/SigillinInterpreterAgent.ts`)
 - 📝 **ChronoPoemGeneratorAgent** – generiert poetische Zeilen (`packages/agents/ChronoPoemGeneratorAgent.ts`)
+- 🎴 **ResonanzPoetik** – erstellt Haikus aus Tasks (`packages/codex-navigator/resonanzPoetik.ts`)
 - 🎚️ **aggregateCREP** – mittelt CREP-Werte (`packages/crep-engine/aggregateCREP.ts`)
 - 🎵 **CREPMusicGenerator** – erzeugt BPM aus CREP (`packages/crep-engine/CREPMusicGenerator.ts`)
 ## 📦 Paketstruktur
@@ -137,6 +138,7 @@ packages/
   ├── services/vector-indexer # Embedding generator service
   ├── services/sigil-trigger  # Beobachtet Sigillin-Änderungen
   ├── services/memorymesh     # Region-Archive und Reflexionsdienste
+  ├── codex-navigator        # Haiku-Generator und Chronik-Exporter
   └── codex-navigator-agent     # Parser für Codex-Instruktionen
 tools/                    # Kleine Helferskripte & Generatoren
 codex/                    # Codex-Workflows und Sigillin-Dateien

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1620,4 +1620,6 @@
   {"commit": "Add Go-Agent watcher", "path": "go-agent/internal/watchers/advancedtodo.go", "task": "Monitor advancedToDo via NATS or polling", "test": "go-agent/test/advancedtodo_test.go"},
   {"commit": "Add POC Run Guide", "path": "docs/demo/POC-Run-Guide.md", "task": "Document POC run with GIF storyboard", "test": ""},
   {"commit": "Validate Swagger Docs", "path": "docs/swagger/README.md", "task": "API endpoint validation", "test": ""}
+, {"commit": "Implement ResonanzPoetik module", "path": "packages/codex-navigator/resonanzPoetik.ts", "task": "Generate haikus and compile YAML chronik", "test": "packages/codex-navigator/resonanzPoetik.test.ts"}
+, {"commit": "Aeon transition sigil workflow", "path": "docs/sigils/advancedconversations.json", "task": "Sync ToDo files before major commits and create new sigils per cycle", "test": ""}
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3086,3 +3086,11 @@ status: done
   path: docs/swagger/README.md
   task: API endpoint validation
   test: ""
+- commit: Implement ResonanzPoetik module
+  path: packages/codex-navigator/resonanzPoetik.ts
+  task: Generate haikus and compile YAML chronik
+  test: packages/codex-navigator/resonanzPoetik.test.ts
+- commit: Aeon transition sigil workflow
+  path: docs/sigils/advancedconversations.json
+  task: Sync ToDo files before major commits and create new sigils per cycle
+  test: ""

--- a/packages/agents/SilenceWatcher.ts
+++ b/packages/agents/SilenceWatcher.ts
@@ -1,11 +1,28 @@
 import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
 
-export function silenceWatcher(thresholdMs = 15000) {
-  let last = Date.now();
-  GPTEventHub.on("*", () => { last = Date.now(); });
-  setInterval(() => {
-    if (Date.now() - last > thresholdMs) {
+export class SilenceWatcher {
+  private last: number;
+  constructor(private thresholdMs = 15000) {
+    this.last = Date.now();
+    GPTEventHub.on('*', () => { this.last = Date.now(); });
+  }
+
+  shouldAnalyze(): boolean {
+    if (Date.now() - this.last > this.thresholdMs) {
       GPTEventHub.emit('orakel:says', { text: '… Stille spricht lauter als Worte.' });
+      this.last = Date.now();
+      return true;
     }
-  }, thresholdMs / 2);
+    return false;
+  }
+
+  start() {
+    setInterval(() => this.shouldAnalyze(), this.thresholdMs / 2);
+  }
+}
+
+export function silenceWatcher(thresholdMs = 15000) {
+  const watcher = new SilenceWatcher(thresholdMs);
+  watcher.start();
+  return watcher;
 }

--- a/packages/codex-navigator/resonanzPoetik.test.ts
+++ b/packages/codex-navigator/resonanzPoetik.test.ts
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+import { ResonanzPoetik, PoeticResult } from './resonanzPoetik';
+
+const task = { id: 't1', description: 'Ein einfacher Testtask fuer Haikus' } as any;
+
+test('generateHaiku creates 3-line poem', () => {
+  const haiku = ResonanzPoetik.generateHaiku(task, 'Alpha', 0.75);
+  const lines = haiku.split('\n');
+  expect(lines).toHaveLength(3);
+  expect(lines[1]).toContain('Alpha');
+});
+
+test('compileYAML writes yaml file', () => {
+  const poem = ResonanzPoetik.generateHaiku(task, 'Beta', 0.5);
+  const results: PoeticResult[] = [{ timestamp: '2024-01-01', taskId: 't1', phase: 'Beta', crepScore: 0.5, vers: poem }];
+  const filename = 'test_poem.yaml';
+  ResonanzPoetik.compileYAML(results, filename);
+  const content = fs.readFileSync(path.join(process.cwd(), filename), 'utf-8');
+  expect(content).toContain('timestamp: 2024-01-01');
+  fs.unlinkSync(path.join(process.cwd(), filename));
+});

--- a/packages/codex-navigator/resonanzPoetik.ts
+++ b/packages/codex-navigator/resonanzPoetik.ts
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import path from 'path';
+import { Task } from '../core/interfaces';
+
+export interface PoeticResult {
+  timestamp: string;
+  taskId: string;
+  phase: string;
+  crepScore: number;
+  vers: string;
+}
+
+export class ResonanzPoetik {
+  static generateHaiku(task: Task, phase: string, score: number): string {
+    const base = task.description || 'Ein leerer Pfad';
+    return [
+      base.split(' ').slice(0, 5).join(' '),
+      `Im Raum von ${phase} bewegt`,
+      `CREP: ${score.toFixed(2)} Klang`
+    ].join('\n');
+  }
+
+  static compileYAML(results: PoeticResult[], filename = 'mandala-chronik.yaml'): void {
+    const yamlBlocks = results.map((r) => {
+      return [
+        '---',
+        `timestamp: ${r.timestamp}`,
+        `taskId: ${r.taskId}`,
+        `phase: ${r.phase}`,
+        `crepScore: ${r.crepScore.toFixed(2)}`,
+        'vers: |',
+        `  ${r.vers.replace(/\n/g, '\n  ')}`
+      ].join('\n');
+    });
+
+    fs.writeFileSync(path.join(process.cwd(), filename), yamlBlocks.join('\n\n'));
+  }
+}


### PR DESCRIPTION
## Summary
- add new codex-navigator module with `ResonanzPoetik`
- extend SilenceWatcher with class implementation
- update README and Handbuch for codex-navigator references
- append new tasks to advanced ToDo files
- add tests for new functionality

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6858239c2978832292634ab2d3eaf77c