### PR TITLE
Add advanced ToDo watcher and documentation

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -189,7 +189,7 @@ GPTEventHub.emit('orakel:says', { content: 'Hallo Welt' });
 
 Weitere Module sind in Arbeit.
 
-Eine Pipeline-Demonstration findest du in [docs/POC-run-guide.md](docs/POC-run-guide.md).
+Eine Pipeline-Demonstration findest du in [docs/demo/POC-Run-Guide.md](docs/demo/POC-Run-Guide.md).
 ## Tools und Skripte
 ### Häufige Probleme
 - `pnpm dev` startet nicht → Node-Version prüfen, `pnpm install` erneut ausführen.

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ npm run dev   # oder: yarn dev
 
 
 Weitere Beispiele und GIF-Demos findest du im [Wiki](https://github.com/GenesisAeon/unified-mandala/wiki).
-Weitere Infos zur Pipeline findest du in [docs/POC-run-guide.md](docs/POC-run-guide.md).
+Weitere Infos zur Pipeline findest du in [docs/demo/POC-Run-Guide.md](docs/demo/POC-Run-Guide.md).
 Ein SVG-Beispiel liegt unter [`docs/assets/unified-mandala.svg`](docs/assets/unified-mandala.svg).
 
 Das `CHRONOPOEM.md` entsteht automatisch – und kann bei jedem Commit erneuert werden.

--- a/docs/demo/POC-Run-Guide.md
+++ b/docs/demo/POC-Run-Guide.md
@@ -1,0 +1,36 @@
+# POC Run: Bio-Sim → Sonification → AI Art
+
+## Overview
+Demonstrate the pipeline from scientific simulation through music and image generation in a single workflow.
+
+### Steps
+1. **Run Bio Simulation**
+   ```bash
+   bio-sim-service --config genome-sim.yaml --output genome-run.jsonl
+   ```
+2. **Compute CREP Scores**
+   ```bash
+   crep-scanner --input genome-run.jsonl --output crep-scores.json
+   ```
+3. **Sonify CREP Timeline**
+   ```bash
+   sonify-run --input crep-scores.json --model melody --output fractal-symphony.mid
+   ```
+4. **Generate AI Image**
+   ```bash
+   curl -X POST https://api.unifiedmandala.org/art/generate \
+     -d '{"prompt":"A fractal symphony of DNA, watercolor style","steps":50}' \
+     -H 'Content-Type: application/json'
+   ```
+
+## GIF Storyboard
+
+| Frame | Scene              | Description                                                            | Duration |
+| ----- | ------------------ | ---------------------------------------------------------------------- | -------- |
+| 1     | Bio Simulation log | Terminal shows `genome-run.jsonl` being produced                       | 3s       |
+| 2     | CREP Scoring       | Heatmap timeline for CREP scores appears                               | 4s       |
+| 3     | Sonification       | MIDI notation scrolls with audio icon                                  | 4s       |
+| 4     | Image Generation   | Progress bar then reveal of AI-generated fractal-DNA watercolor image  | 4s       |
+| 5     | Sigil Creation     | Dashboard flashes new Sigil card with `fractalHash` and artifact links | 3s       |
+
+*Use animated overlays: arrows, labels like “CREP → Melody”, “Genomes → Art”.*

--- a/docs/swagger/README.md
+++ b/docs/swagger/README.md
@@ -1,0 +1,6 @@
+# API Swagger Documentation
+
+This directory collects swagger specs for UnifiedMandala services.
+
+## Validation
+Run `npm run swagger:validate` to ensure all endpoints comply with the spec.

--- a/feedbackcodex.json
+++ b/feedbackcodex.json
@@ -1,3 +1,3 @@
 {
-  "feedback": "Tests and installation run successfully. Documentation updated as per user request."
+  "feedback": "Tests passing. Added advancedtodo watcher and updated docs."
 }

--- a/go-agent/internal/watchers/advancedtodo.go
+++ b/go-agent/internal/watchers/advancedtodo.go
@@ -1,0 +1,40 @@
+package watchers
+
+import (
+    "log"
+    "os"
+    "time"
+)
+
+type AdvancedTodoWatcher struct {
+    path    string
+    lastMod time.Time
+}
+
+func NewAdvancedTodoWatcher(path string) *AdvancedTodoWatcher {
+    return &AdvancedTodoWatcher{path: path}
+}
+
+func (w *AdvancedTodoWatcher) Check() {
+    info, err := os.Stat(w.path)
+    if err != nil {
+        return
+    }
+    if info.ModTime().After(w.lastMod) {
+        w.lastMod = info.ModTime()
+        log.Printf("advancedToDo updated: %s", w.path)
+    }
+}
+
+func (w *AdvancedTodoWatcher) Start(interval time.Duration, stop <-chan struct{}) {
+    ticker := time.NewTicker(interval)
+    defer ticker.Stop()
+    for {
+        select {
+        case <-ticker.C:
+            w.Check()
+        case <-stop:
+            return
+        }
+    }
+}

--- a/go-agent/test/advancedtodo_test.go
+++ b/go-agent/test/advancedtodo_test.go
@@ -1,0 +1,25 @@
+package test
+
+import (
+    "os"
+    "testing"
+
+    "github.com/unified-mandala/go-agent/internal/watchers"
+)
+
+func TestAdvancedTodoWatcher(t *testing.T) {
+    f, err := os.CreateTemp("", "todo")
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer os.Remove(f.Name())
+
+    w := watchers.NewAdvancedTodoWatcher(f.Name())
+    w.Check()
+
+    if _, err := f.WriteString("task"); err != nil {
+        t.Fatal(err)
+    }
+    f.Close()
+    w.Check()
+}


### PR DESCRIPTION
## Summary
- document POC run guide in new demo folder
- add Swagger docs folder with brief README
- implement `AdvancedTodoWatcher` in Go agent
- add unit test for new watcher
- update README and Handbuch references
- log progress in feedbackcodex

## Testing
- `pnpm install --ignore-scripts`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685826747280832292a5862fff95a27e