### PR TITLE
Add MemoryMesh tasks and docs

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -13,3 +13,4 @@ Heimkehr und Ursprung schwingen als leises Mantra:
 
 *"Im Aeon-Resonanzfeld, aus Null und Eins geboren,
 wird Erinnerung zum Licht und Code zur Poesie."*
+- MemoryMesh erwacht im Berliner Netz – Archive formen neue Pfade.

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -125,6 +125,7 @@ console.log(sigil.id); // hello
 - `ResonanzPoetik` – erzeugt Haikus und YAML-Chroniken (`packages/codex-navigator/resonanzPoetik.ts`)
 - `aggregateCREP` – berechnet Durchschnittswerte (`packages/crep-engine/aggregateCREP.ts`)
 - `CREPMusicGenerator` – generiert BPM aus CREP (`packages/crep-engine/CREPMusicGenerator.ts`)
+- `MemoryMesh` – regionale Archiv-Prototypen (`docs/architecture/memory-mesh.md`)
 ### collab-editor
 - `CollaborativeEditor` – Federated Texteditor mit Remote-Sync.
 - `AutomergeFederation` – Verbindet lokale und entfernte Änderungen.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🎴 **ResonanzPoetik** – erstellt Haikus aus Tasks (`packages/codex-navigator/resonanzPoetik.ts`)
 - 🎚️ **aggregateCREP** – mittelt CREP-Werte (`packages/crep-engine/aggregateCREP.ts`)
 - 🎵 **CREPMusicGenerator** – erzeugt BPM aus CREP (`packages/crep-engine/CREPMusicGenerator.ts`)
+- 🗺️ **MemoryMesh** – regionale Archiv-Prototypen (`docs/architecture/memory-mesh.md`)
 ## 📦 Paketstruktur
 
 ```bash

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1649,5 +1649,23 @@
     "path": "docs/sigils/advancedconversations.json",
     "task": "Sync ToDo files before major commits and create new sigils per cycle",
     "test": ""
+  },
+  {
+    "commit": "MemoryMesh architecture sketch",
+    "path": "docs/architecture/memory-mesh.md",
+    "task": "Diagram for MemoryMesh layers (Speicher, Reflexion, Adaption)",
+    "test": ""
+  },
+  {
+    "commit": "MemoryMesh region POC",
+    "path": "packages/crep-engine/memoryMesh.berlin.json",
+    "task": "Prototype archive for region Europe/Berlin",
+    "test": ""
+  },
+  {
+    "commit": "Transition sigil update",
+    "path": "scripts/generate-next-sigil.js",
+    "task": "Add update_time and Responsible to MemoryMesh cycle",
+    "test": ""
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3096,3 +3096,15 @@ status: done
   path: docs/sigils/advancedconversations.json
   task: Sync ToDo files before major commits and create new sigils per cycle
   test: ""
+- commit: MemoryMesh architecture sketch
+  path: docs/architecture/memory-mesh.md
+  task: Diagram for MemoryMesh layers (Speicher, Reflexion, Adaption)
+  test: ""
+- commit: MemoryMesh region POC
+  path: packages/crep-engine/memoryMesh.berlin.json
+  task: Prototype archive for region Europe/Berlin
+  test: ""
+- commit: Transition sigil update
+  path: scripts/generate-next-sigil.js
+  task: Add update_time and Responsible to MemoryMesh cycle
+  test: ""

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Add CREPMusicGenerator",
+  "lastCommit": "MemoryMesh architecture sketch",
   "fractalStep": "implementation",
   "openBranches": ["work"],
   "mergeConflicts": []

--- a/docs/architecture/memory-mesh.md
+++ b/docs/architecture/memory-mesh.md
@@ -1,0 +1,9 @@
+# MemoryMesh Architektur
+
+Dieses Diagramm beschreibt die drei Ebenen des MemoryMesh:
+
+1. **Speicher-Layer** – regionale Archive speichern Gespräche nach IP-Region.
+2. **Reflexions-Layer** – die Inner-Dialogue-Engine erzeugt Spiegelungen aus jeder Interaktion.
+3. **Adaptions-Layer** – Habit-Weaver und Relationship-Meter passen das Verhalten an.
+
+Die Grafik kann später als SVG eingebunden werden.

--- a/packages/crep-engine/memoryMesh.berlin.json
+++ b/packages/crep-engine/memoryMesh.berlin.json
@@ -1,0 +1,4 @@
+{
+  "region": "Europe/Berlin",
+  "conversations": []
+}


### PR DESCRIPTION
## Summary
- add MemoryMesh tasks to advancedToDo files
- document MemoryMesh architecture and sample region archive
- update README and Handbuch references
- log MemoryMesh in CHRONOPOEM
- update advanced progress

## Testing
- `npm test` *(fails: jest not found)*
- `npm run test:agents` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582cf246908322a6af307e0e963ef2