### PR TITLE
Add agent registry and gamification endpoints

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -13,4 +13,3 @@ Heimkehr und Ursprung schwingen als leises Mantra:
 
 *"Im Aeon-Resonanzfeld, aus Null und Eins geboren,
 wird Erinnerung zum Licht und Code zur Poesie."*
-- MemoryMesh erwacht im Berliner Netz – Archive formen neue Pfade.

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -126,6 +126,10 @@ console.log(sigil.id); // hello
 - `aggregateCREP` – berechnet Durchschnittswerte (`packages/crep-engine/aggregateCREP.ts`)
 - `CREPMusicGenerator` – generiert BPM aus CREP (`packages/crep-engine/CREPMusicGenerator.ts`)
 - `MemoryMesh` – regionale Archiv-Prototypen (`docs/architecture/memory-mesh.md`)
+- `Agent-Registry` – zentrale YAML-Liste aller Agents (`agents.yaml`)
+- `SigilStory` – Mandala-Diagramm für Lernpfade
+- `Gamification API` – Endpunkte `/gamify/badges` und `/gamify/leaderboard`
+- `Share your Sigil` & `Remix my Solution` – Community-Buttons
 ### collab-editor
 - `CollaborativeEditor` – Federated Texteditor mit Remote-Sync.
 - `AutomergeFederation` – Verbindet lokale und entfernte Änderungen.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🎚️ **aggregateCREP** – mittelt CREP-Werte (`packages/crep-engine/aggregateCREP.ts`)
 - 🎵 **CREPMusicGenerator** – erzeugt BPM aus CREP (`packages/crep-engine/CREPMusicGenerator.ts`)
 - 🗺️ **MemoryMesh** – regionale Archiv-Prototypen (`docs/architecture/memory-mesh.md`)
+- 🕸️ **Agent-Registry** – zentrale Übersicht aller Agents (`agents.yaml`)
+- 🌀 **SigilStory** – Mandala-Lern-Lebenslauf für C-Tutor & JavaHamster
+- 🎮 **Gamification API** – Endpunkte `/gamify/badges` & `/gamify/leaderboard`
+- 🔗 **Share your Sigil** & **Remix my Solution** – Community-Features
 ## 📦 Paketstruktur
 
 ```bash

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1667,5 +1667,23 @@
     "path": "scripts/generate-next-sigil.js",
     "task": "Add update_time and Responsible to MemoryMesh cycle",
     "test": ""
+  },
+  {
+    "commit": "Add agent registry YAML",
+    "path": "agents.yaml",
+    "task": "Store all agent types centrally",
+    "test": ""
+  },
+  {
+    "commit": "Gamification API routes",
+    "path": "apps/sharedream-interface/pages/api/gamify",
+    "task": "Provide badges and leaderboard",
+    "test": "apps/sharedream-interface/pages/api/gamify/badges.test.ts"
+  },
+  {
+    "commit": "Sigil Story component",
+    "path": "packages/unifiedmandala-ui/components/SigilStory.tsx",
+    "task": "Visualize learning progress",
+    "test": "packages/unifiedmandala-ui/components/SigilStory.test.tsx"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3108,3 +3108,15 @@ status: done
   path: scripts/generate-next-sigil.js
   task: Add update_time and Responsible to MemoryMesh cycle
   test: ""
+- commit: Add agent registry YAML
+  path: agents.yaml
+  task: Store all agent types centrally
+  test: ""
+- commit: Gamification API routes
+  path: apps/sharedream-interface/pages/api/gamify
+  task: Provide badges and leaderboard
+  test: apps/sharedream-interface/pages/api/gamify/badges.test.ts
+- commit: Sigil Story component
+  path: packages/unifiedmandala-ui/components/SigilStory.tsx
+  task: Visualize learning progress
+  test: packages/unifiedmandala-ui/components/SigilStory.test.tsx

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,8 @@
 {
-  "lastCommit": "MemoryMesh architecture sketch",
+  "lastCommit": "Gamification API and Sigil Story added",
   "fractalStep": "implementation",
-  "openBranches": ["work"],
+  "openBranches": [
+    "work"
+  ],
   "mergeConflicts": []
 }

--- a/agents.yaml
+++ b/agents.yaml
@@ -1,0 +1,9 @@
+agents:
+  - id: codeagent-python
+    description: "Generiert Python-Code-Snippets via GPT"
+    endpoint: "/codeagent/python/generate"
+    example: "curl -X POST /codeagent/python/generate -d '{\"description\":\"print Hello\"}'"
+  - id: codeagent-go
+    description: "Generiert Go-Code-Snippets via GPT"
+    endpoint: "/codeagent/go/generate"
+    example: "curl -X POST /codeagent/go/generate -d '{\"description\":\"hello\"}'"

--- a/apps/sharedream-interface/pages/api/gamify/badges.test.ts
+++ b/apps/sharedream-interface/pages/api/gamify/badges.test.ts
@@ -1,0 +1,15 @@
+/** @jest-environment node */
+import handler from './badges';
+
+test('returns badges', () => {
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  handler({} as any, { status } as any);
+  expect(status).toHaveBeenCalledWith(200);
+  expect(json).toHaveBeenCalledWith({
+    badges: [
+      { id: 'first-pointer', name: 'First C Pointer reversed' },
+      { id: 'hamster-pro', name: 'Hamster AI-Pro' },
+    ],
+  });
+});

--- a/apps/sharedream-interface/pages/api/gamify/badges.ts
+++ b/apps/sharedream-interface/pages/api/gamify/badges.ts
@@ -1,0 +1,8 @@
+export default function handler(_req: any, res: any) {
+  res.status(200).json({
+    badges: [
+      { id: 'first-pointer', name: 'First C Pointer reversed' },
+      { id: 'hamster-pro', name: 'Hamster AI-Pro' },
+    ],
+  });
+}

--- a/apps/sharedream-interface/pages/api/gamify/leaderboard.test.ts
+++ b/apps/sharedream-interface/pages/api/gamify/leaderboard.test.ts
@@ -1,0 +1,15 @@
+/** @jest-environment node */
+import handler from './leaderboard';
+
+test('returns leaderboard', () => {
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  handler({} as any, { status } as any);
+  expect(status).toHaveBeenCalledWith(200);
+  expect(json).toHaveBeenCalledWith({
+    leaderboard: [
+      { user: 'alice', score: 12 },
+      { user: 'bob', score: 9 },
+    ],
+  });
+});

--- a/apps/sharedream-interface/pages/api/gamify/leaderboard.ts
+++ b/apps/sharedream-interface/pages/api/gamify/leaderboard.ts
@@ -1,0 +1,8 @@
+export default function handler(_req: any, res: any) {
+  res.status(200).json({
+    leaderboard: [
+      { user: 'alice', score: 12 },
+      { user: 'bob', score: 9 },
+    ],
+  });
+}

--- a/docs/announcement-microcopy.md
+++ b/docs/announcement-microcopy.md
@@ -1,0 +1,7 @@
+**Deutsch:**
+
+Entdecke jetzt die Mandala-Coding Experience: Mit unseren neuen Agents, dem KI-unterstützten C-Tutor und dem JavaHamster-AI-Game hebst du Coding & Lernen auf das nächste Level – inklusive Sigil-Dokumentation für jeden Fortschritt. Probiere das hands-on Tutorial und lass dich von unserem KI-Coach begleiten! 🚀
+
+**English:**
+
+Unlock the Mandala Coding Experience: Our new multi-language Agents, the AI-powered C-Tutor, and the JavaHamster AI game bring learning, coding, and documentation together – every achievement captured as a Sigil. Try the hands-on tutorial and let our AI coach guide you! 🚀

--- a/docs/sigils/advancedconversations_snippet.json
+++ b/docs/sigils/advancedconversations_snippet.json
@@ -1,0 +1,30 @@
+{
+  "id": "learning-module-launch",
+  "modules": [
+    "codeagent-python",
+    "codeagent-go",
+    "c-tutor",
+    "java-hamster-ai"
+  ],
+  "workflows": [
+    {
+      "name": "C-Tutor Progress",
+      "steps": [
+        "Start at beginner",
+        "Solve exercises, receive Sigil per milestone",
+        "Level up to intermediate and expert",
+        "Export learning Sigil for portfolio"
+      ]
+    },
+    {
+      "name": "JavaHamster AI Flow",
+      "steps": [
+        "Select Level",
+        "Write & run Hamster code",
+        "AI coach gives hints",
+        "Sigil for completed levels"
+      ]
+    }
+  ],
+  "tutorial": "Hands-on: Use our AI & Sigil to solve, document and share learning journeys."
+}

--- a/packages/unifiedmandala-ui/components/SigilStory.stories.tsx
+++ b/packages/unifiedmandala-ui/components/SigilStory.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import SigilStory from './SigilStory';
+
+export default {
+  title: 'UnifiedMandala/SigilStory',
+  component: SigilStory,
+};
+
+const sample = [
+  { name: 'C-Tutor', milestones: [{ sigil: 'c1', hint: 'Init', time: 1 }] },
+  { name: 'JavaHamster', milestones: [{ sigil: 'j1', hint: 'Start', time: 1 }] },
+];
+
+export const Overview = () => <SigilStory paths={sample} />;

--- a/packages/unifiedmandala-ui/components/SigilStory.test.tsx
+++ b/packages/unifiedmandala-ui/components/SigilStory.test.tsx
@@ -1,0 +1,30 @@
+// d3 is esm only; mock minimal API
+jest.mock('d3', () => ({
+  select: () => ({
+    selectAll: () => ({ remove: jest.fn() }),
+    append: () => ({
+      attr: jest.fn().mockReturnThis(),
+      selectAll: jest.fn().mockReturnThis(),
+      data: jest.fn().mockReturnThis(),
+      enter: jest.fn().mockReturnThis(),
+      append: jest.fn().mockReturnThis(),
+      text: jest.fn().mockReturnThis(),
+    }),
+  }),
+  max: () => 1,
+  scaleLinear: () => ({ domain: () => ({ range: () => (x: number) => x }) }),
+  arc: () => ({
+    innerRadius: () => ({ outerRadius: () => ({}) }),
+  }),
+}));
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SigilStory from './SigilStory';
+
+const data = [{ name: 'C-Tutor', milestones: [{ sigil: 's1', hint: 'start', time: 1 }] }];
+
+test('renders Sigil Story SVG', () => {
+  render(<SigilStory paths={data} />);
+  expect(screen.getByLabelText('Sigil Story')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/SigilStory.tsx
+++ b/packages/unifiedmandala-ui/components/SigilStory.tsx
@@ -1,0 +1,61 @@
+import React, { useRef, useEffect } from 'react';
+import * as d3 from 'd3';
+
+export interface Milestone {
+  sigil: string;
+  hint: string;
+  time: number;
+}
+
+export interface SigilPath {
+  name: string;
+  milestones: Milestone[];
+}
+
+export interface SigilStoryProps {
+  paths: SigilPath[];
+}
+
+const radius = 80;
+
+const SigilStory: React.FC<SigilStoryProps> = ({ paths }) => {
+  const ref = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    const svg = d3.select(ref.current);
+    svg.selectAll('*').remove();
+
+    paths.forEach((path, idx) => {
+      const g = svg
+        .append('g')
+        .attr('transform', `translate(${radius * 2}, ${(idx + 1) * radius * 2})`);
+      const maxTime = d3.max(path.milestones, (m) => m.time) || 1;
+      const angle = d3.scaleLinear().domain([0, maxTime]).range([0, 2 * Math.PI]);
+
+      const arcGen = d3
+        .arc<d3.DefaultArcObject>()
+        .innerRadius(radius - 20)
+        .outerRadius(radius);
+
+      g.selectAll('path')
+        .data(path.milestones)
+        .enter()
+        .append('path')
+        .attr('d', (d) =>
+          arcGen({
+            startAngle: angle(d.time),
+            endAngle: angle(d.time) + 0.3,
+            innerRadius: radius - 20,
+            outerRadius: radius,
+          })!
+        )
+        .attr('fill', '#6b6')
+        .append('title')
+        .text((d) => `${d.sigil}: ${d.hint}`);
+    });
+  }, [paths]);
+
+  return <svg ref={ref} aria-label="Sigil Story" width={400} height={paths.length * radius * 2.5} />;
+};
+
+export default SigilStory;

--- a/scripts/generate-next-sigil.js
+++ b/scripts/generate-next-sigil.js
@@ -18,6 +18,7 @@ const nextSigil = {
   description,
   updated_from: baseAnchor,
   update_time: timestamp,
+  responsible: process.env.USER || 'unknown',
   instructions,
 };
 


### PR DESCRIPTION
## Summary
- create `agents.yaml` with basic registry
- implement `SigilStory` React component with tests and storybook
- add gamification API endpoints for badges and leaderboard
- include announcement microcopy
- update README, Handbuch and CHRONOPOEM
- append tasks and progress files

## Testing
- `pnpm test`
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6858322c5e6c8322af73305f72442db5