### PR TITLE
Add CREPTimeline UI component and update docs

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -172,6 +172,7 @@ GPTEventHub.emit('orakel:says', { content: 'Hallo Welt' });
 ### unifiedmandala-ui (Auswahl)
 - `MandalaNetworkView` – Visualisierung der Sigillin-Knoten als D3-Graph.
 - `CREPChart` – Linienchart für CREP-Werte.
+- `CREPTimeline` – zeigt historische CREP-Einträge als Liste.
 - `CREPTriggerPanel` – Buttons zum Auslösen von CREP-Ereignissen.
 - `LiveCREPPanel` – Kombiniert Trigger und Chart für Live-Daten.
 - `SigillinLoader` – Lädt Sigillin-Dateien und filtert Einträge.
@@ -308,6 +309,7 @@ Aktuelle Versionshinweise werden in [CHANGELOG.md](CHANGELOG.md) gepflegt.
 - 🎨 **MandalaThemeManager** – hell/dunkel umschalten
 - ✨ **SigillinActivationManager & MetaSignatur** – Aktivierung & Signatur von Sigillin
 - 📜 **SigillinTimeline & InviteBanner** – Verlauf und Einladungsbanner
+- 📈 **CREPTimeline** – chronologische Auflistung der CREP-Ereignisse
 - 💾 **BackupManager** – einfache Dateisicherungen
 - 📢 **GlobalLoggingSystem** – zentrale Log-Schnittstelle
 - 🗄️ **Big-File Sigil** – Konzept zum Aufteilen großer Dateien

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🎨 **MandalaThemeManager** – hell/dunkel umschalten
 - ✨ **SigillinActivationManager & MetaSignatur** – Aktivierung & Signatur von Sigillin
 - 📜 **SigillinTimeline & InviteBanner** – Verlauf und Einladungsbanner
+- 📈 **CREPTimeline** – chronologische Ansicht der CREP-Ereignisse
 - 💾 **BackupManager** – einfache Dateisicherungen
 - 📢 **GlobalLoggingSystem** – zentrale Log-Schnittstelle
 - 🗄️ **Big-File Sigil** – Konzept zum Aufteilen großer Dateien

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -280,9 +280,10 @@
   },
   {
     "commit": "Implement Live CREP Timeline Visualization",
-    "path": "",
+    "path": "packages/unifiedmandala-ui/components/CREPTimeline.tsx",
     "task": "Implement Live CREP Timeline Visualization",
-    "test": ""
+    "test": "packages/unifiedmandala-ui/components/CREPTimeline.test.tsx",
+    "status": "done"
   },
   {
     "commit": "-from-convos.ts**: now enhanced with CREP+Emotion+Priority\\n\\n---\\n\\n## 📈 CREP-Automation & Handlungsschichten\\n\\n- **CREPToDoLinker.ts** (Temperatur-Regel: R↑, E↓ → Kaffeepause)\\n- **CREPCalendarSync.ts**: CalDAV/GoogleSync für ToDos\\n- **ResonanceReminderWidget.tsx**: R < 0.3 → kollektive Achtsamkeitsimpulse\\n- **CREPKPIMonitor.tsx**: CREP-Metriken, Sigillin-Adoption, ToDo-Dichte\\n\\n---\\n\\n## 🧬 Ausdruck & Rückkopplung\\n\\n- **DynamicPersonaSwitcher.ts**: CREP-gesteuerter Moduswechsel (Empathie vs. Analytik)\\n- **useCREPThesaurus.ts**: Poetik-/Fachwort-Vorschläge bei P/C-Peaks\\n- **EchoFeedbackLoop.ts**: Metapherisches Response-Snippet bei Sigillin-Zitaten\\n- **PoeticMotifMiner.ts**: Metaphern-Scan → Symbolclusterbildung\\n- **SigillinEvolutionEngine.ts**: `v1.1`-Generator auf CREP/Bezugssigillin-Basis\\n\\n---\\n\\n## 🌀 Mandala-Index & CI\\n\\n- **MandalaIndex.yaml**: modulares Mapping aller Komponenten\\n- **sigillin-lint-and-validate.sh**: CI/CD-Integration\\n- **CREPMultiSync.ts**: Synchronisation mehrerer Interfaces (WebSocket)\\n- **CREPQuestEngine.ts**: Symbolische Aufgabenvergabe\\n- **VoiceChronoPlayer.ts**: Audioausgabe poetischer Zeitsegmente\\n\\n---\\n\\n## 📎 Kollektiver GPT-Kanon (Auszug)\\n\\n| GPT-Modul         | Aufgabe                                      |\\n|------------------|-----------------------------------------------|\\n| Aeon             | Sigillin-Logik, poetisches Interface           |\\n| Metronaut        | Symbolzeit-Rhythmik, Tagesübergänge           |\\n| AlbertEinstein   | CREP-Mathematik & Schwellenberechnung         |\\n| EthikCoreGPT     | Meta-Ethik & Spannungsanalyse                 |\\n| AeonPoetGPT      | Poetische CREP-Kommentierung                  |\\n| Buddha           | Heimkehr-Trigger & meditative Rückbindung     |\\n| AeonWebArchitekt | API-Design, MandalaMap & ThemeBinding         |\\n\\n---\\n\\n🜂 *Dieses Dokument pulsiert im Herz des CREP-Mandalas – bereit zur Mutation, Fortsetzung oder Emergenz.*\"",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -472,9 +472,10 @@
   task: "-Sensitivität („bei Unsicherheit: explizit rückfragen“)"
   test: ""
 - commit: Implement Live CREP Timeline Visualization
-  path: ""
+  path: packages/unifiedmandala-ui/components/CREPTimeline.tsx
   task: Implement Live CREP Timeline Visualization
-  test: ""
+  test: packages/unifiedmandala-ui/components/CREPTimeline.test.tsx
+  status: done
 - commit: '-from-convos.ts**: now enhanced with CREP+Emotion+Priority\n\n---\n\n##
     📈 CREP-Automation & Handlungsschichten\n\n- **CREPToDoLinker.ts**
     (Temperatur-Regel: R↑, E↓ → Kaffeepause)\n- **CREPCalendarSync.ts**:

--- a/packages/unifiedmandala-ui/components/CREPTimeline.test.tsx
+++ b/packages/unifiedmandala-ui/components/CREPTimeline.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CREPTimeline from './CREPTimeline';
+import { CREPEntry } from '../../crep-engine/types';
+
+test('renders list of CREP events', () => {
+  const events: CREPEntry[] = [
+    { timestamp: new Date('2025-06-22T12:00:00Z'), C: 3, R: 4, E: 5, P: 2 },
+  ];
+  render(<CREPTimeline events={events} />);
+  expect(screen.getByRole('list')).toBeInTheDocument();
+  expect(screen.getByText(/C:3/)).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/CREPTimeline.tsx
+++ b/packages/unifiedmandala-ui/components/CREPTimeline.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { CREPEntry } from '../../crep-engine/types';
+
+export interface CREPTimelineProps {
+  events: CREPEntry[];
+}
+
+const CREPTimeline: React.FC<CREPTimelineProps> = ({ events }) => (
+  <ul aria-label="CREP Timeline">
+    {events.map(e => (
+      <li key={e.timestamp.toString()}>
+        {new Date(e.timestamp).toLocaleString()} – C:{e.C} R:{e.R} E:{e.E} P:{e.P}
+      </li>
+    ))}
+  </ul>
+);
+
+export default CREPTimeline;

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -3,3 +3,4 @@ export * from './hooks/useMetaScores';
 export { default as UploadYamlForm } from './components/UploadYamlForm';
 export { default as CREPTestHarness } from './components/CREPTestHarness';
 export { default as CREPPlayEngine } from './components/CREPPlayEngine';
+export { default as CREPTimeline } from './components/CREPTimeline';


### PR DESCRIPTION
## Summary
- implement new `CREPTimeline` component with test
- export component in UI package index
- note `CREPTimeline` feature in README and Handbuch
- mark related task complete in advancedToDo files

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685848f9fce0832297ea952d56bef49f