### PR TITLE
Add learning module tasks and update docs

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-22, in der Zeit des Tag.
+Am 2025-06-22, in der Zeit des Abend.
 
-Symbolphase: Aktivierung (Fokus: R)
+Symbolphase: Integration (Fokus: E)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -100,6 +100,7 @@ console.log(sigil.id); // hello
 - `MetaScoreComposer` – Aggregiert mehrere Score-Layer.
 - `GoAgent` – Liest advancedToDo-Dateien und listet offene Tasks (Node).
 - `Go-Agent (Golang)` – Autonomer Daemon für parallele Task-Ausführung.
+Die erweiterten ToDos liegen in "advancedToDo_parts/".
 - `CommonsAgent` – Bewertet Open-Science-Aspekte.
 - `AdaptiveThreshold` und `DebounceManager` – steuern CREP-Trigger.
 - `withCircuit` – CircuitBreaker-Helfer für Agenten.
@@ -129,6 +130,7 @@ console.log(sigil.id); // hello
 - `Agent-Registry` – zentrale YAML-Liste aller Agents (`agents.yaml`)
 - `SigilStory` – Mandala-Diagramm für Lernpfade
 - `Gamification API` – Endpunkte `/gamify/badges` und `/gamify/leaderboard`
+- `Learning Modules` – C-Tutor und JavaHamster unter `packages/tutorials`
 - `Share your Sigil` & `Remix my Solution` – Community-Buttons
 ### collab-editor
 - `CollaborativeEditor` – Federated Texteditor mit Remote-Sync.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🗺️ **MemoryMesh** – regionale Archiv-Prototypen (`docs/architecture/memory-mesh.md`)
 - 🕸️ **Agent-Registry** – zentrale Übersicht aller Agents (`agents.yaml`)
 - 🌀 **SigilStory** – Mandala-Lern-Lebenslauf für C-Tutor & JavaHamster
+- 🎓 **Learning Modules** – interactive C-Tutor and JavaHamster workflows (`packages/tutorials/*`)
 - 🎮 **Gamification API** – Endpunkte `/gamify/badges` & `/gamify/leaderboard`
 - 🔗 **Share your Sigil** & **Remix my Solution** – Community-Features
 ## 📦 Paketstruktur
@@ -319,6 +320,7 @@ gespeichert. Nutzen Sie die Helferskripte aus `packages/shared-utils`
 `advancedToDo.json` zu extrahieren.
 
 Pitch-Vorlagen für Events finden sich unter `docs/pitch/`.
+Die ToDo-Liste wurde für mehr Übersicht in "advancedToDo_parts/" aufgeteilt.
 
 Nutze `node scripts/parse-advanced-conversations.js` um Gesprächs-TODOs aus dem Datensatz zu filtern.
 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1686,5 +1686,23 @@
     "path": "packages/unifiedmandala-ui/components/SigilStory.tsx",
     "task": "Visualize learning progress",
     "test": "packages/unifiedmandala-ui/components/SigilStory.test.tsx"
+  },
+  {
+    "commit": "Implement C-Tutor progress workflow",
+    "path": "packages/tutorials/C-Tutor",
+    "task": "Track user progress and award Sigil per milestone",
+    "test": "packages/tutorials/__tests__/C-Tutor.test.ts"
+  },
+  {
+    "commit": "Add JavaHamster AI Flow",
+    "path": "packages/tutorials/JavaHamsterAI",
+    "task": "Interactive hamster coding with AI coach and Sigil rewards",
+    "test": "packages/tutorials/__tests__/JavaHamsterAI.test.ts"
+  },
+  {
+    "commit": "Document learning modules",
+    "path": "docs/learning-modules.md",
+    "task": "Describe workflows from advancedconversations_snippet.json",
+    "test": ""
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1,3 +1,4 @@
+# See advancedToDo_parts/advancedToDo.part1.yaml for new learning-module tasks
 - commit: "- und Progress-Dateien mit diesem Stand."
   path: ""
   task: "- und Progress-Dateien mit diesem Stand."

--- a/advancedToDo_parts/advancedToDo.part1.json
+++ b/advancedToDo_parts/advancedToDo.part1.json
@@ -1,0 +1,20 @@
+[
+  {
+    "commit": "Implement C-Tutor progress workflow",
+    "path": "packages/tutorials/C-Tutor",
+    "task": "Track user progress and award Sigil per milestone",
+    "test": "packages/tutorials/__tests__/C-Tutor.test.ts"
+  },
+  {
+    "commit": "Add JavaHamster AI Flow",
+    "path": "packages/tutorials/JavaHamsterAI",
+    "task": "Interactive hamster coding with AI coach and Sigil rewards",
+    "test": "packages/tutorials/__tests__/JavaHamsterAI.test.ts"
+  },
+  {
+    "commit": "Document learning modules",
+    "path": "docs/learning-modules.md",
+    "task": "Describe workflows from advancedconversations_snippet.json",
+    "test": ""
+  }
+]

--- a/advancedToDo_parts/advancedToDo.part1.yaml
+++ b/advancedToDo_parts/advancedToDo.part1.yaml
@@ -1,0 +1,12 @@
+- commit: "Implement C-Tutor progress workflow"
+  path: packages/tutorials/C-Tutor
+  task: "Track user progress and award Sigil per milestone"
+  test: packages/tutorials/__tests__/C-Tutor.test.ts
+- commit: "Add JavaHamster AI Flow"
+  path: packages/tutorials/JavaHamsterAI
+  task: "Interactive hamster coding with AI coach and Sigil rewards"
+  test: packages/tutorials/__tests__/JavaHamsterAI.test.ts
+- commit: "Document learning modules"
+  path: docs/learning-modules.md
+  task: "Describe workflows from advancedconversations_snippet.json"
+  test: ""

--- a/docs/learning-modules.md
+++ b/docs/learning-modules.md
@@ -1,0 +1,16 @@
+# Learning Modules
+
+This document outlines the experimental learning workflows referenced in `advancedconversations_snippet.json`.
+
+## C-Tutor Progress
+- Begin at the *beginner* level.
+- Solve exercises and receive a Sigil for each milestone.
+- Progress through intermediate to expert levels.
+- Export the earned learning Sigil for portfolio use.
+
+## JavaHamster AI Flow
+- Select your desired difficulty level.
+- Write and run Hamster code with inline AI coaching.
+- Complete each level to earn a dedicated Sigil.
+
+These modules integrate with future packages under `packages/tutorials/`.


### PR DESCRIPTION
## Summary
- split out new advanced ToDo part file with learning module tasks
- document C‑Tutor and JavaHamster workflows
- mention advancedToDo parts in README and Handbuch
- add Learning Modules bullet under features
- auto-update CHRONOPOEM

## Testing
- `pnpm install`
- `npm test`
- `npm run test:agents`


------
https://chatgpt.com/codex/tasks/task_e_68584f3ae90c832280e4088c7e51c956