### PR TITLE
Implement Aeon transition workflow

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -250,6 +250,7 @@ Eine Pipeline-Demonstration findest du in [docs/demo/POC-Run-Guide.md](docs/demo
 | `node scripts/website-to-yaml.js` | Wandelt Webseite in YAML um |
 | `node scripts/symbolzeit-runner.js` | Läuft Symbolzeit-Cronjob |
 | `node scripts/generate-next-sigil.js` | Erstellt Folgesigil nach Zyklus |
+| `node scripts/aeon-transition-workflow.js` | Sync & erzeugt Übergabe-Sigil |
 | `./scripts/setup-mtls.sh` | Erstellt Testzertifikate |
 | `./scripts/setup-kong-jwt.sh` | Konfiguriert JWT Gateway |
 | `node packages/cli-tools/SigillinValidator.ts <file>` | Validiert eine Sigillin-Datei |

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ npm run dev   # oder: yarn dev
 | `node scripts/website-to-yaml.js` | Wandelt Webseite in YAML um |
 | `node scripts/symbolzeit-runner.js` | Läuft Symbolzeit-Cronjob |
 | `node scripts/generate-next-sigil.js` | Erstellt Folgesigil nach Zyklus |
+| `node scripts/aeon-transition-workflow.js` | Sync & erzeugt Übergabe-Sigil |
 | `node packages/cli-tools/sigillin-cli.js convert beispiel.yaml` | YAML ↔ JSON-Konvertierung |
 | `./scripts/setup-mtls.sh` | Erstellt Testzertifikate |
 | `./scripts/setup-kong-jwt.sh` | Konfiguriert JWT Gateway |

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3098,6 +3098,7 @@ status: done
   path: docs/sigils/advancedconversations.json
   task: Sync ToDo files before major commits and create new sigils per cycle
   test: ""
+  status: done
 - commit: MemoryMesh architecture sketch
   path: docs/architecture/memory-mesh.md
   task: Diagram for MemoryMesh layers (Speicher, Reflexion, Adaption)

--- a/advancedToDo_parts/advancedToDo.part2.json
+++ b/advancedToDo_parts/advancedToDo.part2.json
@@ -4,7 +4,7 @@
     "path": "docs/sigils/advancedconversations.json",
     "task": "Reference aeon-transition sigil in new chats and sync ToDo/progress files before major commits; generate new sigil with update_time after each cycle",
     "test": "",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "MemoryMesh region POC",

--- a/advancedToDo_parts/advancedToDo.part2.yaml
+++ b/advancedToDo_parts/advancedToDo.part2.yaml
@@ -2,7 +2,7 @@
   path: docs/sigils/advancedconversations.json
   task: Reference aeon-transition sigil in new chats and sync ToDo/progress files before major commits; generate new sigil with update_time after each cycle
   test: ""
-  status: todo
+  status: done
 - commit: "MemoryMesh region POC"
   path: services/memorymesh
   task: Create MemoryMesh architecture with region-archive, reflection-engine and adaptation-service; start POC for Europe/Berlin region

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "Merge pull request #209 from GenesisAeon/codex/implementiere-agent-registry-und-sigil-story",
-  "fractalStep": "documentation",
+  "lastCommit": "Merge pull request #215 from GenesisAeon/codex/überprüfe-und-implementiere-aufgaben-aus-advancedconversatio",
+  "fractalStep": "implementierung",
   "openBranches": [
     "work"
   ],

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "update:advanced-todo": "node scripts/update-advanced-todo.js",
     "export:crep-docs": "node scripts/export-crep-docs.js",
     "symbolzeit:run": "node scripts/symbolzeit-runner.js",
-    "generate:next-sigil": "node scripts/generate-next-sigil.js"
+    "generate:next-sigil": "node scripts/generate-next-sigil.js",
+    "aeon:transition": "node scripts/aeon-transition-workflow.js"
   },
   "dependencies": {
     "ajv": "^8.0.0",

--- a/scripts/aeon-transition-workflow.js
+++ b/scripts/aeon-transition-workflow.js
@@ -1,0 +1,35 @@
+const path = require('path');
+const fs = require('fs');
+let updateAdvancedTodo;
+try {
+  ({ updateAdvancedTodo } = require('../dist/shared-utils/advancedTodoUpdater.js'));
+} catch {
+  ({ updateAdvancedTodo } = require('../packages/shared-utils/advancedTodoUpdater'));
+}
+const { updateProgress } = require('./update-advancedprogress.js');
+
+const convFile = path.join(__dirname, '../docs/sigils/advancedconversations.json');
+const yamlFile = path.join(__dirname, '../advancedToDo.yaml');
+const jsonFile = path.join(__dirname, '../advancedToDo.json');
+const sigilOut = path.join(__dirname, '../docs/sigils/aeon-transition.sigil.json');
+
+function createTransitionSigil() {
+  const data = JSON.parse(fs.readFileSync(convFile, 'utf8'));
+  const sigil = data.find(c => c.title === 'Aeon Übergabe-Sigil Prozess');
+  if (!sigil) {
+    throw new Error('Aeon Übergabe-Sigil Prozess not found');
+  }
+  sigil.update_time = Date.now() / 1000;
+  fs.writeFileSync(sigilOut, JSON.stringify(sigil, null, 2));
+}
+
+function run() {
+  updateAdvancedTodo(convFile, yamlFile, jsonFile);
+  updateProgress('aeon-transition');
+  createTransitionSigil();
+  console.log('Aeon transition workflow completed');
+}
+
+if (require.main === module) {
+  run();
+}


### PR DESCRIPTION
## Summary
- add aeon-transition-workflow script to sync ToDo and progress and generate a new sigil
- expose new workflow in README and Handbuch
- mark Aeon transition task done in advancedToDo files
- record progress step in advancedprogress.json

## Testing
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_68586caa98008322aa6402e260dce730