### PR TITLE
Add docker quickstart and pre-commit sync

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+node scripts/sync-todo-progress.js

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -206,6 +206,7 @@ Eine Pipeline-Demonstration findest du in [docs/demo/POC-Run-Guide.md](docs/demo
 ## Tools und Skripte
 ### Häufige Probleme
 - `pnpm dev` startet nicht → Node-Version prüfen, `pnpm install` erneut ausführen.
+./scripts/run-demo.sh # Docker-Compose Quickstart
 - Symbolzeit stimmt nicht → Zeitzonen/Locale-Check, `symbolzeit.ts` debuggen.
 
 
@@ -218,6 +219,7 @@ Eine Pipeline-Demonstration findest du in [docs/demo/POC-Run-Guide.md](docs/demo
 | `./scripts/aeon.sh chronopoem` | Erstellt `CHRONOPOEM.md` |
 | `./scripts/aeon.sh onboarding` | Zeigt Onboarding-Ritus |
 | `pnpm dev` | Startet Dev-Server (UI & API) |
+./scripts/run-demo.sh # Docker-Compose Quickstart
 | `pnpm docs:auto` | Generiert TypeDoc-API-Docs |
 | `pnpm lint` | Führt statische Typprüfung aus |
 | `pnpm test` | Führe Unit- & UI-Tests aus |
@@ -263,6 +265,7 @@ Eine Pipeline-Demonstration findest du in [docs/demo/POC-Run-Guide.md](docs/demo
 | `node packages/cli-tools/sigillin-archive.js` | Archiviert Sigillin-Dateien |
 | `node packages/cli-tools/dispatchCmd.ts` | Dispatcher für diverse Befehle |
 | `go run scripts/mock-data.go` | Gibt Beispiel-Mockdaten mit eventHook und fractalHash aus |
+| `./scripts/run-demo.sh` | Startet Docker-Compose Umgebung |
 
 - `scripts/generate-api-docs.js` – Erstellt automatisch die API-Dokumentation mit Typedoc.
 - `scripts/generate-todo-sigil.js` – Erstellt das ToDo-Sigil aus der Mastercanvas.
@@ -411,6 +414,7 @@ git clone https://github.com/GenesisAeon/unified-mandala.git
 cd unified-mandala
 ./scripts/setup-unifiedmandala.sh
 pnpm dev
+./scripts/run-demo.sh # Docker-Compose Quickstart
 ```
 Die generierte API-Dokumentation findest du danach unter `docs/api`.
 Die OpenAPI-Spezifikation für Friendship & SocialGood liegt unter `docs/api/friendship-socialgood.yaml`.
@@ -433,6 +437,7 @@ npm run dev   # oder: yarn dev
 | `./scripts/aeon.sh chronopoem` | Erstellt `CHRONOPOEM.md` |
 | `./scripts/aeon.sh onboarding` | Zeigt Onboarding-Ritus |
 | `pnpm dev` | Startet Dev-Server (UI & API) |
+./scripts/run-demo.sh # Docker-Compose Quickstart
 | `pnpm docs:auto` | Generiert TypeDoc-API-Docs |
 | `pnpm lint` | Führt statische Typprüfung aus |
 | `pnpm test` | Führe Unit- & UI-Tests aus |

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ git clone https://github.com/GenesisAeon/unified-mandala.git
 cd unified-mandala
 ./scripts/setup-unifiedmandala.sh
 pnpm dev
+./scripts/run-demo.sh # Docker-Compose Quickstart
 ```
 Die generierte API-Dokumentation findest du danach unter `docs/api`.
 
@@ -214,6 +215,7 @@ npm run dev   # oder: yarn dev
 | `./scripts/aeon.sh chronopoem` | Erstellt `CHRONOPOEM.md` |
 | `./scripts/aeon.sh onboarding` | Zeigt Onboarding-Ritus |
 | `pnpm dev` | Startet Dev-Server (UI & API) |
+./scripts/run-demo.sh # Docker-Compose Quickstart
 | `pnpm docs:auto` | Generiert TypeDoc-API-Docs |
 | `pnpm lint` | Führt statische Typprüfung aus |
 | `pnpm test` | Führe Unit- & UI-Tests aus |
@@ -258,6 +260,7 @@ npm run dev   # oder: yarn dev
 | `node packages/cli-tools/sigillin-archive.js` | Archiviert Sigillin-Dateien |
 | `node packages/cli-tools/dispatchCmd.ts` | Dispatcher für diverse Befehle |
 | `go run scripts/mock-data.go` | Gibt Beispiel-Mockdaten mit eventHook und fractalHash aus |
+| `./scripts/run-demo.sh` | Startet Docker-Compose Umgebung |
 
 
 
@@ -299,6 +302,7 @@ Deine Idee, deine Story, dein Sigillin sind willkommen! Jeder Pull Request ist e
 ## 🛠 Repository-Reparatur
 ### Häufige Probleme
 - `pnpm dev` startet nicht → Node-Version prüfen, `pnpm install` erneut ausführen.
+./scripts/run-demo.sh # Docker-Compose Quickstart
 - Symbolzeit stimmt nicht → Zeitzonen/Locale-Check, `symbolzeit.ts` debuggen.
 
 

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1,4 +1,4 @@
-# See advancedToDo_parts/advancedToDo.part1.yaml for new learning-module tasks; see advancedToDo_parts/advancedToDo.part2.yaml for transition and memorymesh tasks; see advancedToDo_parts/advancedToDo.part3.yaml for transition docs and friendship system tasks
+# See advancedToDo_parts/advancedToDo.part1.yaml for new learning-module tasks; see advancedToDo_parts/advancedToDo.part2.yaml for transition and memorymesh tasks; see advancedToDo_parts/advancedToDo.part3.yaml for transition docs and friendship system tasks; see advancedToDo_parts/advancedToDo.part4.yaml for automation and docker tasks
 - commit: "- und Progress-Dateien mit diesem Stand."
   path: ""
   task: "- und Progress-Dateien mit diesem Stand."

--- a/advancedToDo_parts/advancedToDo.part4.json
+++ b/advancedToDo_parts/advancedToDo.part4.json
@@ -1,0 +1,20 @@
+[
+  {
+    "commit": "Add pre-commit hook for ToDo sync",
+    "path": ".husky/pre-commit",
+    "task": "Synchronize advanced ToDo and progress files before each commit",
+    "test": "node scripts/sync-todo-progress.js"
+  },
+  {
+    "commit": "Provide Docker Compose setup",
+    "path": "docker-compose.yml",
+    "task": "Quickstart all services via Docker",
+    "test": ""
+  },
+  {
+    "commit": "Add run-demo script",
+    "path": "scripts/run-demo.sh",
+    "task": "Start Docker Compose and local dev server",
+    "test": ""
+  }
+]

--- a/advancedToDo_parts/advancedToDo.part4.yaml
+++ b/advancedToDo_parts/advancedToDo.part4.yaml
@@ -1,0 +1,12 @@
+- commit: "Add pre-commit hook for ToDo sync"
+  path: .husky/pre-commit
+  task: "Synchronize advanced ToDo and progress files before each commit"
+  test: "node scripts/sync-todo-progress.js"
+- commit: "Provide Docker Compose setup"
+  path: docker-compose.yml
+  task: "Quickstart all services via Docker"
+  test: ""
+- commit: "Add run-demo script"
+  path: scripts/run-demo.sh
+  task: "Start Docker Compose and local dev server"
+  test: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  ui:
+    build: .
+    command: pnpm dev
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/workspace/unified-mandala

--- a/scripts/run-demo.sh
+++ b/scripts/run-demo.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if ! command -v docker-compose >/dev/null 2>&1; then
+  echo "docker-compose is required" >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+docker-compose up --build


### PR DESCRIPTION
## Summary
- document new run-demo script and docker compose usage
- add run-demo script and docker-compose.yml
- automate todo syncing via pre-commit
- list new automation tasks in advancedToDo part 4

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685885d10eb08322be9cc9b02b91b84a