### PR TITLE
Add responsive theme hook

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-22, in der Zeit des Nacht.
+Am 2025-06-23, in der Zeit des Morgen.
 
-Symbolphase: Reflexion (Fokus: P)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -320,6 +320,7 @@ Aktuelle Versionshinweise werden in [CHANGELOG.md](CHANGELOG.md) gepflegt.
 - 🌠 **AeonStoryMode & Onboarding-Flow** – Präsentations- und Einstiegskomponenten
 - 🎨 **MandalaThemeManager** – hell/dunkel umschalten
 - ✨ **SigillinActivationManager & MetaSignatur** – Aktivierung & Signatur von Sigillin
+- 🌈 **ThemeProvider & useResponsiveTheme** – reagiert auf CREP
 - 📜 **SigillinTimeline & InviteBanner** – Verlauf und Einladungsbanner
 - 📈 **CREPTimeline** – chronologische Auflistung der CREP-Ereignisse
 - 💾 **BackupManager** – einfache Dateisicherungen

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🌠 **AeonStoryMode & Onboarding-Flow** – Präsentations- und Einstiegskomponenten
 - 🎨 **MandalaThemeManager** – hell/dunkel umschalten
 - ✨ **SigillinActivationManager & MetaSignatur** – Aktivierung & Signatur von Sigillin
+- 🌈 **ThemeProvider & useResponsiveTheme** – CREP-basierte Farbwahl
 - 📜 **SigillinTimeline & InviteBanner** – Verlauf und Einladungsbanner
 - 📈 **CREPTimeline** – chronologische Ansicht der CREP-Ereignisse
 - 💾 **BackupManager** – einfache Dateisicherungen

--- a/advancedToDo_parts/advancedToDo.part1.yaml
+++ b/advancedToDo_parts/advancedToDo.part1.yaml
@@ -2,11 +2,14 @@
   path: packages/tutorials/C-Tutor
   task: "Track user progress and award Sigil per milestone"
   test: packages/tutorials/__tests__/C-Tutor.test.ts
+  status: done
 - commit: "Add JavaHamster AI Flow"
+  status: done
   path: packages/tutorials/JavaHamsterAI
   task: "Interactive hamster coding with AI coach and Sigil rewards"
   test: packages/tutorials/__tests__/JavaHamsterAI.test.ts
 - commit: "Document learning modules"
+  status: done
   path: docs/learning-modules.md
   task: "Describe workflows from advancedconversations_snippet.json"
   test: ""

--- a/advancedToDo_parts/advancedToDo.part3.yaml
+++ b/advancedToDo_parts/advancedToDo.part3.yaml
@@ -1,12 +1,15 @@
 - commit: "Document Aeon Transition guidelines"
   path: docs/sigils/aeon-transition.md
   task: "Summarize transition instructions from conversations"
+  status: done
   test: ""
 - commit: "Draft Friendship system concept"
   path: docs/friendship-system.md
+  status: done
   task: "Outline AI friendship system from Aeon KI Resonanz chat"
   test: ""
 - commit: "Add plugin registry and loader"
   path: plugins/manifest.yaml
   task: "Define manifest schema and implement usePluginLoader"
   test: apps/sharedream-interface/hooks/usePluginLoader.test.ts
+  status: done

--- a/docs/learning-modules.md
+++ b/docs/learning-modules.md
@@ -3,9 +3,9 @@
 The learning modules defined in `advancedconversations_snippet.json` provide simple
 workflows to introduce interactive coding with Sigil rewards.
 
+- The `packages/ui/theme` module provides a `ThemeProvider` and `useResponsiveTheme` hook for mood-aware styling.
 ## C-Tutor Progress
 Refer to `packages/tutorials/C-Tutor` for a minimal progress tracker granting a
-Sigil after all milestones.
 
 ## JavaHamster AI Flow
 `packages/tutorials/JavaHamsterAI` demonstrates gamified hamster coding. A Sigil

--- a/packages/ui/theme/index.test.tsx
+++ b/packages/ui/theme/index.test.tsx
@@ -1,0 +1,24 @@
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import { CREPProvider, useCREPContext } from '../../unifiedmandala-ui/contexts/CREPContext';
+import { ThemeProvider, useResponsiveTheme } from './index';
+
+const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <CREPProvider>
+    <ThemeProvider>{children}</ThemeProvider>
+  </CREPProvider>
+);
+
+test('updates mood based on CREP state', () => {
+  const { result } = renderHook(() => {
+    const ctx = useCREPContext();
+    const theme = useResponsiveTheme();
+    return { ctx, theme };
+  }, { wrapper });
+
+  act(() => {
+    result.current.ctx.triggerCREP({ C: 0, R: 1, E: 5, P: 2 });
+  });
+
+  expect(result.current.theme.theme.mood).toBe('critical');
+});

--- a/packages/ui/theme/index.tsx
+++ b/packages/ui/theme/index.tsx
@@ -1,0 +1,47 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { useCREPContext } from '../unifiedmandala-ui/contexts/CREPContext';
+
+export type Mood = 'neutral' | 'positive' | 'critical';
+export type Style = 'light' | 'dark';
+
+interface ThemeState {
+  mood: Mood;
+  style: Style;
+}
+
+interface ThemeContextValue {
+  theme: ThemeState;
+  toggleStyle: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: { mood: 'neutral', style: 'light' },
+  toggleStyle: () => {},
+});
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { state } = useCREPContext();
+  const [style, setStyle] = useState<Style>('light');
+  const [mood, setMood] = useState<Mood>('neutral');
+
+  useEffect(() => {
+    if (state.history.length > 0) {
+      const latest = state.history[state.history.length - 1];
+      if (latest.E > latest.R) {
+        setMood('critical');
+      } else {
+        setMood('positive');
+      }
+    }
+  }, [state.history]);
+
+  const toggleStyle = () => setStyle(s => (s === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme: { mood, style }, toggleStyle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useResponsiveTheme = () => useContext(ThemeContext);


### PR DESCRIPTION
## Summary
- provide new ThemeProvider and `useResponsiveTheme` in `packages/ui`
- update README and Handbuch with theme info
- document theme hook in learning modules
- mark done tasks in advancedToDo parts
- update CHRONOPOEM automatically

## Testing
- `npx jest packages/ui/theme/index.test.tsx` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6858ef8afd588322a28c64b3e40f64a4