### PR TITLE
Add adaptive layout hook

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -322,6 +322,7 @@ Aktuelle Versionshinweise werden in [CHANGELOG.md](CHANGELOG.md) gepflegt.
 - 🎨 **MandalaThemeManager** – hell/dunkel umschalten
 - ✨ **SigillinActivationManager & MetaSignatur** – Aktivierung & Signatur von Sigillin
 - 🌈 **ThemeProvider & useResponsiveTheme** – reagiert auf CREP
+- 🧩 **useAdaptiveLayout** – passt Gridbereiche an den CREP-Status an
 - 📜 **SigillinTimeline & InviteBanner** – Verlauf und Einladungsbanner
 - 📈 **CREPTimeline** – chronologische Auflistung der CREP-Ereignisse
 - 💾 **BackupManager** – einfache Dateisicherungen

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🎨 **MandalaThemeManager** – hell/dunkel umschalten
 - ✨ **SigillinActivationManager & MetaSignatur** – Aktivierung & Signatur von Sigillin
 - 🌈 **ThemeProvider & useResponsiveTheme** – CREP-basierte Farbwahl
+- 🧩 **useAdaptiveLayout** – reagiert auf CREP-Status
 - 📜 **SigillinTimeline & InviteBanner** – Verlauf und Einladungsbanner
 - 📈 **CREPTimeline** – chronologische Ansicht der CREP-Ereignisse
 - 💾 **BackupManager** – einfache Dateisicherungen

--- a/packages/unifiedmandala-ui/hooks/useAdaptiveLayout.stories.tsx
+++ b/packages/unifiedmandala-ui/hooks/useAdaptiveLayout.stories.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { CREPProvider, useCREPContext } from '../contexts/CREPContext';
+import { useAdaptiveLayout } from './useAdaptiveLayout';
+
+const Demo: React.FC = () => {
+  const { triggerCREP } = useCREPContext();
+  const layout = useAdaptiveLayout();
+  return (
+    <div style={{ display: 'grid', ...layout }}>
+      <div style={{ gridArea: 'header' }}>Header</div>
+      <div style={{ gridArea: 'main' }}>Main</div>
+      {layout.gridTemplateAreas.includes('sidebar') && (
+        <div style={{ gridArea: 'sidebar' }}>Sidebar</div>
+      )}
+      {layout.gridTemplateAreas.includes('alert') && (
+        <div style={{ gridArea: 'alert' }}>Alert</div>
+      )}
+      <button onClick={() => triggerCREP({ C: 2, R: 2, E: 2, P: 1 })}>Critical</button>
+      <button onClick={() => triggerCREP({ C: 5, R: 5, E: 5, P: 1 })}>Warning</button>
+      <button onClick={() => triggerCREP({ C: 8, R: 8, E: 8, P: 1 })}>Safe</button>
+    </div>
+  );
+};
+
+export default {
+  title: 'Hooks/useAdaptiveLayout',
+  component: Demo,
+};
+
+export const Example = () => (
+  <CREPProvider>
+    <Demo />
+  </CREPProvider>
+);

--- a/packages/unifiedmandala-ui/hooks/useAdaptiveLayout.test.tsx
+++ b/packages/unifiedmandala-ui/hooks/useAdaptiveLayout.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import { CREPProvider, useCREPContext } from '../contexts/CREPContext';
+import { useAdaptiveLayout } from './useAdaptiveLayout';
+
+const wrapper: React.FC<{children: React.ReactNode}> = ({ children }) => (
+  <CREPProvider>{children}</CREPProvider>
+);
+
+test('returns critical layout when CREP state is critical', () => {
+  const { result } = renderHook(() => {
+    const ctx = useCREPContext();
+    const layout = useAdaptiveLayout();
+    return { ctx, layout };
+  }, { wrapper });
+
+  act(() => {
+    result.current.ctx.triggerCREP({ C: 1, R: 1, E: 1, P: 1 });
+  });
+
+  expect(result.current.layout.gridTemplateAreas).toContain('alert');
+});
+
+test('returns safe layout when CREP state is safe', () => {
+  const { result } = renderHook(() => {
+    const ctx = useCREPContext();
+    const layout = useAdaptiveLayout();
+    return { ctx, layout };
+  }, { wrapper });
+
+  act(() => {
+    result.current.ctx.triggerCREP({ C: 8, R: 8, E: 8, P: 1 });
+  });
+
+  expect(result.current.layout.gridTemplateAreas).toContain('sidebar');
+});

--- a/packages/unifiedmandala-ui/hooks/useAdaptiveLayout.ts
+++ b/packages/unifiedmandala-ui/hooks/useAdaptiveLayout.ts
@@ -1,0 +1,22 @@
+import { useCREPContext } from '../contexts/CREPContext';
+import { useMemo } from 'react';
+import { latestCREPStatus } from '../../../services/crep-state';
+
+export interface LayoutStyle {
+  gridTemplateAreas: string;
+}
+
+export function useAdaptiveLayout(): LayoutStyle {
+  const { state } = useCREPContext();
+  return useMemo(() => {
+    const status = latestCREPStatus(state.history);
+    switch (status) {
+      case 'critical':
+        return { gridTemplateAreas: `'header' 'main' 'alert'` };
+      case 'warning':
+        return { gridTemplateAreas: `'header header' 'main sidebar'` };
+      default:
+        return { gridTemplateAreas: `'header header' 'sidebar main'` };
+    }
+  }, [state.history]);
+}

--- a/services/crep-state.ts
+++ b/services/crep-state.ts
@@ -1,0 +1,10 @@
+import { getCREPState } from '../packages/crep-engine/CREPEvaluator';
+import { CREPEntry } from '../packages/crep-engine/types';
+
+export type CREPStatus = 'safe' | 'warning' | 'critical';
+
+export function latestCREPStatus(history: CREPEntry[]): CREPStatus {
+  if (history.length === 0) return 'safe';
+  const last = history[history.length - 1];
+  return getCREPState({ C: last.C, R: last.R, E: last.E });
+}


### PR DESCRIPTION
## Summary
- provide `latestCREPStatus` helper
- add `useAdaptiveLayout` hook with Storybook demo
- document adaptive layout in README and Handbuch
- test adaptive layout behaviour

## Testing
- `npx jest`
- `npm run test:agents`
- `npx jest packages/unifiedmandala-ui/hooks/useAdaptiveLayout.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6858f7e6907c83228dd6336507a8f7b1