### PR TITLE
Implement AdminMetrics plugin and finalize tasks

### DIFF
--- a/advancedToDo_parts/advancedToDo.part3.yaml
+++ b/advancedToDo_parts/advancedToDo.part3.yaml
@@ -17,3 +17,4 @@
   path: services/objective2ui.ts
   task: "Generate layout YAML via GPT and store suggestion in plugin manifest"
   test: services/objective2ui.test.ts
+  status: done

--- a/advancedToDo_parts/advancedToDo.part4.yaml
+++ b/advancedToDo_parts/advancedToDo.part4.yaml
@@ -2,11 +2,14 @@
   path: .husky/pre-commit
   task: "Synchronize advanced ToDo and progress files before each commit"
   test: "node scripts/sync-todo-progress.js"
+  status: done
 - commit: "Provide Docker Compose setup"
   path: docker-compose.yml
   task: "Quickstart all services via Docker"
   test: ""
+  status: done
 - commit: "Add run-demo script"
   path: scripts/run-demo.sh
   task: "Start Docker Compose and local dev server"
   test: ""
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "Merge pull request #215 from GenesisAeon/codex/überprüfe-und-implementiere-aufgaben-aus-advancedconversatio",
-  "fractalStep": "implementierung",
+  "lastCommit": "Finalize plugin loader and Objective2UI tasks",
+  "fractalStep": "review",
   "openBranches": [
     "work"
   ],

--- a/apps/sharedream-interface/components/AdminMetrics.stories.tsx
+++ b/apps/sharedream-interface/components/AdminMetrics.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import AdminMetrics from './AdminMetrics';
+import { useAdminMetrics } from '../hooks/useAdminMetrics';
+
+export default {
+  title: 'Components/AdminMetrics',
+  component: AdminMetrics,
+};
+
+export const Default = () => {
+  const { metrics } = useAdminMetrics();
+  if (!metrics) return <div>loading...</div>;
+  return (
+    <AdminMetrics
+      avgCREP={metrics.avgCREP}
+      sigillinAdoption={metrics.sigillinAdoption}
+      openTodos={metrics.openTodos}
+    />
+  );
+};

--- a/apps/sharedream-interface/hooks/useAdminMetrics.test.ts
+++ b/apps/sharedream-interface/hooks/useAdminMetrics.test.ts
@@ -1,0 +1,22 @@
+import { renderHook, act } from '@testing-library/react';
+import { useAdminMetrics } from './useAdminMetrics';
+
+const apiResponse = { avgCREP: 0.8, sigillinAdoption: 3, openTodos: 2 };
+
+describe('useAdminMetrics', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve(apiResponse) })
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('loads admin metrics', async () => {
+    const { result } = renderHook(() => useAdminMetrics());
+    await act(async () => {});
+    expect(result.current.metrics?.avgCREP).toBe(0.8);
+  });
+});

--- a/apps/sharedream-interface/hooks/useAdminMetrics.ts
+++ b/apps/sharedream-interface/hooks/useAdminMetrics.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export interface AdminMetric {
+  avgCREP: number;
+  sigillinAdoption: number;
+  openTodos: number;
+}
+
+export function useAdminMetrics() {
+  const [metrics, setMetrics] = useState<AdminMetric | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/admin-metrics')
+      .then((res) => res.json())
+      .then((data) => setMetrics(data))
+      .catch((err) => {
+        console.error('Fehler beim Laden der Admin-Metriken:', err);
+        setError('Fehler beim Laden der Admin-Metriken');
+      });
+  }, []);
+
+  return { metrics, error };
+}

--- a/apps/sharedream-interface/pages/api/admin-metrics.ts
+++ b/apps/sharedream-interface/pages/api/admin-metrics.ts
@@ -1,0 +1,7 @@
+export default function handler(req: any, res: any) {
+  res.status(200).json({
+    avgCREP: 0.7,
+    sigillinAdoption: 5,
+    openTodos: 3,
+  });
+}

--- a/plugins/manifest.yaml
+++ b/plugins/manifest.yaml
@@ -6,3 +6,11 @@ plugins:
     story: "../apps/sharedream-interface/components/MetaScoreChart.stories.tsx"
     layoutSuggestion: |
       layout: default
+  - name: AdminMetrics
+    version: "1.0.0"
+    component: "../apps/sharedream-interface/components/AdminMetrics"
+    dataHook: "../apps/sharedream-interface/hooks/useAdminMetrics"
+    story: "../apps/sharedream-interface/components/AdminMetrics.stories.tsx"
+    crepCondition: ">=0.7"
+    layoutSuggestion: |
+      layout: admin


### PR DESCRIPTION
## Summary
- create `useAdminMetrics` hook with story and test
- serve admin metrics API for demo
- register AdminMetrics in plugin manifest
- mark Objective2UI and automation tasks as done
- update progress log

## Testing
- `npx jest apps/sharedream-interface/hooks/usePluginLoader.test.ts apps/sharedream-interface/hooks/useAdminMetrics.test.ts --runInBand`
- `npx jest services/objective2ui.test.ts --runInBand`
- `npx jest packages/ui/theme/index.test.tsx packages/unifiedmandala-ui/hooks/useAdaptiveLayout.test.tsx --runInBand`
- `npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6858fd92ebd48322b02318edae015ace