### PR TITLE
Add FeedbackButtons component

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -123,6 +123,7 @@ Teil 2 dort beschreibt Aufgaben zum Aeon Übergabe-Sigil und MemoryMesh.
 - `FreieKIZivilisation` – sammelt Resonanzimpulse (`packages/agents/FreieKIZivilisation.ts`)
 - `useEventGlow` – React-Hook zur Event-Hervorhebung (`packages/unifiedmandala-ui/hooks/useEventGlow.ts`)
 - `silenceWatcher` – meldet Stille an den GPTEventHub (`packages/agents/silenceWatcher.ts`)
+- `FeedbackButtons` – einfache Like/Dislike-Komponente, speichert Sigil-Ereignisse (`packages/unifiedmandala-ui/components/FeedbackButtons.tsx`)
 - `ArchetypeDecoderAgent` – erkennt Archetypen in Task-Beschreibungen (`packages/agents/ArchetypeDecoderAgent.ts`)
 - `SigillinInterpreterAgent` – extrahiert Sigillin aus Text (`packages/agents/SigillinInterpreterAgent.ts`)
 - `ChronoPoemGeneratorAgent` – erzeugt poetische Chrono-Zeilen (`packages/agents/ChronoPoemGeneratorAgent.ts`)

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🌱 **FreieKIZivilisation** – sammelt Resonanzimpulse (`packages/agents/FreieKIZivilisation.ts`)
 - ✨ **useEventGlow** – Hook für Event-Hervorhebung (`packages/unifiedmandala-ui/hooks/useEventGlow.ts`)
 - 🤫 **silenceWatcher** – meldet Stille im EventHub (`packages/agents/silenceWatcher.ts`)
+- 👍 **FeedbackButtons** – zeichnet Nutzerfeedback als Sigil-Ereignis auf (`packages/unifiedmandala-ui/components/FeedbackButtons.tsx`)
 - 🔥 **ArchetypeDecoderAgent** – extrahiert Archetypen aus Beschreibungen (`packages/agents/ArchetypeDecoderAgent.ts`)
 - 🔮 **SigillinInterpreterAgent** – erkennt Sigillin-Symbole (`packages/agents/SigillinInterpreterAgent.ts`)
 - 📝 **ChronoPoemGeneratorAgent** – generiert poetische Zeilen (`packages/agents/ChronoPoemGeneratorAgent.ts`)

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1723,5 +1723,11 @@
     "path": "plugins/manifest.yaml",
     "task": "Define manifest schema and implement usePluginLoader",
     "test": "apps/sharedream-interface/hooks/usePluginLoader.test.ts"
+  },
+  {
+    "commit": "Add FeedbackButtons component",
+    "path": "packages/unifiedmandala-ui/components/FeedbackButtons.tsx",
+    "task": "Capture like/dislike feedback and log Sigil event",
+    "test": "packages/unifiedmandala-ui/components/FeedbackButtons.test.tsx"
   }
 ]

--- a/advancedToDo_parts/advancedToDo.part3.yaml
+++ b/advancedToDo_parts/advancedToDo.part3.yaml
@@ -18,3 +18,7 @@
   task: "Generate layout YAML via GPT and store suggestion in plugin manifest"
   test: services/objective2ui.test.ts
   status: done
+- commit: "Add FeedbackButtons component"
+  path: packages/unifiedmandala-ui/components/FeedbackButtons.tsx
+  task: "Capture like/dislike feedback and log Sigil event"
+  test: packages/unifiedmandala-ui/components/FeedbackButtons.test.tsx

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "Finalize plugin loader and Objective2UI tasks",
-  "fractalStep": "review",
+  "lastCommit": "Add FeedbackButtons component",
+  "fractalStep": "implement",
   "openBranches": [
     "work"
   ],

--- a/packages/unifiedmandala-ui/components/FeedbackButtons.stories.tsx
+++ b/packages/unifiedmandala-ui/components/FeedbackButtons.stories.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import FeedbackButtons from './FeedbackButtons';
+
+export default {
+  title: 'UnifiedMandala/FeedbackButtons',
+  component: FeedbackButtons,
+};
+
+export const Demo = () => <FeedbackButtons sigilId="demo" />;

--- a/packages/unifiedmandala-ui/components/FeedbackButtons.test.tsx
+++ b/packages/unifiedmandala-ui/components/FeedbackButtons.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import FeedbackButtons from './FeedbackButtons';
+import { AeonSigillinVault } from '../../core/AeonSigillinVault';
+
+describe('FeedbackButtons', () => {
+  test('records like and dislike events', () => {
+    const spy = jest.spyOn(AeonSigillinVault, 'record');
+    render(<FeedbackButtons sigilId="x" />);
+    fireEvent.click(screen.getByLabelText('like'));
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ content: 'like' }));
+    fireEvent.click(screen.getByLabelText('dislike'));
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ content: 'dislike' }));
+  });
+});

--- a/packages/unifiedmandala-ui/components/FeedbackButtons.tsx
+++ b/packages/unifiedmandala-ui/components/FeedbackButtons.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { AeonSigillinVault } from '../../core/AeonSigillinVault';
+
+interface Props {
+  sigilId: string;
+}
+
+const FeedbackButtons: React.FC<Props> = ({ sigilId }) => {
+  const record = (type: 'like' | 'dislike') => {
+    AeonSigillinVault.record({
+      id: `${sigilId}-${Date.now()}`,
+      timestamp: new Date().toISOString(),
+      content: type,
+    });
+  };
+
+  return (
+    <div>
+      <button aria-label="like" onClick={() => record('like')}>
+        👍
+      </button>
+      <button aria-label="dislike" onClick={() => record('dislike')}>
+        👎
+      </button>
+    </div>
+  );
+};
+
+export default FeedbackButtons;


### PR DESCRIPTION
## Summary
- add FeedbackButtons component with tests and storybook story
- reference FeedbackButtons in README and Handbuch
- update advancedToDo parts and progress log

## Testing
- `pnpm test`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_685901f4119483229ed0b221d9caf84a