### PR TITLE
Add poetry util

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -128,6 +128,7 @@ Teil 5 ergänzt die Sigil-Historie.
 - `ArchetypeDecoderAgent` – erkennt Archetypen in Task-Beschreibungen (`packages/agents/ArchetypeDecoderAgent.ts`)
 - `SigillinInterpreterAgent` – extrahiert Sigillin aus Text (`packages/agents/SigillinInterpreterAgent.ts`)
 - `ChronoPoemGeneratorAgent` – erzeugt poetische Chrono-Zeilen (`packages/agents/ChronoPoemGeneratorAgent.ts`)
+- `toSigilVerse` – verwandelt Fehlermeldungen in kurze Verse (`packages/utils/poetry.ts`)
 - `ResonanzPoetik` – erzeugt Haikus und YAML-Chroniken (`packages/codex-navigator/resonanzPoetik.ts`)
 - `aggregateCREP` – berechnet Durchschnittswerte (`packages/crep-engine/aggregateCREP.ts`)
 - `CREPMusicGenerator` – generiert BPM aus CREP (`packages/crep-engine/CREPMusicGenerator.ts`)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🔥 **ArchetypeDecoderAgent** – extrahiert Archetypen aus Beschreibungen (`packages/agents/ArchetypeDecoderAgent.ts`)
 - 🔮 **SigillinInterpreterAgent** – erkennt Sigillin-Symbole (`packages/agents/SigillinInterpreterAgent.ts`)
 - 📝 **ChronoPoemGeneratorAgent** – generiert poetische Zeilen (`packages/agents/ChronoPoemGeneratorAgent.ts`)
+- 🌿 **toSigilVerse** – wandelt Fehlermeldungen in kurze Verse (`packages/utils/poetry.ts`)
 - 🎴 **ResonanzPoetik** – erstellt Haikus aus Tasks (`packages/codex-navigator/resonanzPoetik.ts`)
 - 🎚️ **aggregateCREP** – mittelt CREP-Werte (`packages/crep-engine/aggregateCREP.ts`)
 - 🎵 **CREPMusicGenerator** – erzeugt BPM aus CREP (`packages/crep-engine/CREPMusicGenerator.ts`)

--- a/packages/utils/poetry.test.ts
+++ b/packages/utils/poetry.test.ts
@@ -1,0 +1,10 @@
+import { toSigilVerse } from './poetry';
+import * as synapse from '../gpt-bridges/aeon-gpt-synapse';
+
+jest.spyOn(synapse, 'sendToGPT').mockResolvedValue('Ein Vers');
+
+test('generates verse from error message', async () => {
+  const verse = await toSigilVerse('Fehler');
+  expect(synapse.sendToGPT).toHaveBeenCalled();
+  expect(verse).toBe('Ein Vers');
+});

--- a/packages/utils/poetry.ts
+++ b/packages/utils/poetry.ts
@@ -1,0 +1,15 @@
+import { sendToGPT } from '../gpt-bridges/aeon-gpt-synapse';
+import { GPTRole } from '../gpt-bridges/gptRoles';
+
+/**
+ * Generate a short sigil verse for the provided error message using GPT.
+ */
+export async function toSigilVerse(errorMessage: string): Promise<string> {
+  const prompt = `Fasse den folgenden Fehler in zwei poetischen Zeilen:\n${errorMessage}`;
+  try {
+    const verse = await sendToGPT({ role: GPTRole.POET, input: prompt });
+    return verse.trim();
+  } catch {
+    return `Verse konnte nicht erzeugt werden: ${errorMessage}`;
+  }
+}


### PR DESCRIPTION
## Summary
- add `toSigilVerse` helper under packages/utils for GPT‐based poetic errors
- document the new util in README and Handbuch
- include unit test for poetry

## Testing
- `npx --yes jest --passWithNoTests` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859759d7f948322aee41d376a189ef2