### PR TITLE
Add ChatPanel and GPT wrapper

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -125,6 +125,7 @@ Teil 5 ergänzt die Sigil-Historie.
 - `useEventGlow` – React-Hook zur Event-Hervorhebung (`packages/unifiedmandala-ui/hooks/useEventGlow.ts`)
 - `silenceWatcher` – meldet Stille an den GPTEventHub (`packages/agents/silenceWatcher.ts`)
 - `FeedbackButtons` – einfache Like/Dislike-Komponente, speichert Sigil-Ereignisse (`packages/unifiedmandala-ui/components/FeedbackButtons.tsx`)
+- `ChatPanel` – GPT-gestütztes Panel mit CREP-Logging (`packages/unifiedmandala-ui/components/ChatPanel.tsx`)
 - `ArchetypeDecoderAgent` – erkennt Archetypen in Task-Beschreibungen (`packages/agents/ArchetypeDecoderAgent.ts`)
 - `SigillinInterpreterAgent` – extrahiert Sigillin aus Text (`packages/agents/SigillinInterpreterAgent.ts`)
 - `ChronoPoemGeneratorAgent` – erzeugt poetische Chrono-Zeilen (`packages/agents/ChronoPoemGeneratorAgent.ts`)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - ✨ **useEventGlow** – Hook für Event-Hervorhebung (`packages/unifiedmandala-ui/hooks/useEventGlow.ts`)
 - 🤫 **silenceWatcher** – meldet Stille im EventHub (`packages/agents/silenceWatcher.ts`)
 - 👍 **FeedbackButtons** – zeichnet Nutzerfeedback als Sigil-Ereignis auf (`packages/unifiedmandala-ui/components/FeedbackButtons.tsx`)
+- 💬 **ChatPanel** – einfacher GPT-gestützter Chat mit CREP-Logging
 - 🔥 **ArchetypeDecoderAgent** – extrahiert Archetypen aus Beschreibungen (`packages/agents/ArchetypeDecoderAgent.ts`)
 - 🔮 **SigillinInterpreterAgent** – erkennt Sigillin-Symbole (`packages/agents/SigillinInterpreterAgent.ts`)
 - 📝 **ChronoPoemGeneratorAgent** – generiert poetische Zeilen (`packages/agents/ChronoPoemGeneratorAgent.ts`)

--- a/packages/gpt-bridges/ChatGPTWrapper.ts
+++ b/packages/gpt-bridges/ChatGPTWrapper.ts
@@ -1,0 +1,6 @@
+import { sendToGPT } from './aeon-gpt-synapse';
+import { GPTRole } from './gptRoles';
+
+export async function chatWithContext(prompt: string, context = 'C-Tutor'): Promise<string> {
+  return sendToGPT({ role: GPTRole.AEON, input: prompt, context });
+}

--- a/packages/gpt-bridges/index.ts
+++ b/packages/gpt-bridges/index.ts
@@ -2,3 +2,4 @@ export * from './GPTEventHub';
 export * from './aeon-gpt-synapse';
 export * from './GPTConversationLogger';
 export * from './gptRoles';
+export * from './ChatGPTWrapper';

--- a/packages/unifiedmandala-ui/components/ChatPanel.stories.tsx
+++ b/packages/unifiedmandala-ui/components/ChatPanel.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ChatPanel from './ChatPanel';
+import { CREPProvider } from '../contexts/CREPContext';
+
+export default {
+  title: 'UnifiedMandala/ChatPanel',
+  component: ChatPanel,
+};
+
+export const Demo = () => (
+  <CREPProvider>
+    <ChatPanel />
+  </CREPProvider>
+);

--- a/packages/unifiedmandala-ui/components/ChatPanel.test.tsx
+++ b/packages/unifiedmandala-ui/components/ChatPanel.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import ChatPanel from './ChatPanel';
+import { CREPProvider } from '../contexts/CREPContext';
+import * as chat from '../../gpt-bridges/ChatGPTWrapper';
+
+jest.spyOn(chat, 'chatWithContext').mockResolvedValue('ok');
+
+const wrapper: React.FC<{children: React.ReactNode}> = ({ children }) => (
+  <CREPProvider>{children}</CREPProvider>
+);
+
+test('sends message and shows reply', async () => {
+  const { getByLabelText, getByText } = render(<ChatPanel />, { wrapper });
+  fireEvent.change(getByLabelText('chat-input'), { target: { value: 'hi' } });
+  fireEvent.click(getByText('Send'));
+  await waitFor(() => getByText(/AI:/));
+  expect(chat.chatWithContext).toHaveBeenCalledWith('hi', undefined);
+});

--- a/packages/unifiedmandala-ui/components/ChatPanel.tsx
+++ b/packages/unifiedmandala-ui/components/ChatPanel.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { chatWithContext } from '../../gpt-bridges/ChatGPTWrapper';
+import { useCREP } from '../hooks/useCREP';
+
+interface Message { sender: 'user' | 'ai'; text: string }
+
+export const ChatPanel: React.FC<{ context?: string }> = ({ context }) => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const { triggerCREP } = useCREP();
+
+  const send = async () => {
+    if (!input) return;
+    const userMsg: Message = { sender: 'user', text: input };
+    setMessages(m => [...m, userMsg]);
+    setInput('');
+    triggerCREP({ C: 1, R: 1, E: 1, P: 1 });
+    const reply = await chatWithContext(input, context);
+    setMessages(m => [...m, { sender: 'ai', text: reply }]);
+  };
+
+  return (
+    <div>
+      <div aria-label="conversation" className="border p-2 h-40 overflow-y-auto">
+        {messages.map((m, i) => (
+          <div key={i} className={m.sender === 'user' ? 'text-right' : ''}>
+            <span>{m.sender === 'user' ? 'You: ' : 'AI: '}{m.text}</span>
+          </div>
+        ))}
+      </div>
+      <input
+        value={input}
+        onChange={e => setInput(e.target.value)}
+        aria-label="chat-input"
+      />
+      <button onClick={send}>Send</button>
+    </div>
+  );
+};
+
+export default ChatPanel;

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -4,3 +4,4 @@ export { default as UploadYamlForm } from './components/UploadYamlForm';
 export { default as CREPTestHarness } from './components/CREPTestHarness';
 export { default as CREPPlayEngine } from './components/CREPPlayEngine';
 export { default as CREPTimeline } from './components/CREPTimeline';
+export { default as ChatPanel } from './components/ChatPanel';


### PR DESCRIPTION
## Summary
- add `chatWithContext` wrapper in GPT bridges
- create `ChatPanel` component with test and storybook demo
- export ChatPanel in UI package
- document ChatPanel in README and Handbuch

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685987189eb88322b3bb1caf56651c22