### PR TITLE
Update advanced task statuses

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1748,12 +1748,14 @@
     "commit": "Add MandalaGraph visualization",
     "path": "packages/visuals/MandalaGraph.ts",
     "task": "Render mastercanvas nodes with three.js",
-    "test": "packages/visuals/__tests__/MandalaGraph.test.ts"
+    "test": "packages/visuals/__tests__/MandalaGraph.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add GenerativeOverlay stub",
     "path": "packages/art/generativeOverlay.ts",
     "task": "Stub GAN overlay generator",
-    "test": "packages/art/__tests__/generativeOverlay.test.ts"
+    "test": "packages/art/__tests__/generativeOverlay.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo_parts/advancedToDo.part5.json
+++ b/advancedToDo_parts/advancedToDo.part5.json
@@ -1,8 +1,9 @@
 [
   {
-    "commit": "Add transition history script",
-    "path": "scripts/add-transition-history.js",
-    "task": "Keep aeon transition sigils in advancedprogress.json",
-    "test": "scripts/__tests__/add-transition-history.test.ts"
-  }
+  "commit": "Add transition history script",
+  "path": "scripts/add-transition-history.js",
+  "task": "Keep aeon transition sigils in advancedprogress.json",
+  "test": "scripts/__tests__/add-transition-history.test.ts",
+  "status": "done"
+}
 ]

--- a/advancedToDo_parts/advancedToDo.part5.yaml
+++ b/advancedToDo_parts/advancedToDo.part5.yaml
@@ -2,3 +2,4 @@
   path: scripts/add-transition-history.js
   task: "Keep aeon transition sigils in advancedprogress.json"
   test: scripts/__tests__/add-transition-history.test.ts
+  status: done

--- a/advancedToDo_parts/advancedToDo.part6.yaml
+++ b/advancedToDo_parts/advancedToDo.part6.yaml
@@ -2,7 +2,9 @@
   path: packages/visuals/MandalaGraph.ts
   task: "Render mastercanvas nodes with three.js"
   test: packages/visuals/__tests__/MandalaGraph.test.ts
+  status: done
 - commit: "Add GenerativeOverlay stub"
   path: packages/art/generativeOverlay.ts
   task: "Stub GAN overlay generator"
   test: packages/art/__tests__/generativeOverlay.test.ts
+  status: done


### PR DESCRIPTION
## Summary
- mark advanced tasks as done in advancedToDo part files
- sync advancedToDo.json entries

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68598e6d7d24832289c3beaa83fb6120