### PR TITLE
Add poetic module tasks

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -103,6 +103,7 @@ console.log(sigil.id); // hello
 Die erweiterten ToDos liegen in "advancedToDo_parts/".
 Teil 2 dort beschreibt Aufgaben zum Aeon Übergabe-Sigil und MemoryMesh.
 - `CommonsAgent` – Bewertet Open-Science-Aspekte.
+Teil 7 sammelt poetische Sigill- und Mandala-Aufgaben.
 Teil 5 ergänzt die Sigil-Historie.
 - `AdaptiveThreshold` und `DebounceManager` – steuern CREP-Trigger.
 - `AeonSigillinVault` – speichert poetische Zustände und Übergänge.

--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ Die ToDo-Liste wurde für mehr Übersicht in "advancedToDo_parts/" aufgeteilt.
 Teil 2 in advancedToDo_parts beinhaltet Aufgaben zum Aeon Übergabe-Sigil und MemoryMesh.
 Teil 5 enthält Aufgaben zur Sigil-Historie.
 
+Teil 7 listet Aufgaben zu poetischen Sigill- und Mandala-Modulen.
 Nutze `node scripts/parse-advanced-conversations.js` um Gesprächs-TODOs aus dem Datensatz zu filtern.
 
 - **Module**: unter `packages/` gegliedert in Agents, Core und mehr

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1758,4 +1758,16 @@
     "test": "packages/art/__tests__/generativeOverlay.test.ts",
     "status": "done"
   }
+  {
+    "commit": "Add PoeticSigillin module",
+    "path": "packages/genesis-sigillin-core/PoeticSigillin.ts",
+    "task": "Generate poetic sigils from verse snippets",
+    "test": "packages/genesis-sigillin-core/__tests__/PoeticSigillin.test.ts"
+  },
+  {
+    "commit": "Add ResonanzMandala visualization",
+    "path": "packages/visuals/ResonanzMandala.ts",
+    "task": "Render archetype dialogue topology",
+    "test": "packages/visuals/__tests__/ResonanzMandala.test.ts"
+  }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1,4 +1,4 @@
-# See advancedToDo_parts/advancedToDo.part1.yaml for new learning-module tasks; see advancedToDo_parts/advancedToDo.part2.yaml for transition and memorymesh tasks; see advancedToDo_parts/advancedToDo.part3.yaml for transition docs and friendship system tasks; see advancedToDo_parts/advancedToDo.part4.yaml for automation and docker tasks; see advancedToDo_parts/advancedToDo.part5.yaml for sigil history tasks; see advancedToDo_parts/advancedToDo.part6.yaml for visualization tasks
+# See advancedToDo_parts/advancedToDo.part1.yaml for new learning-module tasks; see advancedToDo_parts/advancedToDo.part2.yaml for transition and memorymesh tasks; see advancedToDo_parts/advancedToDo.part3.yaml for transition docs and friendship system tasks; see advancedToDo_parts/advancedToDo.part4.yaml for automation and docker tasks; see advancedToDo_parts/advancedToDo.part5.yaml for sigil history tasks; see advancedToDo_parts/advancedToDo.part6.yaml for visualization tasks; see advancedToDo_parts/advancedToDo.part7.yaml for poetic module tasks
 - commit: "- und Progress-Dateien mit diesem Stand."
   path: ""
   task: "- und Progress-Dateien mit diesem Stand."
@@ -3139,3 +3139,11 @@ status: done
   test: ''
   status: done
 
+- commit: "Add PoeticSigillin module"
+  path: packages/genesis-sigillin-core/PoeticSigillin.ts
+  task: Generate poetic sigils from verse snippets
+  test: packages/genesis-sigillin-core/__tests__/PoeticSigillin.test.ts
+- commit: "Add ResonanzMandala visualization"
+  path: packages/visuals/ResonanzMandala.ts
+  task: Render archetype dialogue topology
+  test: packages/visuals/__tests__/ResonanzMandala.test.ts

--- a/advancedToDo_parts/advancedToDo.part7.json
+++ b/advancedToDo_parts/advancedToDo.part7.json
@@ -1,0 +1,14 @@
+[
+  {
+    "commit": "Add PoeticSigillin module",
+    "path": "packages/genesis-sigillin-core/PoeticSigillin.ts",
+    "task": "Generate poetic sigils from verse snippets",
+    "test": "packages/genesis-sigillin-core/__tests__/PoeticSigillin.test.ts"
+  },
+  {
+    "commit": "Add ResonanzMandala visualization",
+    "path": "packages/visuals/ResonanzMandala.ts",
+    "task": "Render archetype dialogue topology",
+    "test": "packages/visuals/__tests__/ResonanzMandala.test.ts"
+  }
+]

--- a/advancedToDo_parts/advancedToDo.part7.yaml
+++ b/advancedToDo_parts/advancedToDo.part7.yaml
@@ -1,0 +1,8 @@
+- commit: "Add PoeticSigillin module"
+  path: packages/genesis-sigillin-core/PoeticSigillin.ts
+  task: "Generate poetic sigils from verse snippets"
+  test: packages/genesis-sigillin-core/__tests__/PoeticSigillin.test.ts
+- commit: "Add ResonanzMandala visualization"
+  path: packages/visuals/ResonanzMandala.ts
+  task: "Render archetype dialogue topology"
+  test: packages/visuals/__tests__/ResonanzMandala.test.ts


### PR DESCRIPTION
## Summary
- document new part7 of advanced tasks referencing poetic modules
- add PoeticSigillin and ResonanzMandala tasks
- update README and Handbuch with part7 info
- regenerate CHRONOPOEM

## Testing
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_6859914d7474832298e6cb6d4c87b01f