### PR TITLE
Add donation section and todo tools

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -508,3 +508,17 @@ Das `CHRONOPOEM.md` entsteht automatisch – und kann bei jedem Commit erneuert 
 \nDie detaillierte Struktur aller Module, Utilities und Skripte findest du in [repositorypflege/repository_map.yaml](repositorypflege/repository_map.yaml).
 Ergänzende Konzeptinfos liefert [repositorypflege/repo-konzept.yaml](repositorypflege/repo-konzept.yaml).
 Einen Ausblick auf kommende Schritte liefert [codex/codex-roadmap.yaml](codex/codex-roadmap.yaml).
+
+## 🌱 Unterstütze das Mandala-Projekt
+Wenn dir unser Mandala-Ökosystem gefällt und du dazu beitragen möchtest, dass KI, Kreativität und Gemeinwohl weiter wachsen, freuen wir uns über deine Unterstützung. Jeder Beitrag hilft, neue Features, freie Tools und poetische Software weiterzuentwickeln!
+
+**Spendenadressen**
+- **Bitcoin:** `bc1qujx302cs0767gcnjqcyl0fnwvwkxge2cdh90eq`
+- **Ethereum / BNB Smart Chain / TWT / USDT / USDC:** `0xbcfdd442c9d92d491afef1dd3181c27c1f547b1b`
+- **Solana:** `3CpM6r6zNHX8Fn4r7PTJxagyan3qRwGDfSFjwpH3Hc3K`
+
+Hinweis: Bitte gib bei der Spende an, ob du im "Sigil der Unterstützer" erscheinen möchtest – und teile uns ggf. deinen Namen oder ein Wunsch-Sigil mit!
+
+Danke, dass du Teil unseres Mandalas bist. Gemeinsam weben wir das Netz der Zukunft!
+
+– Johann & das UnifiedMandala Team

--- a/README.md
+++ b/README.md
@@ -366,3 +366,17 @@ Nutze `node scripts/parse-advanced-conversations.js` um Gesprächs-TODOs aus dem
 \nDie komplette Ordnerstruktur samt Modulen, Utils und Skripten ist in [repositorypflege/repository_map.yaml](repositorypflege/repository_map.yaml) dokumentiert.
 Weitere Hinweise zum generellen Aufbau findest du zudem in [repositorypflege/repo-konzept.yaml](repositorypflege/repo-konzept.yaml).
 Weitere geplante Entwicklungsschritte findest du in [codex/codex-roadmap.yaml](codex/codex-roadmap.yaml).
+
+## 🌱 Unterstütze das Mandala-Projekt
+Wenn dir unser Mandala-Ökosystem gefällt und du dazu beitragen möchtest, dass KI, Kreativität und Gemeinwohl weiter wachsen, freuen wir uns über deine Unterstützung. Jeder Beitrag hilft, neue Features, freie Tools und poetische Software weiterzuentwickeln!
+
+**Spendenadressen**
+- **Bitcoin:** `bc1qujx302cs0767gcnjqcyl0fnwvwkxge2cdh90eq`
+- **Ethereum / BNB Smart Chain / TWT / USDT / USDC:** `0xbcfdd442c9d92d491afef1dd3181c27c1f547b1b`
+- **Solana:** `3CpM6r6zNHX8Fn4r7PTJxagyan3qRwGDfSFjwpH3Hc3K`
+
+Hinweis: Bitte gib bei der Spende an, ob du im "Sigil der Unterstützer" erscheinen möchtest – und teile uns ggf. deinen Namen oder ein Wunsch-Sigil mit!
+
+Danke, dass du Teil unseres Mandalas bist. Gemeinsam weben wir das Netz der Zukunft!
+
+– Johann & das UnifiedMandala Team

--- a/advancedToDo_parts/advancedToDo.part8.json
+++ b/advancedToDo_parts/advancedToDo.part8.json
@@ -21,18 +21,21 @@
     "commit": "Add Parse TODOs button",
     "path": "apps/web/components/TodoButton.tsx",
     "task": "UI button invokes /usecases/todo/parse",
-    "test": "apps/web/components/__tests__/TodoButton.test.tsx"
+    "test": "apps/web/components/__tests__/TodoButton.test.tsx",
+    "status": "done"
   },
   {
     "commit": "Automate ToDo generation",
     "path": "scripts/todoSigilGenerator.js",
     "task": "Generate tasks from SelfAnalyzer results into advancedToDo.yaml",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Cluster roadmap guidelines",
     "path": "docs/roadmap/cluster-guidelines.md",
     "task": "Provide clusters and practical guard rails for implementation pitches",
-    "test": ""
+    "test": "",
+    "status": "done"
   }
 ]

--- a/advancedToDo_parts/advancedToDo.part8.yaml
+++ b/advancedToDo_parts/advancedToDo.part8.yaml
@@ -14,11 +14,14 @@
   path: apps/web/components/TodoButton.tsx
   task: "UI button invokes /usecases/todo/parse"
   test: apps/web/components/__tests__/TodoButton.test.tsx
+  status: done
 - commit: "Automate ToDo generation"
   path: scripts/todoSigilGenerator.js
   task: "Generate tasks from SelfAnalyzer results into advancedToDo.yaml"
   test: ""
+  status: done
 - commit: "Cluster roadmap guidelines"
   path: docs/roadmap/cluster-guidelines.md
   task: "Provide clusters and practical guard rails for implementation pitches"
   test: ""
+  status: done

--- a/apps/socialgood-ui/src/components/TodoButton.tsx
+++ b/apps/socialgood-ui/src/components/TodoButton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface TodoButtonProps {
+  onComplete?: (data: any) => void;
+}
+
+const TodoButton: React.FC<TodoButtonProps> = ({ onComplete }) => {
+  const handleClick = async () => {
+    try {
+      const res = await fetch('/usecases/todo/parse');
+      const data = await res.json();
+      onComplete?.(data);
+    } catch {
+      onComplete?.(null);
+    }
+  };
+
+  return (
+    <button aria-label="Parse TODOs" onClick={handleClick}>
+      Parse TODOs
+    </button>
+  );
+};
+
+export default TodoButton;

--- a/apps/socialgood-ui/src/components/__tests__/TodoButton.test.tsx
+++ b/apps/socialgood-ui/src/components/__tests__/TodoButton.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TodoButton from '../TodoButton';
+
+const mockFetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({ ok: true }) }));
+// @ts-ignore
+global.fetch = mockFetch;
+
+test('calls endpoint on click', async () => {
+  const cb = jest.fn();
+  render(<TodoButton onComplete={cb} />);
+  fireEvent.click(screen.getByRole('button', { name: /parse todos/i }));
+  await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+  expect(mockFetch).toHaveBeenCalledWith('/usecases/todo/parse');
+  expect(cb).toHaveBeenCalledWith({ ok: true });
+});

--- a/docs/roadmap/cluster-guidelines.md
+++ b/docs/roadmap/cluster-guidelines.md
@@ -1,0 +1,10 @@
+# Cluster Guidelines
+
+Dieses Dokument skizziert praktische Cluster und Leitplanken für kommende Implementierungen.
+
+- **Core Infrastructure**: Basismodulpflege, SelfAnalyzer und Repo-Stats synchron halten.
+- **UI Components**: Buttons, Dashboards und Hooks einheitlich gestalten.
+- **Agent Workflows**: Go-Bridge und Node Agents über gemeinsame Endpunkte verbinden.
+- **Documentation**: Jede Erweiterung kurz im Handbuch und README verlinken.
+
+Diese Richtlinien stammen aus den fortgeschrittenen Gesprächen und sollen die Entwicklung fokussieren.

--- a/scripts/__tests__/todoSigilGenerator.test.ts
+++ b/scripts/__tests__/todoSigilGenerator.test.ts
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+import YAML from 'yaml';
+const { generateTodoFromRepo } = require('../todoSigilGenerator');
+
+test('generateTodoFromRepo appends entries', () => {
+  const yaml = path.join(__dirname, '../../__tmp_todo.yaml');
+  const json = path.join(__dirname, '../../__tmp_todo.json');
+  fs.writeFileSync(yaml, YAML.stringify([]));
+  fs.writeFileSync(json, JSON.stringify([]));
+  const entries = generateTodoFromRepo(yaml, json);
+  const yamlOut = YAML.parse(fs.readFileSync(yaml, 'utf8'));
+  const jsonOut = JSON.parse(fs.readFileSync(json, 'utf8'));
+  expect(entries.length).toBeGreaterThan(0);
+  expect(yamlOut.length).toBeGreaterThan(0);
+  expect(jsonOut.length).toBeGreaterThan(0);
+  fs.rmSync(yaml);
+  fs.rmSync(json);
+});

--- a/scripts/todoSigilGenerator.js
+++ b/scripts/todoSigilGenerator.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+const YAML = require('yaml');
+let analyzeRepo;
+try {
+  ({ analyzeRepo } = require('../dist/shared-utils/selfAnalyzer.js'));
+} catch {
+  ({ analyzeRepo } = require('../packages/shared-utils/selfAnalyzer'));
+}
+
+function appendTasks(entries, yamlFile, jsonFile) {
+  const loadYaml = (f) => (fs.existsSync(f) ? YAML.parse(fs.readFileSync(f, 'utf8')) : []);
+  const loadJson = (f) => (fs.existsSync(f) ? JSON.parse(fs.readFileSync(f, 'utf8')) : []);
+  const merge = (existing, add) => {
+    const known = new Set(existing.map((e) => e.commit));
+    for (const e of add) {
+      if (!known.has(e.commit)) {
+        existing.push(e);
+        known.add(e.commit);
+      }
+    }
+    return existing;
+  };
+  const y = merge(loadYaml(yamlFile), entries);
+  const j = merge(loadJson(jsonFile), entries);
+  fs.writeFileSync(yamlFile, YAML.stringify(y, null, 2));
+  fs.writeFileSync(jsonFile, JSON.stringify(j, null, 2));
+}
+
+function generateTodoFromRepo(yamlFile = path.join(__dirname, '../advancedToDo.yaml'), jsonFile = path.join(__dirname, '../advancedToDo.json')) {
+  const stats = analyzeRepo();
+  const entries = stats.packages.map((pkg) => ({
+    commit: `Add tests for ${pkg}`,
+    path: `packages/${pkg}`,
+    task: `Ensure unit tests exist for ${pkg}`,
+    test: `packages/${pkg}/*.test.ts`
+  }));
+  appendTasks(entries, yamlFile, jsonFile);
+  console.log(`todo entries updated for ${entries.length} packages`);
+  return entries;
+}
+
+if (require.main === module) {
+  generateTodoFromRepo();
+}
+
+module.exports = { generateTodoFromRepo };


### PR DESCRIPTION
## Summary
- add donation information to README and Handbuch
- add example TodoButton component with test
- add script `todoSigilGenerator.js` and test for automated ToDo extraction
- document cluster guidelines
- mark relevant tasks done in advancedToDo part8

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_6859c089937883228e80f3fd1d22afbb