### PR TITLE
Add GPTBridge modules

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -118,7 +118,8 @@ Teil 5 ergänzt die Sigil-Historie.
 - `ResearchAgent` – Automatisierte Forschungsanfragen.
 - `SilenceWatcher` – Beobachtet Inaktivität und triggert Selbstanalyse.
 - `AdvancedHexaAgent` – Erweiterte Analyse mit Research- und SilenceWatcher-Agenten.
-- `go-bridge` – Golang-Client für REST/gRPC/NATS Kommunikation.
+ - `go-bridge` – Golang-Client für REST/gRPC/NATS Kommunikation.
+ - `go-bridge/pkg/gpt` – GPTBridge (API und Link) mit CLI `mandala-gpt.go`.
 
 - `WeightedDispatcher` – verteilt Aufgaben nach Priorität (`packages/agents/WeightedDispatcher.ts`)
 - `patternReactivator` – reaktiviert schwache Erinnerungen (`packages/agents/patternReactivator.ts`)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 - 🗂️ **SigillinLoader** – Import & Filter von Sigillin-Dateien
 - 📚 **AutoDoc & Manifest-Generator** – Dokumentation auf Knopfdruck
 - 🧩 **Plug-in-Architektur** – GPT-Kommunikationsmodule, CLI-Tools
+- 🔗 **GPTBridge (Go)** – API- und Link-basierte GPT-Anbindung (`go-bridge/pkg/gpt`)
 - 🔌 **Plugin-Registry & Dynamic Loader** – `plugins/manifest.yaml` und `usePluginLoader`
 - 📝 **Objective2UI** – generiert Layout-Vorschläge via GPT
 - 🔐 **Ethik-Governance & Heimkehr-Deklaration** – Offene, poetische Ethik als Systembasis
@@ -158,7 +159,7 @@ packages/
   ├── shared-utils              # Hilfsfunktionen für alle Pakete
   │   └── RestClient.ts         # einfacher REST-Helper
   ├── bio                      # Biometrische Hooks und HapticService
-  ├── go-bridge             # Go-Client für REST, gRPC und NATS
+  ├── go-bridge             # Go-Client für REST, gRPC und NATS (inkl. GPTBridge)
   ├── go-agent              # Autonomer Go-Daemon für Tasks
   │   ├── pkg/policy        # Policy Enforcement Stubs
   │   ├── pkg/handler       # Task handlers (CoordinationHandler)
@@ -200,6 +201,7 @@ Jeder Unterordner kann eine eigene README enthalten – siehe die Links in den j
 Utilities liegen in `packages/shared-utils/`, weitere Module findest du ebenfalls unter `packages/`.
 ### 🟦 Go-Bridge (go-bridge/)
 - Polyglottes Interface zu UnifiedMandala für Go (REST, NATS, gRPC, CLI)
+- Enthält **GPTBridge**-Module (`pkg/gpt`) und das Beispiel-CLI `mandala-gpt.go`
 - Ermöglicht Entwicklung externer Tools und Agents in Go
 - [go-bridge/README.md](go-bridge/README.md) enthält Setup & Beispiele
 Kleine Hilfsskripte liegen unter `tools/`.

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2092,5 +2092,17 @@
     "path": "GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json",
     "task": "-  Vielen Dank für die ausführliche Beschreibung des Programms! Es handelt sich um ein äußerst komplexes, holistisches Framework namens **UnifiedMandala**, das als eine Art lebendiges, atemendes Betri",
     "test": ""
+  },
+  {
+    "commit": "feat: add Go GPTBridge modules",
+    "path": "go-bridge/pkg/gpt",
+    "task": "Implement api_client.go and link_processor.go for GPT API and Link ingest",
+    "test": "go build ./..."
+  },
+  {
+    "commit": "feat: add mandala-gpt CLI",
+    "path": "go-bridge/cmd/mandala-gpt.go",
+    "task": "CLI to invoke GPTBridge via api or link",
+    "test": "go build ./..."
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3955,3 +3955,11 @@
     handelt sich um ein äußerst komplexes, holistisches Framework
     namens **UnifiedMandala**, das als eine Art lebendiges, atemendes Betri"
   test: ""
+- commit: feat: add Go GPTBridge modules
+  path: go-bridge/pkg/gpt
+  task: Implement api_client.go and link_processor.go for GPT API and Link ingest
+  test: go build ./...
+- commit: feat: add mandala-gpt CLI
+  path: go-bridge/cmd/mandala-gpt.go
+  task: CLI to invoke GPTBridge via api or link
+  test: go build ./...

--- a/go-bridge/cmd/mandala-gpt.go
+++ b/go-bridge/cmd/mandala-gpt.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/GenesisAeon/unified-mandala/go-bridge/pkg/gpt"
+)
+
+// Simple CLI to demonstrate GPT via API or link
+func main() {
+	mode := flag.String("mode", "api", "api or link")
+	input := flag.String("input", "", "prompt text or URL")
+	endpoint := flag.String("endpoint", "https://api.openai.com/v1/chat/completions", "")
+	apiKey := flag.String("apiKey", "", "")
+	flag.Parse()
+
+	client := gpt.NewClient(*endpoint, *apiKey)
+	var resp string
+	var err error
+
+	if *mode == "link" {
+		resp, err = client.ProcessLink(context.Background(), *input)
+	} else {
+		resp, err = client.Ask(context.Background(), *input)
+	}
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+	fmt.Println(resp)
+}

--- a/go-bridge/pkg/gpt/api_client.go
+++ b/go-bridge/pkg/gpt/api_client.go
@@ -1,0 +1,45 @@
+package gpt
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// GPTClient handles simple GPT API requests
+// It can be reused by CLI or other services.
+type GPTClient struct {
+	Endpoint string
+	APIKey   string
+}
+
+// NewClient creates a GPTClient with endpoint and apiKey
+func NewClient(endpoint, apiKey string) *GPTClient {
+	return &GPTClient{Endpoint: endpoint, APIKey: apiKey}
+}
+
+// Ask sends a prompt to the GPT API and returns the text response
+func (c *GPTClient) Ask(ctx context.Context, prompt string) (string, error) {
+	body := map[string]string{"prompt": prompt}
+	b, _ := json.Marshal(body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.Endpoint, bytes.NewReader(b))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+	var resp struct {
+		Text string `json:"text"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return "", err
+	}
+	return resp.Text, nil
+}

--- a/go-bridge/pkg/gpt/link_processor.go
+++ b/go-bridge/pkg/gpt/link_processor.go
@@ -1,0 +1,28 @@
+package gpt
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"regexp"
+)
+
+// ProcessLink fetches the URL content, strips HTML and sends to GPT API
+func (c *GPTClient) ProcessLink(ctx context.Context, url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	re := regexp.MustCompile("<[^>]*>")
+	text := re.ReplaceAllString(string(data), "")
+	if len(text) > 2000 {
+		text = text[:2000]
+	}
+	return c.Ask(ctx, text)
+}


### PR DESCRIPTION
## Summary
- add `go-bridge/pkg/gpt` with API and link processors
- introduce `mandala-gpt` CLI example
- document new GPTBridge in README and Handbuch
- track tasks in advancedToDo files

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ccfe01c08322ae09f2ed63c1d70b