### PR TITLE
Implement TodoButton web component and update tasks

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-23, in der Zeit des Abend.
+Am 2025-06-23, in der Zeit des Nacht.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Reflexion (Fokus: P)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -415,13 +415,15 @@ config/                  # Zentrale YAML- und Env-Dateien
   ├── memory-manager.yaml  # Cleanup-Interval Konfiguration
 repositorypflege/         # Pflegekonzepte und Repository-Mapping
 apps/
-  └── sharedream-interface      # Web-Schnittstelle & Sync
+  ├── sharedream-interface      # Web-Schnittstelle & Sync
+  └── web                      # Sammelkomponenten (z.B. TodoButton)
 
 scripts/
   ├── aeon.sh                   # Poetisches Bash-CLI für Mandala-Steuerung
   ├── setup-unifiedmandala.sh   # Installer & Initialisierung
   ├── nucleon-scanner-analysis.js   # Auswertung von Scanner-Logs
   ├── generate-chronopoem.js    # Poetische Commit-Signatur
+  ├── todoSigilGenerator.js     # Automatisches ToDo-Sigil aus Repo-Analyse
   └── onboarding-ritual.md      # Onboarding-Ritus für neue Contributors
 ```
 

--- a/README.md
+++ b/README.md
@@ -187,13 +187,15 @@ config/                  # Zentrale YAML- und Env-Dateien
   ├── memory-manager.yaml  # Cleanup-Interval Konfiguration
 repositorypflege/         # Pflegekonzepte und Repository-Mapping
 apps/
-  └── sharedream-interface      # Web-Schnittstelle & Sync
+  ├── sharedream-interface      # Web-Schnittstelle & Sync
+  └── web                      # Sammelkomponenten (z.B. TodoButton)
 
 scripts/
   ├── aeon.sh                   # Poetisches Bash-CLI für Mandala-Steuerung
   ├── nucleon-scanner-analysis.js   # Auswertung von Scanner-Logs
   ├── setup-unifiedmandala.sh   # Installer & Initialisierung
   ├── generate-chronopoem.js    # Poetische Commit-Signatur
+  ├── todoSigilGenerator.js     # Automatisches ToDo-Sigil aus Repo-Analyse
   └── onboarding-ritual.md      # Onboarding-Ritus für neue Contributors
 ```
 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2017,19 +2017,22 @@
     "commit": "Add Parse TODOs button",
     "path": "apps/web/components/TodoButton.tsx",
     "task": "UI button invokes /usecases/todo/parse",
-    "test": "apps/web/components/__tests__/TodoButton.test.tsx"
+    "test": "apps/web/components/__tests__/TodoButton.test.tsx",
+    "status": "done"
   },
   {
     "commit": "Automate ToDo generation",
     "path": "scripts/todoSigilGenerator.js",
     "task": "Generate tasks from SelfAnalyzer results into advancedToDo.yaml",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Cluster roadmap guidelines",
     "path": "docs/roadmap/cluster-guidelines.md",
     "task": "Provide clusters and practical guard rails for implementation pitches",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Add React use-case components for Sigil generation, ToDo parsing, and SocialGood matching",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3886,14 +3886,17 @@
   path: apps/web/components/TodoButton.tsx
   task: UI button invokes /usecases/todo/parse
   test: apps/web/components/__tests__/TodoButton.test.tsx
+  status: done
 - commit: Automate ToDo generation
   path: scripts/todoSigilGenerator.js
   task: Generate tasks from SelfAnalyzer results into advancedToDo.yaml
   test: ""
+  status: done
 - commit: Cluster roadmap guidelines
   path: docs/roadmap/cluster-guidelines.md
   task: Provide clusters and practical guard rails for implementation pitches
   test: ""
+  status: done
 - commit: Add React use-case components for Sigil generation, ToDo parsing, and
     SocialGood matching
   path: apps/socialgood-ui/src/components/UsecaseComponents.tsx
@@ -3951,15 +3954,16 @@
 - commit: TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json -
     bbb21f74-3a0f-45b2-8e8c-25e45e32861e
   path: GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json
-  task: "-  Vielen Dank für die ausführliche Beschreibung des Programms! Es
-    handelt sich um ein äußerst komplexes, holistisches Framework
-    namens **UnifiedMandala**, das als eine Art lebendiges, atemendes Betri"
+  task: >
+    Vielen Dank für die ausführliche Beschreibung des Programms! Es handelt sich
+    um ein äußerst komplexes, holistisches Framework namens **UnifiedMandala**,
+    das als eine Art lebendiges, atemendes Betriebssystem funktioniert.
   test: ""
-- commit: feat: add Go GPTBridge modules
+- commit: "feat: add Go GPTBridge modules"
   path: go-bridge/pkg/gpt
   task: Implement api_client.go and link_processor.go for GPT API and Link ingest
   test: go build ./...
-- commit: feat: add mandala-gpt CLI
+- commit: "feat: add mandala-gpt CLI"
   path: go-bridge/cmd/mandala-gpt.go
   task: CLI to invoke GPTBridge via api or link
   test: go build ./...

--- a/advancedToDo_parts/advancedToDo.part9.json
+++ b/advancedToDo_parts/advancedToDo.part9.json
@@ -21,19 +21,22 @@
     "commit": "Add Parse TODOs button",
     "path": "apps/web/components/TodoButton.tsx",
     "task": "UI button invokes /usecases/todo/parse",
-    "test": "apps/web/components/__tests__/TodoButton.test.tsx"
+    "test": "apps/web/components/__tests__/TodoButton.test.tsx",
+    "status": "done"
   },
   {
     "commit": "Automate ToDo generation",
     "path": "scripts/todoSigilGenerator.js",
     "task": "Generate tasks from SelfAnalyzer results into advancedToDo.yaml",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Cluster roadmap guidelines",
     "path": "docs/roadmap/cluster-guidelines.md",
     "task": "Provide clusters and practical guard rails for implementation pitches",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Add React use-case components for Sigil generation, ToDo parsing, and SocialGood matching",

--- a/advancedToDo_parts/advancedToDo.part9.yaml
+++ b/advancedToDo_parts/advancedToDo.part9.yaml
@@ -18,14 +18,17 @@
   path: apps/web/components/TodoButton.tsx
   task: UI button invokes /usecases/todo/parse
   test: apps/web/components/__tests__/TodoButton.test.tsx
+  status: done
 - commit: Automate ToDo generation
   path: scripts/todoSigilGenerator.js
   task: Generate tasks from SelfAnalyzer results into advancedToDo.yaml
   test: ''
+  status: done
 - commit: Cluster roadmap guidelines
   path: docs/roadmap/cluster-guidelines.md
   task: Provide clusters and practical guard rails for implementation pitches
   test: ''
+  status: done
 - commit: Add React use-case components for Sigil generation, ToDo parsing, and SocialGood
     matching
   path: apps/socialgood-ui/src/components/UsecaseComponents.tsx

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,8 @@
 {
-  "lastCommit": "chore: update advanced progress",
+  "lastCommit": "chore: finalize progress",
   "fractalStep": "sync",
-  "openBranches": ["work"],
+  "openBranches": [
+    "work"
+  ],
   "mergeConflicts": []
 }

--- a/apps/web/components/TodoButton.tsx
+++ b/apps/web/components/TodoButton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface TodoButtonProps {
+  onComplete?: (data: any) => void;
+}
+
+const TodoButton: React.FC<TodoButtonProps> = ({ onComplete }) => {
+  const handleClick = async () => {
+    try {
+      const res = await fetch('/usecases/todo/parse');
+      const data = await res.json();
+      onComplete?.(data);
+    } catch {
+      onComplete?.(null);
+    }
+  };
+
+  return (
+    <button aria-label="Parse TODOs" onClick={handleClick}>
+      Parse TODOs
+    </button>
+  );
+};
+
+export default TodoButton;

--- a/apps/web/components/__tests__/TodoButton.test.tsx
+++ b/apps/web/components/__tests__/TodoButton.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TodoButton from '../TodoButton';
+
+const mockFetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({ ok: true }) }));
+// @ts-ignore
+global.fetch = mockFetch;
+
+test('calls endpoint on click', async () => {
+  const cb = jest.fn();
+  render(<TodoButton onComplete={cb} />);
+  fireEvent.click(screen.getByRole('button', { name: /parse todos/i }));
+  await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+  expect(mockFetch).toHaveBeenCalledWith('/usecases/todo/parse');
+  expect(cb).toHaveBeenCalledWith({ ok: true });
+});


### PR DESCRIPTION
## Summary
- add `apps/web` with TodoButton component and tests
- reference new module and todo generator in README and Handbuch
- mark completed tasks in `advancedToDo` lists
- update advanced progress tracking
- keep CHRONOPOEM auto-update

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6859d5f963b4832296cb83be10de65d3