### PR TITLE
Add markdown ToDo parser script

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -424,6 +424,7 @@ scripts/
   ├── nucleon-scanner-analysis.js   # Auswertung von Scanner-Logs
   ├── generate-chronopoem.js    # Poetische Commit-Signatur
   ├── todoSigilGenerator.js     # Automatisches ToDo-Sigil aus Repo-Analyse
+  ├── parse-md-todo.js          # Liest ToDo-Listen aus Markdown-Dateien
   └── onboarding-ritual.md      # Onboarding-Ritus für neue Contributors
 ```
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ scripts/
   ├── setup-unifiedmandala.sh   # Installer & Initialisierung
   ├── generate-chronopoem.js    # Poetische Commit-Signatur
   ├── todoSigilGenerator.js     # Automatisches ToDo-Sigil aus Repo-Analyse
+  ├── parse-md-todo.js          # Liest ToDo-Listen aus Markdown-Dateien
   └── onboarding-ritual.md      # Onboarding-Ritus für neue Contributors
 ```
 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2107,5 +2107,11 @@
     "path": "go-bridge/cmd/mandala-gpt.go",
     "task": "CLI to invoke GPTBridge via api or link",
     "test": "go build ./..."
+  },
+  {
+    "commit": "Add Markdown ToDo parser",
+    "path": "scripts/parse-md-todo.js",
+    "task": "Parse Markdown task lists and append to advancedToDo files",
+    "test": "scripts/__tests__/parse-md-todo.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3967,3 +3967,7 @@
   path: go-bridge/cmd/mandala-gpt.go
   task: CLI to invoke GPTBridge via api or link
   test: go build ./...
+- commit: Add Markdown ToDo parser
+  path: scripts/parse-md-todo.js
+  task: Parse Markdown task lists and append to advancedToDo files
+  test: scripts/__tests__/parse-md-todo.test.ts

--- a/scripts/__tests__/parse-md-todo.test.ts
+++ b/scripts/__tests__/parse-md-todo.test.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+const { parseMdTodo } = require('../parse-md-todo');
+
+test('parseMdTodo extracts tasks and appends to files', () => {
+  const md = path.join(__dirname, '../../__tmp.md');
+  const yaml = path.join(__dirname, '../../__tmp.yaml');
+  const json = path.join(__dirname, '../../__tmp.json');
+  fs.writeFileSync(md, '* [ ] first task\n* [x] done task');
+  fs.writeFileSync(yaml, '[]');
+  fs.writeFileSync(json, '[]');
+  const entries = parseMdTodo(md, yaml, json);
+  const y = fs.readFileSync(yaml, 'utf8');
+  const j = fs.readFileSync(json, 'utf8');
+  expect(entries.length).toBe(2);
+  expect(y.includes('first task')).toBe(true);
+  expect(j.includes('first task')).toBe(true);
+  fs.rmSync(md);
+  fs.rmSync(yaml);
+  fs.rmSync(json);
+});

--- a/scripts/parse-md-todo.js
+++ b/scripts/parse-md-todo.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const YAML = require('yaml');
+let extractTodosFromFile;
+try {
+  ({ extractTodosFromFile } = require('../dist/shared-utils/todoParser.js'));
+} catch {
+  ({ extractTodosFromFile } = require('../packages/shared-utils/todoParser'));
+}
+
+function appendTasks(entries, yamlFile, jsonFile) {
+  const loadYaml = (f) => (fs.existsSync(f) ? YAML.parse(fs.readFileSync(f, 'utf8')) : []);
+  const loadJson = (f) => (fs.existsSync(f) ? JSON.parse(fs.readFileSync(f, 'utf8')) : []);
+  const merge = (existing, add) => {
+    const known = new Set(existing.map((e) => e.commit));
+    for (const e of add) {
+      if (!known.has(e.commit)) {
+        existing.push(e);
+        known.add(e.commit);
+      }
+    }
+    return existing;
+  };
+  const y = merge(loadYaml(yamlFile), entries);
+  const j = merge(loadJson(jsonFile), entries);
+  fs.writeFileSync(yamlFile, YAML.stringify(y, null, 2));
+  fs.writeFileSync(jsonFile, JSON.stringify(j, null, 2));
+}
+
+function parseMdTodo(mdFile, yamlFile = path.join(__dirname, '../advancedToDo.yaml'), jsonFile = path.join(__dirname, '../advancedToDo.json')) {
+  const todos = extractTodosFromFile(mdFile);
+  const entries = todos.map((t) => ({
+    commit: `TODO from ${path.basename(mdFile)} - ${t.text.slice(0, 40)}`,
+    path: mdFile,
+    task: t.text,
+    test: ''
+  }));
+  appendTasks(entries, yamlFile, jsonFile);
+  console.log(`added ${entries.length} todos from ${mdFile}`);
+  return entries;
+}
+
+if (require.main === module) {
+  const mdFile = process.argv[2];
+  if (!mdFile) {
+    console.error('Usage: node parse-md-todo.js <markdown-file> [yaml-file] [json-file]');
+    process.exit(1);
+  }
+  parseMdTodo(mdFile, process.argv[3], process.argv[4]);
+}
+
+module.exports = { parseMdTodo };


### PR DESCRIPTION
## Summary
- add `parse-md-todo.js` for extracting tasks from Markdown
- include a test for the script
- document the new script in README and Handbuch
- list the task in `advancedToDo.json` and `advancedToDo.yaml`
- update progress metadata

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6859db6c38b883228191312c9e5872b6