### PR TITLE
Update docs and add memory job template

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -378,6 +378,7 @@ packages/
   ├── crep-automation      # CREP-bezogene Automationen
   ├── tts                  # Sprachsynthese
   ├── universum-simulationen # Simulationsmodule
+  │   └── universe-sim       # Beispiel-Simulation mit Go
   ├── nukleon-scanner        # Extrahiert Gesprächsstrukturen
   ├── nukleon-sonifier       # Sonifiziert Memory-Zustände
   ├── sim-domain          # Domänenspezifische Simulationen
@@ -409,10 +410,12 @@ go-agent/               # Go-Daemon zur Layer-Steuerung
   ├── pkg/policy        # Policy Enforcement Stubs
   ├── pkg/handler       # Task handlers (CoordinationHandler)
   └── pkg/hooks         # Event Hook Publisher
+cmd/mandala-codeagent.go    # Beispiel-CLI für CodeAgent
 ci/                      # Test- und Pipeline-Konfigurationen
 config/                  # Zentrale YAML- und Env-Dateien
   └── interfaces.yaml       # API-Endpunkte der Plattform
   ├── memory-manager.yaml  # Cleanup-Interval Konfiguration
+  ├── memory-job-example.yaml # Vorlage für MemoryManager-Jobs
 repositorypflege/         # Pflegekonzepte und Repository-Mapping
 apps/
   ├── sharedream-interface      # Web-Schnittstelle & Sync

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ packages/
   ├── crep-automation      # CREP-bezogene Automationen
   ├── tts                  # Sprachsynthese
   ├── universum-simulationen # Simulationsmodule
+  │   └── universe-sim       # Beispiel-Simulation mit Go
   ├── nukleon-scanner        # Extrahiert Gesprächsstrukturen
   ├── nukleon-sonifier       # Sonifiziert Memory-Zustände
   ├── sim-domain          # Domänenspezifische Simulationen
@@ -164,6 +165,7 @@ packages/
   │   ├── pkg/policy        # Policy Enforcement Stubs
   │   ├── pkg/handler       # Task handlers (CoordinationHandler)
   │   └── pkg/hooks         # Event Hook Publisher
+  ├── cmd/mandala-codeagent.go  # Beispiel-CLI für CodeAgent
   ├── services/vector-indexer # Embedding generator service
   ├── services/sigil-trigger  # Beobachtet Sigillin-Änderungen
   ├── services/memorymesh     # Region-Archive und Reflexionsdienste
@@ -185,6 +187,7 @@ ci/                      # Test- und Pipeline-Konfigurationen
 config/                  # Zentrale YAML- und Env-Dateien
   └── interfaces.yaml       # API-Endpunkte der Plattform
   ├── memory-manager.yaml  # Cleanup-Interval Konfiguration
+  ├── memory-job-example.yaml # Vorlage für MemoryManager-Jobs
 repositorypflege/         # Pflegekonzepte und Repository-Mapping
 apps/
   ├── sharedream-interface      # Web-Schnittstelle & Sync

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3057,6 +3057,7 @@
   path: config
   task: Provide YAML job configuration templates for MemoryManager
   test: ""
+  status: done
 - commit: Parser` – Liest ToDo-Listen aus Markdown-Dateien.
   path: ""
   task: Parser` – Liest ToDo-Listen aus Markdown-Dateien.

--- a/config/memory-job-example.yaml
+++ b/config/memory-job-example.yaml
@@ -1,0 +1,7 @@
+job_name: daily_cleanup
+schedule: "0 0 * * *"
+actions:
+  - type: archive_region
+    region: default
+  - type: clear_cache
+retention_days: 30


### PR DESCRIPTION
## Summary
- add a memory job template YAML for MemoryManager
- reference the template in README and Handbuch
- document `cmd/mandala-codeagent.go` and `simulations/universe-sim`
- mark related advancedToDo entry as done

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859de4e406083228f3ae1ecd7a56d9d