### PR TITLE
Add Docker test environment

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,21 @@
+FROM node:18-bullseye
+
+# Install Go
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends golang-go && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install pnpm globally
+RUN npm install -g pnpm
+
+WORKDIR /workspace/unified-mandala
+
+COPY . .
+
+# Install Node dependencies and download Go modules
+RUN pnpm install && \
+    (cd go-agent && go mod download) && \
+    (cd go-bridge && go mod download) && \
+    (cd services/vector-indexer && go mod download)
+
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ cd unified-mandala
 ./scripts/setup-unifiedmandala.sh
 pnpm dev
 ./scripts/run-demo.sh # Docker-Compose Quickstart
+# Tests ohne lokale Installation
+docker-compose run test
 ```
 Die generierte API-Dokumentation findest du danach unter `docs/api`.
 
@@ -253,6 +255,7 @@ npm run dev   # oder: yarn dev
 | `pnpm lint` | Führt statische Typprüfung aus |
 | `pnpm test` | Führe Unit- & UI-Tests aus |
 | `pnpm vitest run` | Läuft Agenten-Spezialtests |
+| `docker-compose run test` | Führe alle Tests ohne lokale Installationen aus |
 | `node scripts/refresh-handbook.js` | Synchronisiert Handbuch |
 | `node scripts/setup-unifiedmandala.sh` | Installer & Initialisierung |
 | `./scripts/repair-repo.sh` | Repariert Repository-Verbindungen |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,10 @@ services:
       - "3000:3000"
     volumes:
       - .:/workspace/unified-mandala
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    volumes:
+      - .:/workspace/unified-mandala
+    command: ./scripts/run-all-tests.sh

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+pnpm test
+pnpm vitest run
+
+(cd go-agent && go test ./...)
+(cd go-bridge && go test ./...)
+(cd services/vector-indexer && go test ./...)


### PR DESCRIPTION
## Summary
- include Dockerfile.dev with Node, Go and pnpm for offline testing
- add run-all-tests.sh to execute all Node and Go tests
- extend docker-compose with a `test` service using Dockerfile.dev
- document Docker-based tests in README

## Testing
- `pnpm install`
- `pnpm test`
- `pnpm vitest run`
- `go mod download && go test ./...` for go-agent, go-bridge and vector-indexer
- `./scripts/run-all-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a7559d0dc8322962f0560c465321a