### PR TITLE
Improve test coverage for agents and indexer

### DIFF
--- a/docs/agents/GenesisAeonNavigator.md
+++ b/docs/agents/GenesisAeonNavigator.md
@@ -1,0 +1,2 @@
+# GenesisAeonNavigator
+Steuert Phasen im Genesis-Aeon. Fehlt die Phase-Map, wird ein Fehler protokolliert und unbekannte Phasen werden gemeldet.

--- a/docs/agents/PatternReactivator.md
+++ b/docs/agents/PatternReactivator.md
@@ -1,0 +1,2 @@
+# PatternReactivator
+Reaktiviert Aufgaben bei niedrigem CREP-Score. Gibt kein Ereignis aus, wenn keine passende Aufgabe gefunden wird.

--- a/packages/agents/GenesisAeonNavigator.test.ts
+++ b/packages/agents/GenesisAeonNavigator.test.ts
@@ -38,4 +38,13 @@ describe('GenesisAeonNavigator', () => {
       to: 'b'
     });
   });
+
+  it('handles missing phase map gracefully', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const nav = new GenesisAeonNavigator({ phaseMapPath: 'nope.json' });
+    nav.navigate('init');
+    expect((console.error as jest.Mock).mock.calls.length).toBeGreaterThan(0);
+    expect((GPTEventHub.emit as jest.Mock).mock.calls.length).toBe(0);
+    (console.error as jest.Mock).mockRestore();
+  });
 });

--- a/packages/agents/patternReactivator.test.ts
+++ b/packages/agents/patternReactivator.test.ts
@@ -1,6 +1,15 @@
+import fs from 'fs';
+import path from 'path';
 import { patternReactivator } from './patternReactivator';
 import { AeonMemory } from '../core/AeonMemory';
 import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
+
+const CHRONIK = path.resolve('mandala-chronik.yaml');
+
+beforeEach(() => {
+  (AeonMemory as any).entries = [];
+  if (fs.existsSync(CHRONIK)) fs.unlinkSync(CHRONIK);
+});
 
 test('emits reactivate for low crep score', () => {
   const spy = jest.fn();
@@ -8,5 +17,15 @@ test('emits reactivate for low crep score', () => {
   AeonMemory.record('t', { crepScore: 0.2, task: { id: '1', description: 'd' } });
   patternReactivator();
   expect(spy).toHaveBeenCalled();
+  GPTEventHub.off('task:reactivate', spy);
+});
+
+test('does not emit for high score or missing task', () => {
+  const spy = jest.fn();
+  GPTEventHub.on('task:reactivate', spy);
+  AeonMemory.record('t1', { crepScore: 0.8, task: { id: '2', description: 'x' } });
+  AeonMemory.record('t2', { crepScore: 0.1 });
+  patternReactivator();
+  expect(spy).not.toHaveBeenCalled();
   GPTEventHub.off('task:reactivate', spy);
 });

--- a/services/vector-indexer/indexer_test.go
+++ b/services/vector-indexer/indexer_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
     "context"
+    "errors"
+    "strings"
     "testing"
 )
 
@@ -19,5 +21,35 @@ func TestVectorIndexer(t *testing.T) {
     }
     if err := vi.IndexText(context.Background(), "foo"); err != nil {
         t.Fatal(err)
+    }
+}
+
+func TestVectorIndexer_EmbedderError(t *testing.T) {
+    vi := &VectorIndexer{
+        Embedder: func(ctx context.Context, text string) ([]float64, error) {
+            return nil, errors.New("boom")
+        },
+        Sender: func(ctx context.Context, embedding []float64) error {
+            return nil
+        },
+    }
+    err := vi.IndexText(context.Background(), "x")
+    if err == nil || !strings.Contains(err.Error(), "embedding failed") {
+        t.Fatalf("expected embedder error, got %v", err)
+    }
+}
+
+func TestVectorIndexer_SenderError(t *testing.T) {
+    vi := &VectorIndexer{
+        Embedder: func(ctx context.Context, text string) ([]float64, error) {
+            return []float64{1}, nil
+        },
+        Sender: func(ctx context.Context, embedding []float64) error {
+            return errors.New("boom")
+        },
+    }
+    err := vi.IndexText(context.Background(), "x")
+    if err == nil || !strings.Contains(err.Error(), "send failed") {
+        t.Fatalf("expected sender error, got %v", err)
     }
 }


### PR DESCRIPTION
## Summary
- cover embedder and sender failure scenarios in Go indexer tests
- add edge case tests for PatternReactivator and GenesisAeonNavigator
- document expected behaviour for new agents

## Testing
- `pnpm test`
- `pnpm vitest run`
- `go test -run TestVectorIndexer ./services/vector-indexer/...`


------
https://chatgpt.com/codex/tasks/task_e_685a7cc3999883229375f182047339ea