### PR TITLE
Expand agent documentation and add architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ narrative Interfaces und adaptive Bewusstseinsräume.
 > 3. Erkunde das [CHRONOPOEM.md](CHRONOPOEM.md)
 
 Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
+Einen Überblick über die Agenten bietet [docs/architecture/agent-system.md](docs/architecture/agent-system.md).
 
 
 ## 🚀 Features

--- a/docs/agents/CodexAuditAgent.md
+++ b/docs/agents/CodexAuditAgent.md
@@ -1,2 +1,18 @@
 # CodexAuditAgent
-Prüft Module auf Emergenzpotenzial und Tiefe. Ergebnisse fließen in `restructureSuggestions.yaml`.
+
+## Responsibilities
+- Prüft Repository‑Module auf Emergenzpotenzial und Tiefe.
+- Nutzt `audit-core.ts`, `depthvalue-core.ts` und `crepJudgeGPT`.
+- Weist Sigillin aus `sigillin_bundle.sigil.json` zu.
+- Schreibt Empfehlungen in `restructureSuggestions.yaml`.
+
+## Parameters
+- `depthThreshold` – Minimaler `lnSum`‑Wert für eine Prüfung (Standard: 15).
+- `crepState` – Erwarteter CREP‑Zustand, typischerweise `emergence`.
+- `sigillinBundlePath` – Pfad zur Sigillin‑Bundle‑Datei.
+
+## Example usage
+```bash
+node mandala-sync.ts audit --depth 15 --crep emergence
+```
+Generiert eine Empfehlungsliste in `restructureSuggestions.yaml`.

--- a/docs/agents/DepthBundleExporter.md
+++ b/docs/agents/DepthBundleExporter.md
@@ -1,2 +1,14 @@
 # DepthBundleExporter
-Exportiert Tiefen-Daten und erstellt Visualisierungen.
+
+## Responsibilities
+- Exportiert Tiefen-Daten als Sigillin-Bundle und Visualisierungen.
+- Erstellt `sigillin_depth_bundle.sigil.json`, `depth_index.md` und Tiefen-SVGs.
+
+## Parameters
+- `bundlePath` – Zielpfad des Sigillin-Bundles.
+- `eventTrigger` – Optionaler CREP-Event wie `bundleReady`.
+
+## Example usage
+```bash
+node export-depth-bundle.ts --out ./exports
+```

--- a/docs/agents/EvolverGPT.md
+++ b/docs/agents/EvolverGPT.md
@@ -1,2 +1,17 @@
 # EvolverGPT
-Generiert alternative Pfade und schreibt poetische Commits.
+
+## Responsibilities
+- Generiert alternative Entwicklungspfade auf Basis des CREP-Status.
+- Entscheidet mithilfe von `codex-evolver.ts` und `crepdecision-core.ts`.
+- Schreibt poetische Commits in `poeticCommits.md`.
+- Aktualisiert `resonantBranchMap.yaml`.
+
+## Parameters
+- `crepScoreThreshold` – Mindestscore zum Auslösen (≥ 0.6).
+- `symbol` – Symbolisches Tiefen‑Signal, z. B. "🌪".
+- `branchMap` – Pfad zu `resonantBranchMap.yaml`.
+
+## Example usage
+```bash
+node codex-evolver.ts --score 0.7 --symbol "🌪"
+```

--- a/docs/agents/FragmentMapper.md
+++ b/docs/agents/FragmentMapper.md
@@ -1,2 +1,14 @@
 # FragmentMapper
-Ordnet Gesprächsfragmente Themen und Symbolen zu und erzeugt Aufgabenketten.
+
+## Responsibilities
+- Ordnet Gesprächsfragmente Themen und Symbolen zu.
+- Erstellt daraus Aufgabenketten und speichert sie in `codexwork.yaml`.
+
+## Parameters
+- `inputPath` – Pfad zur Datei `fragmented_conversation.json`.
+- `outputPath` – Ziel für das generierte `codexwork.yaml`.
+
+## Example usage
+```bash
+node fragment-mapper.js ./fragmented_conversation.json
+```

--- a/docs/agents/GenesisAeonNavigator.md
+++ b/docs/agents/GenesisAeonNavigator.md
@@ -1,2 +1,14 @@
 # GenesisAeonNavigator
-Steuert Phasen im Genesis-Aeon. Fehlt die Phase-Map, wird ein Fehler protokolliert und unbekannte Phasen werden gemeldet.
+
+## Responsibilities
+- Steuert Phasen im Genesis-Aeon und loggt Übergänge.
+- Meldet unbekannte Phasen, wenn keine Phase-Map vorliegt.
+
+## Parameters
+- `phaseMap` – YAML-Datei mit definierten Phasen.
+- `startPhase` – Name der initialen Phase.
+
+## Example usage
+```bash
+node genesis-aeon-navigator.ts --map ./phase-map.yaml
+```

--- a/docs/agents/PactDepthGatekeeper.md
+++ b/docs/agents/PactDepthGatekeeper.md
@@ -1,2 +1,14 @@
 # PactDepthGatekeeper
-Regelt Zugriffe anhand von Tiefe und freigegebenen Rollen.
+
+## Responsibilities
+- Regelt Zugriffe abhängig von der ermittelten Tiefe.
+- Nutzt `pact-depth-rules.ts` sowie `activatedSigillin.json`.
+
+## Parameters
+- `minLnSum` – erforderliche Mindesttiefe (Standard: 16).
+- `role` – Rolle des anfragenden Nutzers.
+
+## Example usage
+```bash
+node pact-depth-gatekeeper.ts --depth 17 --role admin
+```

--- a/docs/agents/PatternReactivator.md
+++ b/docs/agents/PatternReactivator.md
@@ -1,2 +1,14 @@
 # PatternReactivator
-Reaktiviert Aufgaben bei niedrigem CREP-Score. Gibt kein Ereignis aus, wenn keine passende Aufgabe gefunden wird.
+
+## Responsibilities
+- Reaktiviert Aufgabenketten bei niedrigem CREP-Score.
+- Gibt kein Ereignis aus, wenn kein passendes Muster gefunden wird.
+
+## Parameters
+- `scoreLimit` – CREP-Grenze, unter der reaktiviert wird.
+- `patternStore` – Quelle der gespeicherten Muster.
+
+## Example usage
+```bash
+node pattern-reactivator.ts --score 0.3
+```

--- a/docs/agents/SyncRunner.md
+++ b/docs/agents/SyncRunner.md
@@ -1,2 +1,14 @@
 # SyncRunner
-Synchronisiert CREP-Zustände und initiiert Wiederverbindungen bei Konflikten.
+
+## Responsibilities
+- Synchronisiert CREP-Zustände zwischen laufenden Agenten.
+- Erkennt symbolische Kollisionen und startet Resync-Zyklen.
+
+## Parameters
+- `syncFile` – Quellpfad zu `codexsync.yaml`.
+- `autoResync` – Boolescher Schalter für automatische Zyklen.
+
+## Example usage
+```bash
+node sync-runner.js --file codexsync.yaml
+```

--- a/docs/architecture/agent-system.md
+++ b/docs/architecture/agent-system.md
@@ -1,0 +1,27 @@
+# Agent System Overview
+
+UnifiedMandala orchestrates several agents that communicate via CREP and symbolic links.
+Die folgende Kette zeigt den üblichen Ablauf:
+
+```mermaid
+graph TD
+  FragmentMapper --> CodexAuditAgent
+  CodexAuditAgent --> EvolverGPT
+  EvolverGPT --> SyncRunner
+  SyncRunner --> PactDepthGatekeeper
+  PactDepthGatekeeper --> DepthBundleExporter
+```
+
+Weitere Agenten wie `PatternReactivator` und `GenesisAeonNavigator` arbeiten parallel zur Kette und
+überwachen CREP-Scores sowie Phasenwechsel.
+
+- **FragmentMapper** sammelt Gesprächsfragmente und erzeugt Aufgaben.
+- **CodexAuditAgent** bewertet Tiefe und weist Sigillin zu.
+- **EvolverGPT** erkundet alternative Branches und schreibt poetische Commits.
+- **SyncRunner** gleicht CREP-Zustände zwischen Agenten ab.
+- **PactDepthGatekeeper** erzwingt zugriffsbeschränkende Tiefenregeln.
+- **DepthBundleExporter** erstellt Visualisierungen der Tiefendaten.
+- **PatternReactivator** weckt ruhende Aufgabenketten bei niedrigen Scores.
+- **GenesisAeonNavigator** steuert die Phasen des Gesamtprojekts.
+
+Dieses Dokument verknüpft die Agentenlogik und dient als Einstiegspunkt für eigene Erweiterungen.


### PR DESCRIPTION
## Summary
- add detailed responsibilities, parameters and usage to docs/agents
- document overall agent chain in new `agent-system` page
- reference the architecture page from the README

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685a7eed45908322a8df4d3cb5e0ef36