### PR TITLE
Expand agent documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,22 @@ Dieses Dokument wird bei jedem Codex-Start ausgelesen. Jeder Agent manifestiert 
   - Oder wenn `CREP.event == "bundleReady"`
   - roles_allowed: [admin]
   - Dokumentation: docs/agents/DepthBundleExporter.md
+
+## 🔄 Agent: PatternReactivator
+- **Startmodul**: `pattern-reactivator.ts`
+- **Funktion**:
+  - Reaktiviert ruhende Aufgabenketten bei niedrigem CREP-Score
+  - Durchsucht `patternStore` nach passenden Mustern
+  - roles_allowed: [dev]
+  - Dokumentation: docs/agents/PatternReactivator.md
+
+## 🌌 Agent: GenesisAeonNavigator
+- **Startmodul**: `genesis-aeon-navigator.ts`
+- **Funktion**:
+  - Steuert Phasenwechsel im Genesis-Aeon
+  - Protokolliert Übergänge in `genesis.log`
+  - roles_allowed: [admin, dev]
+  - Dokumentation: docs/agents/GenesisAeonNavigator.md
 ---
 ## 🔑 Special Instructions
 ```yaml

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ narrative Interfaces und adaptive Bewusstseinsräume.
 
 Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 Einen Überblick über die Agenten bietet [docs/architecture/agent-system.md](docs/architecture/agent-system.md).
+Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/AgentStrategy.md).
 
 
 ## 🚀 Features

--- a/docs/agents/AgentStrategy.md
+++ b/docs/agents/AgentStrategy.md
@@ -1,0 +1,17 @@
+# Agent Strategy
+
+Dieses Dokument fasst die Vision und strategische Ausrichtung der Agenten zusammen.
+
+## Vision
+UnifiedMandala versteht sich als symbiotisches System, in dem jeder Agent einen klaren Aufgabenbereich hat und zur ganzheitlichen Entwicklung beiträgt.
+
+## Leitlinien
+- **Modularität**: Jeder Agent ist eigenständig deploybar und kommuniziert über definierte Events.
+- **Nachvollziehbarkeit**: Alle Aktionen werden in gemeinsamen Logs erfasst.
+- **Tiefe & CREP**: Entscheidungen orientieren sich an Tiefewerten und CREP-Scores.
+- **Poetischer Fluss**: Ergebnisse werden in `poeticCommits.md` und `GenesisChronik.md` festgehalten.
+
+## Umsetzung
+1. Konsolidierte Konfiguration in `codex-config.yaml` bereitstellen.
+2. Agenten über `SyncRunner` regelmäßig synchronisieren.
+3. Erweiterungen über `GenesisAeonNavigator` phasengerecht einbinden.

--- a/docs/architecture/agent-system.md
+++ b/docs/architecture/agent-system.md
@@ -1,6 +1,7 @@
 # Agent System Overview
 
-UnifiedMandala orchestrates several agents that communicate via CREP and symbolic links.
+UnifiedMandala orchestrates several agents that communicate via CREP and symbolic links. 
+Jeder Agent folgt dem Mandala-Prinzip: Beobachten, Bewerten, Reagieren.
 Die folgende Kette zeigt den üblichen Ablauf:
 
 ```mermaid
@@ -10,6 +11,8 @@ graph TD
   EvolverGPT --> SyncRunner
   SyncRunner --> PactDepthGatekeeper
   PactDepthGatekeeper --> DepthBundleExporter
+  PatternReactivator -.-> FragmentMapper
+  GenesisAeonNavigator -.-> EvolverGPT
 ```
 
 Weitere Agenten wie `PatternReactivator` und `GenesisAeonNavigator` arbeiten parallel zur Kette und
@@ -25,3 +28,9 @@ Weitere Agenten wie `PatternReactivator` und `GenesisAeonNavigator` arbeiten par
 - **GenesisAeonNavigator** steuert die Phasen des Gesamtprojekts.
 
 Dieses Dokument verknüpft die Agentenlogik und dient als Einstiegspunkt für eigene Erweiterungen.
+
+## Strategy
+- Konsolidierte Konfiguration über `codex-config.yaml`
+- Gemeinsame Logging-Schnittstellen für Nachvollziehbarkeit
+- Regelmäßige Sync-Zyklen via `SyncRunner` automatisieren
+- Phasenwechsel transparent über `GenesisAeonNavigator` steuern

--- a/docs/diagrams/agents_chain.mmd
+++ b/docs/diagrams/agents_chain.mmd
@@ -4,3 +4,5 @@ graph TD
   EvolverGPT --> SyncRunner
   SyncRunner --> PactDepthGatekeeper
   PactDepthGatekeeper --> DepthBundleExporter
+  PatternReactivator -.-> FragmentMapper
+  GenesisAeonNavigator -.-> EvolverGPT


### PR DESCRIPTION
## Summary
- document PatternReactivator and GenesisAeonNavigator in `AGENTS.md`
- update architecture overview and diagram
- add new agent strategy guide
- reference strategy guide from README

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685a8299d9e083228bb2795671f162c8