### PR TITLE
Add StrategicAgentCoordinator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,14 @@ Dieses Dokument wird bei jedem Codex-Start ausgelesen. Jeder Agent manifestiert 
   - roles_allowed: [admin, dev]
   - Dokumentation: docs/agents/VisionContextIntegrator.md
 
+## 🧭 Agent: StrategicAgentCoordinator
+- **Startmodul**: `strategic-agent-coordinator.ts`
+- **Funktion**:
+  - Liest Agentenliste aus `AGENTS.md`
+  - Schreibt `strategy-overview.json`
+  - roles_allowed: [admin, dev]
+  - Dokumentation: docs/agents/StrategicAgentCoordinator.md
+
 ---
 ## 🔑 Special Instructions
 ```yaml

--- a/docs/agents/AgentStrategy.md
+++ b/docs/agents/AgentStrategy.md
@@ -16,3 +16,4 @@ UnifiedMandala versteht sich als symbiotisches System, in dem jeder Agent einen 
 2. Agenten über `SyncRunner` regelmäßig synchronisieren.
 3. Erweiterungen über `GenesisAeonNavigator` phasengerecht einbinden.
 4. Visionen zentral über den VisionContextIntegrator abstimmen.
+5. Agentenübersicht via StrategicAgentCoordinator generieren.

--- a/docs/agents/StrategicAgentCoordinator.md
+++ b/docs/agents/StrategicAgentCoordinator.md
@@ -1,0 +1,14 @@
+# StrategicAgentCoordinator
+
+## Responsibilities
+- Synchronisiert die Agentenliste mit der Strategie.
+- Liest `AGENTS.md` und schreibt `strategy-overview.json`.
+
+## Parameters
+- `agentsFile` – Pfad zur Quelldatei (Standard: `AGENTS.md`).
+- `outputFile` – Zieldatei für die Übersicht.
+
+## Example usage
+```bash
+node strategic-agent-coordinator.ts
+```

--- a/docs/architecture/agent-system.md
+++ b/docs/architecture/agent-system.md
@@ -16,6 +16,7 @@ graph TD
 ```
 
 Weitere Agenten wie `PatternReactivator` und `GenesisAeonNavigator` arbeiten parallel zur Kette und
+- **StrategicAgentCoordinator** synchronisiert die Agentenliste.
 überwachen CREP-Scores sowie Phasenwechsel.
 
 - **FragmentMapper** sammelt Gesprächsfragmente und erzeugt Aufgaben.
@@ -26,6 +27,7 @@ Weitere Agenten wie `PatternReactivator` und `GenesisAeonNavigator` arbeiten par
 - **DepthBundleExporter** erstellt Visualisierungen der Tiefendaten.
 - **PatternReactivator** weckt ruhende Aufgabenketten bei niedrigen Scores.
 - **GenesisAeonNavigator** steuert die Phasen des Gesamtprojekts.
+- **StrategicAgentCoordinator** synchronisiert die Agentenliste.
 
 Dieses Dokument verknüpft die Agentenlogik und dient als Einstiegspunkt für eigene Erweiterungen.
 

--- a/packages/agents/StrategicAgentCoordinator.test.ts
+++ b/packages/agents/StrategicAgentCoordinator.test.ts
@@ -1,0 +1,14 @@
+import fs from 'fs';
+import path from 'path';
+import { StrategicAgentCoordinator } from './StrategicAgentCoordinator';
+
+test('synchronize writes agent list to file', () => {
+  const tmp = fs.mkdtempSync('coord-test');
+  fs.writeFileSync(path.join(tmp, 'AGENTS.md'), '# Test\n\n## \u2728 Agent: Demo\n');
+  const coord = new StrategicAgentCoordinator(tmp);
+  coord.synchronize();
+  const out = path.join(tmp, 'strategy-overview.json');
+  const data = JSON.parse(fs.readFileSync(out, 'utf-8'));
+  expect(data.agents).toEqual(['Demo']);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});

--- a/packages/agents/StrategicAgentCoordinator.ts
+++ b/packages/agents/StrategicAgentCoordinator.ts
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+
+export class StrategicAgentCoordinator {
+  constructor(private baseDir: string = '.') {}
+
+  listAgents(): string[] {
+    const agentsFile = path.join(this.baseDir, 'AGENTS.md');
+    const content = fs.readFileSync(agentsFile, 'utf-8');
+    const regex = /^## .* Agent: ([A-Za-z0-9]+)/gm;
+    const agents: string[] = [];
+    let match;
+    while ((match = regex.exec(content)) !== null) {
+      agents.push(match[1]);
+    }
+    return agents;
+  }
+
+  synchronize(outputFile: string = 'strategy-overview.json'): void {
+    const agents = this.listAgents();
+    const file = path.join(this.baseDir, outputFile);
+    fs.writeFileSync(file, JSON.stringify({ agents }, null, 2), 'utf-8');
+  }
+}

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -42,3 +42,4 @@ export * from './WeightedDispatcher';
 export * from './patternReactivator';
 export * from './ReplayController';
 export * from './silenceWatcher';
+export * from './StrategicAgentCoordinator';


### PR DESCRIPTION
## Summary
- add StrategicAgentCoordinator agent and tests
- export agent in index
- document new agent in AGENTS.md and architecture docs
- extend agent strategy guidelines

## Testing
- `npm test`
- `npm run test:agents`


------
https://chatgpt.com/codex/tasks/task_e_685a8614433883229452b996192d49aa