### PR TITLE
Add Quality Assurance agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ web_modules/
 
 # Optional stylelint cache
 .stylelintcache
+qa-report.log
 
 # Microbundle cache
 .rpt2_cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,14 @@ Dieses Dokument wird bei jedem Codex-Start ausgelesen. Jeder Agent manifestiert 
   - roles_allowed: [admin, dev]
   - Dokumentation: docs/agents/StrategicAgentCoordinator.md
 
+## 🛡 Agent: QualityAssuranceAgent
+- **Startmodul**: `qa-test-runner.ts`
+- **Funktion**:
+  - Führt Lint- und Test-Suites aus
+  - Protokolliert Ergebnisse in `qa-report.log`
+  - roles_allowed: [dev]
+  - Dokumentation: docs/agents/QualityAssuranceAgent.md
+
 ---
 ## 🔑 Special Instructions
 ```yaml

--- a/docs/agents/QualityAssuranceAgent.md
+++ b/docs/agents/QualityAssuranceAgent.md
@@ -1,0 +1,14 @@
+# QualityAssuranceAgent
+
+## Responsibilities
+- Führt Lint- und Test-Suites für alle Pakete aus.
+- Speichert Ergebnisse in `qa-report.log`.
+
+## Parameters
+- `lintCommand` – Standard: `pnpm lint`.
+- `testCommand` – Standard: `pnpm test`.
+
+## Example usage
+```bash
+ts-node scripts/qa-test-runner.ts
+```

--- a/docs/architecture/agent-system.md
+++ b/docs/architecture/agent-system.md
@@ -17,7 +17,8 @@ graph TD
 
 Weitere Agenten wie `PatternReactivator` und `GenesisAeonNavigator` arbeiten parallel zur Kette und
 - **StrategicAgentCoordinator** synchronisiert die Agentenliste.
-überwachen CREP-Scores sowie Phasenwechsel.
+  überwachen CREP-Scores sowie Phasenwechsel.
+- **QualityAssuranceAgent** prüft Codequalität durch Linting und Tests.
 
 - **FragmentMapper** sammelt Gesprächsfragmente und erzeugt Aufgaben.
 - **CodexAuditAgent** bewertet Tiefe und weist Sigillin zu.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "export:crep-docs": "node scripts/export-crep-docs.js",
     "symbolzeit:run": "node scripts/symbolzeit-runner.js",
     "generate:next-sigil": "node scripts/generate-next-sigil.js",
-    "aeon:transition": "node scripts/aeon-transition-workflow.js"
+    "aeon:transition": "node scripts/aeon-transition-workflow.js",
+    "qa": "ts-node scripts/qa-test-runner.ts"
   },
   "dependencies": {
     "ajv": "^8.0.0",

--- a/scripts/qa-test-runner.ts
+++ b/scripts/qa-test-runner.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env ts-node
+import { execSync } from 'child_process';
+import fs from 'fs';
+
+export function runQA(lintCommand = 'pnpm lint', testCommand = 'pnpm test') {
+  const logFile = 'qa-report.log';
+  const options = { stdio: 'inherit' as const };
+  try {
+    execSync(lintCommand, options);
+    execSync(testCommand, options);
+    fs.writeFileSync(logFile, `${new Date().toISOString()} QA successful\n`);
+  } catch (err) {
+    fs.writeFileSync(logFile, `${new Date().toISOString()} QA failed: ${err}\n`);
+    throw err;
+  }
+}
+
+if (require.main === module) {
+  runQA();
+}


### PR DESCRIPTION
## Summary
- introduce a `QualityAssuranceAgent` entry in the agents list
- document the new agent and integrate it in the architecture guide
- provide a `qa-test-runner.ts` script to run lint and tests
- expose the script via an npm command
- ignore generated QA logs

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685a87ef97fc832286da7bff5d8bee49