### PR TITLE
Enhance Aeon Universal compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
 - 🧑‍🔬 **CommonsAgent** – Open‑Science Scoring
 - 🌀 **AdaptiveThreshold** & **DebounceManager** – steuern CREP Trigger-Logik
 - 🗄️ **AeonSigillinVault** – speichert poetische Sigillin-Zustände (`packages/core/AeonSigillinVault.ts`)
-- 🧩 **Aeon Universal** – kompiliert fraktale Befehle in Mandala-Tasks (`packages/aeon-universal`)
+- 🧩 **Aeon Universal** – kompiliert fraktale Befehle in Mandala-Tasks und kann SIG-Anweisungen im `AeonSigillinVault` speichern (`packages/aeon-universal`)
 - 🛡️ **withCircuit** – CircuitBreaker Wrapper für Agenten-Calls
 - 🩺 **healthz.ts** & **metaScores.ts** – API-Routen
 - 🖥️ **Dashboard** – zeigt MetaScoreChart per Hook

--- a/packages/aeon-universal/README.md
+++ b/packages/aeon-universal/README.md
@@ -1,9 +1,11 @@
 # Aeon Universal
 
-Eine fraktale, kontextsensitive Programmiersprache innerhalb des UnifiedMandala. Sie kompiliert einfache Befehle in Mandala-Tasks und speichert Kontext direkt im `AeonMemory`.
+Eine fraktale, kontextsensitive Programmiersprache innerhalb des UnifiedMandala. Sie kompiliert einfache Befehle in Mandala-Tasks und speichert Kontext direkt im `AeonMemory`.  
+Seit `v0.2` unterstützt sie auch **SIG**-Anweisungen, um poetische Zustände im `AeonSigillinVault` festzuhalten.
 
 ## Beispiel
 ```aeon
 TASK Hallo Welt
 REM Sammle Kontext
+SIG Poetischer Zustand
 ```

--- a/packages/aeon-universal/compiler.test.ts
+++ b/packages/aeon-universal/compiler.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { compile } from './compiler';
+import { AeonSigillinVault } from '../core/AeonSigillinVault';
 
 const CHRONIK = path.resolve('mandala-chronik.yaml');
 
@@ -14,5 +15,11 @@ describe('AeonUniversal compile', () => {
     expect(result.tasks[0].description).toBe('Demo');
     const content = fs.readFileSync(CHRONIK, 'utf-8');
     expect(content).toContain('Erinnerung');
+  });
+
+  it('records sigillin states', () => {
+    const spy = jest.spyOn(AeonSigillinVault, 'record');
+    compile('SIG Hallo');
+    expect(spy).toHaveBeenCalled();
   });
 });

--- a/packages/aeon-universal/compiler.ts
+++ b/packages/aeon-universal/compiler.ts
@@ -1,4 +1,5 @@
 import { AeonMemory } from '../core/AeonMemory';
+import { AeonSigillinVault } from '../core/AeonSigillinVault';
 import { Task } from '../core/interfaces';
 
 export interface CompileResult {
@@ -15,6 +16,8 @@ export function compile(source: string): CompileResult {
     const content = rest.join(' ');
     if (cmd.toUpperCase() === 'REM') {
       AeonMemory.record(content);
+    } else if (cmd.toUpperCase() === 'SIG' || cmd.toUpperCase() === 'SIGILLIN') {
+      AeonSigillinVault.record({ id: `${idx}`, timestamp: new Date().toISOString(), content });
     } else if (cmd.toUpperCase() === 'TASK') {
       tasks.push({ id: `${idx}`, description: content });
     }


### PR DESCRIPTION
## Summary
- extend Aeon Universal compiler with `SIG` command
- document the new feature in package README
- update main README feature list
- add unit test for SIG command

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_685a96f867388322b66b0840b88222b5