### PR TITLE
Implement recursive include for AeonUniversal compiler

### DIFF
--- a/packages/aeon-universal/README.md
+++ b/packages/aeon-universal/README.md
@@ -3,9 +3,12 @@
 Eine fraktale, kontextsensitive Programmiersprache innerhalb des UnifiedMandala. Sie kompiliert einfache Befehle in Mandala-Tasks und speichert Kontext direkt im `AeonMemory`.  
 Seit `v0.2` unterstützt sie auch **SIG**-Anweisungen, um poetische Zustände im `AeonSigillinVault` festzuhalten.
 
+Ab Version **0.3** lassen sich weitere Dateien rekursiv einbinden. Die `INCLUDE`-Anweisung liest andere Aeon-Quellen und erweitert so den Task-Baum.
+
 ## Beispiel
 ```aeon
 TASK Hallo Welt
 REM Sammle Kontext
 SIG Poetischer Zustand
+INCLUDE ./mehr.aeon
 ```

--- a/packages/aeon-universal/compiler.test.ts
+++ b/packages/aeon-universal/compiler.test.ts
@@ -22,4 +22,12 @@ describe('AeonUniversal compile', () => {
     compile('SIG Hallo');
     expect(spy).toHaveBeenCalled();
   });
+
+  it('includes other files recursively', () => {
+    const tmp = path.resolve('tmp.aeon');
+    fs.writeFileSync(tmp, 'TASK Subtask');
+    const result = compile(`INCLUDE ${tmp}`);
+    expect(result.tasks[0].description).toBe('Subtask');
+    fs.unlinkSync(tmp);
+  });
 });

--- a/packages/aeon-universal/compiler.ts
+++ b/packages/aeon-universal/compiler.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import { AeonMemory } from '../core/AeonMemory';
 import { AeonSigillinVault } from '../core/AeonSigillinVault';
 import { Task } from '../core/interfaces';
@@ -6,21 +8,39 @@ export interface CompileResult {
   tasks: Task[];
 }
 
-export function compile(source: string): CompileResult {
+export interface CompileOptions {
+  baseDir?: string;
+  visited?: Set<string>;
+}
+
+export function compile(source: string, options: CompileOptions = {}): CompileResult {
   AeonMemory.load();
   const tasks: Task[] = [];
+  const baseDir = options.baseDir || process.cwd();
+  const visited = options.visited || new Set<string>();
+
   source.split(/\n+/).forEach((line, idx) => {
     const trimmed = line.trim();
     if (!trimmed) return;
     const [cmd, ...rest] = trimmed.split(' ');
     const content = rest.join(' ');
+
     if (cmd.toUpperCase() === 'REM') {
       AeonMemory.record(content);
     } else if (cmd.toUpperCase() === 'SIG' || cmd.toUpperCase() === 'SIGILLIN') {
       AeonSigillinVault.record({ id: `${idx}`, timestamp: new Date().toISOString(), content });
     } else if (cmd.toUpperCase() === 'TASK') {
       tasks.push({ id: `${idx}`, description: content });
+    } else if (cmd.toUpperCase() === 'INCLUDE') {
+      const filePath = path.resolve(baseDir, content);
+      if (!visited.has(filePath) && fs.existsSync(filePath)) {
+        visited.add(filePath);
+        const childSource = fs.readFileSync(filePath, 'utf-8');
+        const child = compile(childSource, { baseDir: path.dirname(filePath), visited });
+        tasks.push(...child.tasks);
+      }
     }
   });
+
   return { tasks };
 }


### PR DESCRIPTION
## Summary
- extend AeonUniversal compiler with `INCLUDE` directive
- document new behaviour in AeonUniversal README
- test recursive file inclusion in compiler tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685a9903d5e08322ac20d8b2005de826