### PR TITLE
Add commit memory automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ Aufgaben und Anweisungen aus laufenden Gesprächen werden in
 [`advancedconversations.json`](docs/sigils/advancedconversations.json)
 Es dient als Pendant zum Genesis ZIPMEM.
 Neue Fragmente werden im Ordner `GenesisAeonZIPMEM/` abgelegt, sortiert nach Chatnamen.
+F\u00fcr jeden Commit kann `pnpm store:commit-memory` ausgef\u00fchrt werden, um \u00c4nderungen
+als Patch und `meta.yaml` unter `GenesisAeonZIPMEM/<commit>/` zu speichern.
 gespeichert. Nutzen Sie die Helferskripte aus `packages/shared-utils`
 (`jsonFragmenter.*`), um daraus ToDos für `advancedToDo.yaml` und
 `advancedToDo.json` zu extrahieren.

--- a/dev-agents.md
+++ b/dev-agents.md
@@ -6,3 +6,5 @@ Weitere Hinweise:
 - Nutze **codex-sigil.yaml** als zentralen Arbeitsanker.
 - Folge dem Ablauf in **fraktal-zyklus.md** bei der Umsetzung deiner Aufgaben.
 - Feedback siehe feedbackcodex.json
+- F\u00fchre nach jedem Commit `pnpm store:commit-memory` aus, um einen Patch
+  samt `meta.yaml` im Ordner `GenesisAeonZIPMEM` abzulegen.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "symbolzeit:run": "node scripts/symbolzeit-runner.js",
     "generate:next-sigil": "node scripts/generate-next-sigil.js",
     "aeon:transition": "node scripts/aeon-transition-workflow.js",
-    "qa": "ts-node scripts/qa-test-runner.ts"
+    "qa": "ts-node scripts/qa-test-runner.ts",
+    "store:commit-memory": "node scripts/commit-memory.js"
   },
   "dependencies": {
     "ajv": "^8.0.0",

--- a/scripts/__tests__/commit-memory.test.ts
+++ b/scripts/__tests__/commit-memory.test.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+const { run } = require('../commit-memory');
+
+test('commit-memory writes meta and patch', () => {
+  const commit = execSync('git rev-parse HEAD').toString().trim();
+  const dir = path.join(__dirname, '../../GenesisAeonZIPMEM', commit);
+  if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true, force: true });
+  run();
+  const meta = path.join(dir, 'meta.yaml');
+  const patch = path.join(dir, 'changes.patch');
+  expect(fs.existsSync(meta)).toBe(true);
+  expect(fs.existsSync(patch)).toBe(true);
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/scripts/commit-memory.js
+++ b/scripts/commit-memory.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const YAML = require('yaml');
+
+function run() {
+  const repoRoot = path.resolve(__dirname, '..');
+  const commit = execSync('git rev-parse HEAD').toString().trim();
+  const memoryDir = path.join(repoRoot, 'GenesisAeonZIPMEM', commit);
+  if (fs.existsSync(memoryDir)) {
+    console.log('Memory for this commit already exists.');
+    return;
+  }
+  fs.mkdirSync(memoryDir, { recursive: true });
+  const patch = execSync(`git show ${commit}`).toString();
+  fs.writeFileSync(path.join(memoryDir, 'changes.patch'), patch, 'utf8');
+  const files = execSync(`git diff-tree --no-commit-id --name-only -r ${commit}`)
+    .toString()
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+  const message = execSync(`git log -1 --pretty=%B ${commit}`)
+    .toString()
+    .trim();
+  const meta = {
+    commit,
+    message,
+    patch: 'changes.patch',
+    files,
+    instructions: 'Apply patch with git apply or review for reference.'
+  };
+  fs.writeFileSync(
+    path.join(memoryDir, 'meta.yaml'),
+    YAML.stringify(meta),
+    'utf8'
+  );
+  console.log(`Commit memory stored in ${memoryDir}`);
+}
+
+if (require.main === module) run();
+module.exports = { run };


### PR DESCRIPTION
## Summary
- implement `scripts/commit-memory.js` to store patches and meta in `GenesisAeonZIPMEM`
- expose new command `pnpm store:commit-memory`
- document new workflow in README and dev-agents guide
- cover commit memory script with test

## Testing
- `pnpm install --ignore-scripts`
- `pnpm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a9d61af0483228df3cdc65a0cef35