### PR TITLE
Enhance commit memory metadata

### DIFF
--- a/GenesisAeonZIPMEM/e909c991871bd21d29ff1e47bd662c607b788c0e/changes.patch
+++ b/GenesisAeonZIPMEM/e909c991871bd21d29ff1e47bd662c607b788c0e/changes.patch
@@ -1,0 +1,65 @@
+commit e909c991871bd21d29ff1e47bd662c607b788c0e
+Author: Codex <codex@openai.com>
+Date:   Tue Jun 24 13:10:44 2025 +0000
+
+    chore: enrich commit memory with environment
+
+diff --git a/README.md b/README.md
+index cb27aa6..b96af03 100644
+--- a/README.md
++++ b/README.md
+@@ -375,6 +375,7 @@ Es dient als Pendant zum Genesis ZIPMEM.
+ Neue Fragmente werden im Ordner `GenesisAeonZIPMEM/` abgelegt, sortiert nach Chatnamen.
+ Nach jedem Commit wird `pnpm store:commit-memory` automatisch ausgef\u00fchrt (Husky `post-commit`),
+ um die \u00c4nderungen als Patch und `meta.yaml` unter `GenesisAeonZIPMEM/<commit>/` abzulegen.
++Die `meta.yaml` speichert nun auch Node- und pnpm-Versionen, um Abläufe leichter reproduzierbar zu machen.
+ gespeichert. Nutzen Sie die Helferskripte aus `packages/shared-utils`
+ (`jsonFragmenter.*`), um daraus ToDos für `advancedToDo.yaml` und
+ `advancedToDo.json` zu extrahieren.
+diff --git a/dev-agents.md b/dev-agents.md
+index 132dcb8..3237afc 100644
+--- a/dev-agents.md
++++ b/dev-agents.md
+@@ -8,3 +8,4 @@ Weitere Hinweise:
+ - Feedback siehe feedbackcodex.json
+ - F\u00fchre nach jedem Commit `pnpm store:commit-memory` aus, um einen Patch
+   samt `meta.yaml` im Ordner `GenesisAeonZIPMEM` abzulegen.
++  Die YAML-Datei enthält nun auch die eingesetzten Versionen von Node und pnpm.
+diff --git a/scripts/__tests__/commit-memory.test.ts b/scripts/__tests__/commit-memory.test.ts
+index dd65149..8067720 100644
+--- a/scripts/__tests__/commit-memory.test.ts
++++ b/scripts/__tests__/commit-memory.test.ts
+@@ -14,5 +14,7 @@ test('commit-memory writes meta and patch', () => {
+   expect(fs.existsSync(meta)).toBe(true);
+   expect(fs.existsSync(patch)).toBe(true);
+   expect(fs.existsSync(fragmentDir)).toBe(true);
++  const content = fs.readFileSync(meta, 'utf8');
++  expect(content).toContain('environment');
+   fs.rmSync(dir, { recursive: true, force: true });
+ });
+diff --git a/scripts/commit-memory.js b/scripts/commit-memory.js
+index 06fc104..e1a6522 100644
+--- a/scripts/commit-memory.js
++++ b/scripts/commit-memory.js
+@@ -21,6 +21,13 @@ function run() {
+     .trim()
+     .split('\n')
+     .filter(Boolean);
++  const nodeVersion = process.version;
++  let pnpmVersion = 'unknown';
++  try {
++    pnpmVersion = execSync('pnpm --version').toString().trim();
++  } catch (err) {
++    console.warn('pnpm not found');
++  }
+   for (const file of files) {
+     const fileDir = path.join(fragmentsDir, path.dirname(file));
+     fs.mkdirSync(fileDir, { recursive: true });
+@@ -36,6 +43,7 @@ function run() {
+     patch: 'changes.patch',
+     fragments: 'fragments',
+     files,
++    environment: { node: nodeVersion, pnpm: pnpmVersion },
+     instructions: 'Apply patch with git apply or review for reference.'
+   };
+   fs.writeFileSync(

--- a/GenesisAeonZIPMEM/e909c991871bd21d29ff1e47bd662c607b788c0e/fragments/README.md.patch
+++ b/GenesisAeonZIPMEM/e909c991871bd21d29ff1e47bd662c607b788c0e/fragments/README.md.patch
@@ -1,0 +1,12 @@
+diff --git a/README.md b/README.md
+index cb27aa6..b96af03 100644
+--- a/README.md
++++ b/README.md
+@@ -375,6 +375,7 @@ Es dient als Pendant zum Genesis ZIPMEM.
+ Neue Fragmente werden im Ordner `GenesisAeonZIPMEM/` abgelegt, sortiert nach Chatnamen.
+ Nach jedem Commit wird `pnpm store:commit-memory` automatisch ausgef\u00fchrt (Husky `post-commit`),
+ um die \u00c4nderungen als Patch und `meta.yaml` unter `GenesisAeonZIPMEM/<commit>/` abzulegen.
++Die `meta.yaml` speichert nun auch Node- und pnpm-Versionen, um Abläufe leichter reproduzierbar zu machen.
+ gespeichert. Nutzen Sie die Helferskripte aus `packages/shared-utils`
+ (`jsonFragmenter.*`), um daraus ToDos für `advancedToDo.yaml` und
+ `advancedToDo.json` zu extrahieren.

--- a/GenesisAeonZIPMEM/e909c991871bd21d29ff1e47bd662c607b788c0e/fragments/dev-agents.md.patch
+++ b/GenesisAeonZIPMEM/e909c991871bd21d29ff1e47bd662c607b788c0e/fragments/dev-agents.md.patch
@@ -1,0 +1,9 @@
+diff --git a/dev-agents.md b/dev-agents.md
+index 132dcb8..3237afc 100644
+--- a/dev-agents.md
++++ b/dev-agents.md
+@@ -8,3 +8,4 @@ Weitere Hinweise:
+ - Feedback siehe feedbackcodex.json
+ - F\u00fchre nach jedem Commit `pnpm store:commit-memory` aus, um einen Patch
+   samt `meta.yaml` im Ordner `GenesisAeonZIPMEM` abzulegen.
++  Die YAML-Datei enthält nun auch die eingesetzten Versionen von Node und pnpm.

--- a/GenesisAeonZIPMEM/e909c991871bd21d29ff1e47bd662c607b788c0e/fragments/scripts/__tests__/commit-memory.test.ts.patch
+++ b/GenesisAeonZIPMEM/e909c991871bd21d29ff1e47bd662c607b788c0e/fragments/scripts/__tests__/commit-memory.test.ts.patch
@@ -1,0 +1,12 @@
+diff --git a/scripts/__tests__/commit-memory.test.ts b/scripts/__tests__/commit-memory.test.ts
+index dd65149..8067720 100644
+--- a/scripts/__tests__/commit-memory.test.ts
++++ b/scripts/__tests__/commit-memory.test.ts
+@@ -14,5 +14,7 @@ test('commit-memory writes meta and patch', () => {
+   expect(fs.existsSync(meta)).toBe(true);
+   expect(fs.existsSync(patch)).toBe(true);
+   expect(fs.existsSync(fragmentDir)).toBe(true);
++  const content = fs.readFileSync(meta, 'utf8');
++  expect(content).toContain('environment');
+   fs.rmSync(dir, { recursive: true, force: true });
+ });

--- a/GenesisAeonZIPMEM/e909c991871bd21d29ff1e47bd662c607b788c0e/fragments/scripts/commit-memory.js.patch
+++ b/GenesisAeonZIPMEM/e909c991871bd21d29ff1e47bd662c607b788c0e/fragments/scripts/commit-memory.js.patch
@@ -1,0 +1,26 @@
+diff --git a/scripts/commit-memory.js b/scripts/commit-memory.js
+index 06fc104..e1a6522 100644
+--- a/scripts/commit-memory.js
++++ b/scripts/commit-memory.js
+@@ -21,6 +21,13 @@ function run() {
+     .trim()
+     .split('\n')
+     .filter(Boolean);
++  const nodeVersion = process.version;
++  let pnpmVersion = 'unknown';
++  try {
++    pnpmVersion = execSync('pnpm --version').toString().trim();
++  } catch (err) {
++    console.warn('pnpm not found');
++  }
+   for (const file of files) {
+     const fileDir = path.join(fragmentsDir, path.dirname(file));
+     fs.mkdirSync(fileDir, { recursive: true });
+@@ -36,6 +43,7 @@ function run() {
+     patch: 'changes.patch',
+     fragments: 'fragments',
+     files,
++    environment: { node: nodeVersion, pnpm: pnpmVersion },
+     instructions: 'Apply patch with git apply or review for reference.'
+   };
+   fs.writeFileSync(

--- a/GenesisAeonZIPMEM/e909c991871bd21d29ff1e47bd662c607b788c0e/meta.yaml
+++ b/GenesisAeonZIPMEM/e909c991871bd21d29ff1e47bd662c607b788c0e/meta.yaml
@@ -1,0 +1,13 @@
+commit: e909c991871bd21d29ff1e47bd662c607b788c0e
+message: "chore: enrich commit memory with environment"
+patch: changes.patch
+fragments: fragments
+files:
+  - README.md
+  - dev-agents.md
+  - scripts/__tests__/commit-memory.test.ts
+  - scripts/commit-memory.js
+environment:
+  node: v22.16.0
+  pnpm: 10.5.2
+instructions: Apply patch with git apply or review for reference.

--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Es dient als Pendant zum Genesis ZIPMEM.
 Neue Fragmente werden im Ordner `GenesisAeonZIPMEM/` abgelegt, sortiert nach Chatnamen.
 Nach jedem Commit wird `pnpm store:commit-memory` automatisch ausgef\u00fchrt (Husky `post-commit`),
 um die \u00c4nderungen als Patch und `meta.yaml` unter `GenesisAeonZIPMEM/<commit>/` abzulegen.
+Die `meta.yaml` speichert nun auch Node- und pnpm-Versionen, um Abläufe leichter reproduzierbar zu machen.
 gespeichert. Nutzen Sie die Helferskripte aus `packages/shared-utils`
 (`jsonFragmenter.*`), um daraus ToDos für `advancedToDo.yaml` und
 `advancedToDo.json` zu extrahieren.

--- a/dev-agents.md
+++ b/dev-agents.md
@@ -8,3 +8,4 @@ Weitere Hinweise:
 - Feedback siehe feedbackcodex.json
 - F\u00fchre nach jedem Commit `pnpm store:commit-memory` aus, um einen Patch
   samt `meta.yaml` im Ordner `GenesisAeonZIPMEM` abzulegen.
+  Die YAML-Datei enthält nun auch die eingesetzten Versionen von Node und pnpm.

--- a/scripts/__tests__/commit-memory.test.ts
+++ b/scripts/__tests__/commit-memory.test.ts
@@ -14,5 +14,7 @@ test('commit-memory writes meta and patch', () => {
   expect(fs.existsSync(meta)).toBe(true);
   expect(fs.existsSync(patch)).toBe(true);
   expect(fs.existsSync(fragmentDir)).toBe(true);
+  const content = fs.readFileSync(meta, 'utf8');
+  expect(content).toContain('environment');
   fs.rmSync(dir, { recursive: true, force: true });
 });

--- a/scripts/commit-memory.js
+++ b/scripts/commit-memory.js
@@ -21,6 +21,13 @@ function run() {
     .trim()
     .split('\n')
     .filter(Boolean);
+  const nodeVersion = process.version;
+  let pnpmVersion = 'unknown';
+  try {
+    pnpmVersion = execSync('pnpm --version').toString().trim();
+  } catch (err) {
+    console.warn('pnpm not found');
+  }
   for (const file of files) {
     const fileDir = path.join(fragmentsDir, path.dirname(file));
     fs.mkdirSync(fileDir, { recursive: true });
@@ -36,6 +43,7 @@ function run() {
     patch: 'changes.patch',
     fragments: 'fragments',
     files,
+    environment: { node: nodeVersion, pnpm: pnpmVersion },
     instructions: 'Apply patch with git apply or review for reference.'
   };
   fs.writeFileSync(


### PR DESCRIPTION
## Summary
- record Node and pnpm versions when storing commit memory
- verify metadata in commit-memory test
- document new metadata fields in README and dev-agent notes
- add commit memory for this change

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685aa29bd5ec8322bb60af5879cfdfc3