### PR TITLE
Enhance AeonUniversal compiler

### DIFF
--- a/packages/aeon-universal/README.md
+++ b/packages/aeon-universal/README.md
@@ -9,6 +9,11 @@ Seit **0.4** verfügt Aeon Universal über ein einfaches Makrosystem. Mit `DEFIN
 können Task-Blöcke deklariert und später via `CALL <name>` wiederverwendet. Das
 erlaubt rekursive, fraktale Programmstrukturen ohne externe Abhängigkeiten.
 
+Ab **0.5** kann ein **WITH**-Block genutzt werden, um Kontext hierarchisch
+anzugeben. Alle darin enthaltenen `TASK`s erhalten einen zusammengesetzten
+`context`-Pfad, der später zur Auswertung dient. Ein `ENDWITH` beendet den
+aktuellen Kontext.
+
 ## Beispiel
 ```aeon
 TASK Hallo Welt
@@ -19,4 +24,7 @@ DEFINE begrüßung
   TASK Hallo
 END
 CALL begrüßung
+WITH ProjektX
+  TASK Schritt1
+ENDWITH
 ```

--- a/packages/aeon-universal/compiler.test.ts
+++ b/packages/aeon-universal/compiler.test.ts
@@ -41,4 +41,10 @@ describe('AeonUniversal compile', () => {
     const result = compile(source);
     expect(result.tasks[0].description).toBe('Hello');
   });
+
+  it('handles context blocks with WITH/ENDWITH', () => {
+    const source = ['WITH A', 'TASK Test', 'ENDWITH'].join('\n');
+    const result = compile(source);
+    expect(result.tasks[0].context).toBe('A');
+  });
 });

--- a/packages/aeon-universal/compiler.ts
+++ b/packages/aeon-universal/compiler.ts
@@ -13,6 +13,7 @@ export interface CompileOptions {
   visited?: Set<string>;
   macros?: Record<string, string[]>;
   currentMacro?: string | null;
+  contextStack?: string[];
 }
 
 export function compile(source: string, options: CompileOptions = {}): CompileResult {
@@ -22,6 +23,7 @@ export function compile(source: string, options: CompileOptions = {}): CompileRe
   const visited = options.visited || new Set<string>();
   const macros = options.macros || {};
   let currentMacro = options.currentMacro || null;
+  let contextStack = options.contextStack || [];
 
   const lines = source.split(/\n+/);
   lines.forEach((line, idx) => {
@@ -46,21 +48,25 @@ export function compile(source: string, options: CompileOptions = {}): CompileRe
     } else if (cmd.toUpperCase() === 'CALL') {
       const macroLines = macros[content];
       if (macroLines) {
-        const child = compile(macroLines.join('\n'), { baseDir, visited, macros });
+        const child = compile(macroLines.join('\n'), { baseDir, visited, macros, contextStack });
         tasks.push(...child.tasks);
       }
     } else if (cmd.toUpperCase() === 'REM') {
       AeonMemory.record(content);
     } else if (cmd.toUpperCase() === 'SIG' || cmd.toUpperCase() === 'SIGILLIN') {
       AeonSigillinVault.record({ id: `${idx}`, timestamp: new Date().toISOString(), content });
+    } else if (cmd.toUpperCase() === 'WITH') {
+      contextStack = [...contextStack, content];
+    } else if (cmd.toUpperCase() === 'ENDWITH') {
+      contextStack.pop();
     } else if (cmd.toUpperCase() === 'TASK') {
-      tasks.push({ id: `${idx}`, description: content });
+      tasks.push({ id: `${idx}`, description: content, context: contextStack.join('/') });
     } else if (cmd.toUpperCase() === 'INCLUDE') {
       const filePath = path.resolve(baseDir, content);
       if (!visited.has(filePath) && fs.existsSync(filePath)) {
         visited.add(filePath);
         const childSource = fs.readFileSync(filePath, 'utf-8');
-        const child = compile(childSource, { baseDir: path.dirname(filePath), visited, macros });
+        const child = compile(childSource, { baseDir: path.dirname(filePath), visited, macros, contextStack });
         tasks.push(...child.tasks);
       }
     }


### PR DESCRIPTION
## Summary
- support context stacks in AeonUniversal compiler via `WITH`/`ENDWITH`
- update documentation with new language feature
- extend tests to cover context blocks

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685aabaa35c48322bfecf7d76ddb7708