### PR TITLE
Add GUARD directive for AeonUniversal

### DIFF
--- a/packages/aeon-universal/README.md
+++ b/packages/aeon-universal/README.md
@@ -14,6 +14,10 @@ anzugeben. Alle darin enthaltenen `TASK`s erhalten einen zusammengesetzten
 `context`-Pfad, der später zur Auswertung dient. Ein `ENDWITH` beendet den
 aktuellen Kontext.
 
+Seit **0.6** existiert der Befehl **GUARD**. Er protokolliert Schutz-
+ oder Sicherheitsnotizen im `AeonSigillinVault` und dient der
+dialogischen Selbstabsicherung des Systems.
+
 ## Beispiel
 ```aeon
 TASK Hallo Welt
@@ -26,5 +30,6 @@ END
 CALL begrüßung
 WITH ProjektX
   TASK Schritt1
+GUARD Nur intern verwenden
 ENDWITH
 ```

--- a/packages/aeon-universal/compiler.test.ts
+++ b/packages/aeon-universal/compiler.test.ts
@@ -23,6 +23,12 @@ describe('AeonUniversal compile', () => {
     expect(spy).toHaveBeenCalled();
   });
 
+  it('records guard states', () => {
+    const spy = jest.spyOn(AeonSigillinVault, 'recordGuard');
+    compile('GUARD Schutz');
+    expect(spy).toHaveBeenCalled();
+  });
+
   it('includes other files recursively', () => {
     const tmp = path.resolve('tmp.aeon');
     fs.writeFileSync(tmp, 'TASK Subtask');

--- a/packages/aeon-universal/compiler.ts
+++ b/packages/aeon-universal/compiler.ts
@@ -55,6 +55,8 @@ export function compile(source: string, options: CompileOptions = {}): CompileRe
       AeonMemory.record(content);
     } else if (cmd.toUpperCase() === 'SIG' || cmd.toUpperCase() === 'SIGILLIN') {
       AeonSigillinVault.record({ id: `${idx}`, timestamp: new Date().toISOString(), content });
+    } else if (cmd.toUpperCase() === 'GUARD') {
+      AeonSigillinVault.recordGuard({ id: `${idx}`, timestamp: new Date().toISOString(), content });
     } else if (cmd.toUpperCase() === 'WITH') {
       contextStack = [...contextStack, content];
     } else if (cmd.toUpperCase() === 'ENDWITH') {

--- a/packages/core/AeonSigillinVault.test.ts
+++ b/packages/core/AeonSigillinVault.test.ts
@@ -5,7 +5,9 @@ test('records transitions and resonances', () => {
   AeonSigillinVault.record(state);
   AeonSigillinVault.recordTransition(state);
   AeonSigillinVault.recordResonance(state);
+  AeonSigillinVault.recordGuard(state);
   expect(AeonSigillinVault.latest(1)).toEqual([state]);
   expect(AeonSigillinVault.getTransitions(1)).toEqual([state]);
   expect(AeonSigillinVault.getResonances(1)).toEqual([state]);
+  expect(AeonSigillinVault.getGuards(1)).toEqual([state]);
 });

--- a/packages/core/AeonSigillinVault.ts
+++ b/packages/core/AeonSigillinVault.ts
@@ -8,6 +8,7 @@ export class AeonSigillinVault {
   private static log: PoeticState[] = [];
   private static transitions: PoeticState[] = [];
   private static resonances: PoeticState[] = [];
+  private static guards: PoeticState[] = [];
 
   static record(state: PoeticState): void {
     this.log.push(state);
@@ -19,6 +20,14 @@ export class AeonSigillinVault {
 
   static recordResonance(state: PoeticState): void {
     this.resonances.push(state);
+  }
+
+  static recordGuard(state: PoeticState): void {
+    this.guards.push(state);
+  }
+
+  static getGuards(n = 5): PoeticState[] {
+    return this.guards.slice(-n);
   }
 
   static latest(n = 5): PoeticState[] {


### PR DESCRIPTION
## Summary
- extend `AeonSigillinVault` with guard logging
- support `GUARD` directive in `AeonUniversal` compiler
- document new command in README
- test guard behaviour in compiler and vault

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685ab18b20e883228c4698cb32bb2c5c