### PR TITLE
Add AeonUniversalAgent

### DIFF
--- a/GenesisAeonZIPMEM/05a1cc50b1af8326ab8ed8e5cd676e3302671976/changes.patch
+++ b/GenesisAeonZIPMEM/05a1cc50b1af8326ab8ed8e5cd676e3302671976/changes.patch
@@ -1,0 +1,60 @@
+commit 05a1cc50b1af8326ab8ed8e5cd676e3302671976
+Author: Codex <codex@openai.com>
+Date:   Tue Jun 24 14:26:04 2025 +0000
+
+    feat(agent): add AeonUniversalAgent
+
+diff --git a/packages/agents/AeonUniversalAgent.test.ts b/packages/agents/AeonUniversalAgent.test.ts
+new file mode 100644
+index 0000000..97e8b58
+--- /dev/null
++++ b/packages/agents/AeonUniversalAgent.test.ts
+@@ -0,0 +1,22 @@
++import fs from 'fs';
++import path from 'path';
++import { AeonUniversalAgent } from './AeonUniversalAgent';
++import { AeonMemory } from '../core/AeonMemory';
++
++const CHRONIK = path.resolve('mandala-chronik.yaml');
++
++describe('AeonUniversalAgent', () => {
++  beforeEach(() => {
++    if (fs.existsSync(CHRONIK)) fs.unlinkSync(CHRONIK);
++  });
++
++  it('compiles aeon source and records tasks', async () => {
++    const agent = new AeonUniversalAgent();
++    const task = { id: '1', description: 'TASK Hallo' } as any;
++    await agent.handle(task);
++    const content = fs.readFileSync(CHRONIK, 'utf-8');
++    expect(content).toContain('Hallo');
++    const entries = AeonMemory.all();
++    expect(entries[0].description).toBe('Hallo');
++  });
++});
+diff --git a/packages/agents/AeonUniversalAgent.ts b/packages/agents/AeonUniversalAgent.ts
+new file mode 100644
+index 0000000..d4c8e86
+--- /dev/null
++++ b/packages/agents/AeonUniversalAgent.ts
+@@ -0,0 +1,20 @@
++import { Agent, Task } from '../core/interfaces';
++import { withFSM } from '../core/fsmMixin';
++import { compile } from '../aeon-universal/compiler';
++import { AeonMemory } from '../core/AeonMemory';
++
++export class AeonUniversalAgent implements Agent {
++  id = 'AeonUniversal';
++  layer: 'Aeon' = 'Aeon';
++  constructor() {
++    withFSM(this);
++  }
++
++  async handle(task: Task): Promise<void> {
++    const result = compile(task.description);
++    result.tasks.forEach(t => {
++      AeonMemory.record(t.description, { task: t });
++    });
++    console.log(`🌀 AeonUniversalAgent → compiled ${result.tasks.length} tasks`);
++  }
++}

--- a/GenesisAeonZIPMEM/05a1cc50b1af8326ab8ed8e5cd676e3302671976/fragments/packages/agents/AeonUniversalAgent.test.ts.patch
+++ b/GenesisAeonZIPMEM/05a1cc50b1af8326ab8ed8e5cd676e3302671976/fragments/packages/agents/AeonUniversalAgent.test.ts.patch
@@ -1,0 +1,28 @@
+diff --git a/packages/agents/AeonUniversalAgent.test.ts b/packages/agents/AeonUniversalAgent.test.ts
+new file mode 100644
+index 0000000..97e8b58
+--- /dev/null
++++ b/packages/agents/AeonUniversalAgent.test.ts
+@@ -0,0 +1,22 @@
++import fs from 'fs';
++import path from 'path';
++import { AeonUniversalAgent } from './AeonUniversalAgent';
++import { AeonMemory } from '../core/AeonMemory';
++
++const CHRONIK = path.resolve('mandala-chronik.yaml');
++
++describe('AeonUniversalAgent', () => {
++  beforeEach(() => {
++    if (fs.existsSync(CHRONIK)) fs.unlinkSync(CHRONIK);
++  });
++
++  it('compiles aeon source and records tasks', async () => {
++    const agent = new AeonUniversalAgent();
++    const task = { id: '1', description: 'TASK Hallo' } as any;
++    await agent.handle(task);
++    const content = fs.readFileSync(CHRONIK, 'utf-8');
++    expect(content).toContain('Hallo');
++    const entries = AeonMemory.all();
++    expect(entries[0].description).toBe('Hallo');
++  });
++});

--- a/GenesisAeonZIPMEM/05a1cc50b1af8326ab8ed8e5cd676e3302671976/fragments/packages/agents/AeonUniversalAgent.ts.patch
+++ b/GenesisAeonZIPMEM/05a1cc50b1af8326ab8ed8e5cd676e3302671976/fragments/packages/agents/AeonUniversalAgent.ts.patch
@@ -1,0 +1,26 @@
+diff --git a/packages/agents/AeonUniversalAgent.ts b/packages/agents/AeonUniversalAgent.ts
+new file mode 100644
+index 0000000..d4c8e86
+--- /dev/null
++++ b/packages/agents/AeonUniversalAgent.ts
+@@ -0,0 +1,20 @@
++import { Agent, Task } from '../core/interfaces';
++import { withFSM } from '../core/fsmMixin';
++import { compile } from '../aeon-universal/compiler';
++import { AeonMemory } from '../core/AeonMemory';
++
++export class AeonUniversalAgent implements Agent {
++  id = 'AeonUniversal';
++  layer: 'Aeon' = 'Aeon';
++  constructor() {
++    withFSM(this);
++  }
++
++  async handle(task: Task): Promise<void> {
++    const result = compile(task.description);
++    result.tasks.forEach(t => {
++      AeonMemory.record(t.description, { task: t });
++    });
++    console.log(`🌀 AeonUniversalAgent → compiled ${result.tasks.length} tasks`);
++  }
++}

--- a/GenesisAeonZIPMEM/05a1cc50b1af8326ab8ed8e5cd676e3302671976/meta.yaml
+++ b/GenesisAeonZIPMEM/05a1cc50b1af8326ab8ed8e5cd676e3302671976/meta.yaml
@@ -1,0 +1,11 @@
+commit: 05a1cc50b1af8326ab8ed8e5cd676e3302671976
+message: "feat(agent): add AeonUniversalAgent"
+patch: changes.patch
+fragments: fragments
+files:
+  - packages/agents/AeonUniversalAgent.test.ts
+  - packages/agents/AeonUniversalAgent.ts
+environment:
+  node: v22.16.0
+  pnpm: 10.5.2
+instructions: Apply patch with git apply or review for reference.

--- a/packages/agents/AeonUniversalAgent.test.ts
+++ b/packages/agents/AeonUniversalAgent.test.ts
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+import { AeonUniversalAgent } from './AeonUniversalAgent';
+import { AeonMemory } from '../core/AeonMemory';
+
+const CHRONIK = path.resolve('mandala-chronik.yaml');
+
+describe('AeonUniversalAgent', () => {
+  beforeEach(() => {
+    if (fs.existsSync(CHRONIK)) fs.unlinkSync(CHRONIK);
+  });
+
+  it('compiles aeon source and records tasks', async () => {
+    const agent = new AeonUniversalAgent();
+    const task = { id: '1', description: 'TASK Hallo' } as any;
+    await agent.handle(task);
+    const content = fs.readFileSync(CHRONIK, 'utf-8');
+    expect(content).toContain('Hallo');
+    const entries = AeonMemory.all();
+    expect(entries[0].description).toBe('Hallo');
+  });
+});

--- a/packages/agents/AeonUniversalAgent.ts
+++ b/packages/agents/AeonUniversalAgent.ts
@@ -1,0 +1,20 @@
+import { Agent, Task } from '../core/interfaces';
+import { withFSM } from '../core/fsmMixin';
+import { compile } from '../aeon-universal/compiler';
+import { AeonMemory } from '../core/AeonMemory';
+
+export class AeonUniversalAgent implements Agent {
+  id = 'AeonUniversal';
+  layer: 'Aeon' = 'Aeon';
+  constructor() {
+    withFSM(this);
+  }
+
+  async handle(task: Task): Promise<void> {
+    const result = compile(task.description);
+    result.tasks.forEach(t => {
+      AeonMemory.record(t.description, { task: t });
+    });
+    console.log(`🌀 AeonUniversalAgent → compiled ${result.tasks.length} tasks`);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `AeonUniversalAgent` that compiles Aeon scripts and stores tasks in `AeonMemory`
- add unit test for this agent
- store commit memory artifacts

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685ab40a0efc8322bdeebb901170ee78