### PR TITLE
feat: add JS transpiler for AeonUniversal

### DIFF
--- a/docs/agents/AeonJsTranspilerAgent.md
+++ b/docs/agents/AeonJsTranspilerAgent.md
@@ -1,0 +1,12 @@
+# AeonJsTranspilerAgent
+
+## Responsibilities
+- Wandelt Aeon-Quelltext in ein JavaScript-Snippet um.
+- Nutzt `transpileToJS()` aus `aeon-universal`.
+- Speichert das Ergebnis in einer Datei (Standard: `aeon-output.js`).
+
+## Example usage
+```ts
+const agent = new AeonJsTranspilerAgent('out.js');
+await agent.handle({ id: '1', description: 'TASK Demo' });
+```

--- a/packages/aeon-universal/README.md
+++ b/packages/aeon-universal/README.md
@@ -24,6 +24,9 @@ Kompilat über `transpileToTS()` in TypeScript, `transpileToPython()` in Python,
 Ab **0.8** akzeptieren Makros optionale Parameter. Definiert mit `DEFINE name param`, können Platzhalter
 `$param` innerhalb des Blocks verwendet und bei `CALL name value` ersetzt werden.
 
+Ab **0.9** kann Aeon Universal direkt nach JavaScript transpiliert werden. Die Funktion
+`transpileToJS()` erzeugt ein simples ES-Modul mit `aeonTasks`-Array.
+
 ## Beispiel
 
 ```aeon

--- a/packages/aeon-universal/compiler.test.ts
+++ b/packages/aeon-universal/compiler.test.ts
@@ -5,6 +5,7 @@ import {
   transpileToTS,
   transpileToPython,
   transpileToGo,
+  transpileToJS,
 } from "./compiler";
 import { AeonSigillinVault } from "../core/AeonSigillinVault";
 
@@ -92,5 +93,12 @@ describe("AeonUniversal compile", () => {
     const go = transpileToGo(res);
     expect(go).toContain("package aeon");
     expect(go).toContain("Demo");
+  });
+
+  it("transpiles tasks to JS", () => {
+    const res = compile("TASK Demo");
+    const js = transpileToJS(res);
+    expect(js).toContain("aeonTasks");
+    expect(js).toContain("Demo");
   });
 });

--- a/packages/aeon-universal/compiler.ts
+++ b/packages/aeon-universal/compiler.ts
@@ -199,3 +199,12 @@ export function transpileToRust(result: CompileResult): string {
   lines.push("];");
   return lines.join("\n") + "\n";
 }
+
+export function transpileToJS(result: CompileResult): string {
+  const data = result.tasks.map((t) => ({
+    id: t.id,
+    description: t.description,
+    context: t.context,
+  }));
+  return `export const aeonTasks = ${JSON.stringify(data, null, 2)};\n`;
+}

--- a/packages/agents/AeonJsTranspilerAgent.test.ts
+++ b/packages/agents/AeonJsTranspilerAgent.test.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+import { AeonJsTranspilerAgent } from './AeonJsTranspilerAgent';
+
+describe('AeonJsTranspilerAgent', () => {
+  const output = 'tmp-aeon.js';
+
+  afterEach(() => {
+    if (fs.existsSync(output)) fs.unlinkSync(output);
+  });
+
+  it('transpiles aeon source to JS file', async () => {
+    const agent = new AeonJsTranspilerAgent(output);
+    const task = { id: '1', description: 'TASK Demo' } as any;
+    await agent.handle(task);
+    const content = fs.readFileSync(path.resolve(output), 'utf-8');
+    expect(content).toContain('aeonTasks');
+    expect(content).toContain('Demo');
+  });
+});

--- a/packages/agents/AeonJsTranspilerAgent.ts
+++ b/packages/agents/AeonJsTranspilerAgent.ts
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+import { Agent, Task } from '../core/interfaces';
+import { withFSM } from '../core/fsmMixin';
+import { compile, transpileToJS } from '../aeon-universal';
+
+export class AeonJsTranspilerAgent implements Agent {
+  id = 'AeonJsTranspiler';
+  layer: 'Aeon' = 'Aeon';
+  output: string;
+  constructor(output = 'aeon-output.js') {
+    this.output = output;
+    withFSM(this);
+  }
+
+  async handle(task: Task): Promise<void> {
+    const result = compile(task.description);
+    const code = transpileToJS(result);
+    fs.writeFileSync(path.resolve(this.output), code, 'utf-8');
+    console.log(`🔨 AeonJsTranspilerAgent → wrote ${this.output}`);
+  }
+}

--- a/packages/agents/AeonUniversalCoordinatorAgent.test.ts
+++ b/packages/agents/AeonUniversalCoordinatorAgent.test.ts
@@ -3,7 +3,13 @@ import path from "path";
 import { AeonUniversalCoordinatorAgent } from "./AeonUniversalCoordinatorAgent";
 
 describe("AeonUniversalCoordinatorAgent", () => {
-  const outputs = ["tmp-aeon.ts", "tmp-aeon.py", "tmp-aeon.go", "tmp-aeon.rs"];
+  const outputs = [
+    "tmp-aeon.ts",
+    "tmp-aeon.py",
+    "tmp-aeon.go",
+    "tmp-aeon.rs",
+    "tmp-aeon.js",
+  ];
 
   afterEach(() => {
     outputs.forEach((o) => {

--- a/packages/agents/AeonUniversalCoordinatorAgent.ts
+++ b/packages/agents/AeonUniversalCoordinatorAgent.ts
@@ -4,6 +4,7 @@ import { AeonTranspilerAgent } from "./AeonTranspilerAgent";
 import { AeonPythonTranspilerAgent } from "./AeonPythonTranspilerAgent";
 import { AeonGoTranspilerAgent } from "./AeonGoTranspilerAgent";
 import { AeonRustTranspilerAgent } from "./AeonRustTranspilerAgent";
+import { AeonJsTranspilerAgent } from "./AeonJsTranspilerAgent";
 
 export class AeonUniversalCoordinatorAgent implements Agent {
   id = "AeonUniversalCoordinator";
@@ -12,17 +13,20 @@ export class AeonUniversalCoordinatorAgent implements Agent {
   private pyAgent: AeonPythonTranspilerAgent;
   private goAgent: AeonGoTranspilerAgent;
   private rsAgent: AeonRustTranspilerAgent;
+  private jsAgent: AeonJsTranspilerAgent;
 
   constructor(
     tsOut = "aeon-output.ts",
     pyOut = "aeon-output.py",
     goOut = "aeon-output.go",
     rsOut = "aeon-output.rs",
+    jsOut = "aeon-output.js",
   ) {
     this.tsAgent = new AeonTranspilerAgent(tsOut);
     this.pyAgent = new AeonPythonTranspilerAgent(pyOut);
     this.goAgent = new AeonGoTranspilerAgent(goOut);
     this.rsAgent = new AeonRustTranspilerAgent(rsOut);
+    this.jsAgent = new AeonJsTranspilerAgent(jsOut);
     withFSM(this);
   }
 
@@ -31,5 +35,6 @@ export class AeonUniversalCoordinatorAgent implements Agent {
     await this.pyAgent.handle(task);
     await this.goAgent.handle(task);
     await this.rsAgent.handle(task);
+    await this.jsAgent.handle(task);
   }
 }

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -45,3 +45,4 @@ export * from "./silenceWatcher";
 export * from "./StrategicAgentCoordinator";
 export * from "./AeonUniversalCoordinatorAgent";
 export * from "./AeonRustTranspilerAgent";
+export * from "./AeonJsTranspilerAgent";


### PR DESCRIPTION
## Summary
- support JS transpilation in AeonUniversal compiler
- add AeonJsTranspilerAgent and integrate into coordinator agent
- write tests for new agent and compiler functionality
- export new agent in index and document usage
- update AeonUniversal README with new feature

## Testing
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_685ac43b5b688322af203a6c9ad03e55