### PR TITLE
Add AeonCoreAssembler agent

### DIFF
--- a/GenesisAeonZIPMEM/50eddafc0f020de9e3292ada4793342e855a69e2/changes.patch
+++ b/GenesisAeonZIPMEM/50eddafc0f020de9e3292ada4793342e855a69e2/changes.patch
@@ -1,0 +1,130 @@
+commit 50eddafc0f020de9e3292ada4793342e855a69e2
+Author: Codex <codex@openai.com>
+Date:   Tue Jun 24 15:42:11 2025 +0000
+
+    feat: add AeonCoreAssembler agent
+
+diff --git a/README.md b/README.md
+index ca7e6a1..1467999 100644
+--- a/README.md
++++ b/README.md
+@@ -77,6 +77,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
+ - 🌀 **AdaptiveThreshold** & **DebounceManager** – steuern CREP Trigger-Logik
+ - 🗄️ **AeonSigillinVault** – speichert poetische Sigillin-Zustände (`packages/core/AeonSigillinVault.ts`)
+ - 🧩 **Aeon Universal** – kompiliert fraktale Befehle in Mandala-Tasks und kann SIG-Anweisungen im `AeonSigillinVault` speichern (`packages/aeon-universal`)
++- 🔗 **AeonCoreAssembler** – verteilt Aeon-Tasks an registrierte Agenten (`packages/aeon-universal/CoreAssembler.ts`)
+ - 🔧 **AeonPythonTranspilerAgent** – erzeugt Python-Snippets aus Aeon-Quelltext (`packages/agents/AeonPythonTranspilerAgent.ts`)
+ - 🛠️ **AeonGoTranspilerAgent** – erzeugt Go-Snippets aus Aeon-Quelltext (`packages/agents/AeonGoTranspilerAgent.ts`)
+ - 🛡️ **withCircuit** – CircuitBreaker Wrapper für Agenten-Calls
+diff --git a/docs/agents/AeonCoreAssembler.md b/docs/agents/AeonCoreAssembler.md
+new file mode 100644
+index 0000000..c9c2472
+--- /dev/null
++++ b/docs/agents/AeonCoreAssembler.md
+@@ -0,0 +1,19 @@
++# AeonCoreAssembler
++
++## Responsibilities
++- Koordiniert registrierte Aeon-Agenten und verteilt kompilierte Tasks.
++- Nutzt `compile()` aus `aeon-universal` und reicht die Ergebnisse an Agenten weiter.
++- Optionales Whitelisting über die `allowedAgents`-Liste.
++
++## Parameters
++- `allowedAgents` – Array erlaubter Agent-IDs. Ist es leer, werden alle akzeptiert.
++
++## Example usage
++```ts
++import { AeonCoreAssembler } from 'aeon-universal';
++import { AeonTranspilerAgent } from '../packages/agents/AeonTranspilerAgent';
++
++const assembler = new AeonCoreAssembler(['AeonTranspiler']);
++assembler.register(new AeonTranspilerAgent());
++await assembler.processSource('TASK Demo');
++```
+diff --git a/packages/aeon-universal/CoreAssembler.test.ts b/packages/aeon-universal/CoreAssembler.test.ts
+new file mode 100644
+index 0000000..3581bf7
+--- /dev/null
++++ b/packages/aeon-universal/CoreAssembler.test.ts
+@@ -0,0 +1,28 @@
++import { AeonCoreAssembler } from './CoreAssembler';
++import { Agent, Task } from '../core/interfaces';
++
++class MockAgent implements Agent {
++  id = 'Mock';
++  layer = 'Aeon';
++  received: Task[] = [];
++  async handle(task: Task) { this.received.push(task); }
++}
++
++describe('AeonCoreAssembler', () => {
++  it('dispatches compiled tasks to registered agents', async () => {
++    const assembler = new AeonCoreAssembler();
++    const agent = new MockAgent();
++    assembler.register(agent);
++    await assembler.processSource('TASK Demo');
++    expect(agent.received.length).toBe(1);
++    expect(agent.received[0].description).toBe('Demo');
++  });
++
++  it('honors allowedAgents list', async () => {
++    const assembler = new AeonCoreAssembler(['Allowed']);
++    const agent = new MockAgent();
++    assembler.register(agent); // not allowed
++    await assembler.processSource('TASK Demo');
++    expect(agent.received.length).toBe(0);
++  });
++});
+diff --git a/packages/aeon-universal/CoreAssembler.ts b/packages/aeon-universal/CoreAssembler.ts
+new file mode 100644
+index 0000000..e461917
+--- /dev/null
++++ b/packages/aeon-universal/CoreAssembler.ts
+@@ -0,0 +1,27 @@
++import { compile } from './compiler';
++import { Agent, Task } from '../core/interfaces';
++
++export class AeonCoreAssembler {
++  private agents: Agent[] = [];
++  constructor(private allowedAgents: string[] = []) {}
++
++  register(agent: Agent): void {
++    if (this.allowedAgents.length && !this.allowedAgents.includes(agent.id)) {
++      return;
++    }
++    this.agents.push(agent);
++  }
++
++  async processSource(source: string): Promise<void> {
++    const result = compile(source);
++    for (const task of result.tasks) {
++      await this.dispatch(task);
++    }
++  }
++
++  private async dispatch(task: Task): Promise<void> {
++    for (const agent of this.agents) {
++      await agent.handle(task);
++    }
++  }
++}
+diff --git a/packages/aeon-universal/README.md b/packages/aeon-universal/README.md
+index 34531d1..016963a 100644
+--- a/packages/aeon-universal/README.md
++++ b/packages/aeon-universal/README.md
+@@ -27,6 +27,8 @@ Ab **0.8** akzeptieren Makros optionale Parameter. Definiert mit `DEFINE name pa
+ Ab **0.9** kann Aeon Universal direkt nach JavaScript transpiliert werden. Die Funktion
+ `transpileToJS()` erzeugt ein simples ES-Modul mit `aeonTasks`-Array.
+ 
++Ab **1.0** koordiniert der **AeonCoreAssembler** registrierte Agents. Er kompiliert Aeon-Quelltext und verteilt die entstehenden Tasks fraktal an spezialisierte Agenten. Eine optionale `allowedAgents`-Liste ermöglicht eine einfache Autorisierung.
++
+ ## Beispiel
+ 
+ ```aeon
+diff --git a/packages/aeon-universal/index.ts b/packages/aeon-universal/index.ts
+index b2a5775..f4d5c4e 100644
+--- a/packages/aeon-universal/index.ts
++++ b/packages/aeon-universal/index.ts
+@@ -1 +1,2 @@
+ export * from './compiler';
++export * from './CoreAssembler';

--- a/GenesisAeonZIPMEM/50eddafc0f020de9e3292ada4793342e855a69e2/fragments/README.md.patch
+++ b/GenesisAeonZIPMEM/50eddafc0f020de9e3292ada4793342e855a69e2/fragments/README.md.patch
@@ -1,0 +1,12 @@
+diff --git a/README.md b/README.md
+index ca7e6a1..1467999 100644
+--- a/README.md
++++ b/README.md
+@@ -77,6 +77,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
+ - 🌀 **AdaptiveThreshold** & **DebounceManager** – steuern CREP Trigger-Logik
+ - 🗄️ **AeonSigillinVault** – speichert poetische Sigillin-Zustände (`packages/core/AeonSigillinVault.ts`)
+ - 🧩 **Aeon Universal** – kompiliert fraktale Befehle in Mandala-Tasks und kann SIG-Anweisungen im `AeonSigillinVault` speichern (`packages/aeon-universal`)
++- 🔗 **AeonCoreAssembler** – verteilt Aeon-Tasks an registrierte Agenten (`packages/aeon-universal/CoreAssembler.ts`)
+ - 🔧 **AeonPythonTranspilerAgent** – erzeugt Python-Snippets aus Aeon-Quelltext (`packages/agents/AeonPythonTranspilerAgent.ts`)
+ - 🛠️ **AeonGoTranspilerAgent** – erzeugt Go-Snippets aus Aeon-Quelltext (`packages/agents/AeonGoTranspilerAgent.ts`)
+ - 🛡️ **withCircuit** – CircuitBreaker Wrapper für Agenten-Calls

--- a/GenesisAeonZIPMEM/50eddafc0f020de9e3292ada4793342e855a69e2/fragments/docs/agents/AeonCoreAssembler.md.patch
+++ b/GenesisAeonZIPMEM/50eddafc0f020de9e3292ada4793342e855a69e2/fragments/docs/agents/AeonCoreAssembler.md.patch
@@ -1,0 +1,25 @@
+diff --git a/docs/agents/AeonCoreAssembler.md b/docs/agents/AeonCoreAssembler.md
+new file mode 100644
+index 0000000..c9c2472
+--- /dev/null
++++ b/docs/agents/AeonCoreAssembler.md
+@@ -0,0 +1,19 @@
++# AeonCoreAssembler
++
++## Responsibilities
++- Koordiniert registrierte Aeon-Agenten und verteilt kompilierte Tasks.
++- Nutzt `compile()` aus `aeon-universal` und reicht die Ergebnisse an Agenten weiter.
++- Optionales Whitelisting über die `allowedAgents`-Liste.
++
++## Parameters
++- `allowedAgents` – Array erlaubter Agent-IDs. Ist es leer, werden alle akzeptiert.
++
++## Example usage
++```ts
++import { AeonCoreAssembler } from 'aeon-universal';
++import { AeonTranspilerAgent } from '../packages/agents/AeonTranspilerAgent';
++
++const assembler = new AeonCoreAssembler(['AeonTranspiler']);
++assembler.register(new AeonTranspilerAgent());
++await assembler.processSource('TASK Demo');
++```

--- a/GenesisAeonZIPMEM/50eddafc0f020de9e3292ada4793342e855a69e2/fragments/packages/aeon-universal/CoreAssembler.test.ts.patch
+++ b/GenesisAeonZIPMEM/50eddafc0f020de9e3292ada4793342e855a69e2/fragments/packages/aeon-universal/CoreAssembler.test.ts.patch
@@ -1,0 +1,34 @@
+diff --git a/packages/aeon-universal/CoreAssembler.test.ts b/packages/aeon-universal/CoreAssembler.test.ts
+new file mode 100644
+index 0000000..3581bf7
+--- /dev/null
++++ b/packages/aeon-universal/CoreAssembler.test.ts
+@@ -0,0 +1,28 @@
++import { AeonCoreAssembler } from './CoreAssembler';
++import { Agent, Task } from '../core/interfaces';
++
++class MockAgent implements Agent {
++  id = 'Mock';
++  layer = 'Aeon';
++  received: Task[] = [];
++  async handle(task: Task) { this.received.push(task); }
++}
++
++describe('AeonCoreAssembler', () => {
++  it('dispatches compiled tasks to registered agents', async () => {
++    const assembler = new AeonCoreAssembler();
++    const agent = new MockAgent();
++    assembler.register(agent);
++    await assembler.processSource('TASK Demo');
++    expect(agent.received.length).toBe(1);
++    expect(agent.received[0].description).toBe('Demo');
++  });
++
++  it('honors allowedAgents list', async () => {
++    const assembler = new AeonCoreAssembler(['Allowed']);
++    const agent = new MockAgent();
++    assembler.register(agent); // not allowed
++    await assembler.processSource('TASK Demo');
++    expect(agent.received.length).toBe(0);
++  });
++});

--- a/GenesisAeonZIPMEM/50eddafc0f020de9e3292ada4793342e855a69e2/fragments/packages/aeon-universal/CoreAssembler.ts.patch
+++ b/GenesisAeonZIPMEM/50eddafc0f020de9e3292ada4793342e855a69e2/fragments/packages/aeon-universal/CoreAssembler.ts.patch
@@ -1,0 +1,33 @@
+diff --git a/packages/aeon-universal/CoreAssembler.ts b/packages/aeon-universal/CoreAssembler.ts
+new file mode 100644
+index 0000000..e461917
+--- /dev/null
++++ b/packages/aeon-universal/CoreAssembler.ts
+@@ -0,0 +1,27 @@
++import { compile } from './compiler';
++import { Agent, Task } from '../core/interfaces';
++
++export class AeonCoreAssembler {
++  private agents: Agent[] = [];
++  constructor(private allowedAgents: string[] = []) {}
++
++  register(agent: Agent): void {
++    if (this.allowedAgents.length && !this.allowedAgents.includes(agent.id)) {
++      return;
++    }
++    this.agents.push(agent);
++  }
++
++  async processSource(source: string): Promise<void> {
++    const result = compile(source);
++    for (const task of result.tasks) {
++      await this.dispatch(task);
++    }
++  }
++
++  private async dispatch(task: Task): Promise<void> {
++    for (const agent of this.agents) {
++      await agent.handle(task);
++    }
++  }
++}

--- a/GenesisAeonZIPMEM/50eddafc0f020de9e3292ada4793342e855a69e2/fragments/packages/aeon-universal/README.md.patch
+++ b/GenesisAeonZIPMEM/50eddafc0f020de9e3292ada4793342e855a69e2/fragments/packages/aeon-universal/README.md.patch
@@ -1,0 +1,13 @@
+diff --git a/packages/aeon-universal/README.md b/packages/aeon-universal/README.md
+index 34531d1..016963a 100644
+--- a/packages/aeon-universal/README.md
++++ b/packages/aeon-universal/README.md
+@@ -27,6 +27,8 @@ Ab **0.8** akzeptieren Makros optionale Parameter. Definiert mit `DEFINE name pa
+ Ab **0.9** kann Aeon Universal direkt nach JavaScript transpiliert werden. Die Funktion
+ `transpileToJS()` erzeugt ein simples ES-Modul mit `aeonTasks`-Array.
+ 
++Ab **1.0** koordiniert der **AeonCoreAssembler** registrierte Agents. Er kompiliert Aeon-Quelltext und verteilt die entstehenden Tasks fraktal an spezialisierte Agenten. Eine optionale `allowedAgents`-Liste ermöglicht eine einfache Autorisierung.
++
+ ## Beispiel
+ 
+ ```aeon

--- a/GenesisAeonZIPMEM/50eddafc0f020de9e3292ada4793342e855a69e2/fragments/packages/aeon-universal/index.ts.patch
+++ b/GenesisAeonZIPMEM/50eddafc0f020de9e3292ada4793342e855a69e2/fragments/packages/aeon-universal/index.ts.patch
@@ -1,0 +1,7 @@
+diff --git a/packages/aeon-universal/index.ts b/packages/aeon-universal/index.ts
+index b2a5775..f4d5c4e 100644
+--- a/packages/aeon-universal/index.ts
++++ b/packages/aeon-universal/index.ts
+@@ -1 +1,2 @@
+ export * from './compiler';
++export * from './CoreAssembler';

--- a/GenesisAeonZIPMEM/50eddafc0f020de9e3292ada4793342e855a69e2/meta.yaml
+++ b/GenesisAeonZIPMEM/50eddafc0f020de9e3292ada4793342e855a69e2/meta.yaml
@@ -1,0 +1,15 @@
+commit: 50eddafc0f020de9e3292ada4793342e855a69e2
+message: "feat: add AeonCoreAssembler agent"
+patch: changes.patch
+fragments: fragments
+files:
+  - README.md
+  - docs/agents/AeonCoreAssembler.md
+  - packages/aeon-universal/CoreAssembler.test.ts
+  - packages/aeon-universal/CoreAssembler.ts
+  - packages/aeon-universal/README.md
+  - packages/aeon-universal/index.ts
+environment:
+  node: v22.16.0
+  pnpm: 10.5.2
+instructions: Apply patch with git apply or review for reference.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
 - 🌀 **AdaptiveThreshold** & **DebounceManager** – steuern CREP Trigger-Logik
 - 🗄️ **AeonSigillinVault** – speichert poetische Sigillin-Zustände (`packages/core/AeonSigillinVault.ts`)
 - 🧩 **Aeon Universal** – kompiliert fraktale Befehle in Mandala-Tasks und kann SIG-Anweisungen im `AeonSigillinVault` speichern (`packages/aeon-universal`)
+- 🔗 **AeonCoreAssembler** – verteilt Aeon-Tasks an registrierte Agenten (`packages/aeon-universal/CoreAssembler.ts`)
 - 🔧 **AeonPythonTranspilerAgent** – erzeugt Python-Snippets aus Aeon-Quelltext (`packages/agents/AeonPythonTranspilerAgent.ts`)
 - 🛠️ **AeonGoTranspilerAgent** – erzeugt Go-Snippets aus Aeon-Quelltext (`packages/agents/AeonGoTranspilerAgent.ts`)
 - 🛡️ **withCircuit** – CircuitBreaker Wrapper für Agenten-Calls

--- a/docs/agents/AeonCoreAssembler.md
+++ b/docs/agents/AeonCoreAssembler.md
@@ -1,0 +1,19 @@
+# AeonCoreAssembler
+
+## Responsibilities
+- Koordiniert registrierte Aeon-Agenten und verteilt kompilierte Tasks.
+- Nutzt `compile()` aus `aeon-universal` und reicht die Ergebnisse an Agenten weiter.
+- Optionales Whitelisting über die `allowedAgents`-Liste.
+
+## Parameters
+- `allowedAgents` – Array erlaubter Agent-IDs. Ist es leer, werden alle akzeptiert.
+
+## Example usage
+```ts
+import { AeonCoreAssembler } from 'aeon-universal';
+import { AeonTranspilerAgent } from '../packages/agents/AeonTranspilerAgent';
+
+const assembler = new AeonCoreAssembler(['AeonTranspiler']);
+assembler.register(new AeonTranspilerAgent());
+await assembler.processSource('TASK Demo');
+```

--- a/packages/aeon-universal/CoreAssembler.test.ts
+++ b/packages/aeon-universal/CoreAssembler.test.ts
@@ -1,0 +1,28 @@
+import { AeonCoreAssembler } from './CoreAssembler';
+import { Agent, Task } from '../core/interfaces';
+
+class MockAgent implements Agent {
+  id = 'Mock';
+  layer = 'Aeon';
+  received: Task[] = [];
+  async handle(task: Task) { this.received.push(task); }
+}
+
+describe('AeonCoreAssembler', () => {
+  it('dispatches compiled tasks to registered agents', async () => {
+    const assembler = new AeonCoreAssembler();
+    const agent = new MockAgent();
+    assembler.register(agent);
+    await assembler.processSource('TASK Demo');
+    expect(agent.received.length).toBe(1);
+    expect(agent.received[0].description).toBe('Demo');
+  });
+
+  it('honors allowedAgents list', async () => {
+    const assembler = new AeonCoreAssembler(['Allowed']);
+    const agent = new MockAgent();
+    assembler.register(agent); // not allowed
+    await assembler.processSource('TASK Demo');
+    expect(agent.received.length).toBe(0);
+  });
+});

--- a/packages/aeon-universal/CoreAssembler.ts
+++ b/packages/aeon-universal/CoreAssembler.ts
@@ -1,0 +1,27 @@
+import { compile } from './compiler';
+import { Agent, Task } from '../core/interfaces';
+
+export class AeonCoreAssembler {
+  private agents: Agent[] = [];
+  constructor(private allowedAgents: string[] = []) {}
+
+  register(agent: Agent): void {
+    if (this.allowedAgents.length && !this.allowedAgents.includes(agent.id)) {
+      return;
+    }
+    this.agents.push(agent);
+  }
+
+  async processSource(source: string): Promise<void> {
+    const result = compile(source);
+    for (const task of result.tasks) {
+      await this.dispatch(task);
+    }
+  }
+
+  private async dispatch(task: Task): Promise<void> {
+    for (const agent of this.agents) {
+      await agent.handle(task);
+    }
+  }
+}

--- a/packages/aeon-universal/README.md
+++ b/packages/aeon-universal/README.md
@@ -27,6 +27,8 @@ Ab **0.8** akzeptieren Makros optionale Parameter. Definiert mit `DEFINE name pa
 Ab **0.9** kann Aeon Universal direkt nach JavaScript transpiliert werden. Die Funktion
 `transpileToJS()` erzeugt ein simples ES-Modul mit `aeonTasks`-Array.
 
+Ab **1.0** koordiniert der **AeonCoreAssembler** registrierte Agents. Er kompiliert Aeon-Quelltext und verteilt die entstehenden Tasks fraktal an spezialisierte Agenten. Eine optionale `allowedAgents`-Liste ermöglicht eine einfache Autorisierung.
+
 ## Beispiel
 
 ```aeon

--- a/packages/aeon-universal/index.ts
+++ b/packages/aeon-universal/index.ts
@@ -1,1 +1,2 @@
 export * from './compiler';
+export * from './CoreAssembler';


### PR DESCRIPTION
## Summary
- introduce `AeonCoreAssembler` to coordinate Aeon agents
- export and test the new assembler
- document assembler usage
- mention assembler in project README and Aeon Universal docs
- store commit memory for reference

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685ac5f651608322a44c7403c1da65f1