### PR TITLE
Add AeonUniversal diagnostics and hook framework

### DIFF
--- a/packages/aeon-universal/compiler.ts
+++ b/packages/aeon-universal/compiler.ts
@@ -3,9 +3,12 @@ import path from "path";
 import { AeonMemory } from "../core/AeonMemory";
 import { AeonSigillinVault } from "../core/AeonSigillinVault";
 import { Task } from "../core/interfaces";
+import { AeonDiagnostics, Diagnostic } from "./diagnostics";
+import { HookManager, ASTNode } from "./hooks";
 
 export interface CompileResult {
   tasks: Task[];
+  diagnostics: Diagnostic[];
 }
 
 export interface CompileOptions {
@@ -16,6 +19,8 @@ export interface CompileOptions {
   contextStack?: string[];
   repeatStack?: { count: number; buffer: string[] }[];
   routeStack?: string[];
+  hookManager?: HookManager;
+  diagnostics?: AeonDiagnostics;
 }
 
 export function compile(
@@ -31,9 +36,14 @@ export function compile(
   let contextStack = options.contextStack || [];
   let repeatStack = options.repeatStack || [];
   let routeStack = options.routeStack || [];
+  const hookManager = options.hookManager;
+  const diagnostics = options.diagnostics || new AeonDiagnostics();
+
+  hookManager?.invoke('beforeCompile', { ast: { type: 'Script' }, diagnostics });
 
   const lines = source.split(/\n+/);
   lines.forEach((line, idx) => {
+    try {
     const trimmed = line.trim();
     if (!trimmed) return;
     const [cmd, ...rest] = trimmed.split(" ");
@@ -52,6 +62,8 @@ export function compile(
             contextStack,
             repeatStack,
             routeStack,
+            hookManager,
+            diagnostics,
           });
           tasks.push(...child.tasks);
         }
@@ -92,6 +104,8 @@ export function compile(
           macros,
           contextStack,
           routeStack,
+          hookManager,
+          diagnostics,
         });
         tasks.push(...child.tasks);
       }
@@ -105,6 +119,10 @@ export function compile(
         id: `${idx}`,
         timestamp: new Date().toISOString(),
         content,
+      });
+      hookManager?.invoke('afterEmitSigil', {
+        ast: { type: 'EmitSigil', value: content } as ASTNode,
+        diagnostics,
       });
     } else if (cmd.toUpperCase() === "GUARD") {
       AeonSigillinVault.recordGuard({
@@ -143,13 +161,36 @@ export function compile(
           macros,
           contextStack,
           routeStack,
+          hookManager,
+          diagnostics,
         });
         tasks.push(...child.tasks);
       }
+    } else {
+      diagnostics.report({
+        line: idx + 1,
+        column: 1,
+        message: `Unknown command: ${cmd}`,
+        code: "UNKNOWN_CMD",
+        severity: "warning",
+      });
     }
+  } catch (err) {
+    diagnostics.report({
+      line: idx + 1,
+      column: 1,
+      message: (err as Error).message,
+      code: 'COMPILE_ERROR',
+      severity: 'error',
+    });
+    hookManager?.invoke('onError', {
+      ast: { type: 'Error', error: err } as ASTNode,
+      diagnostics,
+    });
+  }
   });
 
-  return { tasks };
+  return { tasks, diagnostics: diagnostics.getAll() };
 }
 
 export function transpileToTS(result: CompileResult): string {

--- a/packages/aeon-universal/diagnostics.ts
+++ b/packages/aeon-universal/diagnostics.ts
@@ -1,0 +1,19 @@
+export interface Diagnostic {
+  line: number;
+  column: number;
+  message: string;
+  code: string;
+  severity: 'error' | 'warning';
+}
+
+export class AeonDiagnostics {
+  private diagnostics: Diagnostic[] = [];
+
+  report(d: Diagnostic): void {
+    this.diagnostics.push(d);
+  }
+
+  getAll(): Diagnostic[] {
+    return this.diagnostics;
+  }
+}

--- a/packages/aeon-universal/grammar.ebnf
+++ b/packages/aeon-universal/grammar.ebnf
@@ -1,0 +1,14 @@
+AeonScript      = { Statement } ;
+Statement       = EmitSigil | TaskDecl | IfStmt | LoopStmt | HookStmt ;
+EmitSigil       = "emitSigil" "(" StringLiteral "," StringLiteral "," OptParams ")" ";" ;
+TaskDecl        = "task" Identifier "{" { Statement } "}" ;
+IfStmt          = "if" "(" Expression ")" "{" { Statement } "}" [ "else" "{" { Statement } "}" ] ;
+LoopStmt        = ("while" | "for") LoopHeader "{" { Statement } "}" ;
+HookStmt        = "hook" "on" Identifier "->" Identifier ";" ;
+Expression      = /* bool, comparison, arithmetic */ ;
+OptParams       = [ ParamList ] ;
+ParamList       = Param { "," Param } ;
+Param           = Identifier ":" (StringLiteral | Number) ;
+Identifier      = Letter { Letter | Digit | "_" } ;
+StringLiteral   = '"' { AnyCharExcept('"') } '"' ;
+Number          = Digit { Digit } [ "." Digit { Digit } ] ;

--- a/packages/aeon-universal/hooks-diagnostics.test.ts
+++ b/packages/aeon-universal/hooks-diagnostics.test.ts
@@ -1,0 +1,17 @@
+import { compile } from './compiler';
+import { HookManager } from './hooks';
+import { AeonDiagnostics } from './diagnostics';
+
+describe('AeonUniversal hooks and diagnostics', () => {
+  it('invokes hooks and collects diagnostics', () => {
+    const manager = new HookManager();
+    const called: string[] = [];
+    manager.register('afterEmitSigil', ctx => {
+      called.push(ctx.ast.type);
+    });
+    const diagnostics = new AeonDiagnostics();
+    const result = compile('SIG Hello\nUNKNOWN', { hookManager: manager, diagnostics });
+    expect(called[0]).toBe('EmitSigil');
+    expect(result.diagnostics[0].code).toBe('UNKNOWN_CMD');
+  });
+});

--- a/packages/aeon-universal/hooks.ts
+++ b/packages/aeon-universal/hooks.ts
@@ -1,0 +1,33 @@
+import { AeonDiagnostics } from './diagnostics';
+
+export type HookName = 'beforeCompile' | 'afterEmitSigil' | 'onError';
+
+export interface ASTNode {
+  type: string;
+  [key: string]: any;
+}
+
+export interface AeonHookContext {
+  ast: ASTNode;
+  diagnostics: AeonDiagnostics;
+}
+
+export type AeonHook = (ctx: AeonHookContext) => Promise<void> | void;
+
+export class HookManager {
+  private hooks: Record<HookName, AeonHook[]> = {
+    beforeCompile: [],
+    afterEmitSigil: [],
+    onError: [],
+  };
+
+  register(name: HookName, fn: AeonHook): void {
+    this.hooks[name].push(fn);
+  }
+
+  async invoke(name: HookName, ctx: AeonHookContext): Promise<void> {
+    for (const fn of this.hooks[name]) {
+      await Promise.resolve(fn(ctx));
+    }
+  }
+}

--- a/packages/aeon-universal/index.ts
+++ b/packages/aeon-universal/index.ts
@@ -1,2 +1,4 @@
 export * from './compiler';
 export * from './CoreAssembler';
+export * from './diagnostics';
+export * from './hooks';


### PR DESCRIPTION
## Summary
- add grammar spec for AeonUniversal
- introduce diagnostics utilities
- introduce hook manager for plugin callbacks
- integrate hooks/diagnostics into compiler
- export new modules and test hook integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ace98e714832295ba78224a302b9f