### PR TITLE
Add compile caching for AeonUniversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
 - 🌀 **AdaptiveThreshold** & **DebounceManager** – steuern CREP Trigger-Logik
 - 🗄️ **AeonSigillinVault** – speichert poetische Sigillin-Zustände (`packages/core/AeonSigillinVault.ts`)
 - 🧩 **Aeon Universal** – kompiliert fraktale Befehle in Mandala-Tasks und kann SIG-Anweisungen im `AeonSigillinVault` speichern (`packages/aeon-universal`)
+- 🗂️ **Compile Cache** – speichert kompilierte Aeon-Skripte (`packages/aeon-universal/cache.ts`)
 - 🔗 **AeonCoreAssembler** – verteilt Aeon-Tasks an registrierte Agenten (`packages/aeon-universal/CoreAssembler.ts`)
 - 🔧 **AeonPythonTranspilerAgent** – erzeugt Python-Snippets aus Aeon-Quelltext (`packages/agents/AeonPythonTranspilerAgent.ts`)
 - 🛠️ **AeonGoTranspilerAgent** – erzeugt Go-Snippets aus Aeon-Quelltext (`packages/agents/AeonGoTranspilerAgent.ts`)

--- a/packages/aeon-universal/cache.test.ts
+++ b/packages/aeon-universal/cache.test.ts
@@ -1,0 +1,11 @@
+import { compile } from './compiler';
+import { compileCache } from './cache';
+
+describe('compile cache', () => {
+  it('reuses cached result for identical source', () => {
+    compileCache.clear();
+    const res1 = compile('TASK X');
+    const res2 = compile('TASK X');
+    expect(res1).toBe(res2);
+  });
+});

--- a/packages/aeon-universal/cache.ts
+++ b/packages/aeon-universal/cache.ts
@@ -1,0 +1,24 @@
+import crypto from 'crypto';
+import { CompileResult } from './compiler';
+
+class CompileCache {
+  private cache = new Map<string, CompileResult>();
+
+  get(key: string): CompileResult | undefined {
+    return this.cache.get(key);
+  }
+
+  set(key: string, value: CompileResult): void {
+    this.cache.set(key, value);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+}
+
+export const compileCache = new CompileCache();
+
+export function hashSource(source: string): string {
+  return crypto.createHash('sha256').update(source).digest('hex');
+}

--- a/packages/aeon-universal/compiler.ts
+++ b/packages/aeon-universal/compiler.ts
@@ -5,6 +5,7 @@ import { AeonSigillinVault } from "../core/AeonSigillinVault";
 import { Task } from "../core/interfaces";
 import { AeonDiagnostics, Diagnostic } from "./diagnostics";
 import { HookManager, ASTNode } from "./hooks";
+import { compileCache, hashSource } from './cache';
 
 export interface CompileResult {
   tasks: Task[];
@@ -21,6 +22,7 @@ export interface CompileOptions {
   routeStack?: string[];
   hookManager?: HookManager;
   diagnostics?: AeonDiagnostics;
+  disableCache?: boolean;
 }
 
 export function compile(
@@ -28,6 +30,13 @@ export function compile(
   options: CompileOptions = {},
 ): CompileResult {
   AeonMemory.load();
+  const hash = hashSource(source);
+  if (!options.disableCache) {
+    const cached = compileCache.get(hash);
+    if (cached) {
+      return cached;
+    }
+  }
   const tasks: Task[] = [];
   const baseDir = options.baseDir || process.cwd();
   const visited = options.visited || new Set<string>();
@@ -226,7 +235,11 @@ export function compile(
   }
   });
 
-  return { tasks, diagnostics: diagnostics.getAll() };
+  const result = { tasks, diagnostics: diagnostics.getAll() };
+  if (!options.disableCache) {
+    compileCache.set(hash, result);
+  }
+  return result;
 }
 
 export function transpileToTS(result: CompileResult): string {

--- a/packages/aeon-universal/index.ts
+++ b/packages/aeon-universal/index.ts
@@ -2,3 +2,4 @@ export * from './compiler';
 export * from './CoreAssembler';
 export * from './diagnostics';
 export * from './hooks';
+export * from './cache';


### PR DESCRIPTION
## Summary
- add simple cache mechanism for Aeon compiler
- expose cache from package entrypoint
- test caching behaviour
- document cache in README

## Testing
- `npx jest packages/aeon-universal`

------
https://chatgpt.com/codex/tasks/task_e_685ad44d6e188322a591fd1d9a682033