### PR TITLE
Add simple neural net module

### DIFF
--- a/packages/simple-neural-net/Network.ts
+++ b/packages/simple-neural-net/Network.ts
@@ -1,0 +1,45 @@
+import { Neuron } from './Neuron';
+import { sigmoid, meanSquareLoss } from './util';
+
+export class Network {
+  private neurons: Neuron[] = [
+    new Neuron(), new Neuron(), new Neuron(), // input
+    new Neuron(), new Neuron(), // hidden
+    new Neuron() // output
+  ];
+
+  predict(input1: number, input2: number): number {
+    const n = this.neurons;
+    return n[5].compute(
+      n[4].compute(
+        n[2].compute(input1, input2, sigmoid),
+        n[1].compute(input1, input2, sigmoid),
+        sigmoid
+      ),
+      n[3].compute(
+        n[1].compute(input1, input2, sigmoid),
+        n[0].compute(input1, input2, sigmoid),
+        sigmoid
+      ),
+      sigmoid
+    );
+  }
+
+  train(data: [number, number][], answers: number[], epochs = 1000) {
+    let bestLoss: number | null = null;
+    for (let epoch = 0; epoch < epochs; epoch++) {
+      const neuron = this.neurons[epoch % this.neurons.length];
+      neuron.mutate();
+
+      const predictions = data.map(d => this.predict(d[0], d[1]));
+      const loss = meanSquareLoss(answers, predictions);
+
+      if (bestLoss === null || loss < bestLoss) {
+        bestLoss = loss;
+        neuron.remember();
+      } else {
+        neuron.forget();
+      }
+    }
+  }
+}

--- a/packages/simple-neural-net/Neuron.ts
+++ b/packages/simple-neural-net/Neuron.ts
@@ -1,0 +1,41 @@
+export class Neuron {
+  private random = Math.random;
+
+  private oldBias: number = this.random() * 2 - 1;
+  private bias: number = this.random() * 2 - 1;
+
+  public oldWeight1: number = this.random() * 2 - 1;
+  public weight1: number = this.random() * 2 - 1;
+
+  private oldWeight2: number = this.random() * 2 - 1;
+  private weight2: number = this.random() * 2 - 1;
+
+  compute(input1: number, input2: number, activation: (x: number) => number): number {
+    const preActivation = (this.weight1 * input1) + (this.weight2 * input2) + this.bias;
+    return activation(preActivation);
+  }
+
+  mutate() {
+    const prop = Math.floor(this.random() * 3);
+    const change = this.random() * 2 - 1;
+    if (prop === 0) {
+      this.bias += change;
+    } else if (prop === 1) {
+      this.weight1 += change;
+    } else {
+      this.weight2 += change;
+    }
+  }
+
+  forget() {
+    this.bias = this.oldBias;
+    this.weight1 = this.oldWeight1;
+    this.weight2 = this.oldWeight2;
+  }
+
+  remember() {
+    this.oldBias = this.bias;
+    this.oldWeight1 = this.weight1;
+    this.oldWeight2 = this.weight2;
+  }
+}

--- a/packages/simple-neural-net/README.md
+++ b/packages/simple-neural-net/README.md
@@ -1,0 +1,22 @@
+# Simple Neural Net
+
+This package implements a minimal neural network as described in the tutorial. It uses a small set of `Neuron` instances organised into a `Network` with a feed forward prediction pipeline and a mutation based training loop.
+
+## Usage
+
+```ts
+import { Network } from 'simple-neural-net';
+
+const data = [
+  [115, 66],
+  [175, 78],
+  [205, 72],
+  [120, 67]
+];
+const answers = [1, 0, 0, 1];
+
+const net = new Network();
+net.train(data, answers);
+
+console.log(net.predict(130, 66));
+```

--- a/packages/simple-neural-net/__tests__/Network.test.ts
+++ b/packages/simple-neural-net/__tests__/Network.test.ts
@@ -1,0 +1,15 @@
+import { Network } from '../Network';
+
+test('trains towards sample data', () => {
+  const data = [
+    [115, 66],
+    [175, 78],
+    [205, 72],
+    [120, 67]
+  ];
+  const answers = [1, 0, 0, 1];
+  const net = new Network();
+  net.train(data, answers, 10);
+  const out = net.predict(115, 66);
+  expect(typeof out).toBe('number');
+});

--- a/packages/simple-neural-net/index.ts
+++ b/packages/simple-neural-net/index.ts
@@ -1,0 +1,3 @@
+export { Neuron } from './Neuron';
+export { Network } from './Network';
+export * as Util from './util';

--- a/packages/simple-neural-net/util.ts
+++ b/packages/simple-neural-net/util.ts
@@ -1,0 +1,12 @@
+export function sigmoid(x: number): number {
+  return 1 / (1 + Math.exp(-x));
+}
+
+export function meanSquareLoss(targets: number[], predictions: number[]): number {
+  let sum = 0;
+  for (let i = 0; i < targets.length; i++) {
+    const error = targets[i] - predictions[i];
+    sum += error * error;
+  }
+  return sum / targets.length;
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,3 +18,4 @@ packages:
   - 'packages/codex-navigator-agent'
   - 'apps/*'
   - 'packages/tutorials'
+  - 'packages/simple-neural-net'


### PR DESCRIPTION
## Summary
- implement basic neural network in new `simple-neural-net` package
- include training logic and utilities
- add small test and update workspace configuration

## Testing
- `pnpm lint` *(fails: Cannot find module 'react' et al.)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae0f50d1c8322ae004d8fdf3702b4