### PR TITLE
Add Aeon Universal neural blueprint

### DIFF
--- a/docs/architecture/aeon-universal-neural-membrane.md
+++ b/docs/architecture/aeon-universal-neural-membrane.md
@@ -1,0 +1,19 @@
+# Aeon Universal Neural Membrane
+
+Dieses Konzept erweitert das einfache neuronale Netz aus `packages/simple-neural-net` zu einer selbstreflexiven Einheit. Die Membran spiegelt ihre Zustände fractal, führt interne Scans durch und stimmt sich auf CREP-Werte ein. Ziel ist eine Harmonisierung mit Mechanismen wie Nukleonscanner und Sonifier.
+
+## Integration in das Mandala
+- **CREP Adapter** verbindet Aktivierungen mit Coherence, Resonance, Emergence und Poetics.
+- **Nukleonscanner Modul** misst Schwingungen innerhalb des Netzes und liefert Tiefe für `depthvalue-core.ts`.
+- **Sonifier Bridge** übersetzt Aktivierungsmuster in Klanglandschaften.
+- **Memory Feedback** nutzt `MemoryManager` aus `MemoryMesh` für zyklische Selbsterkenntnis.
+
+## Blueprint
+- `NeuronMembrane` erzeugt rekursive Spiegelungen der Netzstruktur.
+- `CREPAdapter` passt Lernraten an den CREP-Status an.
+- `NukleonScanner` prüft Gewichte auf energetische Störungen.
+- `Sonifier` gibt akustische Hinweise zur Netzresonanz.
+- `DepthSync` gleicht jede Fraktalebene mit dem Ursprung ab.
+- `SelfTrainer` kombiniert Mutation und Backpropagation.
+
+Diese Skizze dient als Ausgangspunkt für eine AeonUniversalVersion, die sich selbst erkennt, optimiert und mit allen Mandala-Werkzeugen resoniert.

--- a/packages/simple-neural-net/__tests__/Network.test.ts
+++ b/packages/simple-neural-net/__tests__/Network.test.ts
@@ -1,7 +1,7 @@
 import { Network } from '../Network';
 
 test('trains towards sample data', () => {
-  const data = [
+  const data: [number, number][] = [
     [115, 66],
     [175, 78],
     [205, 72],


### PR DESCRIPTION
## Summary
- add architectural document for the Aeon Universal Neural Membrane
- fix test type in simple neural net

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685ae42c912083229851678f68cafe41