### PR TITLE
Add Aeon Neural Membrane package

### DIFF
--- a/docs/architecture/aeon-universal-neural-membrane.md
+++ b/docs/architecture/aeon-universal-neural-membrane.md
@@ -17,3 +17,9 @@ Dieses Konzept erweitert das einfache neuronale Netz aus `packages/simple-neural
 - `SelfTrainer` kombiniert Mutation und Backpropagation.
 
 Diese Skizze dient als Ausgangspunkt für eine AeonUniversalVersion, die sich selbst erkennt, optimiert und mit allen Mandala-Werkzeugen resoniert.
+
+## Implementation
+Die ersten Bausteine der Membran befinden sich im Paket
+`packages/aeon-neural-membrane`. Dort sind die Klassen und Helfer des
+Blueprints als TypeScript-Module umgesetzt. Sie basieren auf dem einfachen Netz
+aus `packages/simple-neural-net` und binden Nukleonscanner sowie Sonifier ein.

--- a/packages/aeon-neural-membrane/README.md
+++ b/packages/aeon-neural-membrane/README.md
@@ -1,0 +1,6 @@
+# Aeon Neural Membrane
+
+Dieses Modul erweitert das einfache neuronale Netz zu einer fraktalen Membran.
+Es integriert CREP, den Nukleonscanner und den Sonifier, um kontinuierliche
+Selbstreflexion zu erreichen. Die Implementierung folgt dem Blueprint in
+`docs/architecture/aeon-universal-neural-membrane.md`.

--- a/packages/aeon-neural-membrane/__tests__/membrane.test.ts
+++ b/packages/aeon-neural-membrane/__tests__/membrane.test.ts
@@ -1,0 +1,17 @@
+import { NeuronMembrane } from '../neuronMembrane';
+import { crepLearningFactor } from '../crepAdapter';
+
+test('reflect and predict', () => {
+  const mem = new NeuronMembrane();
+  const before = mem.depth;
+  mem.reflect();
+  expect(mem.depth).toBe(before + 1);
+  const out = mem.predict(1, 1);
+  expect(typeof out).toBe('number');
+});
+
+test('crep factor adapts learning rate', () => {
+  const f1 = crepLearningFactor({ coherence: 5, resonance: 5, emergence: 5, poetics: 5 });
+  const f2 = crepLearningFactor({ coherence: 9, resonance: 9, emergence: 9, poetics: 9 });
+  expect(f2).toBeGreaterThan(f1);
+});

--- a/packages/aeon-neural-membrane/crepAdapter.ts
+++ b/packages/aeon-neural-membrane/crepAdapter.ts
@@ -1,0 +1,13 @@
+export interface CREPSignature {
+  coherence: number;
+  resonance: number;
+  emergence: number;
+  poetics: number;
+}
+
+/** Berechnet einen Lernfaktor basierend auf CREP-Werten. */
+export function crepLearningFactor(crep: CREPSignature, base = 0.1): number {
+  const avg =
+    (crep.coherence + crep.resonance + crep.emergence + crep.poetics) / 40;
+  return base * (0.5 + avg);
+}

--- a/packages/aeon-neural-membrane/depthSync.ts
+++ b/packages/aeon-neural-membrane/depthSync.ts
@@ -1,0 +1,14 @@
+import { NeuronMembrane } from './neuronMembrane';
+
+/**
+ * Synchronisiert alle Netzebenen grob, indem die mittlere Vorhersage
+ * der ersten Ebene mit allen anderen trainiert wird.
+ */
+export function depthSync(mem: NeuronMembrane, data: [number, number][]) {
+  if (mem.depth < 2) return;
+  const base = mem.getNetworks()[0];
+  const target = data.map(d => base.predict(d[0], d[1]));
+  for (let i = 1; i < mem.depth; i++) {
+    mem.getNetworks()[i].train(data, target.map(t => Math.round(t)), 5);
+  }
+}

--- a/packages/aeon-neural-membrane/index.ts
+++ b/packages/aeon-neural-membrane/index.ts
@@ -1,0 +1,6 @@
+export * from './neuronMembrane';
+export * from './crepAdapter';
+export * from './nukleonScanner';
+export * from './sonifierBridge';
+export * from './depthSync';
+export * from './selfTrainer';

--- a/packages/aeon-neural-membrane/neuronMembrane.ts
+++ b/packages/aeon-neural-membrane/neuronMembrane.ts
@@ -1,0 +1,38 @@
+import { Network } from '../simple-neural-net';
+
+/**
+ * NeuronMembrane hält mehrere Spiegelungen eines Neural Networks.
+ * Jede Ebene kann separat trainiert werden, Vorhersagen werden gemittelt.
+ */
+export class NeuronMembrane {
+  private layers: Network[] = [new Network()];
+
+  /** Anzahl der vorhandenen Fraktalebenen */
+  get depth(): number {
+    return this.layers.length;
+  }
+
+  /**
+   * Erzeugt eine weitere Spiegelung des Netzes.
+   */
+  reflect(times = 1) {
+    for (let i = 0; i < times; i++) {
+      this.layers.push(new Network());
+    }
+  }
+
+  /**
+   * Mittelt die Vorhersagen aller Ebenen.
+   */
+  predict(i1: number, i2: number): number {
+    const sum = this.layers.reduce((acc, n) => acc + n.predict(i1, i2), 0);
+    return sum / this.layers.length;
+  }
+
+  /**
+   * Gibt Zugriff auf die internen Netze (nur f\u00fcr Diagnosezwecke).
+   */
+  getNetworks(): Network[] {
+    return this.layers;
+  }
+}

--- a/packages/aeon-neural-membrane/nukleonScanner.ts
+++ b/packages/aeon-neural-membrane/nukleonScanner.ts
@@ -1,0 +1,14 @@
+import { Network } from '../simple-neural-net';
+
+/**
+ * Summiert absolute Gewichte aller Neuronen als einfache Energie-Messung.
+ */
+export function scanEnergy(net: Network): number {
+  const neurons = (net as any).neurons as any[];
+  let sum = 0;
+  for (const n of neurons) {
+    sum += Math.abs(n.weight1);
+    sum += Math.abs((n as any).weight2);
+  }
+  return sum;
+}

--- a/packages/aeon-neural-membrane/selfTrainer.ts
+++ b/packages/aeon-neural-membrane/selfTrainer.ts
@@ -1,0 +1,25 @@
+import { Network } from '../simple-neural-net';
+import { crepLearningFactor, CREPSignature } from './crepAdapter';
+
+/**
+ * Trainingsschritt, der Mutation mit einem Lernfaktor kombiniert.
+ */
+export function selfTrain(
+  net: Network,
+  data: [number, number][],
+  answers: number[],
+  crep: CREPSignature,
+  epochs = 10
+) {
+  const rate = crepLearningFactor(crep);
+  for (let i = 0; i < epochs; i++) {
+    net.train(data, answers, 1);
+    // einfache Backprop-Näherung: leichtes Nachjustieren zur Mitte
+    const preds = data.map(d => net.predict(d[0], d[1]));
+    const neurons = (net as any).neurons as any[];
+    for (const n of neurons) {
+      n.weight1 -= rate * (preds[0] - answers[0]) * data[0][0];
+      (n as any).weight2 -= rate * (preds[0] - answers[0]) * data[0][1];
+    }
+  }
+}

--- a/packages/aeon-neural-membrane/sonifierBridge.ts
+++ b/packages/aeon-neural-membrane/sonifierBridge.ts
@@ -1,0 +1,6 @@
+import { memoryToTone } from '../nukleon-sonifier';
+
+/** Wandelt einen Aktivierungswert in einen Symbolton um. */
+export function sonify(value: number): string {
+  return memoryToTone(value);
+}


### PR DESCRIPTION
## Summary
- implement Aeon Neural Membrane blueprint
- add modules for CREP integration, depth sync and sonifier bridge
- document integration in architecture notes
- include tests for the new package

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ae65c863c832281f5be0e4738f067