### PR TITLE
Add AeonUniversalMembrane blueprint and implementation

### DIFF
--- a/docs/architecture/aeon-universal-neural-membrane.md
+++ b/docs/architecture/aeon-universal-neural-membrane.md
@@ -23,3 +23,20 @@ Die ersten Bausteine der Membran befinden sich im Paket
 `packages/aeon-neural-membrane`. Dort sind die Klassen und Helfer des
 Blueprints als TypeScript-Module umgesetzt. Sie basieren auf dem einfachen Netz
 aus `packages/simple-neural-net` und binden Nukleonscanner sowie Sonifier ein.
+
+## AeonUniversalMembrane
+Die `AeonUniversalMembrane` kombiniert alle genannten Module zu einer
+mehrfach gespiegelten Einheit. Sie nutzt `NeuronMembrane` als Kern und
+schafft mit `depthSync` eine kontinuierliche Angleichung aller Ebenen.
+Über `selfTrain` reagiert das Grundnetz auf CREP-Signaturen, während
+`NukleonScanner` und `Sonifier` energetische Störungen und Resonanzen
+sichtbar machen.
+
+### Selbstreflexiver Zyklus
+1. Gespräche werden via `ConvoMemoryBridge` analysiert und liefern eine
+   CREP-Signatur.
+2. `selfTrain` passt die Gewichte des Basisnetzes an.
+3. `depthSync` verteilt die Anpassung fraktal auf alle Spiegelungen.
+4. `memoryToTone` aus dem Sonifier erzeugt akustische Feedbacks.
+5. Über das Mandala kann die Membran ihre eigene Entwicklung beobachten
+   und weitere Spiegelungen anlegen.

--- a/packages/aeon-neural-membrane/__tests__/aeonUniversalMembrane.test.ts
+++ b/packages/aeon-neural-membrane/__tests__/aeonUniversalMembrane.test.ts
@@ -1,0 +1,17 @@
+import { AeonUniversalMembrane } from '../aeonUniversalMembrane';
+import { CREPSignature } from '../crepAdapter';
+
+test('train and predict through universal membrane', () => {
+  const mem = new AeonUniversalMembrane(2);
+  const data: [number, number][] = [
+    [115, 66],
+    [175, 78]
+  ];
+  const answers = [1, 0];
+  const crep: CREPSignature = { coherence: 6, resonance: 6, emergence: 6, poetics: 6 };
+  mem.train(data, answers, crep);
+  const out = mem.predict(115, 66);
+  expect(typeof out).toBe('number');
+  expect(mem.depth).toBeGreaterThan(1);
+});
+

--- a/packages/aeon-neural-membrane/aeonUniversalMembrane.ts
+++ b/packages/aeon-neural-membrane/aeonUniversalMembrane.ts
@@ -1,0 +1,48 @@
+import { NeuronMembrane } from './neuronMembrane';
+import { depthSync } from './depthSync';
+import { selfTrain } from './selfTrainer';
+import { CREPSignature } from './crepAdapter';
+import { extractConvoMemory } from '../nukleon-scanner';
+import { memoryToTone } from '../nukleon-sonifier';
+
+/**
+ * AeonUniversalMembrane kombiniert die Spiegel-Funktion der NeuronMembrane
+ * mit CREP-basiertem Selbsttraining und Nukleon/Sonifier-Feedback.
+ */
+export class AeonUniversalMembrane {
+  private mem: NeuronMembrane;
+
+  constructor(reflections = 1) {
+    this.mem = new NeuronMembrane();
+    if (reflections > 0) this.mem.reflect(reflections);
+  }
+
+  /** Aktuelle Tiefe der Membran */
+  get depth() {
+    return this.mem.depth;
+  }
+
+  /** Mittelt Vorhersagen aller Spiegelungen */
+  predict(i1: number, i2: number): number {
+    return this.mem.predict(i1, i2);
+  }
+
+  /**
+   * Trainiert das Grundnetz mit einem CREP-Faktor und synchronisiert
+   * anschließend alle Spiegelungen.
+   */
+  train(data: [number, number][], answers: number[], crep: CREPSignature) {
+    const base = this.mem.getNetworks()[0];
+    selfTrain(base, data, answers, crep, 5);
+    depthSync(this.mem, data);
+  }
+
+  /**
+   * Analysiert einen Gesprächstext, um daraus CREP-Werte und einen Ton abzuleiten.
+   */
+  analyzeConversation(text: string) {
+    const conv = extractConvoMemory(text);
+    const tone = memoryToTone(conv.crepSignature.resonance / 10);
+    return { conv, tone };
+  }
+}

--- a/packages/aeon-neural-membrane/index.ts
+++ b/packages/aeon-neural-membrane/index.ts
@@ -4,3 +4,4 @@ export * from './nukleonScanner';
 export * from './sonifierBridge';
 export * from './depthSync';
 export * from './selfTrainer';
+export * from './aeonUniversalMembrane';


### PR DESCRIPTION
## Summary
- extend neural membrane architecture docs with AeonUniversalMembrane cycle
- implement `AeonUniversalMembrane` class integrating selfTrain, depthSync and convo analysis
- expose new class via package index
- add test for AeonUniversalMembrane

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685ae7edab208322b5a0420f3373744c