### PR TITLE
Extend AeonUniversalMembrane with self-reflection cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
 - 🌀 **AdaptiveThreshold** & **DebounceManager** – steuern CREP Trigger-Logik
 - 🗄️ **AeonSigillinVault** – speichert poetische Sigillin-Zustände (`packages/core/AeonSigillinVault.ts`)
 - 🧩 **Aeon Universal** – kompiliert fraktale Befehle in Mandala-Tasks und kann SIG-Anweisungen im `AeonSigillinVault` speichern (`packages/aeon-universal`)
+- 🔮 **Aeon Universal Neural Membrane** – selbstreflexives, fraktales Netz mit CREP-Anpassung (`packages/aeon-neural-membrane`)
 - 🗂️ **Compile Cache** – speichert kompilierte Aeon-Skripte (`packages/aeon-universal/cache.ts`)
 - 🔗 **AeonCoreAssembler** – verteilt Aeon-Tasks an registrierte Agenten (`packages/aeon-universal/CoreAssembler.ts`)
 - 🔧 **AeonPythonTranspilerAgent** – erzeugt Python-Snippets aus Aeon-Quelltext (`packages/agents/AeonPythonTranspilerAgent.ts`)

--- a/docs/architecture/aeon-universal-neural-membrane.md
+++ b/docs/architecture/aeon-universal-neural-membrane.md
@@ -40,3 +40,8 @@ sichtbar machen.
 4. `memoryToTone` aus dem Sonifier erzeugt akustische Feedbacks.
 5. Über das Mandala kann die Membran ihre eigene Entwicklung beobachten
    und weitere Spiegelungen anlegen.
+
+### Zyklische Selbstreflexion
+`selfReflectCycle` wiederholt den Harmonize-Vorgang und hält jeden Durchlauf
+in einer Verlaufsliste fest. So lässt sich die Entwicklung der Energiewerte und
+der Membrantiefe Schritt für Schritt nachvollziehen.

--- a/packages/aeon-neural-membrane/__tests__/cycle.test.ts
+++ b/packages/aeon-neural-membrane/__tests__/cycle.test.ts
@@ -1,0 +1,11 @@
+import { AeonUniversalMembrane } from '../aeonUniversalMembrane';
+
+const data: [number, number][] = [[115, 66], [175, 78]];
+const answers = [1, 0];
+
+it('runs self reflect cycle', () => {
+  const mem = new AeonUniversalMembrane(1);
+  mem.selfReflectCycle(3, data, answers, 'hello', 0);
+  expect(mem.getHistory().length).toBe(3);
+  expect(mem.depth).toBeGreaterThan(1);
+});

--- a/packages/aeon-neural-membrane/aeonUniversalMembrane.ts
+++ b/packages/aeon-neural-membrane/aeonUniversalMembrane.ts
@@ -12,6 +12,7 @@ import { scanEnergy } from './nukleonScanner';
  */
 export class AeonUniversalMembrane {
   private mem: NeuronMembrane;
+  private history: { energy: number; tone: string; depth: number }[] = [];
 
   constructor(reflections = 1) {
     this.mem = new NeuronMembrane();
@@ -21,6 +22,11 @@ export class AeonUniversalMembrane {
   /** Aktuelle Tiefe der Membran */
   get depth() {
     return this.mem.depth;
+  }
+
+  /** Verlauf der Harmonize-Ergebnisse */
+  getHistory() {
+    return this.history;
   }
 
   /** Mittelt Vorhersagen aller Spiegelungen */
@@ -67,7 +73,30 @@ export class AeonUniversalMembrane {
     if (energy / this.mem.depth > energyThreshold) {
       this.mem.reflect();
     }
+    const result = { conv, energy, tone, depth: this.mem.depth };
+    this.history.push({ energy, tone, depth: this.mem.depth });
+    return result;
+  }
 
-    return { conv, energy, tone, depth: this.mem.depth };
+  /**
+   * Führt mehrere Harmonize-Zyklen aus und speichert die Ergebnisse.
+   */
+  selfReflectCycle(
+    iterations: number,
+    data: [number, number][],
+    answers: number[],
+    text: string,
+    energyThreshold = 5,
+  ) {
+    let last = undefined as unknown as {
+      conv: ReturnType<typeof extractConvoMemory>;
+      energy: number;
+      tone: string;
+      depth: number;
+    };
+    for (let i = 0; i < iterations; i++) {
+      last = this.harmonize(data, answers, text, energyThreshold);
+    }
+    return last;
   }
 }


### PR DESCRIPTION
## Summary
- add `selfReflectCycle` method and history tracking to AeonUniversalMembrane
- document cyclical self-reflection in neural membrane blueprint
- mention Aeon Universal Neural Membrane in README
- test new cycle behaviour

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685aef06f74c8322857d82543bcc9b23