### PR TITLE
Add AeonMembraneAgent and blueprint update

### DIFF
--- a/docs/architecture/aeon-universal-neural-membrane.md
+++ b/docs/architecture/aeon-universal-neural-membrane.md
@@ -51,3 +51,9 @@ Die Methode `scanResonance()` liefert f\u00fcr jede Fraktalebene die aktuelle
 Energie sowie den durch den Sonifier abgeleiteten Ton. So kann das Mandala
 ein Resonanzprofil \u00fcber alle Spiegelungen hinweg erstellen und gezielt auf
 energetische Anomalien reagieren.
+
+## Agent Integration
+Ein `AeonMembraneAgent` bindet die Membran in das Agentsystem ein.
+Jeder bearbeitete Task l\u00f6st einen Harmonize-Lauf aus. Die dabei
+entstehenden Energie- und Klangwerte k\u00f6nnen von Agenten wie dem
+`AeonKIResonanzAgent` oder dem `CREPHistorian` weiterverarbeitet werden.

--- a/packages/agents/AeonMembraneAgent.ts
+++ b/packages/agents/AeonMembraneAgent.ts
@@ -1,0 +1,30 @@
+import { Agent, Task } from '../core/interfaces';
+import { withFSM } from '../core/fsmMixin';
+import { AeonUniversalMembrane } from '../aeon-neural-membrane';
+
+export class AeonMembraneAgent implements Agent {
+  id = 'AeonMembrane';
+  layer: 'Aeon' = 'Aeon';
+  private mem: AeonUniversalMembrane;
+
+  constructor(reflections = 1) {
+    this.mem = new AeonUniversalMembrane(reflections);
+    withFSM(this);
+  }
+
+  async handle(task: Task): Promise<void> {
+    const nums = (task.description.match(/\d+/g) || []).map(n => parseInt(n, 10));
+    const pairs: [number, number][] = [];
+    for (let i = 0; i < nums.length; i += 2) {
+      if (nums[i + 1] !== undefined) pairs.push([nums[i], nums[i + 1]]);
+    }
+    if (pairs.length === 0) {
+      pairs.push([task.description.length, task.id.length]);
+    }
+    const answers = pairs.map(() => 1);
+    const res = this.mem.harmonize(pairs, answers, task.description, 2);
+    console.log(
+      `🧠 AeonMembraneAgent → energy ${res.energy.toFixed(2)} depth ${res.depth}`
+    );
+  }
+}

--- a/packages/agents/__tests__/AeonMembraneAgent.spec.ts
+++ b/packages/agents/__tests__/AeonMembraneAgent.spec.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AeonMembraneAgent } from '../AeonMembraneAgent';
+
+vi.spyOn(console, 'log').mockImplementation(() => {});
+
+describe('AeonMembraneAgent', () => {
+  it('harmonizes task input', async () => {
+    const agent = new AeonMembraneAgent(0);
+    await agent.handle({ id: 'm-1', description: 'test 10 20' });
+    expect((console.log as any).mock.calls[0][0]).toContain('AeonMembraneAgent');
+  });
+});

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -47,3 +47,4 @@ export * from "./AeonUniversalCoordinatorAgent";
 export * from "./AeonRustTranspilerAgent";
 export * from "./AeonJsTranspilerAgent";
 export * from './AeonAuraAgent';
+export * from './AeonMembraneAgent';


### PR DESCRIPTION
## Summary
- extend neural membrane blueprint with agent integration
- implement `AeonMembraneAgent` using `AeonUniversalMembrane`
- export new agent
- add unit test for the agent

## Testing
- `npm run lint`
- `npm test`
- `npm run test:agents`


------
https://chatgpt.com/codex/tasks/task_e_685af32b31948322bbd6c2768384b1ec