### PR TITLE
Fix express import syntax

### DIFF
--- a/GenesisAeonZIPMEM/615a7585df886e9d14e795bcc7d82ea384ae3f97/changes.patch
+++ b/GenesisAeonZIPMEM/615a7585df886e9d14e795bcc7d82ea384ae3f97/changes.patch
@@ -1,0 +1,28 @@
+commit 615a7585df886e9d14e795bcc7d82ea384ae3f97
+Author: Codex <codex@openai.com>
+Date:   Tue Jun 24 20:16:35 2025 +0000
+
+    refactor: use esm imports for express routes
+
+diff --git a/packages/core/routes/healthz.ts b/packages/core/routes/healthz.ts
+index 1b971e6..a2e6c6e 100644
+--- a/packages/core/routes/healthz.ts
++++ b/packages/core/routes/healthz.ts
+@@ -1,5 +1,4 @@
+-// eslint-disable-next-line @typescript-eslint/no-var-requires
+-const express = require('express');
++import express from 'express';
+ const router = express.Router();
+ 
+ router.get('/healthz', async (_req: any, res: any) => {
+diff --git a/packages/core/routes/metaScores.ts b/packages/core/routes/metaScores.ts
+index 551a3e5..fa47739 100644
+--- a/packages/core/routes/metaScores.ts
++++ b/packages/core/routes/metaScores.ts
+@@ -1,5 +1,4 @@
+-// eslint-disable-next-line @typescript-eslint/no-var-requires
+-const express = require('express');
++import express from 'express';
+ const router = express.Router();
+ 
+ router.get('/api/meta-scores', (_req: any, res: any) => {

--- a/GenesisAeonZIPMEM/615a7585df886e9d14e795bcc7d82ea384ae3f97/fragments/packages/core/routes/healthz.ts.patch
+++ b/GenesisAeonZIPMEM/615a7585df886e9d14e795bcc7d82ea384ae3f97/fragments/packages/core/routes/healthz.ts.patch
@@ -1,0 +1,11 @@
+diff --git a/packages/core/routes/healthz.ts b/packages/core/routes/healthz.ts
+index 1b971e6..a2e6c6e 100644
+--- a/packages/core/routes/healthz.ts
++++ b/packages/core/routes/healthz.ts
+@@ -1,5 +1,4 @@
+-// eslint-disable-next-line @typescript-eslint/no-var-requires
+-const express = require('express');
++import express from 'express';
+ const router = express.Router();
+ 
+ router.get('/healthz', async (_req: any, res: any) => {

--- a/GenesisAeonZIPMEM/615a7585df886e9d14e795bcc7d82ea384ae3f97/fragments/packages/core/routes/metaScores.ts.patch
+++ b/GenesisAeonZIPMEM/615a7585df886e9d14e795bcc7d82ea384ae3f97/fragments/packages/core/routes/metaScores.ts.patch
@@ -1,0 +1,11 @@
+diff --git a/packages/core/routes/metaScores.ts b/packages/core/routes/metaScores.ts
+index 551a3e5..fa47739 100644
+--- a/packages/core/routes/metaScores.ts
++++ b/packages/core/routes/metaScores.ts
+@@ -1,5 +1,4 @@
+-// eslint-disable-next-line @typescript-eslint/no-var-requires
+-const express = require('express');
++import express from 'express';
+ const router = express.Router();
+ 
+ router.get('/api/meta-scores', (_req: any, res: any) => {

--- a/GenesisAeonZIPMEM/615a7585df886e9d14e795bcc7d82ea384ae3f97/meta.yaml
+++ b/GenesisAeonZIPMEM/615a7585df886e9d14e795bcc7d82ea384ae3f97/meta.yaml
@@ -1,0 +1,11 @@
+commit: 615a7585df886e9d14e795bcc7d82ea384ae3f97
+message: "refactor: use esm imports for express routes"
+patch: changes.patch
+fragments: fragments
+files:
+  - packages/core/routes/healthz.ts
+  - packages/core/routes/metaScores.ts
+environment:
+  node: v22.16.0
+  pnpm: 10.5.2
+instructions: Apply patch with git apply or review for reference.

--- a/packages/core/routes/healthz.ts
+++ b/packages/core/routes/healthz.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const express = require('express');
+import express from 'express';
 const router = express.Router();
 
 router.get('/healthz', async (_req: any, res: any) => {

--- a/packages/core/routes/metaScores.ts
+++ b/packages/core/routes/metaScores.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const express = require('express');
+import express from 'express';
 const router = express.Router();
 
 router.get('/api/meta-scores', (_req: any, res: any) => {


### PR DESCRIPTION
## Summary
- use ESM-style express imports in health routes
- store commit patch

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b069186f48322a981d0551ada833c