### PR TITLE
Add Objective2UI layout suggester component

### DIFF
--- a/GenesisAeonZIPMEM/8a52d248a66230794bdf255ceb8676c500f2070b/changes.patch
+++ b/GenesisAeonZIPMEM/8a52d248a66230794bdf255ceb8676c500f2070b/changes.patch
@@ -1,0 +1,99 @@
+commit 8a52d248a66230794bdf255ceb8676c500f2070b
+Author: Codex <codex@openai.com>
+Date:   Tue Jun 24 21:22:47 2025 +0000
+
+    feat(ui): add Objective2UI component
+
+diff --git a/Handbuch.md b/Handbuch.md
+index be15d9f..e00a4ea 100644
+--- a/Handbuch.md
++++ b/Handbuch.md
+@@ -324,7 +324,7 @@ Aktuelle Versionshinweise werden in [CHANGELOG.md](CHANGELOG.md) gepflegt.
+ - 🧩 **Plug-in-Architektur** – GPT-Kommunikationsmodule, CLI-Tools
+ - 🔗 **GPTBridge (Go)** – API- und Link-basierte GPT-Anbindung (`go-bridge/pkg/gpt`)
+ - 🔌 **Plugin-Registry & Dynamic Loader** – `plugins/manifest.yaml` und `usePluginLoader`
+-- 📝 **Objective2UI** – generiert Layout-Vorschläge via GPT
++- 📝 **Objective2UI** – generiert Layout-Vorschläge via GPT (`packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx`)
+ - 🔐 **Ethik-Governance & Heimkehr-Deklaration** – Offene, poetische Ethik als Systembasis
+ - 🎭 **Poesie & Automation** – Bash-Interface (`aeon.sh`), automatisches Chronopoem, symbolisches Onboarding
+ - 🌟 **CREP-Illumination** – Chronopoem reflektiert aktuellen CREP-Zustand
+diff --git a/README.md b/README.md
+index 422bf26..d0356fc 100644
+--- a/README.md
++++ b/README.md
+@@ -32,7 +32,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
+ - 🧩 **Plug-in-Architektur** – GPT-Kommunikationsmodule, CLI-Tools
+ - 🔗 **GPTBridge (Go)** – API- und Link-basierte GPT-Anbindung (`go-bridge/pkg/gpt`)
+ - 🔌 **Plugin-Registry & Dynamic Loader** – `plugins/manifest.yaml` und `usePluginLoader`
+-- 📝 **Objective2UI** – generiert Layout-Vorschläge via GPT
++- 📝 **Objective2UI** – generiert Layout-Vorschläge via GPT (`packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx`)
+ - 🔐 **Ethik-Governance & Heimkehr-Deklaration** – Offene, poetische Ethik als Systembasis
+ - 🎭 **Poesie & Automation** – Bash-Interface (`aeon.sh`), automatisches Chronopoem, symbolisches Onboarding
+ - 🌟 **CREP-Illumination** – Chronopoem reflektiert aktuellen CREP-Zustand
+diff --git a/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.test.tsx b/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.test.tsx
+new file mode 100644
+index 0000000..71f1cbd
+--- /dev/null
++++ b/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.test.tsx
+@@ -0,0 +1,15 @@
++import { render, screen, fireEvent, waitFor } from '@testing-library/react';
++import '@testing-library/jest-dom';
++import ObjectiveLayoutSuggester from './ObjectiveLayoutSuggester';
++import * as service from '../../../services/objective2ui';
++
++jest.spyOn(service, 'objectiveToLayout').mockResolvedValue('layout: sample');
++
++test('generates layout suggestion', async () => {
++  render(<ObjectiveLayoutSuggester />);
++  fireEvent.change(screen.getByLabelText('objective-input'), { target: { value: 'dashboard' } });
++  fireEvent.click(screen.getByText('Generate Layout'));
++  await waitFor(() => screen.getByLabelText('layout-output'));
++  expect(service.objectiveToLayout).toHaveBeenCalledWith('dashboard');
++  expect(screen.getByLabelText('layout-output').textContent).toBe('layout: sample');
++});
+diff --git a/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx b/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx
+new file mode 100644
+index 0000000..8c4cbe6
+--- /dev/null
++++ b/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx
+@@ -0,0 +1,31 @@
++import React, { useState } from 'react';
++import { objectiveToLayout } from '../../../services/objective2ui';
++
++const ObjectiveLayoutSuggester: React.FC = () => {
++  const [objective, setObjective] = useState('');
++  const [layout, setLayout] = useState('');
++
++  const generate = async () => {
++    if (!objective) return;
++    try {
++      const yaml = await objectiveToLayout(objective);
++      setLayout(yaml);
++    } catch {
++      setLayout('');
++    }
++  };
++
++  return (
++    <div>
++      <textarea
++        aria-label="objective-input"
++        value={objective}
++        onChange={e => setObjective(e.target.value)}
++      />
++      <button onClick={generate}>Generate Layout</button>
++      {layout && <pre aria-label="layout-output">{layout}</pre>}
++    </div>
++  );
++};
++
++export default ObjectiveLayoutSuggester;
+diff --git a/packages/unifiedmandala-ui/index.ts b/packages/unifiedmandala-ui/index.ts
+index 7b8ba79..bc78d4b 100644
+--- a/packages/unifiedmandala-ui/index.ts
++++ b/packages/unifiedmandala-ui/index.ts
+@@ -5,3 +5,4 @@ export { default as CREPTestHarness } from './components/CREPTestHarness';
+ export { default as CREPPlayEngine } from './components/CREPPlayEngine';
+ export { default as CREPTimeline } from './components/CREPTimeline';
+ export { default as ChatPanel } from './components/ChatPanel';
++export { default as ObjectiveLayoutSuggester } from './components/ObjectiveLayoutSuggester';

--- a/GenesisAeonZIPMEM/8a52d248a66230794bdf255ceb8676c500f2070b/fragments/Handbuch.md.patch
+++ b/GenesisAeonZIPMEM/8a52d248a66230794bdf255ceb8676c500f2070b/fragments/Handbuch.md.patch
@@ -1,0 +1,13 @@
+diff --git a/Handbuch.md b/Handbuch.md
+index be15d9f..e00a4ea 100644
+--- a/Handbuch.md
++++ b/Handbuch.md
+@@ -324,7 +324,7 @@ Aktuelle Versionshinweise werden in [CHANGELOG.md](CHANGELOG.md) gepflegt.
+ - 🧩 **Plug-in-Architektur** – GPT-Kommunikationsmodule, CLI-Tools
+ - 🔗 **GPTBridge (Go)** – API- und Link-basierte GPT-Anbindung (`go-bridge/pkg/gpt`)
+ - 🔌 **Plugin-Registry & Dynamic Loader** – `plugins/manifest.yaml` und `usePluginLoader`
+-- 📝 **Objective2UI** – generiert Layout-Vorschläge via GPT
++- 📝 **Objective2UI** – generiert Layout-Vorschläge via GPT (`packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx`)
+ - 🔐 **Ethik-Governance & Heimkehr-Deklaration** – Offene, poetische Ethik als Systembasis
+ - 🎭 **Poesie & Automation** – Bash-Interface (`aeon.sh`), automatisches Chronopoem, symbolisches Onboarding
+ - 🌟 **CREP-Illumination** – Chronopoem reflektiert aktuellen CREP-Zustand

--- a/GenesisAeonZIPMEM/8a52d248a66230794bdf255ceb8676c500f2070b/fragments/README.md.patch
+++ b/GenesisAeonZIPMEM/8a52d248a66230794bdf255ceb8676c500f2070b/fragments/README.md.patch
@@ -1,0 +1,13 @@
+diff --git a/README.md b/README.md
+index 422bf26..d0356fc 100644
+--- a/README.md
++++ b/README.md
+@@ -32,7 +32,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
+ - 🧩 **Plug-in-Architektur** – GPT-Kommunikationsmodule, CLI-Tools
+ - 🔗 **GPTBridge (Go)** – API- und Link-basierte GPT-Anbindung (`go-bridge/pkg/gpt`)
+ - 🔌 **Plugin-Registry & Dynamic Loader** – `plugins/manifest.yaml` und `usePluginLoader`
+-- 📝 **Objective2UI** – generiert Layout-Vorschläge via GPT
++- 📝 **Objective2UI** – generiert Layout-Vorschläge via GPT (`packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx`)
+ - 🔐 **Ethik-Governance & Heimkehr-Deklaration** – Offene, poetische Ethik als Systembasis
+ - 🎭 **Poesie & Automation** – Bash-Interface (`aeon.sh`), automatisches Chronopoem, symbolisches Onboarding
+ - 🌟 **CREP-Illumination** – Chronopoem reflektiert aktuellen CREP-Zustand

--- a/GenesisAeonZIPMEM/8a52d248a66230794bdf255ceb8676c500f2070b/fragments/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.test.tsx.patch
+++ b/GenesisAeonZIPMEM/8a52d248a66230794bdf255ceb8676c500f2070b/fragments/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.test.tsx.patch
@@ -1,0 +1,21 @@
+diff --git a/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.test.tsx b/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.test.tsx
+new file mode 100644
+index 0000000..71f1cbd
+--- /dev/null
++++ b/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.test.tsx
+@@ -0,0 +1,15 @@
++import { render, screen, fireEvent, waitFor } from '@testing-library/react';
++import '@testing-library/jest-dom';
++import ObjectiveLayoutSuggester from './ObjectiveLayoutSuggester';
++import * as service from '../../../services/objective2ui';
++
++jest.spyOn(service, 'objectiveToLayout').mockResolvedValue('layout: sample');
++
++test('generates layout suggestion', async () => {
++  render(<ObjectiveLayoutSuggester />);
++  fireEvent.change(screen.getByLabelText('objective-input'), { target: { value: 'dashboard' } });
++  fireEvent.click(screen.getByText('Generate Layout'));
++  await waitFor(() => screen.getByLabelText('layout-output'));
++  expect(service.objectiveToLayout).toHaveBeenCalledWith('dashboard');
++  expect(screen.getByLabelText('layout-output').textContent).toBe('layout: sample');
++});

--- a/GenesisAeonZIPMEM/8a52d248a66230794bdf255ceb8676c500f2070b/fragments/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx.patch
+++ b/GenesisAeonZIPMEM/8a52d248a66230794bdf255ceb8676c500f2070b/fragments/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx.patch
@@ -1,0 +1,37 @@
+diff --git a/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx b/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx
+new file mode 100644
+index 0000000..8c4cbe6
+--- /dev/null
++++ b/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx
+@@ -0,0 +1,31 @@
++import React, { useState } from 'react';
++import { objectiveToLayout } from '../../../services/objective2ui';
++
++const ObjectiveLayoutSuggester: React.FC = () => {
++  const [objective, setObjective] = useState('');
++  const [layout, setLayout] = useState('');
++
++  const generate = async () => {
++    if (!objective) return;
++    try {
++      const yaml = await objectiveToLayout(objective);
++      setLayout(yaml);
++    } catch {
++      setLayout('');
++    }
++  };
++
++  return (
++    <div>
++      <textarea
++        aria-label="objective-input"
++        value={objective}
++        onChange={e => setObjective(e.target.value)}
++      />
++      <button onClick={generate}>Generate Layout</button>
++      {layout && <pre aria-label="layout-output">{layout}</pre>}
++    </div>
++  );
++};
++
++export default ObjectiveLayoutSuggester;

--- a/GenesisAeonZIPMEM/8a52d248a66230794bdf255ceb8676c500f2070b/fragments/packages/unifiedmandala-ui/index.ts.patch
+++ b/GenesisAeonZIPMEM/8a52d248a66230794bdf255ceb8676c500f2070b/fragments/packages/unifiedmandala-ui/index.ts.patch
@@ -1,0 +1,9 @@
+diff --git a/packages/unifiedmandala-ui/index.ts b/packages/unifiedmandala-ui/index.ts
+index 7b8ba79..bc78d4b 100644
+--- a/packages/unifiedmandala-ui/index.ts
++++ b/packages/unifiedmandala-ui/index.ts
+@@ -5,3 +5,4 @@ export { default as CREPTestHarness } from './components/CREPTestHarness';
+ export { default as CREPPlayEngine } from './components/CREPPlayEngine';
+ export { default as CREPTimeline } from './components/CREPTimeline';
+ export { default as ChatPanel } from './components/ChatPanel';
++export { default as ObjectiveLayoutSuggester } from './components/ObjectiveLayoutSuggester';

--- a/GenesisAeonZIPMEM/8a52d248a66230794bdf255ceb8676c500f2070b/meta.yaml
+++ b/GenesisAeonZIPMEM/8a52d248a66230794bdf255ceb8676c500f2070b/meta.yaml
@@ -1,0 +1,14 @@
+commit: 8a52d248a66230794bdf255ceb8676c500f2070b
+message: "feat(ui): add Objective2UI component"
+patch: changes.patch
+fragments: fragments
+files:
+  - Handbuch.md
+  - README.md
+  - packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.test.tsx
+  - packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx
+  - packages/unifiedmandala-ui/index.ts
+environment:
+  node: v22.16.0
+  pnpm: 10.5.2
+instructions: Apply patch with git apply or review for reference.

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -324,7 +324,7 @@ Aktuelle Versionshinweise werden in [CHANGELOG.md](CHANGELOG.md) gepflegt.
 - 🧩 **Plug-in-Architektur** – GPT-Kommunikationsmodule, CLI-Tools
 - 🔗 **GPTBridge (Go)** – API- und Link-basierte GPT-Anbindung (`go-bridge/pkg/gpt`)
 - 🔌 **Plugin-Registry & Dynamic Loader** – `plugins/manifest.yaml` und `usePluginLoader`
-- 📝 **Objective2UI** – generiert Layout-Vorschläge via GPT
+- 📝 **Objective2UI** – generiert Layout-Vorschläge via GPT (`packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx`)
 - 🔐 **Ethik-Governance & Heimkehr-Deklaration** – Offene, poetische Ethik als Systembasis
 - 🎭 **Poesie & Automation** – Bash-Interface (`aeon.sh`), automatisches Chronopoem, symbolisches Onboarding
 - 🌟 **CREP-Illumination** – Chronopoem reflektiert aktuellen CREP-Zustand

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
 - 🧩 **Plug-in-Architektur** – GPT-Kommunikationsmodule, CLI-Tools
 - 🔗 **GPTBridge (Go)** – API- und Link-basierte GPT-Anbindung (`go-bridge/pkg/gpt`)
 - 🔌 **Plugin-Registry & Dynamic Loader** – `plugins/manifest.yaml` und `usePluginLoader`
-- 📝 **Objective2UI** – generiert Layout-Vorschläge via GPT
+- 📝 **Objective2UI** – generiert Layout-Vorschläge via GPT (`packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx`)
 - 🔐 **Ethik-Governance & Heimkehr-Deklaration** – Offene, poetische Ethik als Systembasis
 - 🎭 **Poesie & Automation** – Bash-Interface (`aeon.sh`), automatisches Chronopoem, symbolisches Onboarding
 - 🌟 **CREP-Illumination** – Chronopoem reflektiert aktuellen CREP-Zustand

--- a/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.test.tsx
+++ b/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ObjectiveLayoutSuggester from './ObjectiveLayoutSuggester';
+import * as service from '../../../services/objective2ui';
+
+jest.spyOn(service, 'objectiveToLayout').mockResolvedValue('layout: sample');
+
+test('generates layout suggestion', async () => {
+  render(<ObjectiveLayoutSuggester />);
+  fireEvent.change(screen.getByLabelText('objective-input'), { target: { value: 'dashboard' } });
+  fireEvent.click(screen.getByText('Generate Layout'));
+  await waitFor(() => screen.getByLabelText('layout-output'));
+  expect(service.objectiveToLayout).toHaveBeenCalledWith('dashboard');
+  expect(screen.getByLabelText('layout-output').textContent).toBe('layout: sample');
+});

--- a/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx
+++ b/packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { objectiveToLayout } from '../../../services/objective2ui';
+
+const ObjectiveLayoutSuggester: React.FC = () => {
+  const [objective, setObjective] = useState('');
+  const [layout, setLayout] = useState('');
+
+  const generate = async () => {
+    if (!objective) return;
+    try {
+      const yaml = await objectiveToLayout(objective);
+      setLayout(yaml);
+    } catch {
+      setLayout('');
+    }
+  };
+
+  return (
+    <div>
+      <textarea
+        aria-label="objective-input"
+        value={objective}
+        onChange={e => setObjective(e.target.value)}
+      />
+      <button onClick={generate}>Generate Layout</button>
+      {layout && <pre aria-label="layout-output">{layout}</pre>}
+    </div>
+  );
+};
+
+export default ObjectiveLayoutSuggester;

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -5,3 +5,4 @@ export { default as CREPTestHarness } from './components/CREPTestHarness';
 export { default as CREPPlayEngine } from './components/CREPPlayEngine';
 export { default as CREPTimeline } from './components/CREPTimeline';
 export { default as ChatPanel } from './components/ChatPanel';
+export { default as ObjectiveLayoutSuggester } from './components/ObjectiveLayoutSuggester';


### PR DESCRIPTION
## Summary
- implement `ObjectiveLayoutSuggester` component for UI layout proposals
- test component integration with `objective2ui` service
- export the component
- document Objective2UI feature in README and Handbuch
- archive commit details in `GenesisAeonZIPMEM`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685b15e9e4b48322a947bf7b61911e37