### PR TITLE
Enhance SilenceWatcher

### DIFF
--- a/packages/agents/silenceWatcher.test.ts
+++ b/packages/agents/silenceWatcher.test.ts
@@ -1,6 +1,29 @@
 import { SilenceWatcher } from './silenceWatcher';
+import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
 
-test('returns false by default', () => {
-  const sw = new SilenceWatcher();
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+test('detects silence after threshold', () => {
+  const sw = new SilenceWatcher(1000);
   expect(sw.shouldAnalyze()).toBe(false);
+  jest.advanceTimersByTime(1500);
+  expect(sw.shouldAnalyze()).toBe(true);
+  sw.stop();
+});
+
+test('resets timer on event', () => {
+  const sw = new SilenceWatcher(1000);
+  jest.advanceTimersByTime(900);
+  GPTEventHub.emit('test');
+  jest.advanceTimersByTime(900);
+  expect(sw.shouldAnalyze()).toBe(false);
+  jest.advanceTimersByTime(200);
+  expect(sw.shouldAnalyze()).toBe(true);
+  sw.stop();
 });

--- a/packages/agents/silenceWatcher.ts
+++ b/packages/agents/silenceWatcher.ts
@@ -1,5 +1,20 @@
+import { GPTEventHub } from '../gpt-bridges/GPTEventHub';
+
 export class SilenceWatcher {
+  private lastEvent = Date.now();
+  private handler = () => {
+    this.lastEvent = Date.now();
+  };
+
+  constructor(private thresholdMs = 60000, private hub = GPTEventHub) {
+    this.hub.on('*', this.handler as any);
+  }
+
   shouldAnalyze(): boolean {
-    return false;
+    return Date.now() - this.lastEvent > this.thresholdMs;
+  }
+
+  stop(): void {
+    this.hub.off('*', this.handler as any);
   }
 }


### PR DESCRIPTION
## Summary
- track GPTEventHub activity in `SilenceWatcher`
- allow inactivity threshold configuration
- test silence detection and reset behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b1bbe9cb0832298316a735e4e1d3a