### PR TITLE
Add event bus docs

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -156,6 +156,8 @@ Teil 5 ergänzt die Sigil-Historie.
 
 ### event-bus
 - `NatsEventBus` – Layer für NATS Nachrichtenkommunikation.
+  Siehe [packages/event-bus/README.md](packages/event-bus/README.md) für
+  verfügbare Subjects und Integration.
 
 ### conversation-analysis
 - `CREPConversationScanner` – scannt Gesprächslogs nach CREP-Phrasen.

--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ Kurze Beschreibungen findest du nun direkt in den READMEs der Pakete
 `bio`, `codex-navigator`, `collab-editor`, `core`, `crep-automation`,
 `event-bus`, `nukleon-scanner`, `nukleon-sonifier`, `sharedream-interface`,
 `tts`, `tutorials`, `ui`, `utils` und `visuals`.
+Eine Übersicht zur NATS-basierten Kommunikation bietet das
+[packages/event-bus/README.md](packages/event-bus/README.md).
 -### 🟦 Go-Bridge (go-bridge/)
 - Polyglottes Interface zu UnifiedMandala für Go (REST, NATS, gRPC, CLI)
 - Enthält **GPTBridge**-Module (`pkg/gpt`) und die Beispiel-CLIs `mandala-gpt.go`

--- a/packages/event-bus/README.md
+++ b/packages/event-bus/README.md
@@ -1,17 +1,27 @@
 # Event Bus
 
-Thin wrapper around NATS messaging for the Mandala ecosystem.
+The `NatsEventBus` provides a lightweight wrapper over the NATS client for communication between UnifiedMandala services.
 
 ## Key modules
-- `NatsEventBus.ts` – connect, publish and subscribe helpers.
-- `subjects.ts` – enumerates well known event subjects.
+- `NatsEventBus.ts` – connect, publish, subscribe and close helpers.
+- `subjects.ts` – enumerates all well known subjects.
 
-## Basic usage
+## Available subjects
+- `CREP_UPDATE` – broadcast when CREP metrics change
+- `AGENT_HEARTBEAT` – periodic heartbeat of active agents
+
+## Example integration
 ```ts
 import { NatsEventBus, Subjects } from '@unified-mandala/event-bus';
+
 const bus = new NatsEventBus();
-await bus.connect();
-await bus.publish(Subjects.CREP_UPDATE, { value: 1 });
+await bus.connect('nats://localhost:4222');
+
+bus.subscribe(Subjects.AGENT_HEARTBEAT, data => {
+  console.log('Heartbeat', data);
+});
+
+await bus.publish(Subjects.CREP_UPDATE, { score: 0.9 });
 ```
 
 ## Tests


### PR DESCRIPTION
## Summary
- expand event bus README with subjects and integration sample
- link event bus documentation from the root README and Handbuch

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685b1d07e84c8322a9f50d0a90a13883