### PR TITLE
Add links for coordinator, vision and QA agents

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -97,6 +97,9 @@ console.log(sigil.id); // hello
 - `BewusstseinsResonanzComparator` – Vergleicht Bewusstseins- und Resonanzwerte.
 - `AeonKIResonanzAnalyzer` – Analysiert Resonanzmuster in Gesprächen.
 - `KIBewusstseinResonanzMonitor` – Überwacht Bewusstseins- und Resonanzmetriken.
+- `StrategicAgentCoordinator` – synchronisiert die Agentenliste und schreibt `strategy-overview.json` ([docs/agents/StrategicAgentCoordinator.md](docs/agents/StrategicAgentCoordinator.md))
+- `VisionContextIntegrator` – verteilt die Vision aus `AgentStrategy.md` an alle Agenten ([docs/agents/VisionContextIntegrator.md](docs/agents/VisionContextIntegrator.md))
+- `QualityAssuranceAgent` – führt Lint- und Test-Suites aus ([docs/agents/QualityAssuranceAgent.md](docs/agents/QualityAssuranceAgent.md))
 ### collab-editor
 - `CollaborativeEditor` – Federated Texteditor mit Remote-Sync.
 - `AutomergeFederation` – Verbindet lokale und entfernte Änderungen.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
 - 📄 **Memory Feedback Loops** – Konzept für ein selbstverwaltendes Gedächtnis (`docs/MemoryFeedbackLoops.md`)
 - 🤝 **Friendship System** – Konzept unter `docs/friendship-system.md`
 - 🕸️ **Agent-Registry** – zentrale Übersicht aller Agents (`agents.yaml`)
+- 🧭 **StrategicAgentCoordinator** – synchronisiert AGENTS.md und erstellt eine Strategieübersicht ([docs/agents/StrategicAgentCoordinator.md](docs/agents/StrategicAgentCoordinator.md))
+- 🎯 **VisionContextIntegrator** – verteilt Vision-Kontext an alle Agenten ([docs/agents/VisionContextIntegrator.md](docs/agents/VisionContextIntegrator.md))
+- 🛡 **QualityAssuranceAgent** – führt Lint- und Test-Suites aus ([docs/agents/QualityAssuranceAgent.md](docs/agents/QualityAssuranceAgent.md))
 - 🌀 **SigilStory** – Mandala-Lern-Lebenslauf für C-Tutor & JavaHamster
 - 🎓 **Learning Modules** – interactive C-Tutor and JavaHamster workflows (`packages/tutorials/*`)
 - 🎮 **Gamification API** – Endpunkte `/gamify/badges` & `/gamify/leaderboard`


### PR DESCRIPTION
## Summary
- expand README with new agent links
- mention StrategicAgentCoordinator and others in Handbuch

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685b244ef4f48322af9ad21e1fc19f2b