### PR TITLE
Add Node dev container

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ cd unified-mandala
 pnpm install
 ./scripts/setup-unifiedmandala.sh
 pnpm dev
+docker-compose build ui   # installiert Node-Abh\u00e4ngigkeiten
+docker-compose up ui      # startet Dev-Server
 ./scripts/run-demo.sh # Docker-Compose Quickstart
 # Tests ohne lokale Installation
 docker-compose run test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '3.8'
 services:
   ui:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
     command: pnpm dev
     ports:
       - "3000:3000"


### PR DESCRIPTION
## Summary
- use Dockerfile.dev for ui service so Node dependencies are installed
- document docker-compose usage in quickstart instructions

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685b270f69a4832296f4f314369c6966