### PR TITLE
Add retry and loading to useMetaScores

### DIFF
--- a/apps/sharedream-interface/components/MetaScoreChart.test.tsx
+++ b/apps/sharedream-interface/components/MetaScoreChart.test.tsx
@@ -10,6 +10,8 @@ jest.mock('../hooks/useMetaScores', () => ({
       { id: 'b', value: 0.7 },
     ],
     error: null,
+    loading: false,
+    retry: jest.fn(),
   }),
 }));
 

--- a/apps/sharedream-interface/hooks/useMetaScores.test.ts
+++ b/apps/sharedream-interface/hooks/useMetaScores.test.ts
@@ -13,7 +13,9 @@ afterEach(() => {
 
 test('loads meta scores', async () => {
   const { result } = renderHook(() => useMetaScores());
+  expect(result.current.loading).toBe(true);
   await act(async () => {});
+  expect(result.current.loading).toBe(false);
   expect(result.current.scores[0]).toEqual({ id: 't', value: 0.5 });
   expect(result.current.error).toBeNull();
 });
@@ -23,5 +25,25 @@ test('handles fetch error', async () => {
   const { result } = renderHook(() => useMetaScores());
   await act(async () => {});
   expect(result.current.error).toBe('Fehler beim Laden der Meta-Scores');
+  expect(result.current.loading).toBe(false);
   expect(result.current.scores).toEqual([]);
+});
+
+test('retry fetches scores after failure', async () => {
+  (global as any).fetch = jest.fn(() => Promise.reject('fail'));
+  const { result } = renderHook(() => useMetaScores());
+  await act(async () => {});
+  expect(result.current.error).toBe('Fehler beim Laden der Meta-Scores');
+
+  (global as any).fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve({ scores: [{ id: 'r', value: 0.9 }] }) })
+  );
+
+  await act(async () => {
+    await result.current.retry();
+  });
+
+  expect(result.current.loading).toBe(false);
+  expect(result.current.error).toBeNull();
+  expect(result.current.scores[0]).toEqual({ id: 'r', value: 0.9 });
 });

--- a/apps/sharedream-interface/hooks/useMetaScores.ts
+++ b/apps/sharedream-interface/hooks/useMetaScores.ts
@@ -1,20 +1,33 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export interface MetaScore { id: string; value: number; }
 
 export function useMetaScores() {
   const [scores, setScores] = useState<MetaScore[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
 
-  useEffect(() => {
-    fetch('/api/meta-scores')
+  const fetchScores = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    return fetch('/api/meta-scores')
       .then((res) => res.json())
-      .then((data) => setScores(data.scores || []))
+      .then((data) => {
+        setScores(data.scores || []);
+        setLoading(false);
+      })
       .catch((err) => {
         console.error('Fehler beim Laden der Meta-Scores:', err);
         setError('Fehler beim Laden der Meta-Scores');
+        setLoading(false);
       });
   }, []);
 
-  return { scores, error };
+  useEffect(() => {
+    fetchScores();
+  }, []);
+
+  const retry = () => fetchScores();
+
+  return { scores, error, loading, retry };
 }


### PR DESCRIPTION
## Summary
- track loading state for `useMetaScores` hook
- expose `retry()` for re-fetching scores
- adjust chart test mocking to new hook API
- update `useMetaScores` tests and cover retry logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b2c727ff083228163cb1cdea6daf0