### PR TITLE
Stabilize usePulse test

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-24, in der Zeit des Abend.
+Am 2025-06-24, in der Zeit des Nacht.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Reflexion (Fokus: P)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/GenesisAeonZIPMEM/fe477e54e0305981c08f59d654c8fb00be2b4524/changes.patch
+++ b/GenesisAeonZIPMEM/fe477e54e0305981c08f59d654c8fb00be2b4524/changes.patch
@@ -1,0 +1,23 @@
+commit fe477e54e0305981c08f59d654c8fb00be2b4524
+Author: Codex <codex@openai.com>
+Date:   Tue Jun 24 23:07:07 2025 +0000
+
+    test: stabilize usePulse hook test
+
+diff --git a/packages/bio/__tests__/usePulse.test.tsx b/packages/bio/__tests__/usePulse.test.tsx
+index 7c5b315..e5d993b 100644
+--- a/packages/bio/__tests__/usePulse.test.tsx
++++ b/packages/bio/__tests__/usePulse.test.tsx
+@@ -4,10 +4,12 @@ import { usePulse } from '../usePulse';
+ jest.useFakeTimers();
+ 
+ test('updates pulse over time', () => {
++  const randSpy = jest.spyOn(Math, 'random').mockReturnValue(0.2);
+   const { result } = renderHook(() => usePulse(500));
+   const initial = result.current;
+   act(() => {
+     jest.advanceTimersByTime(500);
+   });
+   expect(result.current).not.toBe(initial);
++  randSpy.mockRestore();
+ });

--- a/GenesisAeonZIPMEM/fe477e54e0305981c08f59d654c8fb00be2b4524/fragments/packages/bio/__tests__/usePulse.test.tsx.patch
+++ b/GenesisAeonZIPMEM/fe477e54e0305981c08f59d654c8fb00be2b4524/fragments/packages/bio/__tests__/usePulse.test.tsx.patch
@@ -1,0 +1,17 @@
+diff --git a/packages/bio/__tests__/usePulse.test.tsx b/packages/bio/__tests__/usePulse.test.tsx
+index 7c5b315..e5d993b 100644
+--- a/packages/bio/__tests__/usePulse.test.tsx
++++ b/packages/bio/__tests__/usePulse.test.tsx
+@@ -4,10 +4,12 @@ import { usePulse } from '../usePulse';
+ jest.useFakeTimers();
+ 
+ test('updates pulse over time', () => {
++  const randSpy = jest.spyOn(Math, 'random').mockReturnValue(0.2);
+   const { result } = renderHook(() => usePulse(500));
+   const initial = result.current;
+   act(() => {
+     jest.advanceTimersByTime(500);
+   });
+   expect(result.current).not.toBe(initial);
++  randSpy.mockRestore();
+ });

--- a/GenesisAeonZIPMEM/fe477e54e0305981c08f59d654c8fb00be2b4524/meta.yaml
+++ b/GenesisAeonZIPMEM/fe477e54e0305981c08f59d654c8fb00be2b4524/meta.yaml
@@ -1,0 +1,10 @@
+commit: fe477e54e0305981c08f59d654c8fb00be2b4524
+message: "test: stabilize usePulse hook test"
+patch: changes.patch
+fragments: fragments
+files:
+  - packages/bio/__tests__/usePulse.test.tsx
+environment:
+  node: v22.16.0
+  pnpm: 10.5.2
+instructions: Apply patch with git apply or review for reference.

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: update progress",
+  "lastCommit": "Merge pull request #316 from GenesisAeon/codex/modify-usemetascores-hook-to-track-loading-state",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/packages/bio/__tests__/usePulse.test.tsx
+++ b/packages/bio/__tests__/usePulse.test.tsx
@@ -4,10 +4,12 @@ import { usePulse } from '../usePulse';
 jest.useFakeTimers();
 
 test('updates pulse over time', () => {
+  const randSpy = jest.spyOn(Math, 'random').mockReturnValue(0.2);
   const { result } = renderHook(() => usePulse(500));
   const initial = result.current;
   act(() => {
     jest.advanceTimersByTime(500);
   });
   expect(result.current).not.toBe(initial);
+  randSpy.mockRestore();
 });


### PR DESCRIPTION
## Summary
- stabilize usePulse hook test by mocking `Math.random`
- store commit memory for this update

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_685b2df3e210832292282cf13c21b121