### PR TITLE
Improve aeon-gpt-synapse error handling

### DIFF
--- a/packages/gpt-bridges/README.md
+++ b/packages/gpt-bridges/README.md
@@ -3,7 +3,9 @@
 Stub-Module zur Kommunikation mit GPT-Diensten.
 
 - **GPTEventHub** – Einfacher EventEmitter auf Basis von mitt
-- **aeon-gpt-synapse.ts** – Sende/Empfange Anfragen an GPT
+- **aeon-gpt-synapse.ts** – Sende/Empfange Anfragen an GPT. Die Funktion
+  `sendToGPT` wiederholt fehlgeschlagene Netzaufrufe bis zu drei Mal und gibt
+  bei endgültigem Fehlschlag eine aussagekräftige Fehlermeldung zurück.
 - **AEONPOET** und **CREPJUDGE** – Platzhalter für spezialisierte GPT-Rollen
 - **GPTConversationLogger** – zeichnet Prompts und Antworten über den EventHub auf
 

--- a/packages/gpt-bridges/aeon-gpt-synapse.test.ts
+++ b/packages/gpt-bridges/aeon-gpt-synapse.test.ts
@@ -1,17 +1,43 @@
 import { sendToGPT } from './aeon-gpt-synapse';
 import { GPTRole } from './gptRoles';
 
-global.fetch = jest.fn(() =>
-  Promise.resolve({
-    ok: true,
-    json: () => Promise.resolve({ response: 'Hallo' })
-  })
-) as any;
+beforeEach(() => {
+  jest.resetAllMocks();
+});
 
 describe('sendToGPT', () => {
   it('sends request and returns response with prefix', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ response: 'Hallo' })
+      })
+    ) as any;
     const result = await sendToGPT({ role: GPTRole.AEON, input: 'test' });
     expect(fetch).toHaveBeenCalled();
     expect(result).toContain('Hallo');
+  });
+
+  it('retries on network failure', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('net'))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ response: 'Hallo' })
+      });
+    global.fetch = mockFetch as any;
+    const result = await sendToGPT({ role: GPTRole.AEON, input: 'test' });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result).toContain('Hallo');
+  });
+
+  it('throws after max retries', async () => {
+    const mockFetch = jest.fn().mockRejectedValue(new Error('offline'));
+    global.fetch = mockFetch as any;
+    await expect(
+      sendToGPT({ role: GPTRole.AEON, input: 'test' })
+    ).rejects.toThrow(/Network request failed/);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/gpt-bridges/aeon-gpt-synapse.ts
+++ b/packages/gpt-bridges/aeon-gpt-synapse.ts
@@ -10,7 +10,10 @@ import { getSymbolzeitPhase } from '../shared-utils/symbolzeitModulator';
 import { loadSymbolphasen } from '../shared-utils/loadSymbolphasen';
 import { isValidRole } from './gptRoles';
 
-export async function sendToGPT(request: GPTRequest): Promise<string> {
+export async function sendToGPT(
+  request: GPTRequest,
+  retries = 2
+): Promise<string> {
   if (!isValidRole(request.role)) {
     throw new Error(`Unbekannte GPT-Rolle: ${request.role}`);
   }
@@ -19,15 +22,26 @@ export async function sendToGPT(request: GPTRequest): Promise<string> {
   const prefix = phases[phaseId]?.phase ? `[${phases[phaseId].phase}] ` : '';
 
   const endpoint = process.env.GPT_ENDPOINT || 'http://localhost:3000/gpt';
-  const response = await fetch(endpoint, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ ...request, phase: phaseId })
-  });
-  if (!response.ok) {
-    throw new Error(`GPT request failed: ${response.status}`);
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...request, phase: phaseId })
+      });
+      if (!response.ok) {
+        throw new Error(`GPT request failed: ${response.status}`);
+      }
+      const data = await response.json();
+      const answer = data.response ?? '';
+      return `${prefix}${answer}`;
+    } catch (err) {
+      if (attempt === retries) {
+        throw new Error(
+          `Network request failed after ${retries + 1} attempts: ${(err as Error).message}`
+        );
+      }
+    }
   }
-  const data = await response.json();
-  const answer = data.response ?? '';
-  return `${prefix}${answer}`;
+  throw new Error('Unreachable');
 }


### PR DESCRIPTION
## Summary
- handle network errors in aeon-gpt-synapse and retry
- test retry logic
- document new behaviour in README

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_685bb01272d0832289f559e9b7fd8ed3