### PR TITLE
Improve file operation error handling

### DIFF
--- a/packages/cli-tools/SigillinOnDemandGenerator.test.ts
+++ b/packages/cli-tools/SigillinOnDemandGenerator.test.ts
@@ -14,3 +14,12 @@ test('saves sigillin file', () => {
   expect(fs.existsSync(file)).toBe(true);
   fs.unlinkSync(file);
 });
+
+test('throws when save fails', () => {
+  const spy = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+    throw new Error('disk full');
+  });
+  const sig = generateSigillin('err');
+  expect(() => saveSigillin(sig, 'fail.json')).toThrow('Failed to write sigillin file');
+  spy.mockRestore();
+});

--- a/packages/cli-tools/SigillinOnDemandGenerator.ts
+++ b/packages/cli-tools/SigillinOnDemandGenerator.ts
@@ -13,5 +13,9 @@ export function generateSigillin(phrase: string): SigillinTemplate {
 }
 
 export function saveSigillin(template: SigillinTemplate, file: string): void {
-  fs.writeFileSync(file, JSON.stringify(template, null, 2), 'utf-8');
+  try {
+    fs.writeFileSync(file, JSON.stringify(template, null, 2), 'utf-8');
+  } catch (err: any) {
+    throw new Error(`Failed to write sigillin file ${file}: ${err.message}`);
+  }
 }

--- a/packages/shared-utils/BackupManager.test.ts
+++ b/packages/shared-utils/BackupManager.test.ts
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import path from 'path';
+import { BackupManager } from './BackupManager';
+
+describe('BackupManager', () => {
+  const tmpDir = path.join(__dirname, '__backup_test');
+  const source = path.join(tmpDir, 'a.txt');
+  const destDir = path.join(tmpDir, 'dest');
+
+  beforeAll(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(source, 'content');
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('copies file to destination', () => {
+    const manager = new BackupManager(destDir);
+    manager.backupFile(source);
+    const target = path.join(destDir, 'a.txt');
+    expect(fs.existsSync(target)).toBe(true);
+  });
+
+  it('throws when copy fails', () => {
+    const spy = jest.spyOn(fs, 'copyFileSync').mockImplementation(() => {
+      throw new Error('fail');
+    });
+    const manager = new BackupManager(destDir);
+    expect(() => manager.backupFile(source)).toThrow('Failed to backup');
+    spy.mockRestore();
+  });
+});

--- a/packages/shared-utils/BackupManager.ts
+++ b/packages/shared-utils/BackupManager.ts
@@ -9,6 +9,10 @@ export class BackupManager {
   backupFile(file: string) {
     const base = path.basename(file);
     const target = path.join(this.dest, base);
-    fs.copyFileSync(file, target);
+    try {
+      fs.copyFileSync(file, target);
+    } catch (err: any) {
+      throw new Error(`Failed to backup ${file} to ${target}: ${err.message}`);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add try/catch around file copying in `BackupManager`
- add try/catch around sigillin saving in `SigillinOnDemandGenerator`
- extend `SigillinOnDemandGenerator` tests for failure cases
- add new `BackupManager` tests for success and failure

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685bb2250008832285e45661879a2ec0