### PR TITLE
Add persistent compile cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ package-lock.json
 docs/sigils/todo-from-convos.yaml
 codex/website.yaml
 mandala-chronik.yaml
+.aeoncache

--- a/packages/aeon-universal/cache.test.ts
+++ b/packages/aeon-universal/cache.test.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import { compile } from './compiler';
 import { compileCache } from './cache';
 
@@ -7,5 +9,24 @@ describe('compile cache', () => {
     const res1 = compile('TASK X');
     const res2 = compile('TASK X');
     expect(res1).toBe(res2);
+  });
+
+  it('persists cached result when enabled', () => {
+    const dir = path.resolve('.aeoncache');
+    if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true, force: true });
+    jest.resetModules();
+    const { compile: firstCompile } = require('./compiler');
+    const { hashSource: hashFn } = require('./cache');
+    const hash = hashFn('SIG Hi');
+    firstCompile('SIG Hi', { persistentCache: true });
+    const file = path.join(dir, `${hash}.json`);
+    expect(fs.existsSync(file)).toBe(true);
+
+    jest.resetModules();
+    const { compile: secondCompile } = require('./compiler');
+    const { AeonSigillinVault: Vault } = require('../core/AeonSigillinVault');
+    const result = secondCompile('SIG Hi', { persistentCache: true });
+    expect(Vault.latest().length).toBe(0);
+    expect(result.tasks.length).toBe(0);
   });
 });

--- a/packages/aeon-universal/cache.ts
+++ b/packages/aeon-universal/cache.ts
@@ -1,19 +1,53 @@
 import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
 import { CompileResult } from './compiler';
 
 class CompileCache {
   private cache = new Map<string, CompileResult>();
+  private persistent = process.env.AEON_PERSIST_CACHE === '1';
+  private cacheDir = path.resolve('.aeoncache');
+
+  setPersistent(enabled: boolean) {
+    this.persistent = enabled;
+    if (this.persistent) {
+      fs.mkdirSync(this.cacheDir, { recursive: true });
+    }
+  }
+
+  private filePath(key: string): string {
+    return path.join(this.cacheDir, `${key}.json`);
+  }
 
   get(key: string): CompileResult | undefined {
-    return this.cache.get(key);
+    const mem = this.cache.get(key);
+    if (mem) return mem;
+    if (this.persistent) {
+      const file = this.filePath(key);
+      if (fs.existsSync(file)) {
+        const data = JSON.parse(fs.readFileSync(file, 'utf8')) as CompileResult;
+        this.cache.set(key, data);
+        return data;
+      }
+    }
+    return undefined;
   }
 
   set(key: string, value: CompileResult): void {
     this.cache.set(key, value);
+    if (this.persistent) {
+      fs.mkdirSync(this.cacheDir, { recursive: true });
+      fs.writeFileSync(this.filePath(key), JSON.stringify(value));
+    }
   }
 
   clear(): void {
     this.cache.clear();
+    if (this.persistent && fs.existsSync(this.cacheDir)) {
+      for (const f of fs.readdirSync(this.cacheDir)) {
+        fs.unlinkSync(path.join(this.cacheDir, f));
+      }
+    }
   }
 }
 

--- a/packages/aeon-universal/compiler.ts
+++ b/packages/aeon-universal/compiler.ts
@@ -23,6 +23,7 @@ export interface CompileOptions {
   hookManager?: HookManager;
   diagnostics?: AeonDiagnostics;
   disableCache?: boolean;
+  persistentCache?: boolean;
 }
 
 export function compile(
@@ -31,6 +32,8 @@ export function compile(
 ): CompileResult {
   AeonMemory.load();
   const hash = hashSource(source);
+  const persist = options.persistentCache ?? process.env.AEON_PERSIST_CACHE === '1';
+  compileCache.setPersistent(persist);
   if (!options.disableCache) {
     const cached = compileCache.get(hash);
     if (cached) {


### PR DESCRIPTION
## Summary
- support persistent caching in `compileCache`
- control persistence with `AEON_PERSIST_CACHE` or `persistentCache` option
- update tests for persistent cache
- ignore `.aeoncache` directory

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685bb7dbfa048322a7f80c56ea69a57b