### PR TITLE
Add pnpm install note and qa pre-check

### DIFF
--- a/GenesisAeonZIPMEM/4dbbca46fea77d4f5d749f868c2b259c6021fcda/changes.patch
+++ b/GenesisAeonZIPMEM/4dbbca46fea77d4f5d749f868c2b259c6021fcda/changes.patch
@@ -1,0 +1,47 @@
+commit 4dbbca46fea77d4f5d749f868c2b259c6021fcda
+Author: Codex <codex@openai.com>
+Date:   Wed Jun 25 11:43:19 2025 +0000
+
+    docs: note pnpm install before qa
+
+diff --git a/Handbuch.md b/Handbuch.md
+index bad62f3..3549a25 100644
+--- a/Handbuch.md
++++ b/Handbuch.md
+@@ -331,6 +331,8 @@ npm run dev   # oder: yarn dev
+ ## QA-Workflow
+ Führe `pnpm run qa` aus, um Linting und Tests zu starten. Das Skript `scripts/qa-test-runner.ts` erstellt im Projektstamm die Datei `qa-report.log`.
+ 
++> **Hinweis:** Stelle sicher, dass du zuvor `pnpm install` ausgeführt hast, bevor du Lint-, Test- oder QA-Befehle startest.
++
+ 
+ 
+ 
+diff --git a/README.md b/README.md
+index 5426b5a..6501e94 100644
+--- a/README.md
++++ b/README.md
+@@ -263,6 +263,8 @@ docker-compose run test
+ pnpm run qa # fuehrt Linting und Tests aus und erzeugt qa-report.log
+ ```
+ 
++> **Hinweis:** Führe vor allen Lint-, Test- oder QA-Befehlen stets `pnpm install` aus, damit `node_modules` vorhanden sind.
++
+ ## 🔄 Systemstart
+ 
+ - Abhängigkeiten installieren: `pnpm install`
+diff --git a/scripts/qa-test-runner.ts b/scripts/qa-test-runner.ts
+index de417d3..2c44573 100755
+--- a/scripts/qa-test-runner.ts
++++ b/scripts/qa-test-runner.ts
+@@ -5,6 +5,10 @@ import fs from 'fs';
+ export function runQA(lintCommand = 'pnpm lint', testCommand = 'pnpm test') {
+   const logFile = 'qa-report.log';
+   const options = { stdio: 'inherit' as const };
++  if (!fs.existsSync('node_modules')) {
++    console.error("node_modules not found. Bitte zuerst 'pnpm install' ausführen.");
++    process.exit(1);
++  }
+   try {
+     execSync(lintCommand, options);
+     execSync(testCommand, options);

--- a/GenesisAeonZIPMEM/4dbbca46fea77d4f5d749f868c2b259c6021fcda/fragments/Handbuch.md.patch
+++ b/GenesisAeonZIPMEM/4dbbca46fea77d4f5d749f868c2b259c6021fcda/fragments/Handbuch.md.patch
@@ -1,0 +1,13 @@
+diff --git a/Handbuch.md b/Handbuch.md
+index bad62f3..3549a25 100644
+--- a/Handbuch.md
++++ b/Handbuch.md
+@@ -331,6 +331,8 @@ npm run dev   # oder: yarn dev
+ ## QA-Workflow
+ Führe `pnpm run qa` aus, um Linting und Tests zu starten. Das Skript `scripts/qa-test-runner.ts` erstellt im Projektstamm die Datei `qa-report.log`.
+ 
++> **Hinweis:** Stelle sicher, dass du zuvor `pnpm install` ausgeführt hast, bevor du Lint-, Test- oder QA-Befehle startest.
++
+ 
+ 
+ 

--- a/GenesisAeonZIPMEM/4dbbca46fea77d4f5d749f868c2b259c6021fcda/fragments/README.md.patch
+++ b/GenesisAeonZIPMEM/4dbbca46fea77d4f5d749f868c2b259c6021fcda/fragments/README.md.patch
@@ -1,0 +1,13 @@
+diff --git a/README.md b/README.md
+index 5426b5a..6501e94 100644
+--- a/README.md
++++ b/README.md
+@@ -263,6 +263,8 @@ docker-compose run test
+ pnpm run qa # fuehrt Linting und Tests aus und erzeugt qa-report.log
+ ```
+ 
++> **Hinweis:** Führe vor allen Lint-, Test- oder QA-Befehlen stets `pnpm install` aus, damit `node_modules` vorhanden sind.
++
+ ## 🔄 Systemstart
+ 
+ - Abhängigkeiten installieren: `pnpm install`

--- a/GenesisAeonZIPMEM/4dbbca46fea77d4f5d749f868c2b259c6021fcda/fragments/scripts/qa-test-runner.ts.patch
+++ b/GenesisAeonZIPMEM/4dbbca46fea77d4f5d749f868c2b259c6021fcda/fragments/scripts/qa-test-runner.ts.patch
@@ -1,0 +1,15 @@
+diff --git a/scripts/qa-test-runner.ts b/scripts/qa-test-runner.ts
+index de417d3..2c44573 100755
+--- a/scripts/qa-test-runner.ts
++++ b/scripts/qa-test-runner.ts
+@@ -5,6 +5,10 @@ import fs from 'fs';
+ export function runQA(lintCommand = 'pnpm lint', testCommand = 'pnpm test') {
+   const logFile = 'qa-report.log';
+   const options = { stdio: 'inherit' as const };
++  if (!fs.existsSync('node_modules')) {
++    console.error("node_modules not found. Bitte zuerst 'pnpm install' ausführen.");
++    process.exit(1);
++  }
+   try {
+     execSync(lintCommand, options);
+     execSync(testCommand, options);

--- a/GenesisAeonZIPMEM/4dbbca46fea77d4f5d749f868c2b259c6021fcda/meta.yaml
+++ b/GenesisAeonZIPMEM/4dbbca46fea77d4f5d749f868c2b259c6021fcda/meta.yaml
@@ -1,0 +1,12 @@
+commit: 4dbbca46fea77d4f5d749f868c2b259c6021fcda
+message: "docs: note pnpm install before qa"
+patch: changes.patch
+fragments: fragments
+files:
+  - Handbuch.md
+  - README.md
+  - scripts/qa-test-runner.ts
+environment:
+  node: v22.16.0
+  pnpm: 10.5.2
+instructions: Apply patch with git apply or review for reference.

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -331,6 +331,8 @@ npm run dev   # oder: yarn dev
 ## QA-Workflow
 Führe `pnpm run qa` aus, um Linting und Tests zu starten. Das Skript `scripts/qa-test-runner.ts` erstellt im Projektstamm die Datei `qa-report.log`.
 
+> **Hinweis:** Stelle sicher, dass du zuvor `pnpm install` ausgeführt hast, bevor du Lint-, Test- oder QA-Befehle startest.
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ docker-compose run test
 pnpm run qa # fuehrt Linting und Tests aus und erzeugt qa-report.log
 ```
 
+> **Hinweis:** Führe vor allen Lint-, Test- oder QA-Befehlen stets `pnpm install` aus, damit `node_modules` vorhanden sind.
+
 ## 🔄 Systemstart
 
 - Abhängigkeiten installieren: `pnpm install`

--- a/scripts/qa-test-runner.ts
+++ b/scripts/qa-test-runner.ts
@@ -5,6 +5,10 @@ import fs from 'fs';
 export function runQA(lintCommand = 'pnpm lint', testCommand = 'pnpm test') {
   const logFile = 'qa-report.log';
   const options = { stdio: 'inherit' as const };
+  if (!fs.existsSync('node_modules')) {
+    console.error("node_modules not found. Bitte zuerst 'pnpm install' ausführen.");
+    process.exit(1);
+  }
   try {
     execSync(lintCommand, options);
     execSync(testCommand, options);


### PR DESCRIPTION
## Summary
- clarify that `pnpm install` is required before QA commands in README and Handbuch
- verify `node_modules` exists in `qa-test-runner` and warn if missing
- store commit memory for reference

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685bdff169f08322b282f75c93f46e37