### PR TITLE
Add agent docs and schema version

### DIFF
--- a/GenesisAeonAdvancedAi/agents.md
+++ b/GenesisAeonAdvancedAi/agents.md
@@ -1,11 +1,13 @@
 # Agents – AeonNeuroNetz
+schema_version: "1.0"
 
 ## Standard Agents
-- **CoreAgent:** Zentrale Steuerung
-- **MembraneAgent:** Symbolische Schnittstelle
-- **AuditAgent:** CREP-Ethik- & Selbstreflexion
+- **CoreAgent:** Zentrale Steuerung ([Dokumentation](../docs/agents/AeonCoreAssembler.md))
+- **MembraneAgent:** Symbolische Schnittstelle ([Dokumentation](../docs/architecture/aeon-universal-neural-membrane.md))
+- **AuditAgent:** CREP-Ethik- & Selbstreflexion ([Dokumentation](../docs/agents/CodexAuditAgent.md))
 
 ## Erweiterte Agents
-- **VisualAgent:** Visualisierung & UI-Steuerung
-- **SoundAgent:** Sonifizierung numerischer Daten
-- **SymbolAgent:** Management symbolischer Bedeutungen
+- **VisualAgent:** Visualisierung & UI-Steuerung ([Dokumentation](../docs/agents/VisualAgent.md))
+- **SoundAgent:** Sonifizierung numerischer Daten ([Dokumentation](../docs/agents/SoundAgent.md))
+- **SymbolAgent:** Management symbolischer Bedeutungen ([Dokumentation](../docs/agents/SymbolAgent.md))
+

--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -184,7 +184,7 @@ todos:
     status: offen
   - id: todo-62
     beschreibung: "Agents.md um schema_version-Feld erweitern"
-    status: offen
+    status: erledigt
   - id: todo-63
     beschreibung: "Rollenverwaltung im PactDepthGatekeeper implementieren"
     status: offen

--- a/docs/agents/SoundAgent.md
+++ b/docs/agents/SoundAgent.md
@@ -1,0 +1,14 @@
+# SoundAgent
+
+## Responsibilities
+- Wandelt numerische Werte in Audiosignale um.
+- Liefert akustisches Feedback für symbolische Ereignisse.
+
+## Parameters
+- `volume` – Ausgabelautstärke zwischen 0.0 und 1.0.
+- `preset` – Optionales Klangpreset.
+
+## Example usage
+```bash
+node sound-agent.js --preset ambient --volume 0.8
+```

--- a/docs/agents/SymbolAgent.md
+++ b/docs/agents/SymbolAgent.md
@@ -1,0 +1,14 @@
+# SymbolAgent
+
+## Responsibilities
+- Verwaltert symbolische Repräsentationen und deren Zuordnungen.
+- Aktualisiert Sigillin-Metadaten für andere Agenten.
+
+## Parameters
+- `sigilPath` – Pfad zu Sigillin-Dateien.
+- `cache` – Aktiviert das Zwischenspeichern von Symbolen.
+
+## Example usage
+```bash
+node symbol-agent.js --sigils ./sigils
+```

--- a/docs/agents/VisualAgent.md
+++ b/docs/agents/VisualAgent.md
@@ -1,0 +1,14 @@
+# VisualAgent
+
+## Responsibilities
+- Visualisiert Datenströme im Mandala-UI und steuert VR-Ansichten.
+- Übersetzt symbolische Zustände in interaktive Grafiken.
+
+## Parameters
+- `canvasId` – DOM‑Element oder Canvas‑Selector.
+- `vrMode` – Aktiviert den VR‑Erlebnisraum.
+
+## Example usage
+```bash
+node visual-agent.js --canvas main --vr
+```


### PR DESCRIPTION
## Summary
- document visual, sound and symbol agents
- link docs in `GenesisAeonAdvancedAi/agents.md`
- add `schema_version` field and mark TODO done

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_685c2782e3a083228299e03ae09ed1e4