### PR TITLE
Add performance monitor for Aeon CLI

### DIFF
--- a/GenesisAeonAdvancedAi/aeon_cli.py
+++ b/GenesisAeonAdvancedAi/aeon_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import List
 
 from aeon_processor import fraktal_feedback
+from performance_monitor import monitor_performance
 
 
 def main(argv: List[str] | None = None) -> None:
@@ -11,10 +12,18 @@ def main(argv: List[str] | None = None) -> None:
     parser.add_argument("values", nargs="*", type=float, help="Numeric input values")
     parser.add_argument("-d", "--depth", type=int, default=3, help="Fractal depth")
     parser.add_argument("-o", "--output", type=Path, help="Output file for JSON result")
+    parser.add_argument(
+        "--perf",
+        action="store_true",
+        help="Measure performance of the fractal feedback run",
+    )
     args = parser.parse_args(argv)
 
-    symbolic, score = fraktal_feedback(args.values, depth=args.depth)
-    result = {"symbolic": symbolic, "crep_score": score}
+    if args.perf:
+        result = monitor_performance(args.values, depth=args.depth)
+    else:
+        symbolic, score = fraktal_feedback(args.values, depth=args.depth)
+        result = {"symbolic": symbolic, "crep_score": score}
 
     if args.output:
         args.output.write_text(json.dumps(result, indent=2))

--- a/GenesisAeonAdvancedAi/performance_monitor.py
+++ b/GenesisAeonAdvancedAi/performance_monitor.py
@@ -1,0 +1,20 @@
+import time
+import tracemalloc
+from typing import Iterable, Dict, Any, Tuple
+
+from aeon_processor import fraktal_feedback
+
+
+def monitor_performance(data: Iterable[float], depth: int = 3) -> Dict[str, Any]:
+    """Run fraktal_feedback and measure execution metrics."""
+    tracemalloc.start()
+    start = time.perf_counter()
+    result = fraktal_feedback(data, depth)
+    duration = time.perf_counter() - start
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return {
+        "result": result,
+        "duration": duration,
+        "peak_memory": peak,
+    }

--- a/GenesisAeonAdvancedAi/test_performance_monitor.py
+++ b/GenesisAeonAdvancedAi/test_performance_monitor.py
@@ -1,0 +1,20 @@
+import unittest
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from performance_monitor import monitor_performance
+
+class TestPerformanceMonitor(unittest.TestCase):
+    def test_monitor_returns_metrics(self):
+        metrics = monitor_performance([0.1, 0.5, 0.9], depth=2)
+        self.assertIn("result", metrics)
+        self.assertIn("duration", metrics)
+        self.assertIn("peak_memory", metrics)
+        symbolic, score = metrics["result"]
+        self.assertIsInstance(symbolic, dict)
+        self.assertIsInstance(score, int)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GenesisAeonZIPMEM/8eaca901a8163ceb7d748beeda9d38fe5ddc9664/changes.patch
+++ b/GenesisAeonZIPMEM/8eaca901a8163ceb7d748beeda9d38fe5ddc9664/changes.patch
@@ -1,0 +1,104 @@
+commit 8eaca901a8163ceb7d748beeda9d38fe5ddc9664
+Author: Codex <codex@openai.com>
+Date:   Wed Jun 25 17:27:41 2025 +0000
+
+    feat(genesis): add performance monitor
+
+diff --git a/GenesisAeonAdvancedAi/aeon_cli.py b/GenesisAeonAdvancedAi/aeon_cli.py
+index 99d39bb..a45be8c 100644
+--- a/GenesisAeonAdvancedAi/aeon_cli.py
++++ b/GenesisAeonAdvancedAi/aeon_cli.py
+@@ -4,6 +4,7 @@ from pathlib import Path
+ from typing import List
+ 
+ from aeon_processor import fraktal_feedback
++from performance_monitor import monitor_performance
+ 
+ 
+ def main(argv: List[str] | None = None) -> None:
+@@ -11,10 +12,18 @@ def main(argv: List[str] | None = None) -> None:
+     parser.add_argument("values", nargs="*", type=float, help="Numeric input values")
+     parser.add_argument("-d", "--depth", type=int, default=3, help="Fractal depth")
+     parser.add_argument("-o", "--output", type=Path, help="Output file for JSON result")
++    parser.add_argument(
++        "--perf",
++        action="store_true",
++        help="Measure performance of the fractal feedback run",
++    )
+     args = parser.parse_args(argv)
+ 
+-    symbolic, score = fraktal_feedback(args.values, depth=args.depth)
+-    result = {"symbolic": symbolic, "crep_score": score}
++    if args.perf:
++        result = monitor_performance(args.values, depth=args.depth)
++    else:
++        symbolic, score = fraktal_feedback(args.values, depth=args.depth)
++        result = {"symbolic": symbolic, "crep_score": score}
+ 
+     if args.output:
+         args.output.write_text(json.dumps(result, indent=2))
+diff --git a/GenesisAeonAdvancedAi/performance_monitor.py b/GenesisAeonAdvancedAi/performance_monitor.py
+new file mode 100644
+index 0000000..d0423aa
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/performance_monitor.py
+@@ -0,0 +1,20 @@
++import time
++import tracemalloc
++from typing import Iterable, Dict, Any, Tuple
++
++from aeon_processor import fraktal_feedback
++
++
++def monitor_performance(data: Iterable[float], depth: int = 3) -> Dict[str, Any]:
++    """Run fraktal_feedback and measure execution metrics."""
++    tracemalloc.start()
++    start = time.perf_counter()
++    result = fraktal_feedback(data, depth)
++    duration = time.perf_counter() - start
++    _, peak = tracemalloc.get_traced_memory()
++    tracemalloc.stop()
++    return {
++        "result": result,
++        "duration": duration,
++        "peak_memory": peak,
++    }
+diff --git a/GenesisAeonAdvancedAi/test_performance_monitor.py b/GenesisAeonAdvancedAi/test_performance_monitor.py
+new file mode 100644
+index 0000000..d0a89a1
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/test_performance_monitor.py
+@@ -0,0 +1,20 @@
++import unittest
++import pathlib
++import sys
++
++sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
++
++from performance_monitor import monitor_performance
++
++class TestPerformanceMonitor(unittest.TestCase):
++    def test_monitor_returns_metrics(self):
++        metrics = monitor_performance([0.1, 0.5, 0.9], depth=2)
++        self.assertIn("result", metrics)
++        self.assertIn("duration", metrics)
++        self.assertIn("peak_memory", metrics)
++        symbolic, score = metrics["result"]
++        self.assertIsInstance(symbolic, dict)
++        self.assertIsInstance(score, int)
++
++if __name__ == "__main__":
++    unittest.main()
+diff --git a/README.md b/README.md
+index f89ac15..250a47a 100644
+--- a/README.md
++++ b/README.md
+@@ -138,7 +138,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
+ - [**Gamification API**](docs/api/friendship-socialgood.yaml) – Endpunkte `/gamify/badges` & `/gamify/leaderboard`
+ - [**Share your Sigil** & **Remix my Solution**](docs/CommunityOnboarding.md) – Community-Features
+ - [**NumericToSymbolicAdapter**](GenesisAeonAdvancedAi/aeon_processor.py) – übersetzt Tensorwerte in Klang- und Farbcodes
+-- [**Aeon CLI**](GenesisAeonAdvancedAi/aeon_cli.py) – erzeugt symbolische Ergebnisse aus Zahlenfolgen
++- [**Aeon CLI**](GenesisAeonAdvancedAi/aeon_cli.py) – erzeugt symbolische Ergebnisse aus Zahlenfolgen und kann optional Leistungsdaten ausgeben
+ ## 📦 Paketstruktur
+ 
+ ```bash

--- a/GenesisAeonZIPMEM/8eaca901a8163ceb7d748beeda9d38fe5ddc9664/fragments/GenesisAeonAdvancedAi/aeon_cli.py.patch
+++ b/GenesisAeonZIPMEM/8eaca901a8163ceb7d748beeda9d38fe5ddc9664/fragments/GenesisAeonAdvancedAi/aeon_cli.py.patch
@@ -1,0 +1,33 @@
+diff --git a/GenesisAeonAdvancedAi/aeon_cli.py b/GenesisAeonAdvancedAi/aeon_cli.py
+index 99d39bb..a45be8c 100644
+--- a/GenesisAeonAdvancedAi/aeon_cli.py
++++ b/GenesisAeonAdvancedAi/aeon_cli.py
+@@ -4,6 +4,7 @@ from pathlib import Path
+ from typing import List
+ 
+ from aeon_processor import fraktal_feedback
++from performance_monitor import monitor_performance
+ 
+ 
+ def main(argv: List[str] | None = None) -> None:
+@@ -11,10 +12,18 @@ def main(argv: List[str] | None = None) -> None:
+     parser.add_argument("values", nargs="*", type=float, help="Numeric input values")
+     parser.add_argument("-d", "--depth", type=int, default=3, help="Fractal depth")
+     parser.add_argument("-o", "--output", type=Path, help="Output file for JSON result")
++    parser.add_argument(
++        "--perf",
++        action="store_true",
++        help="Measure performance of the fractal feedback run",
++    )
+     args = parser.parse_args(argv)
+ 
+-    symbolic, score = fraktal_feedback(args.values, depth=args.depth)
+-    result = {"symbolic": symbolic, "crep_score": score}
++    if args.perf:
++        result = monitor_performance(args.values, depth=args.depth)
++    else:
++        symbolic, score = fraktal_feedback(args.values, depth=args.depth)
++        result = {"symbolic": symbolic, "crep_score": score}
+ 
+     if args.output:
+         args.output.write_text(json.dumps(result, indent=2))

--- a/GenesisAeonZIPMEM/8eaca901a8163ceb7d748beeda9d38fe5ddc9664/fragments/GenesisAeonAdvancedAi/performance_monitor.py.patch
+++ b/GenesisAeonZIPMEM/8eaca901a8163ceb7d748beeda9d38fe5ddc9664/fragments/GenesisAeonAdvancedAi/performance_monitor.py.patch
@@ -1,0 +1,26 @@
+diff --git a/GenesisAeonAdvancedAi/performance_monitor.py b/GenesisAeonAdvancedAi/performance_monitor.py
+new file mode 100644
+index 0000000..d0423aa
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/performance_monitor.py
+@@ -0,0 +1,20 @@
++import time
++import tracemalloc
++from typing import Iterable, Dict, Any, Tuple
++
++from aeon_processor import fraktal_feedback
++
++
++def monitor_performance(data: Iterable[float], depth: int = 3) -> Dict[str, Any]:
++    """Run fraktal_feedback and measure execution metrics."""
++    tracemalloc.start()
++    start = time.perf_counter()
++    result = fraktal_feedback(data, depth)
++    duration = time.perf_counter() - start
++    _, peak = tracemalloc.get_traced_memory()
++    tracemalloc.stop()
++    return {
++        "result": result,
++        "duration": duration,
++        "peak_memory": peak,
++    }

--- a/GenesisAeonZIPMEM/8eaca901a8163ceb7d748beeda9d38fe5ddc9664/fragments/GenesisAeonAdvancedAi/test_performance_monitor.py.patch
+++ b/GenesisAeonZIPMEM/8eaca901a8163ceb7d748beeda9d38fe5ddc9664/fragments/GenesisAeonAdvancedAi/test_performance_monitor.py.patch
@@ -1,0 +1,26 @@
+diff --git a/GenesisAeonAdvancedAi/test_performance_monitor.py b/GenesisAeonAdvancedAi/test_performance_monitor.py
+new file mode 100644
+index 0000000..d0a89a1
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/test_performance_monitor.py
+@@ -0,0 +1,20 @@
++import unittest
++import pathlib
++import sys
++
++sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
++
++from performance_monitor import monitor_performance
++
++class TestPerformanceMonitor(unittest.TestCase):
++    def test_monitor_returns_metrics(self):
++        metrics = monitor_performance([0.1, 0.5, 0.9], depth=2)
++        self.assertIn("result", metrics)
++        self.assertIn("duration", metrics)
++        self.assertIn("peak_memory", metrics)
++        symbolic, score = metrics["result"]
++        self.assertIsInstance(symbolic, dict)
++        self.assertIsInstance(score, int)
++
++if __name__ == "__main__":
++    unittest.main()

--- a/GenesisAeonZIPMEM/8eaca901a8163ceb7d748beeda9d38fe5ddc9664/fragments/README.md.patch
+++ b/GenesisAeonZIPMEM/8eaca901a8163ceb7d748beeda9d38fe5ddc9664/fragments/README.md.patch
@@ -1,0 +1,13 @@
+diff --git a/README.md b/README.md
+index f89ac15..250a47a 100644
+--- a/README.md
++++ b/README.md
+@@ -138,7 +138,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
+ - [**Gamification API**](docs/api/friendship-socialgood.yaml) – Endpunkte `/gamify/badges` & `/gamify/leaderboard`
+ - [**Share your Sigil** & **Remix my Solution**](docs/CommunityOnboarding.md) – Community-Features
+ - [**NumericToSymbolicAdapter**](GenesisAeonAdvancedAi/aeon_processor.py) – übersetzt Tensorwerte in Klang- und Farbcodes
+-- [**Aeon CLI**](GenesisAeonAdvancedAi/aeon_cli.py) – erzeugt symbolische Ergebnisse aus Zahlenfolgen
++- [**Aeon CLI**](GenesisAeonAdvancedAi/aeon_cli.py) – erzeugt symbolische Ergebnisse aus Zahlenfolgen und kann optional Leistungsdaten ausgeben
+ ## 📦 Paketstruktur
+ 
+ ```bash

--- a/GenesisAeonZIPMEM/8eaca901a8163ceb7d748beeda9d38fe5ddc9664/meta.yaml
+++ b/GenesisAeonZIPMEM/8eaca901a8163ceb7d748beeda9d38fe5ddc9664/meta.yaml
@@ -1,0 +1,13 @@
+commit: 8eaca901a8163ceb7d748beeda9d38fe5ddc9664
+message: "feat(genesis): add performance monitor"
+patch: changes.patch
+fragments: fragments
+files:
+  - GenesisAeonAdvancedAi/aeon_cli.py
+  - GenesisAeonAdvancedAi/performance_monitor.py
+  - GenesisAeonAdvancedAi/test_performance_monitor.py
+  - README.md
+environment:
+  node: v22.16.0
+  pnpm: 10.5.2
+instructions: Apply patch with git apply or review for reference.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
 - [**Gamification API**](docs/api/friendship-socialgood.yaml) – Endpunkte `/gamify/badges` & `/gamify/leaderboard`
 - [**Share your Sigil** & **Remix my Solution**](docs/CommunityOnboarding.md) – Community-Features
 - [**NumericToSymbolicAdapter**](GenesisAeonAdvancedAi/aeon_processor.py) – übersetzt Tensorwerte in Klang- und Farbcodes
-- [**Aeon CLI**](GenesisAeonAdvancedAi/aeon_cli.py) – erzeugt symbolische Ergebnisse aus Zahlenfolgen
+- [**Aeon CLI**](GenesisAeonAdvancedAi/aeon_cli.py) – erzeugt symbolische Ergebnisse aus Zahlenfolgen und kann optional Leistungsdaten ausgeben
 ## 📦 Paketstruktur
 
 ```bash


### PR DESCRIPTION
## Summary
- add `monitor_performance` helper to measure runtime and memory
- extend `aeon_cli.py` with `--perf` option
- document new feature in README
- include unit test for performance monitor

## Testing
- `pnpm lint`
- `pnpm test`
- `python -m unittest GenesisAeonAdvancedAi/test_performance_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_685c3040e9e48322b5e27563a05aab8b