### PR TITLE
Add memory store for AEON CLI

### DIFF
--- a/GenesisAeonAdvancedAi/aeon_cli.py
+++ b/GenesisAeonAdvancedAi/aeon_cli.py
@@ -5,6 +5,7 @@ from typing import List
 
 from aeon_processor import fraktal_feedback
 from performance_monitor import monitor_performance
+from memory_store import store_result
 
 
 def main(argv: List[str] | None = None) -> None:
@@ -12,6 +13,11 @@ def main(argv: List[str] | None = None) -> None:
     parser.add_argument("values", nargs="*", type=float, help="Numeric input values")
     parser.add_argument("-d", "--depth", type=int, default=3, help="Fractal depth")
     parser.add_argument("-o", "--output", type=Path, help="Output file for JSON result")
+    parser.add_argument(
+        "--memory",
+        type=Path,
+        help="Append result to a persistent memory JSON file",
+    )
     parser.add_argument(
         "--perf",
         action="store_true",
@@ -29,6 +35,9 @@ def main(argv: List[str] | None = None) -> None:
         args.output.write_text(json.dumps(result, indent=2))
     else:
         print(json.dumps(result, indent=2))
+
+    if args.memory:
+        store_result(result, args.memory)
 
 
 if __name__ == "__main__":

--- a/GenesisAeonAdvancedAi/memory_store.py
+++ b/GenesisAeonAdvancedAi/memory_store.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def store_result(result: Dict[str, Any], path: Path) -> None:
+    """Append result to a JSON list stored at path."""
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError:
+            data = []
+    else:
+        data = []
+    data.append(result)
+    path.write_text(json.dumps(data, indent=2))

--- a/GenesisAeonAdvancedAi/test_memory_store.py
+++ b/GenesisAeonAdvancedAi/test_memory_store.py
@@ -1,0 +1,27 @@
+import unittest
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from memory_store import store_result
+
+
+class TestMemoryStore(unittest.TestCase):
+    def test_store_appends(self):
+        path = pathlib.Path('temp_mem.json')
+        if path.exists():
+            path.unlink()
+        store_result({'a': 1}, path)
+        self.assertTrue(path.exists())
+        data = json.loads(path.read_text())
+        self.assertEqual(len(data), 1)
+        store_result({'b': 2}, path)
+        data = json.loads(path.read_text())
+        self.assertEqual(len(data), 2)
+        path.unlink()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `aeon_cli.py` with a `--memory` option
- persist CLI results with new `memory_store.py`
- cover persistence logic with `test_memory_store.py`

## Testing
- `python -m unittest GenesisAeonAdvancedAi/test_performance_monitor.py GenesisAeonAdvancedAi/test_memory_store.py`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685c335ae81c8322bae259ab226b19e2