### PR TITLE
Add Trikaya factorization

### DIFF
--- a/GenesisAeonAdvancedAi/Trikaya.md
+++ b/GenesisAeonAdvancedAi/Trikaya.md
@@ -1,0 +1,16 @@
+# Trikaya-Faktorisierung
+
+Das CREP-System liefert numerische Bewertungen von -1 bis 1. Diese Werte werden
+in drei grundlegende Bewusstseinszustände übersetzt:
+
+| CREP-Wert | Zustand    |
+|-----------|-----------|
+| 1         | PRÄSENZ    |
+| 0         | LEERE      |
+| -1        | AUFLÖSUNG  |
+
+Weitere Werte werden als **UNBEKANNT** eingestuft.
+
+Das Modul `trikaya.py` stellt die Funktion `trikaya_state` bereit, die diese
+Abbildung übernimmt und in `aeon_cli.py` genutzt wird.
+

--- a/GenesisAeonAdvancedAi/aeon_cli.py
+++ b/GenesisAeonAdvancedAi/aeon_cli.py
@@ -6,6 +6,7 @@ from typing import List
 from aeon_processor import fraktal_feedback
 from performance_monitor import monitor_performance
 from memory_store import store_result
+from trikaya import trikaya_state
 
 
 def main(argv: List[str] | None = None) -> None:
@@ -29,7 +30,11 @@ def main(argv: List[str] | None = None) -> None:
         result = monitor_performance(args.values, depth=args.depth)
     else:
         symbolic, score = fraktal_feedback(args.values, depth=args.depth)
-        result = {"symbolic": symbolic, "crep_score": score}
+        result = {
+            "symbolic": symbolic,
+            "crep_score": score,
+            "trikaya_state": trikaya_state(score),
+        }
 
     if args.output:
         args.output.write_text(json.dumps(result, indent=2))

--- a/GenesisAeonAdvancedAi/test_trikaya.py
+++ b/GenesisAeonAdvancedAi/test_trikaya.py
@@ -1,0 +1,15 @@
+import unittest
+from trikaya import trikaya_state
+
+
+class TestTrikaya(unittest.TestCase):
+    def test_mapping(self):
+        self.assertEqual(trikaya_state(1), "PRÄSENZ")
+        self.assertEqual(trikaya_state(0), "LEERE")
+        self.assertEqual(trikaya_state(-1), "AUFLÖSUNG")
+        self.assertEqual(trikaya_state(2), "UNBEKANNT")
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/GenesisAeonAdvancedAi/trikaya.py
+++ b/GenesisAeonAdvancedAi/trikaya.py
@@ -1,0 +1,18 @@
+"""Trikaya factorization utilities."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+
+TRIKAYA_STATES = {
+    1: "PRÄSENZ",
+    0: "LEERE",
+    -1: "AUFLÖSUNG",
+}
+
+
+def trikaya_state(score: int) -> Literal["PRÄSENZ", "LEERE", "AUFLÖSUNG", "UNBEKANNT"]:
+    """Map a CREP score to a Trikaya state."""
+    return TRIKAYA_STATES.get(score, "UNBEKANNT")
+


### PR DESCRIPTION
## Summary
- map CREP scores to Trikaya states
- expose factorization with `trikaya_state`
- include Trikaya output in `aeon_cli`
- document the mapping
- test `trikaya` module

## Testing
- `npm run lint`
- `npm test`
- `python -m unittest GenesisAeonAdvancedAi/test_memory_store.py GenesisAeonAdvancedAi/test_performance_monitor.py GenesisAeonAdvancedAi/test_trikaya.py`

------
https://chatgpt.com/codex/tasks/task_e_685c354787808322aa4200f9d47a9a9d