### PR TITLE
Add input file option to Aeon CLI

### DIFF
--- a/GenesisAeonAdvancedAi/aeon_cli.py
+++ b/GenesisAeonAdvancedAi/aeon_cli.py
@@ -11,7 +11,15 @@ from trikaya import trikaya_state
 
 def main(argv: List[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Run Aeon fractal feedback")
-    parser.add_argument("values", nargs="*", type=float, help="Numeric input values")
+    parser.add_argument(
+        "values", nargs="*", type=float, help="Numeric input values"
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=Path,
+        help="Path to file containing whitespace separated numeric values",
+    )
     parser.add_argument("-d", "--depth", type=int, default=3, help="Fractal depth")
     parser.add_argument("-o", "--output", type=Path, help="Output file for JSON result")
     parser.add_argument(
@@ -26,10 +34,16 @@ def main(argv: List[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
+    values = list(args.values)
+    if args.input:
+        text = args.input.read_text().strip()
+        if text:
+            values.extend(float(t) for t in text.split())
+
     if args.perf:
-        result = monitor_performance(args.values, depth=args.depth)
+        result = monitor_performance(values, depth=args.depth)
     else:
-        symbolic, score = fraktal_feedback(args.values, depth=args.depth)
+        symbolic, score = fraktal_feedback(values, depth=args.depth)
         result = {
             "symbolic": symbolic,
             "crep_score": score,

--- a/GenesisAeonAdvancedAi/test_cli.py
+++ b/GenesisAeonAdvancedAi/test_cli.py
@@ -1,0 +1,21 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestAeonCLI(unittest.TestCase):
+    def test_input_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "vals.txt"
+            input_path.write_text("0.1 0.2 0.3")
+            result = subprocess.run(
+                [sys.executable, "aeon_cli.py", "--input", str(input_path), "-d", "2"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            data = json.loads(result.stdout)
+            self.assertTrue("symbolic" in data or "result" in data)


### PR DESCRIPTION
## Summary
- extend `aeon_cli` to load numeric values from a file via `--input`
- add unit test for new CLI option

## Testing
- `python -m unittest discover -v`
- `pnpm run qa`

------
https://chatgpt.com/codex/tasks/task_e_685c36b555e48322a28703d8cdff95a9