### PR TITLE
Add memory loader and CLI option

### DIFF
--- a/GenesisAeonAdvancedAi/aeon_cli.py
+++ b/GenesisAeonAdvancedAi/aeon_cli.py
@@ -5,7 +5,7 @@ from typing import List
 
 from aeon_processor import fraktal_feedback
 from performance_monitor import monitor_performance
-from memory_store import store_result
+from memory_store import store_result, load_results
 from trikaya import trikaya_state
 
 
@@ -28,11 +28,23 @@ def main(argv: List[str] | None = None) -> None:
         help="Append result to a persistent memory JSON file",
     )
     parser.add_argument(
+        "--show-memory",
+        action="store_true",
+        help="Display stored memory results and exit (requires --memory)",
+    )
+    parser.add_argument(
         "--perf",
         action="store_true",
         help="Measure performance of the fractal feedback run",
     )
     args = parser.parse_args(argv)
+
+    if args.show_memory:
+        if not args.memory:
+            parser.error("--show-memory requires --memory")
+        results = load_results(args.memory)
+        print(json.dumps(results, indent=2))
+        return
 
     values = list(args.values)
     if args.input:

--- a/GenesisAeonAdvancedAi/memory_store.py
+++ b/GenesisAeonAdvancedAi/memory_store.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 
 def store_result(result: Dict[str, Any], path: Path) -> None:
@@ -14,5 +15,18 @@ def store_result(result: Dict[str, Any], path: Path) -> None:
             data = []
     else:
         data = []
-    data.append(result)
+
+    entry = dict(result)
+    entry.setdefault("timestamp", time.time())
+    data.append(entry)
     path.write_text(json.dumps(data, indent=2))
+
+
+def load_results(path: Path) -> List[Dict[str, Any]]:
+    """Load list of stored results or return empty list."""
+    if path.exists():
+        try:
+            return json.loads(path.read_text())
+        except json.JSONDecodeError:
+            return []
+    return []

--- a/GenesisAeonAdvancedAi/test_memory_store.py
+++ b/GenesisAeonAdvancedAi/test_memory_store.py
@@ -5,7 +5,7 @@ import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
-from memory_store import store_result
+from memory_store import store_result, load_results
 
 
 class TestMemoryStore(unittest.TestCase):
@@ -20,6 +20,17 @@ class TestMemoryStore(unittest.TestCase):
         store_result({'b': 2}, path)
         data = json.loads(path.read_text())
         self.assertEqual(len(data), 2)
+        path.unlink()
+
+    def test_load_results(self):
+        path = pathlib.Path('temp_mem.json')
+        if path.exists():
+            path.unlink()
+        store_result({'x': 1}, path)
+        store_result({'y': 2}, path)
+        results = load_results(path)
+        self.assertEqual(len(results), 2)
+        self.assertIsInstance(results[0], dict)
         path.unlink()
 
 


### PR DESCRIPTION
## Summary
- enhance `memory_store` with timestamps and `load_results`
- update CLI to show stored memory on demand
- test new memory loading logic

## Testing
- `pnpm test`
- `cd GenesisAeonAdvancedAi && python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_685c396c98d483229b869d9f6f6dda88