### PR TITLE
Add sigil loader and CLI integration

### DIFF
--- a/GenesisAeonAdvancedAi/aeon_cli.py
+++ b/GenesisAeonAdvancedAi/aeon_cli.py
@@ -6,6 +6,7 @@ from typing import List
 from aeon_processor import fraktal_feedback
 from performance_monitor import monitor_performance
 from memory_store import store_result, load_results
+from sigil_loader import load_sigil
 from trikaya import trikaya_state
 
 
@@ -33,6 +34,11 @@ def main(argv: List[str] | None = None) -> None:
         help="Display stored memory results and exit (requires --memory)",
     )
     parser.add_argument(
+        "--sigil",
+        type=Path,
+        help="Path to a sigil JSON file to include in the output",
+    )
+    parser.add_argument(
         "--perf",
         action="store_true",
         help="Measure performance of the fractal feedback run",
@@ -52,8 +58,14 @@ def main(argv: List[str] | None = None) -> None:
         if text:
             values.extend(float(t) for t in text.split())
 
+    sigil_data = None
+    if args.sigil:
+        sigil_data = load_sigil(args.sigil)
+
     if args.perf:
         result = monitor_performance(values, depth=args.depth)
+        if sigil_data is not None:
+            result["sigil"] = sigil_data
     else:
         symbolic, score = fraktal_feedback(values, depth=args.depth)
         result = {
@@ -61,6 +73,8 @@ def main(argv: List[str] | None = None) -> None:
             "crep_score": score,
             "trikaya_state": trikaya_state(score),
         }
+        if sigil_data is not None:
+            result["sigil"] = sigil_data
 
     if args.output:
         args.output.write_text(json.dumps(result, indent=2))

--- a/GenesisAeonAdvancedAi/sigil_loader.py
+++ b/GenesisAeonAdvancedAi/sigil_loader.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def load_sigil(path: Path) -> Dict[str, Any]:
+    """Load sigil JSON file and return parsed data.
+
+    Parameters
+    ----------
+    path:
+        Path to a JSON file containing a sigil structure.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Sigil file not found: {path}")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid sigil JSON: {e}")

--- a/GenesisAeonAdvancedAi/test_cli.py
+++ b/GenesisAeonAdvancedAi/test_cli.py
@@ -11,11 +11,28 @@ class TestAeonCLI(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             input_path = Path(tmpdir) / "vals.txt"
             input_path.write_text("0.1 0.2 0.3")
+            cli_path = Path(__file__).resolve().parent / "aeon_cli.py"
             result = subprocess.run(
-                [sys.executable, "aeon_cli.py", "--input", str(input_path), "-d", "2"],
+                [sys.executable, str(cli_path), "--input", str(input_path), "-d", "2"],
                 capture_output=True,
                 text=True,
                 check=True,
             )
             data = json.loads(result.stdout)
             self.assertTrue("symbolic" in data or "result" in data)
+
+    def test_with_sigil(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "vals.txt"
+            input_path.write_text("0.1")
+            sigil_path = Path(tmpdir) / "sigil.json"
+            sigil_path.write_text('{"sigillin": {"id": "TEST"}}')
+            cli_path = Path(__file__).resolve().parent / "aeon_cli.py"
+            result = subprocess.run(
+                [sys.executable, str(cli_path), "--input", str(input_path), "--sigil", str(sigil_path)],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            data = json.loads(result.stdout)
+            self.assertIn("sigil", data)

--- a/GenesisAeonAdvancedAi/test_sigil_loader.py
+++ b/GenesisAeonAdvancedAi/test_sigil_loader.py
@@ -1,0 +1,30 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from sigil_loader import load_sigil
+
+
+class TestSigilLoader(unittest.TestCase):
+    def test_load_valid(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "sigil.json"
+            path.write_text('{"sigillin": {"id": "TEST"}}')
+            data = load_sigil(path)
+            self.assertIn("sigillin", data)
+
+    def test_missing_file(self):
+        with self.assertRaises(FileNotFoundError):
+            load_sigil(Path("nonexistent.json"))
+
+    def test_invalid_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "bad.json"
+            path.write_text('{invalid}')
+            with self.assertRaises(ValueError):
+                load_sigil(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend Aeon CLI with `--sigil` option
- support parsing sigil JSON files
- test CLI sigil behaviour and new loader

## Testing
- `pnpm lint`
- `pnpm test`
- `python -m unittest discover GenesisAeonAdvancedAi`

------
https://chatgpt.com/codex/tasks/task_e_685c3e7dba6c8322a270eb9589d8ccdb