### PR TITLE
Enhance Aeon symbol mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,7 @@ Alle relevanten Änderungen dieses Projekts werden in diesem Dokument festgehalt
 
 ## [0.1.0] - 2024-04-10
 - Initiale Struktur mit Mandala-Komponenten.
+
+## [Unreleased]
+- Verfeinerte Symbolzuordnung in `aeon_processor.assign_symbol`
+  für differenziertere Ausgabe.

--- a/GenesisAeonAdvancedAi/aeon_processor.py
+++ b/GenesisAeonAdvancedAi/aeon_processor.py
@@ -16,10 +16,24 @@ def visualize_light(values: Iterable[float]) -> list[str]:
 
 
 def assign_symbol(values: Iterable[float]) -> str:
-    """Assign a symbolic marker based on the average value."""
+    """Assign a symbolic marker based on the average value.
+
+    Mapping inspired by project guidelines:
+    - avg > 0.8 → sun symbol (☀️)
+    - avg > 0.5 → growth symbol (🌱)
+    - avg > 0.2 → fluid symbol (💧)
+    - otherwise → void symbol (⚫)
+    """
     vals = list(values)
     avg = sum(vals) / len(vals) if vals else 0
-    return "\u2605" if avg > 0.5 else "\u25CF"
+    if avg > 0.8:
+        return "\u2600"  # ☀️
+    elif avg > 0.5:
+        return "\U0001F331"  # 🌱
+    elif avg > 0.2:
+        return "\U0001F4A7"  # 💧
+    else:
+        return "\u26AB"  # ⚫
 
 
 def translate_numeric_to_symbolic(tensor: Iterable[float]) -> Dict[str, Any]:

--- a/GenesisAeonAdvancedAi/test_aeon_processor.py
+++ b/GenesisAeonAdvancedAi/test_aeon_processor.py
@@ -1,0 +1,15 @@
+import unittest
+
+from aeon_processor import assign_symbol
+
+
+class TestAssignSymbol(unittest.TestCase):
+    def test_symbol_thresholds(self):
+        self.assertEqual(assign_symbol([0.9]), "\u2600")
+        self.assertEqual(assign_symbol([0.6]), "\U0001F331")
+        self.assertEqual(assign_symbol([0.3]), "\U0001F4A7")
+        self.assertEqual(assign_symbol([0.1]), "\u26AB")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enrich `assign_symbol` with multi-tier emoji mapping for clearer output
- cover new behavior in unit tests
- document change in `CHANGELOG`

## Testing
- `pytest GenesisAeonAdvancedAi`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c42a79654832289de39f5c50e86e7