### PR TITLE
Add AeonAgent with persistence

### DIFF
--- a/GenesisAeonAdvancedAi/aeon_agent.py
+++ b/GenesisAeonAdvancedAi/aeon_agent.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Dict, Any, List
+
+from aeon_processor import fraktal_feedback_metrics
+from trikaya import trikaya_state
+from memory_store import store_result
+
+
+class AeonAgent:
+    """Simple agent orchestrating fractal feedback and storing results."""
+
+    def __init__(self, memory: List[Dict[str, Any]] | None = None) -> None:
+        self.memory: List[Dict[str, Any]] = list(memory) if memory else []
+
+    def act(self, input_values: Iterable[float], depth: int = 3) -> tuple[str, Dict[str, Any]]:
+        """Process input and decide an action.
+
+        Parameters
+        ----------
+        input_values:
+            Iterable of numeric values.
+        depth:
+            Depth for the fractal feedback loop.
+        Returns
+        -------
+        Tuple of chosen action string and the stored record.
+        """
+        symbolic, score, metrics = fraktal_feedback_metrics(
+            list(input_values), depth=depth, prev_states=self.memory[-1:] if self.memory else None
+        )
+        record = {
+            "symbolic": symbolic,
+            "crep_score": score,
+            "metrics": metrics,
+            "trikaya_state": trikaya_state(score),
+        }
+        action = "Beobachten"
+        if score == 1:
+            action = "Kooperation anbieten"
+        elif score == -1:
+            action = "Selbst-Reset"
+        record["action"] = action
+        self.memory.append(record)
+        return action, record
+
+    def persist(self, path: Path) -> None:
+        """Persist memory to a JSON file using :func:`store_result`."""
+        for entry in self.memory:
+            store_result(entry, path)

--- a/GenesisAeonAdvancedAi/test_aeon_agent.py
+++ b/GenesisAeonAdvancedAi/test_aeon_agent.py
@@ -1,0 +1,28 @@
+import unittest
+import pathlib
+
+from aeon_agent import AeonAgent
+
+
+class TestAeonAgent(unittest.TestCase):
+    def test_act_records_memory(self):
+        agent = AeonAgent()
+        action, record = agent.act([0.1, 0.5, 0.9], depth=2)
+        self.assertEqual(len(agent.memory), 1)
+        self.assertIs(record, agent.memory[0])
+        self.assertIn("action", record)
+        self.assertIn("crep_score", record)
+
+    def test_persist(self):
+        agent = AeonAgent()
+        agent.act([0.1])
+        path = pathlib.Path('aeon_agent_mem.json')
+        if path.exists():
+            path.unlink()
+        agent.persist(path)
+        self.assertTrue(path.exists())
+        path.unlink()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `AeonAgent` class that wraps fractal feedback and stores results
- test AeonAgent behaviour and persistence
- run `pnpm store:commit-memory` after commit

## Testing
- `pytest GenesisAeonAdvancedAi -q`
- `pnpm store:commit-memory`

------
https://chatgpt.com/codex/tasks/task_e_685c480688e883229001cf8f73bf7476