### PR TITLE
Improve CREP resonance metric

### DIFF
--- a/GenesisAeonAdvancedAi/aeon_processor.py
+++ b/GenesisAeonAdvancedAi/aeon_processor.py
@@ -2,6 +2,21 @@ from typing import Iterable, Dict, Any, List
 from statistics import variance, mean
 
 
+def pearson_corr(xs: List[float], ys: List[float]) -> float:
+    """Return Pearson correlation coefficient for two equal-length lists."""
+    n = len(xs)
+    if n != len(ys) or n == 0:
+        return 0.0
+    mean_x = sum(xs) / n
+    mean_y = sum(ys) / n
+    num = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    den_x = sum((x - mean_x) ** 2 for x in xs) ** 0.5
+    den_y = sum((y - mean_y) ** 2 for y in ys) ** 0.5
+    if den_x == 0 or den_y == 0:
+        return 0.0
+    return num / (den_x * den_y)
+
+
 def sonify(values: Iterable[float]) -> list[float]:
     """Map numeric values to simple tone frequencies."""
     return [440.0 + v * 40.0 for v in values]
@@ -76,13 +91,10 @@ def advanced_crep_eval(
 
     resonance = 0.0
     if prev_states:
-        prev = prev_states[-1].get("klang", [])
+        prev = [float(f) for f in prev_states[-1].get("klang", [])]
         m = min(len(prev), len(klang))
         if m:
-            prev_avg = mean(prev[:m])
-            curr_avg = mean(klang[:m])
-            denom = max(abs(prev_avg), abs(curr_avg), 1)
-            resonance = 1.0 - abs(curr_avg - prev_avg) / denom
+            resonance = pearson_corr(prev[:m], klang[:m])
 
     emergence = (
         mean(abs(klang[i] - klang[i - 1]) for i in range(1, len(klang)))

--- a/GenesisAeonAdvancedAi/test_advanced_crep.py
+++ b/GenesisAeonAdvancedAi/test_advanced_crep.py
@@ -16,5 +16,17 @@ class TestAdvancedCREP(unittest.TestCase):
         self.assertIsInstance(metrics, dict)
         self.assertIn("präsenz", metrics)
 
+    def test_resonance_correlation(self):
+        prev = translate_numeric_to_symbolic([0.1, 0.2, 0.3])
+        curr = translate_numeric_to_symbolic([0.1, 0.2, 0.3])
+        metrics = advanced_crep_eval(curr, [prev])
+        self.assertAlmostEqual(metrics["resonanz"], 1.0, places=5)
+
+    def test_resonance_negative(self):
+        prev = translate_numeric_to_symbolic([0.1, 0.2, 0.3])
+        curr = translate_numeric_to_symbolic([0.3, 0.2, 0.1])
+        metrics = advanced_crep_eval(curr, [prev])
+        self.assertAlmostEqual(round(metrics["resonanz"], 5), -1.0)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- refine `advanced_crep_eval` to compute resonance via Pearson correlation
- add `pearson_corr` helper
- extend tests for correlation scenarios

## Testing
- `pnpm lint`
- `pnpm test`
- `python -m pytest GenesisAeonAdvancedAi`

------
https://chatgpt.com/codex/tasks/task_e_685c4c3021c88322a2bc39d3055ddd18