### PR TITLE
Add YAML fallback warning in Aeon CLI

### DIFF
--- a/GenesisAeonAdvancedAi/aeon_cli.py
+++ b/GenesisAeonAdvancedAi/aeon_cli.py
@@ -2,13 +2,26 @@ import argparse
 import json
 from pathlib import Path
 from typing import List
-import yaml
+try:
+    import yaml
+    _HAS_YAML = True
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
+    _HAS_YAML = False
 
 from aeon_processor import fraktal_feedback, fraktal_feedback_metrics
 from performance_monitor import monitor_performance
 from memory_store import store_result, load_results
 from sigil_loader import load_sigil
 from trikaya import trikaya_state
+
+
+def dump_yaml(data: dict) -> str:
+    """Return YAML if available or JSON as fallback with a warning."""
+    if not _HAS_YAML:
+        print("PyYAML not installed; using JSON")
+        return json.dumps(data, indent=2)
+    return yaml.safe_dump(data, allow_unicode=True, sort_keys=False)
 
 
 def main(argv: List[str] | None = None) -> None:
@@ -95,7 +108,7 @@ def main(argv: List[str] | None = None) -> None:
             result["sigil"] = sigil_data
 
     if args.yaml:
-        text_output = yaml.safe_dump(result, allow_unicode=True, sort_keys=False)
+        text_output = dump_yaml(result)
     else:
         text_output = json.dumps(result, indent=2)
 

--- a/GenesisAeonAdvancedAi/test_cli.py
+++ b/GenesisAeonAdvancedAi/test_cli.py
@@ -4,6 +4,13 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+import importlib.util
+
+try:
+    import yaml  # type: ignore
+    HAS_YAML = True
+except Exception:
+    HAS_YAML = False
 
 
 class TestAeonCLI(unittest.TestCase):
@@ -37,6 +44,7 @@ class TestAeonCLI(unittest.TestCase):
             data = json.loads(result.stdout)
             self.assertIn("sigil", data)
 
+    @unittest.skipUnless(HAS_YAML, "PyYAML not installed")
     def test_yaml_output(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             input_path = Path(tmpdir) / "vals.txt"
@@ -48,9 +56,9 @@ class TestAeonCLI(unittest.TestCase):
                 text=True,
                 check=True,
             )
-            import yaml
-            data = yaml.safe_load(result.stdout)
-            self.assertTrue("symbolic" in data or "result" in data)
+            if HAS_YAML:
+                data = yaml.safe_load(result.stdout)
+                self.assertTrue("symbolic" in data or "result" in data)
 
     def test_metrics_flag(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -65,3 +73,24 @@ class TestAeonCLI(unittest.TestCase):
             )
             data = json.loads(result.stdout)
             self.assertIn("metrics", data)
+
+    def test_yaml_fallback_warning(self):
+        import io
+        from unittest import mock
+        cli_dir = Path(__file__).resolve().parent
+        sys.path.insert(0, str(cli_dir))
+        try:
+            aeon_cli = importlib.import_module("aeon_cli")
+        finally:
+            sys.path.pop(0)
+
+        with mock.patch.object(aeon_cli, "_HAS_YAML", False), \
+             mock.patch.object(aeon_cli, "yaml", None), \
+             mock.patch("sys.stdout", new_callable=io.StringIO) as buf:
+            aeon_cli.main(["1", "--yaml"])
+            output = buf.getvalue()
+
+        self.assertIn("PyYAML not installed", output)
+        lines = output.splitlines()
+        data = json.loads("\n".join(lines[1:]))
+        self.assertTrue("symbolic" in data or "result" in data)

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
 - [**Gamification API**](docs/api/friendship-socialgood.yaml) – Endpunkte `/gamify/badges` & `/gamify/leaderboard`
 - [**Share your Sigil** & **Remix my Solution**](docs/CommunityOnboarding.md) – Community-Features
 - [**NumericToSymbolicAdapter**](GenesisAeonAdvancedAi/aeon_processor.py) – übersetzt Tensorwerte in Klang- und Farbcodes
-- [**Aeon CLI**](GenesisAeonAdvancedAi/aeon_cli.py) – erzeugt symbolische Ergebnisse aus Zahlenfolgen, kann Leistungsdaten und nun auch CREP-Metriken ausgeben
+- [**Aeon CLI**](GenesisAeonAdvancedAi/aeon_cli.py) – erzeugt symbolische Ergebnisse aus Zahlenfolgen, kann Leistungsdaten und nun auch CREP-Metriken ausgeben. Fehlt PyYAML, gibt die CLI stattdessen JSON aus und weist per Warnung darauf hin.
 ## 📦 Paketstruktur
 
 ```bash


### PR DESCRIPTION
## Summary
- warn and fallback to JSON when PyYAML is missing
- document fallback behaviour in README
- test warning message via unittest mock

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c532583308322a74b0d8bb69b2490