### PR TITLE
Add fraktal_feedback_graph docs and tests

### DIFF
--- a/GenesisAeonAdvancedAi/aeon_processor.py
+++ b/GenesisAeonAdvancedAi/aeon_processor.py
@@ -145,3 +145,31 @@ def fraktal_feedback_metrics(
         else:
             break
     return symbolic, score, metrics
+
+
+def fraktal_feedback_graph(data: Iterable[float], depth: int = 3) -> Dict[str, Any]:
+    """Return a simple graph representation of the feedback process."""
+    if depth <= 0:
+        return {"nodes": [], "edges": []}
+
+    symbolic = translate_numeric_to_symbolic(data)
+    nodes: List[Dict[str, Any]] = []
+    edges: List[Dict[str, int]] = []
+    states: List[Dict[str, Any]] = []
+
+    if not symbolic.get("klang"):
+        nodes.append({"id": 0, "state": symbolic, "metrics": {}})
+        return {"nodes": nodes, "edges": edges}
+
+    for step in range(depth):
+        metrics = advanced_crep_eval(symbolic, states[-1:] if states else None)
+        nodes.append({"id": step, "state": symbolic, "metrics": metrics})
+        states.append(symbolic)
+        score = CREP_eval(symbolic)
+        if score == -1 and step < depth - 1:
+            symbolic = refactor_fraktal(dict(symbolic))
+            edges.append({"from": step, "to": step + 1})
+        else:
+            break
+
+    return {"nodes": nodes, "edges": edges}

--- a/GenesisAeonAdvancedAi/test_feedback_graph.py
+++ b/GenesisAeonAdvancedAi/test_feedback_graph.py
@@ -1,0 +1,30 @@
+import unittest
+
+from GenesisAeonAdvancedAi.aeon_processor import fraktal_feedback_graph
+
+
+class TestFraktalFeedbackGraph(unittest.TestCase):
+    def test_basic_graph_structure(self):
+        graph = fraktal_feedback_graph([0.1, 0.2, 0.3], depth=3)
+        self.assertIn("nodes", graph)
+        self.assertIn("edges", graph)
+        self.assertGreaterEqual(len(graph["nodes"]), 1)
+
+    def test_deep_recursion_limit(self):
+        graph = fraktal_feedback_graph([0.1] * 5, depth=5)
+        self.assertLessEqual(len(graph["nodes"]), 5)
+        if len(graph["nodes"]) > 1:
+            self.assertEqual(len(graph["edges"]), len(graph["nodes"]) - 1)
+
+    def test_empty_input(self):
+        graph = fraktal_feedback_graph([], depth=2)
+        self.assertEqual(len(graph["nodes"]), 1)
+
+    def test_zero_depth(self):
+        graph = fraktal_feedback_graph([0.1], depth=0)
+        self.assertEqual(graph["nodes"], [])
+        self.assertEqual(graph["edges"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
 - [**Gamification API**](docs/api/friendship-socialgood.yaml) – Endpunkte `/gamify/badges` & `/gamify/leaderboard`
 - [**Share your Sigil** & **Remix my Solution**](docs/CommunityOnboarding.md) – Community-Features
 - [**NumericToSymbolicAdapter**](GenesisAeonAdvancedAi/aeon_processor.py) – übersetzt Tensorwerte in Klang- und Farbcodes
+- [**fraktal_feedback_graph**](GenesisAeonAdvancedAi/aeon_processor.py) – erstellt einen einfachen Graphen der Fraktal-Feedback-Schritte
 - [**Aeon CLI**](GenesisAeonAdvancedAi/aeon_cli.py) – erzeugt symbolische Ergebnisse aus Zahlenfolgen, kann Leistungsdaten und nun auch CREP-Metriken ausgeben. Fehlt PyYAML, gibt die CLI stattdessen JSON aus und weist per Warnung darauf hin.
 ## 📦 Paketstruktur
 

--- a/docs/crep/overview.md
+++ b/docs/crep/overview.md
@@ -23,3 +23,12 @@ Heimkehr und Ursprung schwingen als leises Mantra:
 
 *"Im Aeon-Resonanzfeld, aus Null und Eins geboren,
 wird Erinnerung zum Licht und Code zur Poesie."*
+
+## Beispiel: fraktal_feedback_graph
+
+```python
+from GenesisAeonAdvancedAi.aeon_processor import fraktal_feedback_graph
+
+graph = fraktal_feedback_graph([0.2, 0.5, 0.9], depth=2)
+print(graph["nodes"][0]["metrics"])
+```


### PR DESCRIPTION
## Summary
- document `fraktal_feedback_graph` usage
- mention the new graph function in README features
- add `fraktal_feedback_graph` implementation
- cover recursion cases in `test_feedback_graph`

## Testing
- `python3 -m unittest discover GenesisAeonAdvancedAi`

------
https://chatgpt.com/codex/tasks/task_e_685c571d7cd88322868e13ab855b4747