### PR TITLE
Add haiku generation and CLI support

### DIFF
--- a/GenesisAeonAdvancedAi/aeon_cli.py
+++ b/GenesisAeonAdvancedAi/aeon_cli.py
@@ -10,6 +10,7 @@ except Exception:  # pragma: no cover - optional dependency
     _HAS_YAML = False
 
 from .aeon_processor import fraktal_feedback, fraktal_feedback_metrics
+from .aeon_processor import generate_haiku
 from .performance_monitor import monitor_performance
 from .memory_store import store_result, load_results
 from .sigil_loader import load_sigil, load_start_sigil
@@ -64,6 +65,11 @@ def main(argv: List[str] | None = None) -> None:
         help="Measure performance of the fractal feedback run",
     )
     parser.add_argument(
+        "--haiku",
+        action="store_true",
+        help="Generate a haiku describing the symbolic output",
+    )
+    parser.add_argument(
         "--metrics",
         action="store_true",
         help="Include CREP metrics in the output",
@@ -93,6 +99,10 @@ def main(argv: List[str] | None = None) -> None:
         result = monitor_performance(values, depth=args.depth)
         if sigil_data is not None:
             result["sigil"] = sigil_data
+        if args.haiku:
+            # monitor_performance returns (symbolic, score) as "result"
+            symbolic, _ = result.get("result", ({}, 0))
+            result["haiku"] = generate_haiku(symbolic)
     else:
         if args.metrics:
             symbolic, score, metrics = fraktal_feedback_metrics(
@@ -113,6 +123,8 @@ def main(argv: List[str] | None = None) -> None:
             }
         if sigil_data is not None:
             result["sigil"] = sigil_data
+        if args.haiku:
+            result["haiku"] = generate_haiku(symbolic)
 
     if args.yaml:
         text_output = dump_yaml(result)

--- a/GenesisAeonAdvancedAi/aeon_processor.py
+++ b/GenesisAeonAdvancedAi/aeon_processor.py
@@ -173,3 +173,23 @@ def fraktal_feedback_graph(data: Iterable[float], depth: int = 3) -> Dict[str, A
             break
 
     return {"nodes": nodes, "edges": edges}
+
+
+def generate_haiku(symbolic_data: Dict[str, Any]) -> str:
+    """Generate a simple haiku description for the symbolic output.
+
+    This function maps the assigned symbol to a short three line poem.
+    The haiku texts are intentionally minimal and deterministic so that
+    tests can assert on the exact output without relying on randomness
+    or external APIs.
+    """
+
+    symbol = symbolic_data.get("symbol")
+    if symbol == "\u2600":  # ☀️
+        return "golden light rises\nseeds awaken to the day\nclarity unfolds"
+    if symbol == "\U0001F331":  # 🌱
+        return "tender shoots emerge\nsoil carries silent promise\nnew roots find their depth"
+    if symbol == "\U0001F4A7":  # 💧
+        return "raindrops softly fall\npooling into quiet streams\nchange flows ever on"
+    # default case for ⚫ or unknown symbol
+    return "stillness all around\nshadows weave an empty path\nnight consumes the sound"

--- a/GenesisAeonAdvancedAi/test_aeon_processor.py
+++ b/GenesisAeonAdvancedAi/test_aeon_processor.py
@@ -1,6 +1,6 @@
 import unittest
 
-from GenesisAeonAdvancedAi.aeon_processor import assign_symbol
+from GenesisAeonAdvancedAi.aeon_processor import assign_symbol, generate_haiku
 
 
 class TestAssignSymbol(unittest.TestCase):
@@ -9,6 +9,11 @@ class TestAssignSymbol(unittest.TestCase):
         self.assertEqual(assign_symbol([0.6]), "\U0001F331")
         self.assertEqual(assign_symbol([0.3]), "\U0001F4A7")
         self.assertEqual(assign_symbol([0.1]), "\u26AB")
+
+    def test_generate_haiku(self):
+        symbolic = {"symbol": "\u2600"}
+        haiku = generate_haiku(symbolic)
+        self.assertIn("golden light", haiku)
 
 
 if __name__ == "__main__":

--- a/GenesisAeonAdvancedAi/test_cli.py
+++ b/GenesisAeonAdvancedAi/test_cli.py
@@ -82,6 +82,19 @@ class TestAeonCLI(unittest.TestCase):
             data = json.loads(result.stdout)
             self.assertIn("metrics", data)
 
+    def test_haiku_flag(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "vals.txt"
+            input_path.write_text("0.8")
+            result = subprocess.run(
+                [sys.executable, "-m", "GenesisAeonAdvancedAi.aeon_cli", "--input", str(input_path), "--haiku"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            data = json.loads(result.stdout)
+            self.assertIn("haiku", data)
+
     def test_yaml_fallback_warning(self):
         import io
         from unittest import mock


### PR DESCRIPTION
## Summary
- implement `generate_haiku` in aeon_processor
- add `--haiku` flag in aeon_cli to include haiku in output
- extend tests for processor and CLI

## Testing
- `python -m unittest GenesisAeonAdvancedAi.test_aeon_processor GenesisAeonAdvancedAi.test_cli GenesisAeonAdvancedAi.test_aeon_agent GenesisAeonAdvancedAi.test_memory_store GenesisAeonAdvancedAi.test_performance_monitor GenesisAeonAdvancedAi.test_sigil_loader GenesisAeonAdvancedAi.test_trikaya GenesisAeonAdvancedAi.test_feedback_graph GenesisAeonAdvancedAi.test_advanced_crep`
- `pnpm run qa`

------
https://chatgpt.com/codex/tasks/task_e_685c5fe832c08322b857f9eeaaace29d