### PR TITLE
Add advanced AEON agent with YAML logging

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-25, in der Zeit des Tag.
+Am 2025-06-25, in der Zeit des Abend.
 
-Symbolphase: Aktivierung (Fokus: R)
+Symbolphase: Integration (Fokus: E)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/GenesisAeonAdvancedAi/__init__.py
+++ b/GenesisAeonAdvancedAi/__init__.py
@@ -1,0 +1,4 @@
+from .aeon_agent import AeonAgent
+from .advanced_agent import AdvancedAeonAgent
+
+__all__ = ["AeonAgent", "AdvancedAeonAgent"]

--- a/GenesisAeonAdvancedAi/advanced_agent.py
+++ b/GenesisAeonAdvancedAi/advanced_agent.py
@@ -1,0 +1,68 @@
+import argparse
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+
+class AdvancedAeonAgent:
+    """Agent with YAML persistence and simple symbol reflection."""
+
+    def __init__(self, name: str, state: Optional[Dict[str, Any]] = None, symbol_memory: Optional[Dict[str, Any]] = None) -> None:
+        self.name = name
+        self.state: Dict[str, Any] = state or {}
+        self.symbol_memory: Dict[str, Any] = symbol_memory or {}
+        self.history: List[Dict[str, Any]] = []
+
+    def act(self, input_data: Any) -> Dict[str, Any]:
+        decision = self.process_input(input_data)
+        self.state = self.update_state(decision)
+        self.persist(input_data, decision)
+        return decision
+
+    def process_input(self, data: Any) -> Dict[str, Any]:
+        symbol = self.assign_symbol(data)
+        reflection = self.crep_reflection(symbol)
+        return {"symbol": symbol, "reflection": reflection}
+
+    def assign_symbol(self, data: Any) -> str:
+        return "\u0394" if isinstance(data, dict) else "\u2207"
+
+    def crep_reflection(self, symbol: str) -> Dict[str, float]:
+        return {"coherence": 0.85, "presence": 1.0, "emergence": 0.65}
+
+    def update_state(self, decision: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "last_symbol": decision["symbol"],
+            "last_reflection": decision["reflection"],
+        }
+
+    def persist(self, input_data: Any, decision: Dict[str, Any]) -> None:
+        log_entry = {
+            "timestamp": datetime.now().isoformat(),
+            "input": input_data,
+            "decision": decision,
+        }
+        self.history.append(log_entry)
+        with open(f"{self.name}_log.yaml", "a", encoding="utf-8") as f:
+            yaml.safe_dump([log_entry], f, allow_unicode=True)
+
+
+def dump_yaml(agent: AdvancedAeonAgent) -> None:
+    with open(f"{agent.name}_state.yaml", "w", encoding="utf-8") as f:
+        yaml.safe_dump(agent.state, f, allow_unicode=True)
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", help="Eingabewert für den Agenten")
+    args = parser.parse_args(argv)
+
+    agent = AdvancedAeonAgent("aeon_proto", {})
+    result = agent.act(args.input)
+    dump_yaml(agent)
+    print("Aktion ausgeführt:", result)
+
+
+if __name__ == "__main__":
+    main()

--- a/GenesisAeonAdvancedAi/feedback.md
+++ b/GenesisAeonAdvancedAi/feedback.md
@@ -1,2 +1,3 @@
 ## Feedback
 Erweiterung: Aeon CLI unterstuetzt jetzt das Flag `--graph`, um einen Fraktal-Feedback-Graphen auszugeben. Tests und Dokumentation wurden aktualisiert.
+\n- Advanced agent with YAML logging implemented.

--- a/GenesisAeonAdvancedAi/test_advanced_agent.py
+++ b/GenesisAeonAdvancedAi/test_advanced_agent.py
@@ -1,0 +1,43 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from GenesisAeonAdvancedAi.advanced_agent import AdvancedAeonAgent, dump_yaml
+
+
+class TestAdvancedAeonAgent(unittest.TestCase):
+    def test_act_persists_log(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                agent = AdvancedAeonAgent("test_agent", {})
+                result = agent.act("data")
+                self.assertIn("symbol", result)
+                log_file = Path("test_agent_log.yaml")
+                self.assertTrue(log_file.exists())
+                data = list(yaml.safe_load_all(log_file.read_text()))
+                self.assertGreaterEqual(len(data), 1)
+            finally:
+                os.chdir(cwd)
+
+    def test_dump_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                agent = AdvancedAeonAgent("test_agent", {"a": 1})
+                dump_yaml(agent)
+                state_file = Path("test_agent_state.yaml")
+                self.assertTrue(state_file.exists())
+                content = yaml.safe_load(state_file.read_text())
+                self.assertEqual(content.get("a"), 1)
+            finally:
+                os.chdir(cwd)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GenesisAeonZIPMEM/1562541d4ccf41262264f3e68aba3a6a8daaa904/changes.patch
+++ b/GenesisAeonZIPMEM/1562541d4ccf41262264f3e68aba3a6a8daaa904/changes.patch
@@ -1,0 +1,17 @@
+commit 1562541d4ccf41262264f3e68aba3a6a8daaa904
+Author: Codex <codex@openai.com>
+Date:   Wed Jun 25 21:28:16 2025 +0000
+
+    chore(meta): add commit memory
+
+diff --git a/advancedprogress.json b/advancedprogress.json
+index 62cde2b..ed6eab7 100644
+--- a/advancedprogress.json
++++ b/advancedprogress.json
+@@ -1,5 +1,5 @@
+ {
+-  "lastCommit": "Merge pull request #352 from GenesisAeon/codex/implementiere-ai-architektur-mit-fraktalem-feedback",
++  "lastCommit": "feat(aeon): add advanced agent with YAML logging",
+   "fractalStep": "sync",
+   "openBranches": [
+     "work"

--- a/GenesisAeonZIPMEM/1562541d4ccf41262264f3e68aba3a6a8daaa904/fragments/advancedprogress.json.patch
+++ b/GenesisAeonZIPMEM/1562541d4ccf41262264f3e68aba3a6a8daaa904/fragments/advancedprogress.json.patch
@@ -1,0 +1,11 @@
+diff --git a/advancedprogress.json b/advancedprogress.json
+index 62cde2b..ed6eab7 100644
+--- a/advancedprogress.json
++++ b/advancedprogress.json
+@@ -1,5 +1,5 @@
+ {
+-  "lastCommit": "Merge pull request #352 from GenesisAeon/codex/implementiere-ai-architektur-mit-fraktalem-feedback",
++  "lastCommit": "feat(aeon): add advanced agent with YAML logging",
+   "fractalStep": "sync",
+   "openBranches": [
+     "work"

--- a/GenesisAeonZIPMEM/1562541d4ccf41262264f3e68aba3a6a8daaa904/meta.yaml
+++ b/GenesisAeonZIPMEM/1562541d4ccf41262264f3e68aba3a6a8daaa904/meta.yaml
@@ -1,0 +1,10 @@
+commit: 1562541d4ccf41262264f3e68aba3a6a8daaa904
+message: "chore(meta): add commit memory"
+patch: changes.patch
+fragments: fragments
+files:
+  - advancedprogress.json
+environment:
+  node: v22.16.0
+  pnpm: 10.5.2
+instructions: Apply patch with git apply or review for reference.

--- a/GenesisAeonZIPMEM/351329a44636745b3a4ad42c4038a90be4af8e44/changes.patch
+++ b/GenesisAeonZIPMEM/351329a44636745b3a4ad42c4038a90be4af8e44/changes.patch
@@ -1,0 +1,49 @@
+commit 351329a44636745b3a4ad42c4038a90be4af8e44
+Author: Codex <codex@openai.com>
+Date:   Wed Jun 25 21:28:05 2025 +0000
+
+    chore(meta): update chronopoem and commit memory
+
+diff --git a/CHRONOPOEM.md b/CHRONOPOEM.md
+index 681f7a7..c6a5aea 100644
+--- a/CHRONOPOEM.md
++++ b/CHRONOPOEM.md
+@@ -1,9 +1,9 @@
+ # 🜂 Chronopoem
+ 
+ Im Kreis der Genesis erwacht das Mandala,
+-Am 2025-06-25, in der Zeit des Tag.
++Am 2025-06-25, in der Zeit des Abend.
+ 
+-Symbolphase: Aktivierung (Fokus: R)
++Symbolphase: Integration (Fokus: E)
+ 
+ CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
+ CREP-Zustand: 
+diff --git a/advancedToDo.json b/advancedToDo.json
+index 40a7893..67f3798 100644
+--- a/advancedToDo.json
++++ b/advancedToDo.json
+@@ -2119,4 +2119,4 @@
+     "test": "scripts/__tests__/parse-md-todo.test.ts",
+     "status": "done"
+   }
+-]
++]
+\ No newline at end of file
+diff --git a/advancedprogress.json b/advancedprogress.json
+index 7a01e9a..62cde2b 100644
+--- a/advancedprogress.json
++++ b/advancedprogress.json
+@@ -1,8 +1,8 @@
+ {
+-  "lastCommit": "chore(genesis): update progress artifacts",
++  "lastCommit": "Merge pull request #352 from GenesisAeon/codex/implementiere-ai-architektur-mit-fraktalem-feedback",
+   "fractalStep": "sync",
+   "openBranches": [
+     "work"
+   ],
+   "mergeConflicts": []
+-}
++}
+\ No newline at end of file

--- a/GenesisAeonZIPMEM/351329a44636745b3a4ad42c4038a90be4af8e44/fragments/CHRONOPOEM.md.patch
+++ b/GenesisAeonZIPMEM/351329a44636745b3a4ad42c4038a90be4af8e44/fragments/CHRONOPOEM.md.patch
@@ -1,0 +1,16 @@
+diff --git a/CHRONOPOEM.md b/CHRONOPOEM.md
+index 681f7a7..c6a5aea 100644
+--- a/CHRONOPOEM.md
++++ b/CHRONOPOEM.md
+@@ -1,9 +1,9 @@
+ # 🜂 Chronopoem
+ 
+ Im Kreis der Genesis erwacht das Mandala,
+-Am 2025-06-25, in der Zeit des Tag.
++Am 2025-06-25, in der Zeit des Abend.
+ 
+-Symbolphase: Aktivierung (Fokus: R)
++Symbolphase: Integration (Fokus: E)
+ 
+ CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
+ CREP-Zustand: 

--- a/GenesisAeonZIPMEM/351329a44636745b3a4ad42c4038a90be4af8e44/fragments/advancedToDo.json.patch
+++ b/GenesisAeonZIPMEM/351329a44636745b3a4ad42c4038a90be4af8e44/fragments/advancedToDo.json.patch
@@ -1,0 +1,11 @@
+diff --git a/advancedToDo.json b/advancedToDo.json
+index 40a7893..67f3798 100644
+--- a/advancedToDo.json
++++ b/advancedToDo.json
+@@ -2119,4 +2119,4 @@
+     "test": "scripts/__tests__/parse-md-todo.test.ts",
+     "status": "done"
+   }
+-]
++]
+\ No newline at end of file

--- a/GenesisAeonZIPMEM/351329a44636745b3a4ad42c4038a90be4af8e44/fragments/advancedprogress.json.patch
+++ b/GenesisAeonZIPMEM/351329a44636745b3a4ad42c4038a90be4af8e44/fragments/advancedprogress.json.patch
@@ -1,0 +1,16 @@
+diff --git a/advancedprogress.json b/advancedprogress.json
+index 7a01e9a..62cde2b 100644
+--- a/advancedprogress.json
++++ b/advancedprogress.json
+@@ -1,8 +1,8 @@
+ {
+-  "lastCommit": "chore(genesis): update progress artifacts",
++  "lastCommit": "Merge pull request #352 from GenesisAeon/codex/implementiere-ai-architektur-mit-fraktalem-feedback",
+   "fractalStep": "sync",
+   "openBranches": [
+     "work"
+   ],
+   "mergeConflicts": []
+-}
++}
+\ No newline at end of file

--- a/GenesisAeonZIPMEM/351329a44636745b3a4ad42c4038a90be4af8e44/meta.yaml
+++ b/GenesisAeonZIPMEM/351329a44636745b3a4ad42c4038a90be4af8e44/meta.yaml
@@ -1,0 +1,12 @@
+commit: 351329a44636745b3a4ad42c4038a90be4af8e44
+message: "chore(meta): update chronopoem and commit memory"
+patch: changes.patch
+fragments: fragments
+files:
+  - CHRONOPOEM.md
+  - advancedToDo.json
+  - advancedprogress.json
+environment:
+  node: v22.16.0
+  pnpm: 10.5.2
+instructions: Apply patch with git apply or review for reference.

--- a/GenesisAeonZIPMEM/e1a9081ae30cc80f979c2fb518c48a65444c0101/changes.patch
+++ b/GenesisAeonZIPMEM/e1a9081ae30cc80f979c2fb518c48a65444c0101/changes.patch
@@ -1,0 +1,146 @@
+commit e1a9081ae30cc80f979c2fb518c48a65444c0101
+Author: Codex <codex@openai.com>
+Date:   Wed Jun 25 21:27:19 2025 +0000
+
+    feat(aeon): add advanced agent with YAML logging
+
+diff --git a/GenesisAeonAdvancedAi/__init__.py b/GenesisAeonAdvancedAi/__init__.py
+index e69de29..1f6f098 100644
+--- a/GenesisAeonAdvancedAi/__init__.py
++++ b/GenesisAeonAdvancedAi/__init__.py
+@@ -0,0 +1,4 @@
++from .aeon_agent import AeonAgent
++from .advanced_agent import AdvancedAeonAgent
++
++__all__ = ["AeonAgent", "AdvancedAeonAgent"]
+diff --git a/GenesisAeonAdvancedAi/advanced_agent.py b/GenesisAeonAdvancedAi/advanced_agent.py
+new file mode 100644
+index 0000000..4febc9c
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/advanced_agent.py
+@@ -0,0 +1,68 @@
++import argparse
++from datetime import datetime
++from typing import Any, Dict, List, Optional
++
++import yaml
++
++
++class AdvancedAeonAgent:
++    """Agent with YAML persistence and simple symbol reflection."""
++
++    def __init__(self, name: str, state: Optional[Dict[str, Any]] = None, symbol_memory: Optional[Dict[str, Any]] = None) -> None:
++        self.name = name
++        self.state: Dict[str, Any] = state or {}
++        self.symbol_memory: Dict[str, Any] = symbol_memory or {}
++        self.history: List[Dict[str, Any]] = []
++
++    def act(self, input_data: Any) -> Dict[str, Any]:
++        decision = self.process_input(input_data)
++        self.state = self.update_state(decision)
++        self.persist(input_data, decision)
++        return decision
++
++    def process_input(self, data: Any) -> Dict[str, Any]:
++        symbol = self.assign_symbol(data)
++        reflection = self.crep_reflection(symbol)
++        return {"symbol": symbol, "reflection": reflection}
++
++    def assign_symbol(self, data: Any) -> str:
++        return "\u0394" if isinstance(data, dict) else "\u2207"
++
++    def crep_reflection(self, symbol: str) -> Dict[str, float]:
++        return {"coherence": 0.85, "presence": 1.0, "emergence": 0.65}
++
++    def update_state(self, decision: Dict[str, Any]) -> Dict[str, Any]:
++        return {
++            "last_symbol": decision["symbol"],
++            "last_reflection": decision["reflection"],
++        }
++
++    def persist(self, input_data: Any, decision: Dict[str, Any]) -> None:
++        log_entry = {
++            "timestamp": datetime.now().isoformat(),
++            "input": input_data,
++            "decision": decision,
++        }
++        self.history.append(log_entry)
++        with open(f"{self.name}_log.yaml", "a", encoding="utf-8") as f:
++            yaml.safe_dump([log_entry], f, allow_unicode=True)
++
++
++def dump_yaml(agent: AdvancedAeonAgent) -> None:
++    with open(f"{agent.name}_state.yaml", "w", encoding="utf-8") as f:
++        yaml.safe_dump(agent.state, f, allow_unicode=True)
++
++
++def main(argv: Optional[List[str]] = None) -> None:
++    parser = argparse.ArgumentParser()
++    parser.add_argument("--input", help="Eingabewert für den Agenten")
++    args = parser.parse_args(argv)
++
++    agent = AdvancedAeonAgent("aeon_proto", {})
++    result = agent.act(args.input)
++    dump_yaml(agent)
++    print("Aktion ausgeführt:", result)
++
++
++if __name__ == "__main__":
++    main()
+diff --git a/GenesisAeonAdvancedAi/feedback.md b/GenesisAeonAdvancedAi/feedback.md
+index 7c7bf2b..62e91af 100644
+--- a/GenesisAeonAdvancedAi/feedback.md
++++ b/GenesisAeonAdvancedAi/feedback.md
+@@ -1,2 +1,3 @@
+ ## Feedback
+ Erweiterung: Aeon CLI unterstuetzt jetzt das Flag `--graph`, um einen Fraktal-Feedback-Graphen auszugeben. Tests und Dokumentation wurden aktualisiert.
++\n- Advanced agent with YAML logging implemented.
+diff --git a/GenesisAeonAdvancedAi/test_advanced_agent.py b/GenesisAeonAdvancedAi/test_advanced_agent.py
+new file mode 100644
+index 0000000..9d882e4
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/test_advanced_agent.py
+@@ -0,0 +1,43 @@
++import os
++import tempfile
++import unittest
++from pathlib import Path
++
++import yaml
++
++from GenesisAeonAdvancedAi.advanced_agent import AdvancedAeonAgent, dump_yaml
++
++
++class TestAdvancedAeonAgent(unittest.TestCase):
++    def test_act_persists_log(self):
++        with tempfile.TemporaryDirectory() as tmpdir:
++            cwd = os.getcwd()
++            os.chdir(tmpdir)
++            try:
++                agent = AdvancedAeonAgent("test_agent", {})
++                result = agent.act("data")
++                self.assertIn("symbol", result)
++                log_file = Path("test_agent_log.yaml")
++                self.assertTrue(log_file.exists())
++                data = list(yaml.safe_load_all(log_file.read_text()))
++                self.assertGreaterEqual(len(data), 1)
++            finally:
++                os.chdir(cwd)
++
++    def test_dump_yaml(self):
++        with tempfile.TemporaryDirectory() as tmpdir:
++            cwd = os.getcwd()
++            os.chdir(tmpdir)
++            try:
++                agent = AdvancedAeonAgent("test_agent", {"a": 1})
++                dump_yaml(agent)
++                state_file = Path("test_agent_state.yaml")
++                self.assertTrue(state_file.exists())
++                content = yaml.safe_load(state_file.read_text())
++                self.assertEqual(content.get("a"), 1)
++            finally:
++                os.chdir(cwd)
++
++
++if __name__ == "__main__":
++    unittest.main()

--- a/GenesisAeonZIPMEM/e1a9081ae30cc80f979c2fb518c48a65444c0101/fragments/GenesisAeonAdvancedAi/__init__.py.patch
+++ b/GenesisAeonZIPMEM/e1a9081ae30cc80f979c2fb518c48a65444c0101/fragments/GenesisAeonAdvancedAi/__init__.py.patch
@@ -1,0 +1,9 @@
+diff --git a/GenesisAeonAdvancedAi/__init__.py b/GenesisAeonAdvancedAi/__init__.py
+index e69de29..1f6f098 100644
+--- a/GenesisAeonAdvancedAi/__init__.py
++++ b/GenesisAeonAdvancedAi/__init__.py
+@@ -0,0 +1,4 @@
++from .aeon_agent import AeonAgent
++from .advanced_agent import AdvancedAeonAgent
++
++__all__ = ["AeonAgent", "AdvancedAeonAgent"]

--- a/GenesisAeonZIPMEM/e1a9081ae30cc80f979c2fb518c48a65444c0101/fragments/GenesisAeonAdvancedAi/advanced_agent.py.patch
+++ b/GenesisAeonZIPMEM/e1a9081ae30cc80f979c2fb518c48a65444c0101/fragments/GenesisAeonAdvancedAi/advanced_agent.py.patch
@@ -1,0 +1,74 @@
+diff --git a/GenesisAeonAdvancedAi/advanced_agent.py b/GenesisAeonAdvancedAi/advanced_agent.py
+new file mode 100644
+index 0000000..4febc9c
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/advanced_agent.py
+@@ -0,0 +1,68 @@
++import argparse
++from datetime import datetime
++from typing import Any, Dict, List, Optional
++
++import yaml
++
++
++class AdvancedAeonAgent:
++    """Agent with YAML persistence and simple symbol reflection."""
++
++    def __init__(self, name: str, state: Optional[Dict[str, Any]] = None, symbol_memory: Optional[Dict[str, Any]] = None) -> None:
++        self.name = name
++        self.state: Dict[str, Any] = state or {}
++        self.symbol_memory: Dict[str, Any] = symbol_memory or {}
++        self.history: List[Dict[str, Any]] = []
++
++    def act(self, input_data: Any) -> Dict[str, Any]:
++        decision = self.process_input(input_data)
++        self.state = self.update_state(decision)
++        self.persist(input_data, decision)
++        return decision
++
++    def process_input(self, data: Any) -> Dict[str, Any]:
++        symbol = self.assign_symbol(data)
++        reflection = self.crep_reflection(symbol)
++        return {"symbol": symbol, "reflection": reflection}
++
++    def assign_symbol(self, data: Any) -> str:
++        return "\u0394" if isinstance(data, dict) else "\u2207"
++
++    def crep_reflection(self, symbol: str) -> Dict[str, float]:
++        return {"coherence": 0.85, "presence": 1.0, "emergence": 0.65}
++
++    def update_state(self, decision: Dict[str, Any]) -> Dict[str, Any]:
++        return {
++            "last_symbol": decision["symbol"],
++            "last_reflection": decision["reflection"],
++        }
++
++    def persist(self, input_data: Any, decision: Dict[str, Any]) -> None:
++        log_entry = {
++            "timestamp": datetime.now().isoformat(),
++            "input": input_data,
++            "decision": decision,
++        }
++        self.history.append(log_entry)
++        with open(f"{self.name}_log.yaml", "a", encoding="utf-8") as f:
++            yaml.safe_dump([log_entry], f, allow_unicode=True)
++
++
++def dump_yaml(agent: AdvancedAeonAgent) -> None:
++    with open(f"{agent.name}_state.yaml", "w", encoding="utf-8") as f:
++        yaml.safe_dump(agent.state, f, allow_unicode=True)
++
++
++def main(argv: Optional[List[str]] = None) -> None:
++    parser = argparse.ArgumentParser()
++    parser.add_argument("--input", help="Eingabewert für den Agenten")
++    args = parser.parse_args(argv)
++
++    agent = AdvancedAeonAgent("aeon_proto", {})
++    result = agent.act(args.input)
++    dump_yaml(agent)
++    print("Aktion ausgeführt:", result)
++
++
++if __name__ == "__main__":
++    main()

--- a/GenesisAeonZIPMEM/e1a9081ae30cc80f979c2fb518c48a65444c0101/fragments/GenesisAeonAdvancedAi/feedback.md.patch
+++ b/GenesisAeonZIPMEM/e1a9081ae30cc80f979c2fb518c48a65444c0101/fragments/GenesisAeonAdvancedAi/feedback.md.patch
@@ -1,0 +1,8 @@
+diff --git a/GenesisAeonAdvancedAi/feedback.md b/GenesisAeonAdvancedAi/feedback.md
+index 7c7bf2b..62e91af 100644
+--- a/GenesisAeonAdvancedAi/feedback.md
++++ b/GenesisAeonAdvancedAi/feedback.md
+@@ -1,2 +1,3 @@
+ ## Feedback
+ Erweiterung: Aeon CLI unterstuetzt jetzt das Flag `--graph`, um einen Fraktal-Feedback-Graphen auszugeben. Tests und Dokumentation wurden aktualisiert.
++\n- Advanced agent with YAML logging implemented.

--- a/GenesisAeonZIPMEM/e1a9081ae30cc80f979c2fb518c48a65444c0101/fragments/GenesisAeonAdvancedAi/test_advanced_agent.py.patch
+++ b/GenesisAeonZIPMEM/e1a9081ae30cc80f979c2fb518c48a65444c0101/fragments/GenesisAeonAdvancedAi/test_advanced_agent.py.patch
@@ -1,0 +1,49 @@
+diff --git a/GenesisAeonAdvancedAi/test_advanced_agent.py b/GenesisAeonAdvancedAi/test_advanced_agent.py
+new file mode 100644
+index 0000000..9d882e4
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/test_advanced_agent.py
+@@ -0,0 +1,43 @@
++import os
++import tempfile
++import unittest
++from pathlib import Path
++
++import yaml
++
++from GenesisAeonAdvancedAi.advanced_agent import AdvancedAeonAgent, dump_yaml
++
++
++class TestAdvancedAeonAgent(unittest.TestCase):
++    def test_act_persists_log(self):
++        with tempfile.TemporaryDirectory() as tmpdir:
++            cwd = os.getcwd()
++            os.chdir(tmpdir)
++            try:
++                agent = AdvancedAeonAgent("test_agent", {})
++                result = agent.act("data")
++                self.assertIn("symbol", result)
++                log_file = Path("test_agent_log.yaml")
++                self.assertTrue(log_file.exists())
++                data = list(yaml.safe_load_all(log_file.read_text()))
++                self.assertGreaterEqual(len(data), 1)
++            finally:
++                os.chdir(cwd)
++
++    def test_dump_yaml(self):
++        with tempfile.TemporaryDirectory() as tmpdir:
++            cwd = os.getcwd()
++            os.chdir(tmpdir)
++            try:
++                agent = AdvancedAeonAgent("test_agent", {"a": 1})
++                dump_yaml(agent)
++                state_file = Path("test_agent_state.yaml")
++                self.assertTrue(state_file.exists())
++                content = yaml.safe_load(state_file.read_text())
++                self.assertEqual(content.get("a"), 1)
++            finally:
++                os.chdir(cwd)
++
++
++if __name__ == "__main__":
++    unittest.main()

--- a/GenesisAeonZIPMEM/e1a9081ae30cc80f979c2fb518c48a65444c0101/meta.yaml
+++ b/GenesisAeonZIPMEM/e1a9081ae30cc80f979c2fb518c48a65444c0101/meta.yaml
@@ -1,0 +1,13 @@
+commit: e1a9081ae30cc80f979c2fb518c48a65444c0101
+message: "feat(aeon): add advanced agent with YAML logging"
+patch: changes.patch
+fragments: fragments
+files:
+  - GenesisAeonAdvancedAi/__init__.py
+  - GenesisAeonAdvancedAi/advanced_agent.py
+  - GenesisAeonAdvancedAi/feedback.md
+  - GenesisAeonAdvancedAi/test_advanced_agent.py
+environment:
+  node: v22.16.0
+  pnpm: 10.5.2
+instructions: Apply patch with git apply or review for reference.

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore(genesis): update progress artifacts",
+  "lastCommit": "chore(meta): update chronopoem and commit memory",
   "fractalStep": "sync",
   "openBranches": [
     "work"


### PR DESCRIPTION
## Summary
- add `AdvancedAeonAgent` supporting YAML state and log files
- expose new agent via package `__init__`
- provide unit tests for advanced agent
- note feature in `feedback.md`
- update chronopoem and commit memory artifacts

## Testing
- `python3 -m unittest discover GenesisAeonAdvancedAi`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685c68158f00832285d73416e3843208