### PR TITLE
feat(agent): add haiku option

### DIFF
--- a/GenesisAeonAdvancedAi/advanced_agent.py
+++ b/GenesisAeonAdvancedAi/advanced_agent.py
@@ -1,8 +1,22 @@
 import argparse
 from datetime import datetime
 from typing import Any, Dict, List, Optional
-
 import yaml
+
+
+def generate_basic_haiku(symbol: str) -> str:
+    """Return a deterministic haiku for the given symbol."""
+    if symbol == "\u0394":
+        return (
+            "change weaves its path\n"
+            "memory traces interlace\n"
+            "delta guides the flow"
+        )
+    return (
+        "nested loops unfold\n"
+        "reflections echo the core\n"
+        "nabla draws us in"
+    )
 
 
 class AdvancedAeonAgent:
@@ -67,6 +81,7 @@ def main(argv: Optional[List[str]] = None) -> None:
     parser.add_argument("--input", help="Eingabewert für den Agenten")
     parser.add_argument("--log-file", help="Pfad für YAML-Logdatei")
     parser.add_argument("--state-file", help="Pfad für YAML-State-Datei")
+    parser.add_argument("--haiku", action="store_true", help="Gibt ein Haiku zum Ergebnis aus")
     args = parser.parse_args(argv)
 
     agent = AdvancedAeonAgent(
@@ -77,6 +92,8 @@ def main(argv: Optional[List[str]] = None) -> None:
     )
     result = agent.act(args.input)
     dump_yaml(agent)
+    if args.haiku:
+        print(generate_basic_haiku(result["symbol"]))
     print("Aktion ausgeführt:", result)
 
 

--- a/GenesisAeonAdvancedAi/feedback.md
+++ b/GenesisAeonAdvancedAi/feedback.md
@@ -2,3 +2,4 @@
 Erweiterung: Aeon CLI unterstuetzt jetzt das Flag `--graph`, um einen Fraktal-Feedback-Graphen auszugeben. Tests und Dokumentation wurden aktualisiert.
 \n- Advanced agent with YAML logging implemented.
 \n- Advanced agent allows custom log and state file paths via `--log-file` and `--state-file`.
+\n- Advanced agent outputs a deterministic haiku when invoked with `--haiku`.

--- a/GenesisAeonAdvancedAi/test_advanced_agent_cli.py
+++ b/GenesisAeonAdvancedAi/test_advanced_agent_cli.py
@@ -27,5 +27,21 @@ class TestAdvancedAgentCLI(unittest.TestCase):
             self.assertTrue(log_file.exists())
             self.assertTrue(state_file.exists())
 
+    def test_haiku_output(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "GenesisAeonAdvancedAi.advanced_agent",
+                "--input",
+                "data",
+                "--haiku",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("\n", result.stdout)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `AdvancedAeonAgent` to print a deterministic haiku
- add `--haiku` CLI flag and test coverage
- note haiku capability in `feedback.md`

## Testing
- `python -m unittest discover GenesisAeonAdvancedAi`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685c6c0f462c8322ad42eb040fb9a7cd