### PR TITLE
Implement symbol memory persistence in Advanced Agent

### DIFF
--- a/GenesisAeonAdvancedAi/advanced_agent.py
+++ b/GenesisAeonAdvancedAi/advanced_agent.py
@@ -29,6 +29,7 @@ class AdvancedAeonAgent:
         symbol_memory: Optional[Dict[str, Any]] = None,
         log_path: Optional[str] = None,
         state_path: Optional[str] = None,
+        symbol_memory_path: Optional[str] = None,
     ) -> None:
         self.name = name
         self.state: Dict[str, Any] = state or {}
@@ -36,6 +37,7 @@ class AdvancedAeonAgent:
         self.history: List[Dict[str, Any]] = []
         self.log_path = log_path or f"{self.name}_log.yaml"
         self.state_path = state_path or f"{self.name}_state.yaml"
+        self.symbol_memory_path = symbol_memory_path or f"{self.name}_symbols.yaml"
 
     def act(self, input_data: Any) -> Dict[str, Any]:
         decision = self.process_input(input_data)
@@ -46,6 +48,7 @@ class AdvancedAeonAgent:
     def process_input(self, data: Any) -> Dict[str, Any]:
         symbol = self.assign_symbol(data)
         reflection = self.crep_reflection(symbol)
+        self.symbol_memory[symbol] = self.symbol_memory.get(symbol, 0) + 1
         return {"symbol": symbol, "reflection": reflection}
 
     def assign_symbol(self, data: Any) -> str:
@@ -70,6 +73,14 @@ class AdvancedAeonAgent:
         with open(self.log_path, "a", encoding="utf-8") as f:
             yaml.safe_dump([log_entry], f, allow_unicode=True)
 
+    def save_symbol_memory(self, path: Optional[str] = None) -> None:
+        """Persist symbol memory to a YAML file."""
+        file_path = path or self.symbol_memory_path
+        if not file_path:
+            return
+        with open(file_path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(self.symbol_memory, f, allow_unicode=True)
+
 
 def dump_yaml(agent: AdvancedAeonAgent) -> None:
     with open(agent.state_path, "w", encoding="utf-8") as f:
@@ -81,6 +92,10 @@ def main(argv: Optional[List[str]] = None) -> None:
     parser.add_argument("--input", help="Eingabewert für den Agenten")
     parser.add_argument("--log-file", help="Pfad für YAML-Logdatei")
     parser.add_argument("--state-file", help="Pfad für YAML-State-Datei")
+    parser.add_argument(
+        "--symbol-memory-file",
+        help="Pfad für YAML-Datei zum Speichern des Symbolspeichers",
+    )
     parser.add_argument("--haiku", action="store_true", help="Gibt ein Haiku zum Ergebnis aus")
     args = parser.parse_args(argv)
 
@@ -89,9 +104,11 @@ def main(argv: Optional[List[str]] = None) -> None:
         {},
         log_path=args.log_file,
         state_path=args.state_file,
+        symbol_memory_path=args.symbol_memory_file,
     )
     result = agent.act(args.input)
     dump_yaml(agent)
+    agent.save_symbol_memory(args.symbol_memory_file)
     if args.haiku:
         print(generate_basic_haiku(result["symbol"]))
     print("Aktion ausgeführt:", result)

--- a/GenesisAeonAdvancedAi/feedback.json
+++ b/GenesisAeonAdvancedAi/feedback.json
@@ -1,0 +1,5 @@
+{
+  "meta_commit_finalized": true,
+  "message": "Advanced agent updated with symbol memory persistence",
+  "timestamp": "2025-06-25T21:49:41Z"
+}

--- a/GenesisAeonAdvancedAi/feedback.md
+++ b/GenesisAeonAdvancedAi/feedback.md
@@ -3,3 +3,4 @@ Erweiterung: Aeon CLI unterstuetzt jetzt das Flag `--graph`, um einen Fraktal-Fe
 \n- Advanced agent with YAML logging implemented.
 \n- Advanced agent allows custom log and state file paths via `--log-file` and `--state-file`.
 \n- Advanced agent outputs a deterministic haiku when invoked with `--haiku`.
+\n- Advanced agent now persists symbol memory via `--symbol-memory-file`.

--- a/GenesisAeonAdvancedAi/test_advanced_agent.py
+++ b/GenesisAeonAdvancedAi/test_advanced_agent.py
@@ -38,6 +38,21 @@ class TestAdvancedAeonAgent(unittest.TestCase):
             finally:
                 os.chdir(cwd)
 
+    def test_save_symbol_memory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                agent = AdvancedAeonAgent("test_agent", {})
+                agent.act("data")
+                mem_file = Path("symbols.yaml")
+                agent.save_symbol_memory(str(mem_file))
+                self.assertTrue(mem_file.exists())
+                data = yaml.safe_load(mem_file.read_text())
+                self.assertIn("\u2207", data)
+            finally:
+                os.chdir(cwd)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/GenesisAeonAdvancedAi/test_advanced_agent_cli.py
+++ b/GenesisAeonAdvancedAi/test_advanced_agent_cli.py
@@ -10,6 +10,7 @@ class TestAdvancedAgentCLI(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             log_file = Path(tmpdir) / "custom_log.yaml"
             state_file = Path(tmpdir) / "custom_state.yaml"
+            symbol_file = Path(tmpdir) / "symbols.yaml"
             subprocess.run(
                 [
                     sys.executable,
@@ -21,11 +22,17 @@ class TestAdvancedAgentCLI(unittest.TestCase):
                     str(log_file),
                     "--state-file",
                     str(state_file),
+                    "--symbol-memory-file",
+                    str(symbol_file),
                 ],
                 check=True,
             )
             self.assertTrue(log_file.exists())
             self.assertTrue(state_file.exists())
+            self.assertTrue(symbol_file.exists())
+            import yaml
+            data = yaml.safe_load(symbol_file.read_text())
+            self.assertIsInstance(data, dict)
 
     def test_haiku_output(self):
         result = subprocess.run(


### PR DESCRIPTION
## Summary
- allow specifying a symbol memory file for `AdvancedAeonAgent`
- store symbol usage in memory and persist it
- expose `--symbol-memory-file` option in `advanced_agent` CLI
- test symbol memory persistence
- document new option in `feedback.md`
- record completion in `feedback.json`

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685c6de9875c8322b8d50f94445824fb