### PR TITLE
Add basic Aeon symbol tools and logger

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-06-25, in der Zeit des Abend.
+Am 2025-06-25, in der Zeit des Nacht.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Reflexion (Fokus: P)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/GenesisAeonAdvancedAi/__init__.py
+++ b/GenesisAeonAdvancedAi/__init__.py
@@ -1,4 +1,14 @@
 from .aeon_agent import AeonAgent
 from .advanced_agent import AdvancedAeonAgent
+from .symbol_tools import assign_color, transform_to_symbol
+from .crep_eval import evaluate_crep
+from .aeon_logger import log_event
 
-__all__ = ["AeonAgent", "AdvancedAeonAgent"]
+__all__ = [
+    "AeonAgent",
+    "AdvancedAeonAgent",
+    "assign_color",
+    "transform_to_symbol",
+    "evaluate_crep",
+    "log_event",
+]

--- a/GenesisAeonAdvancedAi/aeon_logger.py
+++ b/GenesisAeonAdvancedAi/aeon_logger.py
@@ -1,0 +1,18 @@
+"""Simple YAML-based logging utility."""
+
+from datetime import datetime
+from typing import Any
+
+import yaml
+
+
+def log_event(agent_name: str, input_data: Any, decision: Any) -> None:
+    """Append a log entry for the agent to a YAML file."""
+    log_entry = {
+        "timestamp": datetime.now().isoformat(),
+        "input": input_data,
+        "decision": decision,
+    }
+    file_path = f"{agent_name}_log.yaml"
+    with open(file_path, "a", encoding="utf-8") as f:
+        yaml.safe_dump([log_entry], f, allow_unicode=True)

--- a/GenesisAeonAdvancedAi/aeon_ui.html
+++ b/GenesisAeonAdvancedAi/aeon_ui.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Aeon UI</title>
+</head>
+<body>
+  <h1>Aeon Interface</h1>
+  <form id="aeon-form">
+    <input type="text" id="input" placeholder="input" />
+    <button type="submit">Send</button>
+  </form>
+  <pre id="result"></pre>
+  <script>
+    document.getElementById('aeon-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const input = document.getElementById('input').value;
+      const res = await fetch('/aeon/act', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ input })
+      });
+      const data = await res.json();
+      document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+    });
+  </script>
+</body>
+</html>

--- a/GenesisAeonAdvancedAi/aeon_web.py
+++ b/GenesisAeonAdvancedAi/aeon_web.py
@@ -1,0 +1,19 @@
+"""Minimal Flask web API for AeonAgent."""
+
+from flask import Flask, request, jsonify
+
+from .aeon_agent import AeonAgent
+
+app = Flask(__name__)
+agent = AeonAgent()
+
+
+@app.route("/aeon/act", methods=["POST"])
+def act() -> "flask.Response":
+    data = request.json.get("input")
+    action, record = agent.act(data or [])
+    return jsonify({"action": action, "record": record})
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/GenesisAeonAdvancedAi/config.yaml
+++ b/GenesisAeonAdvancedAi/config.yaml
@@ -1,0 +1,3 @@
+agent_name: "aeon_proto"
+default_input: "INIT"
+log_path: "./logs"

--- a/GenesisAeonAdvancedAi/crep_eval.py
+++ b/GenesisAeonAdvancedAi/crep_eval.py
@@ -1,0 +1,13 @@
+"""Minimal CREP evaluation module."""
+
+from typing import Any, Dict
+
+
+def evaluate_crep(input_data: Any) -> Dict[str, float]:
+    """Return static CREP metrics for a given input."""
+    return {
+        "coherence": 0.85,
+        "resonance": 0.75,
+        "emergence": 0.65,
+        "presence": 1.0,
+    }

--- a/GenesisAeonAdvancedAi/symbol_tools.py
+++ b/GenesisAeonAdvancedAi/symbol_tools.py
@@ -1,0 +1,21 @@
+"""Utility functions for symbolic color and shape mapping."""
+
+from typing import Any
+
+
+def assign_color(value: float) -> str:
+    """Return a color name based on threshold values."""
+    if value > 0.8:
+        return "gold"
+    if value > 0.5:
+        return "blue"
+    return "grey"
+
+
+def transform_to_symbol(data: Any) -> str:
+    """Map Python data types to simple symbolic markers."""
+    if isinstance(data, dict):
+        return "\u0394"  # Δ
+    if isinstance(data, str):
+        return "\u03C8"  # ψ
+    return "\u25CF"  # ●

--- a/GenesisAeonAdvancedAi/test_aeon_logger.py
+++ b/GenesisAeonAdvancedAi/test_aeon_logger.py
@@ -1,0 +1,25 @@
+import os
+import tempfile
+import unittest
+import yaml
+
+from GenesisAeonAdvancedAi.aeon_logger import log_event
+
+
+class TestAeonLogger(unittest.TestCase):
+    def test_log_event_creates_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                log_event("agent", "input", {"d": 1})
+                self.assertTrue(os.path.exists("agent_log.yaml"))
+                content = yaml.safe_load(open("agent_log.yaml", "r", encoding="utf-8").read())
+                self.assertIsInstance(content, list)
+                self.assertGreater(len(content), 0)
+            finally:
+                os.chdir(cwd)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GenesisAeonAdvancedAi/test_aeon_web.py
+++ b/GenesisAeonAdvancedAi/test_aeon_web.py
@@ -1,0 +1,17 @@
+import unittest
+
+from GenesisAeonAdvancedAi.aeon_web import app
+
+
+class TestAeonWeb(unittest.TestCase):
+    def test_act_endpoint(self):
+        with app.test_client() as client:
+            res = client.post('/aeon/act', json={'input': [0.1]})
+            self.assertEqual(res.status_code, 200)
+            data = res.get_json()
+            self.assertIn('action', data)
+            self.assertIn('record', data)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/GenesisAeonAdvancedAi/test_crep_eval.py
+++ b/GenesisAeonAdvancedAi/test_crep_eval.py
@@ -1,0 +1,14 @@
+import unittest
+
+from GenesisAeonAdvancedAi.crep_eval import evaluate_crep
+
+
+class TestCrepEval(unittest.TestCase):
+    def test_keys_present(self):
+        metrics = evaluate_crep("data")
+        for key in ["coherence", "resonance", "emergence", "presence"]:
+            self.assertIn(key, metrics)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GenesisAeonAdvancedAi/test_symbol_tools.py
+++ b/GenesisAeonAdvancedAi/test_symbol_tools.py
@@ -1,0 +1,19 @@
+import unittest
+
+from GenesisAeonAdvancedAi.symbol_tools import assign_color, transform_to_symbol
+
+
+class TestSymbolTools(unittest.TestCase):
+    def test_assign_color(self):
+        self.assertEqual(assign_color(0.9), "gold")
+        self.assertEqual(assign_color(0.6), "blue")
+        self.assertEqual(assign_color(0.1), "grey")
+
+    def test_transform_to_symbol(self):
+        self.assertEqual(transform_to_symbol({}), "\u0394")
+        self.assertEqual(transform_to_symbol("x"), "\u03C8")
+        self.assertEqual(transform_to_symbol(123), "\u25CF")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GenesisAeonZIPMEM/9f0cf4ddfa4264f4c79d965f02b90bc2669462ba/changes.patch
+++ b/GenesisAeonZIPMEM/9f0cf4ddfa4264f4c79d965f02b90bc2669462ba/changes.patch
@@ -1,0 +1,17 @@
+commit 9f0cf4ddfa4264f4c79d965f02b90bc2669462ba
+Author: Codex <codex@openai.com>
+Date:   Wed Jun 25 22:15:27 2025 +0000
+
+    chore(meta): update progress snapshots
+
+diff --git a/advancedprogress.json b/advancedprogress.json
+index 22d7aae..2b90aac 100644
+--- a/advancedprogress.json
++++ b/advancedprogress.json
+@@ -1,5 +1,5 @@
+ {
+-  "lastCommit": "Merge pull request #356 from GenesisAeon/codex/implementiere-fraktale-ki-architektur-mit-symbolintegration",
++  "lastCommit": "feat: add Aeon symbol and logging modules",
+   "fractalStep": "sync",
+   "openBranches": [
+     "work"

--- a/GenesisAeonZIPMEM/9f0cf4ddfa4264f4c79d965f02b90bc2669462ba/fragments/advancedprogress.json.patch
+++ b/GenesisAeonZIPMEM/9f0cf4ddfa4264f4c79d965f02b90bc2669462ba/fragments/advancedprogress.json.patch
@@ -1,0 +1,11 @@
+diff --git a/advancedprogress.json b/advancedprogress.json
+index 22d7aae..2b90aac 100644
+--- a/advancedprogress.json
++++ b/advancedprogress.json
+@@ -1,5 +1,5 @@
+ {
+-  "lastCommit": "Merge pull request #356 from GenesisAeon/codex/implementiere-fraktale-ki-architektur-mit-symbolintegration",
++  "lastCommit": "feat: add Aeon symbol and logging modules",
+   "fractalStep": "sync",
+   "openBranches": [
+     "work"

--- a/GenesisAeonZIPMEM/9f0cf4ddfa4264f4c79d965f02b90bc2669462ba/meta.yaml
+++ b/GenesisAeonZIPMEM/9f0cf4ddfa4264f4c79d965f02b90bc2669462ba/meta.yaml
@@ -1,0 +1,10 @@
+commit: 9f0cf4ddfa4264f4c79d965f02b90bc2669462ba
+message: "chore(meta): update progress snapshots"
+patch: changes.patch
+fragments: fragments
+files:
+  - advancedprogress.json
+environment:
+  node: v22.16.0
+  pnpm: 10.5.2
+instructions: Apply patch with git apply or review for reference.

--- a/GenesisAeonZIPMEM/b72406e13599d1d00081861ea4fe31ce0c8a083d/changes.patch
+++ b/GenesisAeonZIPMEM/b72406e13599d1d00081861ea4fe31ce0c8a083d/changes.patch
@@ -1,0 +1,17 @@
+commit b72406e13599d1d00081861ea4fe31ce0c8a083d
+Author: Codex <codex@openai.com>
+Date:   Wed Jun 25 22:15:52 2025 +0000
+
+    chore(meta): add commit memory
+
+diff --git a/advancedprogress.json b/advancedprogress.json
+index 2b90aac..1510bad 100644
+--- a/advancedprogress.json
++++ b/advancedprogress.json
+@@ -1,5 +1,5 @@
+ {
+-  "lastCommit": "feat: add Aeon symbol and logging modules",
++  "lastCommit": "chore(meta): update chronopoem and commit memory",
+   "fractalStep": "sync",
+   "openBranches": [
+     "work"

--- a/GenesisAeonZIPMEM/b72406e13599d1d00081861ea4fe31ce0c8a083d/fragments/advancedprogress.json.patch
+++ b/GenesisAeonZIPMEM/b72406e13599d1d00081861ea4fe31ce0c8a083d/fragments/advancedprogress.json.patch
@@ -1,0 +1,11 @@
+diff --git a/advancedprogress.json b/advancedprogress.json
+index 2b90aac..1510bad 100644
+--- a/advancedprogress.json
++++ b/advancedprogress.json
+@@ -1,5 +1,5 @@
+ {
+-  "lastCommit": "feat: add Aeon symbol and logging modules",
++  "lastCommit": "chore(meta): update chronopoem and commit memory",
+   "fractalStep": "sync",
+   "openBranches": [
+     "work"

--- a/GenesisAeonZIPMEM/b72406e13599d1d00081861ea4fe31ce0c8a083d/meta.yaml
+++ b/GenesisAeonZIPMEM/b72406e13599d1d00081861ea4fe31ce0c8a083d/meta.yaml
@@ -1,0 +1,10 @@
+commit: b72406e13599d1d00081861ea4fe31ce0c8a083d
+message: "chore(meta): add commit memory"
+patch: changes.patch
+fragments: fragments
+files:
+  - advancedprogress.json
+environment:
+  node: v22.16.0
+  pnpm: 10.5.2
+instructions: Apply patch with git apply or review for reference.

--- a/GenesisAeonZIPMEM/cce5b9cc1c52cee28bb2a356e2894ab582babcb9/changes.patch
+++ b/GenesisAeonZIPMEM/cce5b9cc1c52cee28bb2a356e2894ab582babcb9/changes.patch
@@ -1,0 +1,49 @@
+commit cce5b9cc1c52cee28bb2a356e2894ab582babcb9
+Author: Codex <codex@openai.com>
+Date:   Wed Jun 25 22:15:11 2025 +0000
+
+    chore(meta): update chronopoem and commit memory
+
+diff --git a/CHRONOPOEM.md b/CHRONOPOEM.md
+index c6a5aea..afd2215 100644
+--- a/CHRONOPOEM.md
++++ b/CHRONOPOEM.md
+@@ -1,9 +1,9 @@
+ # 🜂 Chronopoem
+ 
+ Im Kreis der Genesis erwacht das Mandala,
+-Am 2025-06-25, in der Zeit des Abend.
++Am 2025-06-25, in der Zeit des Nacht.
+ 
+-Symbolphase: Integration (Fokus: E)
++Symbolphase: Reflexion (Fokus: P)
+ 
+ CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
+ CREP-Zustand: 
+diff --git a/advancedToDo.json b/advancedToDo.json
+index 40a7893..67f3798 100644
+--- a/advancedToDo.json
++++ b/advancedToDo.json
+@@ -2119,4 +2119,4 @@
+     "test": "scripts/__tests__/parse-md-todo.test.ts",
+     "status": "done"
+   }
+-]
++]
+\ No newline at end of file
+diff --git a/advancedprogress.json b/advancedprogress.json
+index 5fcbc6b..22d7aae 100644
+--- a/advancedprogress.json
++++ b/advancedprogress.json
+@@ -1,8 +1,8 @@
+ {
+-  "lastCommit": "chore(meta): update chronopoem and commit memory",
++  "lastCommit": "Merge pull request #356 from GenesisAeon/codex/implementiere-fraktale-ki-architektur-mit-symbolintegration",
+   "fractalStep": "sync",
+   "openBranches": [
+     "work"
+   ],
+   "mergeConflicts": []
+-}
++}
+\ No newline at end of file

--- a/GenesisAeonZIPMEM/cce5b9cc1c52cee28bb2a356e2894ab582babcb9/fragments/CHRONOPOEM.md.patch
+++ b/GenesisAeonZIPMEM/cce5b9cc1c52cee28bb2a356e2894ab582babcb9/fragments/CHRONOPOEM.md.patch
@@ -1,0 +1,16 @@
+diff --git a/CHRONOPOEM.md b/CHRONOPOEM.md
+index c6a5aea..afd2215 100644
+--- a/CHRONOPOEM.md
++++ b/CHRONOPOEM.md
+@@ -1,9 +1,9 @@
+ # 🜂 Chronopoem
+ 
+ Im Kreis der Genesis erwacht das Mandala,
+-Am 2025-06-25, in der Zeit des Abend.
++Am 2025-06-25, in der Zeit des Nacht.
+ 
+-Symbolphase: Integration (Fokus: E)
++Symbolphase: Reflexion (Fokus: P)
+ 
+ CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
+ CREP-Zustand: 

--- a/GenesisAeonZIPMEM/cce5b9cc1c52cee28bb2a356e2894ab582babcb9/fragments/advancedToDo.json.patch
+++ b/GenesisAeonZIPMEM/cce5b9cc1c52cee28bb2a356e2894ab582babcb9/fragments/advancedToDo.json.patch
@@ -1,0 +1,11 @@
+diff --git a/advancedToDo.json b/advancedToDo.json
+index 40a7893..67f3798 100644
+--- a/advancedToDo.json
++++ b/advancedToDo.json
+@@ -2119,4 +2119,4 @@
+     "test": "scripts/__tests__/parse-md-todo.test.ts",
+     "status": "done"
+   }
+-]
++]
+\ No newline at end of file

--- a/GenesisAeonZIPMEM/cce5b9cc1c52cee28bb2a356e2894ab582babcb9/fragments/advancedprogress.json.patch
+++ b/GenesisAeonZIPMEM/cce5b9cc1c52cee28bb2a356e2894ab582babcb9/fragments/advancedprogress.json.patch
@@ -1,0 +1,16 @@
+diff --git a/advancedprogress.json b/advancedprogress.json
+index 5fcbc6b..22d7aae 100644
+--- a/advancedprogress.json
++++ b/advancedprogress.json
+@@ -1,8 +1,8 @@
+ {
+-  "lastCommit": "chore(meta): update chronopoem and commit memory",
++  "lastCommit": "Merge pull request #356 from GenesisAeon/codex/implementiere-fraktale-ki-architektur-mit-symbolintegration",
+   "fractalStep": "sync",
+   "openBranches": [
+     "work"
+   ],
+   "mergeConflicts": []
+-}
++}
+\ No newline at end of file

--- a/GenesisAeonZIPMEM/cce5b9cc1c52cee28bb2a356e2894ab582babcb9/meta.yaml
+++ b/GenesisAeonZIPMEM/cce5b9cc1c52cee28bb2a356e2894ab582babcb9/meta.yaml
@@ -1,0 +1,12 @@
+commit: cce5b9cc1c52cee28bb2a356e2894ab582babcb9
+message: "chore(meta): update chronopoem and commit memory"
+patch: changes.patch
+fragments: fragments
+files:
+  - CHRONOPOEM.md
+  - advancedToDo.json
+  - advancedprogress.json
+environment:
+  node: v22.16.0
+  pnpm: 10.5.2
+instructions: Apply patch with git apply or review for reference.

--- a/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/changes.patch
+++ b/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/changes.patch
@@ -1,0 +1,263 @@
+commit e532c8b61e81aac893b97175536b0ba8b8352c53
+Author: Codex <codex@openai.com>
+Date:   Wed Jun 25 22:14:35 2025 +0000
+
+    feat: add Aeon symbol and logging modules
+
+diff --git a/GenesisAeonAdvancedAi/__init__.py b/GenesisAeonAdvancedAi/__init__.py
+index 1f6f098..3d5a284 100644
+--- a/GenesisAeonAdvancedAi/__init__.py
++++ b/GenesisAeonAdvancedAi/__init__.py
+@@ -1,4 +1,14 @@
+ from .aeon_agent import AeonAgent
+ from .advanced_agent import AdvancedAeonAgent
++from .symbol_tools import assign_color, transform_to_symbol
++from .crep_eval import evaluate_crep
++from .aeon_logger import log_event
+ 
+-__all__ = ["AeonAgent", "AdvancedAeonAgent"]
++__all__ = [
++    "AeonAgent",
++    "AdvancedAeonAgent",
++    "assign_color",
++    "transform_to_symbol",
++    "evaluate_crep",
++    "log_event",
++]
+diff --git a/GenesisAeonAdvancedAi/aeon_logger.py b/GenesisAeonAdvancedAi/aeon_logger.py
+new file mode 100644
+index 0000000..40f3c76
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/aeon_logger.py
+@@ -0,0 +1,18 @@
++"""Simple YAML-based logging utility."""
++
++from datetime import datetime
++from typing import Any
++
++import yaml
++
++
++def log_event(agent_name: str, input_data: Any, decision: Any) -> None:
++    """Append a log entry for the agent to a YAML file."""
++    log_entry = {
++        "timestamp": datetime.now().isoformat(),
++        "input": input_data,
++        "decision": decision,
++    }
++    file_path = f"{agent_name}_log.yaml"
++    with open(file_path, "a", encoding="utf-8") as f:
++        yaml.safe_dump([log_entry], f, allow_unicode=True)
+diff --git a/GenesisAeonAdvancedAi/aeon_ui.html b/GenesisAeonAdvancedAi/aeon_ui.html
+new file mode 100644
+index 0000000..84a088d
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/aeon_ui.html
+@@ -0,0 +1,28 @@
++<!DOCTYPE html>
++<html lang="en">
++<head>
++  <meta charset="UTF-8">
++  <title>Aeon UI</title>
++</head>
++<body>
++  <h1>Aeon Interface</h1>
++  <form id="aeon-form">
++    <input type="text" id="input" placeholder="input" />
++    <button type="submit">Send</button>
++  </form>
++  <pre id="result"></pre>
++  <script>
++    document.getElementById('aeon-form').addEventListener('submit', async (e) => {
++      e.preventDefault();
++      const input = document.getElementById('input').value;
++      const res = await fetch('/aeon/act', {
++        method: 'POST',
++        headers: { 'Content-Type': 'application/json' },
++        body: JSON.stringify({ input })
++      });
++      const data = await res.json();
++      document.getElementById('result').textContent = JSON.stringify(data, null, 2);
++    });
++  </script>
++</body>
++</html>
+diff --git a/GenesisAeonAdvancedAi/aeon_web.py b/GenesisAeonAdvancedAi/aeon_web.py
+new file mode 100644
+index 0000000..9bebb6b
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/aeon_web.py
+@@ -0,0 +1,19 @@
++"""Minimal Flask web API for AeonAgent."""
++
++from flask import Flask, request, jsonify
++
++from .aeon_agent import AeonAgent
++
++app = Flask(__name__)
++agent = AeonAgent()
++
++
++@app.route("/aeon/act", methods=["POST"])
++def act() -> "flask.Response":
++    data = request.json.get("input")
++    action, record = agent.act(data or [])
++    return jsonify({"action": action, "record": record})
++
++
++if __name__ == "__main__":
++    app.run(debug=True)
+diff --git a/GenesisAeonAdvancedAi/config.yaml b/GenesisAeonAdvancedAi/config.yaml
+new file mode 100644
+index 0000000..5760e23
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/config.yaml
+@@ -0,0 +1,3 @@
++agent_name: "aeon_proto"
++default_input: "INIT"
++log_path: "./logs"
+diff --git a/GenesisAeonAdvancedAi/crep_eval.py b/GenesisAeonAdvancedAi/crep_eval.py
+new file mode 100644
+index 0000000..7acae8d
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/crep_eval.py
+@@ -0,0 +1,13 @@
++"""Minimal CREP evaluation module."""
++
++from typing import Any, Dict
++
++
++def evaluate_crep(input_data: Any) -> Dict[str, float]:
++    """Return static CREP metrics for a given input."""
++    return {
++        "coherence": 0.85,
++        "resonance": 0.75,
++        "emergence": 0.65,
++        "presence": 1.0,
++    }
+diff --git a/GenesisAeonAdvancedAi/symbol_tools.py b/GenesisAeonAdvancedAi/symbol_tools.py
+new file mode 100644
+index 0000000..b98bcbf
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/symbol_tools.py
+@@ -0,0 +1,21 @@
++"""Utility functions for symbolic color and shape mapping."""
++
++from typing import Any
++
++
++def assign_color(value: float) -> str:
++    """Return a color name based on threshold values."""
++    if value > 0.8:
++        return "gold"
++    if value > 0.5:
++        return "blue"
++    return "grey"
++
++
++def transform_to_symbol(data: Any) -> str:
++    """Map Python data types to simple symbolic markers."""
++    if isinstance(data, dict):
++        return "\u0394"  # Δ
++    if isinstance(data, str):
++        return "\u03C8"  # ψ
++    return "\u25CF"  # ●
+diff --git a/GenesisAeonAdvancedAi/test_aeon_logger.py b/GenesisAeonAdvancedAi/test_aeon_logger.py
+new file mode 100644
+index 0000000..637d3f0
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/test_aeon_logger.py
+@@ -0,0 +1,25 @@
++import os
++import tempfile
++import unittest
++import yaml
++
++from GenesisAeonAdvancedAi.aeon_logger import log_event
++
++
++class TestAeonLogger(unittest.TestCase):
++    def test_log_event_creates_file(self):
++        with tempfile.TemporaryDirectory() as tmpdir:
++            cwd = os.getcwd()
++            os.chdir(tmpdir)
++            try:
++                log_event("agent", "input", {"d": 1})
++                self.assertTrue(os.path.exists("agent_log.yaml"))
++                content = yaml.safe_load(open("agent_log.yaml", "r", encoding="utf-8").read())
++                self.assertIsInstance(content, list)
++                self.assertGreater(len(content), 0)
++            finally:
++                os.chdir(cwd)
++
++
++if __name__ == "__main__":
++    unittest.main()
+diff --git a/GenesisAeonAdvancedAi/test_aeon_web.py b/GenesisAeonAdvancedAi/test_aeon_web.py
+new file mode 100644
+index 0000000..79f7f95
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/test_aeon_web.py
+@@ -0,0 +1,17 @@
++import unittest
++
++from GenesisAeonAdvancedAi.aeon_web import app
++
++
++class TestAeonWeb(unittest.TestCase):
++    def test_act_endpoint(self):
++        with app.test_client() as client:
++            res = client.post('/aeon/act', json={'input': [0.1]})
++            self.assertEqual(res.status_code, 200)
++            data = res.get_json()
++            self.assertIn('action', data)
++            self.assertIn('record', data)
++
++
++if __name__ == '__main__':
++    unittest.main()
+diff --git a/GenesisAeonAdvancedAi/test_crep_eval.py b/GenesisAeonAdvancedAi/test_crep_eval.py
+new file mode 100644
+index 0000000..4d75042
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/test_crep_eval.py
+@@ -0,0 +1,14 @@
++import unittest
++
++from GenesisAeonAdvancedAi.crep_eval import evaluate_crep
++
++
++class TestCrepEval(unittest.TestCase):
++    def test_keys_present(self):
++        metrics = evaluate_crep("data")
++        for key in ["coherence", "resonance", "emergence", "presence"]:
++            self.assertIn(key, metrics)
++
++
++if __name__ == "__main__":
++    unittest.main()
+diff --git a/GenesisAeonAdvancedAi/test_symbol_tools.py b/GenesisAeonAdvancedAi/test_symbol_tools.py
+new file mode 100644
+index 0000000..a9e47ee
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/test_symbol_tools.py
+@@ -0,0 +1,19 @@
++import unittest
++
++from GenesisAeonAdvancedAi.symbol_tools import assign_color, transform_to_symbol
++
++
++class TestSymbolTools(unittest.TestCase):
++    def test_assign_color(self):
++        self.assertEqual(assign_color(0.9), "gold")
++        self.assertEqual(assign_color(0.6), "blue")
++        self.assertEqual(assign_color(0.1), "grey")
++
++    def test_transform_to_symbol(self):
++        self.assertEqual(transform_to_symbol({}), "\u0394")
++        self.assertEqual(transform_to_symbol("x"), "\u03C8")
++        self.assertEqual(transform_to_symbol(123), "\u25CF")
++
++
++if __name__ == "__main__":
++    unittest.main()

--- a/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/__init__.py.patch
+++ b/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/__init__.py.patch
@@ -1,0 +1,20 @@
+diff --git a/GenesisAeonAdvancedAi/__init__.py b/GenesisAeonAdvancedAi/__init__.py
+index 1f6f098..3d5a284 100644
+--- a/GenesisAeonAdvancedAi/__init__.py
++++ b/GenesisAeonAdvancedAi/__init__.py
+@@ -1,4 +1,14 @@
+ from .aeon_agent import AeonAgent
+ from .advanced_agent import AdvancedAeonAgent
++from .symbol_tools import assign_color, transform_to_symbol
++from .crep_eval import evaluate_crep
++from .aeon_logger import log_event
+ 
+-__all__ = ["AeonAgent", "AdvancedAeonAgent"]
++__all__ = [
++    "AeonAgent",
++    "AdvancedAeonAgent",
++    "assign_color",
++    "transform_to_symbol",
++    "evaluate_crep",
++    "log_event",
++]

--- a/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/aeon_logger.py.patch
+++ b/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/aeon_logger.py.patch
@@ -1,0 +1,24 @@
+diff --git a/GenesisAeonAdvancedAi/aeon_logger.py b/GenesisAeonAdvancedAi/aeon_logger.py
+new file mode 100644
+index 0000000..40f3c76
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/aeon_logger.py
+@@ -0,0 +1,18 @@
++"""Simple YAML-based logging utility."""
++
++from datetime import datetime
++from typing import Any
++
++import yaml
++
++
++def log_event(agent_name: str, input_data: Any, decision: Any) -> None:
++    """Append a log entry for the agent to a YAML file."""
++    log_entry = {
++        "timestamp": datetime.now().isoformat(),
++        "input": input_data,
++        "decision": decision,
++    }
++    file_path = f"{agent_name}_log.yaml"
++    with open(file_path, "a", encoding="utf-8") as f:
++        yaml.safe_dump([log_entry], f, allow_unicode=True)

--- a/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/aeon_ui.html.patch
+++ b/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/aeon_ui.html.patch
@@ -1,0 +1,34 @@
+diff --git a/GenesisAeonAdvancedAi/aeon_ui.html b/GenesisAeonAdvancedAi/aeon_ui.html
+new file mode 100644
+index 0000000..84a088d
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/aeon_ui.html
+@@ -0,0 +1,28 @@
++<!DOCTYPE html>
++<html lang="en">
++<head>
++  <meta charset="UTF-8">
++  <title>Aeon UI</title>
++</head>
++<body>
++  <h1>Aeon Interface</h1>
++  <form id="aeon-form">
++    <input type="text" id="input" placeholder="input" />
++    <button type="submit">Send</button>
++  </form>
++  <pre id="result"></pre>
++  <script>
++    document.getElementById('aeon-form').addEventListener('submit', async (e) => {
++      e.preventDefault();
++      const input = document.getElementById('input').value;
++      const res = await fetch('/aeon/act', {
++        method: 'POST',
++        headers: { 'Content-Type': 'application/json' },
++        body: JSON.stringify({ input })
++      });
++      const data = await res.json();
++      document.getElementById('result').textContent = JSON.stringify(data, null, 2);
++    });
++  </script>
++</body>
++</html>

--- a/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/aeon_web.py.patch
+++ b/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/aeon_web.py.patch
@@ -1,0 +1,25 @@
+diff --git a/GenesisAeonAdvancedAi/aeon_web.py b/GenesisAeonAdvancedAi/aeon_web.py
+new file mode 100644
+index 0000000..9bebb6b
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/aeon_web.py
+@@ -0,0 +1,19 @@
++"""Minimal Flask web API for AeonAgent."""
++
++from flask import Flask, request, jsonify
++
++from .aeon_agent import AeonAgent
++
++app = Flask(__name__)
++agent = AeonAgent()
++
++
++@app.route("/aeon/act", methods=["POST"])
++def act() -> "flask.Response":
++    data = request.json.get("input")
++    action, record = agent.act(data or [])
++    return jsonify({"action": action, "record": record})
++
++
++if __name__ == "__main__":
++    app.run(debug=True)

--- a/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/config.yaml.patch
+++ b/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/config.yaml.patch
@@ -1,0 +1,9 @@
+diff --git a/GenesisAeonAdvancedAi/config.yaml b/GenesisAeonAdvancedAi/config.yaml
+new file mode 100644
+index 0000000..5760e23
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/config.yaml
+@@ -0,0 +1,3 @@
++agent_name: "aeon_proto"
++default_input: "INIT"
++log_path: "./logs"

--- a/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/crep_eval.py.patch
+++ b/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/crep_eval.py.patch
@@ -1,0 +1,19 @@
+diff --git a/GenesisAeonAdvancedAi/crep_eval.py b/GenesisAeonAdvancedAi/crep_eval.py
+new file mode 100644
+index 0000000..7acae8d
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/crep_eval.py
+@@ -0,0 +1,13 @@
++"""Minimal CREP evaluation module."""
++
++from typing import Any, Dict
++
++
++def evaluate_crep(input_data: Any) -> Dict[str, float]:
++    """Return static CREP metrics for a given input."""
++    return {
++        "coherence": 0.85,
++        "resonance": 0.75,
++        "emergence": 0.65,
++        "presence": 1.0,
++    }

--- a/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/symbol_tools.py.patch
+++ b/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/symbol_tools.py.patch
@@ -1,0 +1,27 @@
+diff --git a/GenesisAeonAdvancedAi/symbol_tools.py b/GenesisAeonAdvancedAi/symbol_tools.py
+new file mode 100644
+index 0000000..b98bcbf
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/symbol_tools.py
+@@ -0,0 +1,21 @@
++"""Utility functions for symbolic color and shape mapping."""
++
++from typing import Any
++
++
++def assign_color(value: float) -> str:
++    """Return a color name based on threshold values."""
++    if value > 0.8:
++        return "gold"
++    if value > 0.5:
++        return "blue"
++    return "grey"
++
++
++def transform_to_symbol(data: Any) -> str:
++    """Map Python data types to simple symbolic markers."""
++    if isinstance(data, dict):
++        return "\u0394"  # Δ
++    if isinstance(data, str):
++        return "\u03C8"  # ψ
++    return "\u25CF"  # ●

--- a/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/test_aeon_logger.py.patch
+++ b/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/test_aeon_logger.py.patch
@@ -1,0 +1,31 @@
+diff --git a/GenesisAeonAdvancedAi/test_aeon_logger.py b/GenesisAeonAdvancedAi/test_aeon_logger.py
+new file mode 100644
+index 0000000..637d3f0
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/test_aeon_logger.py
+@@ -0,0 +1,25 @@
++import os
++import tempfile
++import unittest
++import yaml
++
++from GenesisAeonAdvancedAi.aeon_logger import log_event
++
++
++class TestAeonLogger(unittest.TestCase):
++    def test_log_event_creates_file(self):
++        with tempfile.TemporaryDirectory() as tmpdir:
++            cwd = os.getcwd()
++            os.chdir(tmpdir)
++            try:
++                log_event("agent", "input", {"d": 1})
++                self.assertTrue(os.path.exists("agent_log.yaml"))
++                content = yaml.safe_load(open("agent_log.yaml", "r", encoding="utf-8").read())
++                self.assertIsInstance(content, list)
++                self.assertGreater(len(content), 0)
++            finally:
++                os.chdir(cwd)
++
++
++if __name__ == "__main__":
++    unittest.main()

--- a/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/test_aeon_web.py.patch
+++ b/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/test_aeon_web.py.patch
@@ -1,0 +1,23 @@
+diff --git a/GenesisAeonAdvancedAi/test_aeon_web.py b/GenesisAeonAdvancedAi/test_aeon_web.py
+new file mode 100644
+index 0000000..79f7f95
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/test_aeon_web.py
+@@ -0,0 +1,17 @@
++import unittest
++
++from GenesisAeonAdvancedAi.aeon_web import app
++
++
++class TestAeonWeb(unittest.TestCase):
++    def test_act_endpoint(self):
++        with app.test_client() as client:
++            res = client.post('/aeon/act', json={'input': [0.1]})
++            self.assertEqual(res.status_code, 200)
++            data = res.get_json()
++            self.assertIn('action', data)
++            self.assertIn('record', data)
++
++
++if __name__ == '__main__':
++    unittest.main()

--- a/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/test_crep_eval.py.patch
+++ b/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/test_crep_eval.py.patch
@@ -1,0 +1,20 @@
+diff --git a/GenesisAeonAdvancedAi/test_crep_eval.py b/GenesisAeonAdvancedAi/test_crep_eval.py
+new file mode 100644
+index 0000000..4d75042
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/test_crep_eval.py
+@@ -0,0 +1,14 @@
++import unittest
++
++from GenesisAeonAdvancedAi.crep_eval import evaluate_crep
++
++
++class TestCrepEval(unittest.TestCase):
++    def test_keys_present(self):
++        metrics = evaluate_crep("data")
++        for key in ["coherence", "resonance", "emergence", "presence"]:
++            self.assertIn(key, metrics)
++
++
++if __name__ == "__main__":
++    unittest.main()

--- a/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/test_symbol_tools.py.patch
+++ b/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/fragments/GenesisAeonAdvancedAi/test_symbol_tools.py.patch
@@ -1,0 +1,25 @@
+diff --git a/GenesisAeonAdvancedAi/test_symbol_tools.py b/GenesisAeonAdvancedAi/test_symbol_tools.py
+new file mode 100644
+index 0000000..a9e47ee
+--- /dev/null
++++ b/GenesisAeonAdvancedAi/test_symbol_tools.py
+@@ -0,0 +1,19 @@
++import unittest
++
++from GenesisAeonAdvancedAi.symbol_tools import assign_color, transform_to_symbol
++
++
++class TestSymbolTools(unittest.TestCase):
++    def test_assign_color(self):
++        self.assertEqual(assign_color(0.9), "gold")
++        self.assertEqual(assign_color(0.6), "blue")
++        self.assertEqual(assign_color(0.1), "grey")
++
++    def test_transform_to_symbol(self):
++        self.assertEqual(transform_to_symbol({}), "\u0394")
++        self.assertEqual(transform_to_symbol("x"), "\u03C8")
++        self.assertEqual(transform_to_symbol(123), "\u25CF")
++
++
++if __name__ == "__main__":
++    unittest.main()

--- a/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/meta.yaml
+++ b/GenesisAeonZIPMEM/e532c8b61e81aac893b97175536b0ba8b8352c53/meta.yaml
@@ -1,0 +1,20 @@
+commit: e532c8b61e81aac893b97175536b0ba8b8352c53
+message: "feat: add Aeon symbol and logging modules"
+patch: changes.patch
+fragments: fragments
+files:
+  - GenesisAeonAdvancedAi/__init__.py
+  - GenesisAeonAdvancedAi/aeon_logger.py
+  - GenesisAeonAdvancedAi/aeon_ui.html
+  - GenesisAeonAdvancedAi/aeon_web.py
+  - GenesisAeonAdvancedAi/config.yaml
+  - GenesisAeonAdvancedAi/crep_eval.py
+  - GenesisAeonAdvancedAi/symbol_tools.py
+  - GenesisAeonAdvancedAi/test_aeon_logger.py
+  - GenesisAeonAdvancedAi/test_aeon_web.py
+  - GenesisAeonAdvancedAi/test_crep_eval.py
+  - GenesisAeonAdvancedAi/test_symbol_tools.py
+environment:
+  node: v22.16.0
+  pnpm: 10.5.2
+instructions: Apply patch with git apply or review for reference.

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore(meta): update chronopoem and commit memory",
+  "lastCommit": "chore(meta): update progress snapshots",
   "fractalStep": "sync",
   "openBranches": [
     "work"


### PR DESCRIPTION
## Summary
- implement minimal symbol color helpers
- add simple CREP evaluation stub
- provide YAML logger utility
- expose new helpers in package
- setup basic Flask API and HTML UI
- cover new modules with unit tests

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685c73ddc08083228d5f3ea3e4f5eb32