### PR TITLE
Add poetic commentary to Aeon CLI

### DIFF
--- a/GenesisAeonAdvancedAi/aeon_cli.py
+++ b/GenesisAeonAdvancedAi/aeon_cli.py
@@ -14,7 +14,11 @@ from .aeon_processor import (
     fraktal_feedback_metrics,
     fraktal_feedback_graph,
 )
-from .aeon_processor import generate_haiku
+from .aeon_processor import (
+    generate_haiku,
+    generate_poetic_commentary,
+    advanced_crep_eval,
+)
 from .performance_monitor import monitor_performance
 from .memory_store import store_result, load_results
 from .sigil_loader import load_sigil, load_start_sigil
@@ -74,6 +78,11 @@ def main(argv: List[str] | None = None) -> None:
         help="Generate a haiku describing the symbolic output",
     )
     parser.add_argument(
+        "--poetry",
+        action="store_true",
+        help="Generate a short poetic comment based on CREP metrics",
+    )
+    parser.add_argument(
         "--metrics",
         action="store_true",
         help="Include CREP metrics in the output",
@@ -115,7 +124,7 @@ def main(argv: List[str] | None = None) -> None:
         if args.graph:
             result["graph"] = fraktal_feedback_graph(values, depth=args.depth)
     else:
-        if args.metrics:
+        if args.metrics or args.poetry or args.graph:
             symbolic, score, metrics = fraktal_feedback_metrics(
                 values, depth=args.depth
             )
@@ -136,6 +145,9 @@ def main(argv: List[str] | None = None) -> None:
             result["sigil"] = sigil_data
         if args.haiku:
             result["haiku"] = generate_haiku(symbolic)
+        if args.poetry:
+            metrics = result.get("metrics") or advanced_crep_eval(symbolic)
+            result["poetry"] = generate_poetic_commentary(metrics)
         if args.graph:
             result["graph"] = fraktal_feedback_graph(values, depth=args.depth)
 

--- a/GenesisAeonAdvancedAi/aeon_processor.py
+++ b/GenesisAeonAdvancedAi/aeon_processor.py
@@ -193,3 +193,14 @@ def generate_haiku(symbolic_data: Dict[str, Any]) -> str:
         return "raindrops softly fall\npooling into quiet streams\nchange flows ever on"
     # default case for ⚫ or unknown symbol
     return "stillness all around\nshadows weave an empty path\nnight consumes the sound"
+
+
+
+def generate_poetic_commentary(metrics: Dict[str, float]) -> str:
+    """Return a short deterministic poetic line based on CREP metrics."""
+    avg = sum(metrics.values()) / len(metrics) if metrics else 0.0
+    if avg >= 0.8:
+        return "resonant patterns bloom"
+    if avg >= 0.5:
+        return "subtle waves converge"
+    return "quiet traces fade"

--- a/GenesisAeonAdvancedAi/test_aeon_processor.py
+++ b/GenesisAeonAdvancedAi/test_aeon_processor.py
@@ -1,6 +1,10 @@
 import unittest
 
-from GenesisAeonAdvancedAi.aeon_processor import assign_symbol, generate_haiku
+from GenesisAeonAdvancedAi.aeon_processor import (
+    assign_symbol,
+    generate_haiku,
+    generate_poetic_commentary,
+)
 
 
 class TestAssignSymbol(unittest.TestCase):
@@ -14,6 +18,11 @@ class TestAssignSymbol(unittest.TestCase):
         symbolic = {"symbol": "\u2600"}
         haiku = generate_haiku(symbolic)
         self.assertIn("golden light", haiku)
+
+    def test_poetic_commentary(self):
+        metrics = {"kohärenz": 0.9, "resonanz": 0.9, "emergenz": 0.9, "präsenz": 0.9}
+        comment = generate_poetic_commentary(metrics)
+        self.assertEqual(comment, "resonant patterns bloom")
 
 
 if __name__ == "__main__":

--- a/GenesisAeonAdvancedAi/test_cli.py
+++ b/GenesisAeonAdvancedAi/test_cli.py
@@ -131,3 +131,23 @@ class TestAeonCLI(unittest.TestCase):
             data = json.loads(result.stdout)
             self.assertIn("graph", data)
             self.assertIn("nodes", data["graph"])
+
+    def test_poetry_flag(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "vals.txt"
+            input_path.write_text("0.4 0.5")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "GenesisAeonAdvancedAi.aeon_cli",
+                    "--input",
+                    str(input_path),
+                    "--poetry",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            data = json.loads(result.stdout)
+            self.assertIn("poetry", data)

--- a/GenesisAeonZIPMEM/36d98b56c6ec1ccc8f0ad472d0ef3f3b5a9705e8/changes.patch
+++ b/GenesisAeonZIPMEM/36d98b56c6ec1ccc8f0ad472d0ef3f3b5a9705e8/changes.patch
@@ -1,0 +1,142 @@
+commit 36d98b56c6ec1ccc8f0ad472d0ef3f3b5a9705e8
+Author: Codex <codex@openai.com>
+Date:   Thu Jun 26 08:53:54 2025 +0000
+
+    feat: add poetic commentary option
+
+diff --git a/GenesisAeonAdvancedAi/aeon_cli.py b/GenesisAeonAdvancedAi/aeon_cli.py
+index f944892..b8a2ded 100644
+--- a/GenesisAeonAdvancedAi/aeon_cli.py
++++ b/GenesisAeonAdvancedAi/aeon_cli.py
+@@ -14,7 +14,11 @@ from .aeon_processor import (
+     fraktal_feedback_metrics,
+     fraktal_feedback_graph,
+ )
+-from .aeon_processor import generate_haiku
++from .aeon_processor import (
++    generate_haiku,
++    generate_poetic_commentary,
++    advanced_crep_eval,
++)
+ from .performance_monitor import monitor_performance
+ from .memory_store import store_result, load_results
+ from .sigil_loader import load_sigil, load_start_sigil
+@@ -73,6 +77,11 @@ def main(argv: List[str] | None = None) -> None:
+         action="store_true",
+         help="Generate a haiku describing the symbolic output",
+     )
++    parser.add_argument(
++        "--poetry",
++        action="store_true",
++        help="Generate a short poetic comment based on CREP metrics",
++    )
+     parser.add_argument(
+         "--metrics",
+         action="store_true",
+@@ -115,7 +124,7 @@ def main(argv: List[str] | None = None) -> None:
+         if args.graph:
+             result["graph"] = fraktal_feedback_graph(values, depth=args.depth)
+     else:
+-        if args.metrics:
++        if args.metrics or args.poetry or args.graph:
+             symbolic, score, metrics = fraktal_feedback_metrics(
+                 values, depth=args.depth
+             )
+@@ -136,6 +145,9 @@ def main(argv: List[str] | None = None) -> None:
+             result["sigil"] = sigil_data
+         if args.haiku:
+             result["haiku"] = generate_haiku(symbolic)
++        if args.poetry:
++            metrics = result.get("metrics") or advanced_crep_eval(symbolic)
++            result["poetry"] = generate_poetic_commentary(metrics)
+         if args.graph:
+             result["graph"] = fraktal_feedback_graph(values, depth=args.depth)
+ 
+diff --git a/GenesisAeonAdvancedAi/aeon_processor.py b/GenesisAeonAdvancedAi/aeon_processor.py
+index f09a99a..06193f6 100644
+--- a/GenesisAeonAdvancedAi/aeon_processor.py
++++ b/GenesisAeonAdvancedAi/aeon_processor.py
+@@ -193,3 +193,14 @@ def generate_haiku(symbolic_data: Dict[str, Any]) -> str:
+         return "raindrops softly fall\npooling into quiet streams\nchange flows ever on"
+     # default case for ⚫ or unknown symbol
+     return "stillness all around\nshadows weave an empty path\nnight consumes the sound"
++
++
++
++def generate_poetic_commentary(metrics: Dict[str, float]) -> str:
++    """Return a short deterministic poetic line based on CREP metrics."""
++    avg = sum(metrics.values()) / len(metrics) if metrics else 0.0
++    if avg >= 0.8:
++        return "resonant patterns bloom"
++    if avg >= 0.5:
++        return "subtle waves converge"
++    return "quiet traces fade"
+diff --git a/GenesisAeonAdvancedAi/test_aeon_processor.py b/GenesisAeonAdvancedAi/test_aeon_processor.py
+index 1505eba..bf2ea1f 100644
+--- a/GenesisAeonAdvancedAi/test_aeon_processor.py
++++ b/GenesisAeonAdvancedAi/test_aeon_processor.py
+@@ -1,6 +1,10 @@
+ import unittest
+ 
+-from GenesisAeonAdvancedAi.aeon_processor import assign_symbol, generate_haiku
++from GenesisAeonAdvancedAi.aeon_processor import (
++    assign_symbol,
++    generate_haiku,
++    generate_poetic_commentary,
++)
+ 
+ 
+ class TestAssignSymbol(unittest.TestCase):
+@@ -15,6 +19,11 @@ class TestAssignSymbol(unittest.TestCase):
+         haiku = generate_haiku(symbolic)
+         self.assertIn("golden light", haiku)
+ 
++    def test_poetic_commentary(self):
++        metrics = {"kohärenz": 0.9, "resonanz": 0.9, "emergenz": 0.9, "präsenz": 0.9}
++        comment = generate_poetic_commentary(metrics)
++        self.assertEqual(comment, "resonant patterns bloom")
++
+ 
+ if __name__ == "__main__":
+     unittest.main()
+diff --git a/GenesisAeonAdvancedAi/test_cli.py b/GenesisAeonAdvancedAi/test_cli.py
+index 8c73564..1c813c7 100644
+--- a/GenesisAeonAdvancedAi/test_cli.py
++++ b/GenesisAeonAdvancedAi/test_cli.py
+@@ -131,3 +131,23 @@ class TestAeonCLI(unittest.TestCase):
+             data = json.loads(result.stdout)
+             self.assertIn("graph", data)
+             self.assertIn("nodes", data["graph"])
++
++    def test_poetry_flag(self):
++        with tempfile.TemporaryDirectory() as tmpdir:
++            input_path = Path(tmpdir) / "vals.txt"
++            input_path.write_text("0.4 0.5")
++            result = subprocess.run(
++                [
++                    sys.executable,
++                    "-m",
++                    "GenesisAeonAdvancedAi.aeon_cli",
++                    "--input",
++                    str(input_path),
++                    "--poetry",
++                ],
++                capture_output=True,
++                text=True,
++                check=True,
++            )
++            data = json.loads(result.stdout)
++            self.assertIn("poetry", data)
+diff --git a/README.md b/README.md
+index 71eecbc..85a21b4 100644
+--- a/README.md
++++ b/README.md
+@@ -139,7 +139,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
+ - [**Share your Sigil** & **Remix my Solution**](docs/CommunityOnboarding.md) – Community-Features
+ - [**NumericToSymbolicAdapter**](GenesisAeonAdvancedAi/aeon_processor.py) – übersetzt Tensorwerte in Klang- und Farbcodes
+ - [**fraktal_feedback_graph**](GenesisAeonAdvancedAi/aeon_processor.py) – erstellt einen einfachen Graphen der Fraktal-Feedback-Schritte
+-- [**Aeon CLI**](GenesisAeonAdvancedAi/aeon_cli.py) – erzeugt symbolische Ergebnisse aus Zahlenfolgen, kann Leistungsdaten, CREP-Metriken und nun auch einen Fraktal-Graphen (``--graph``) ausgeben. Fehlt PyYAML, gibt die CLI stattdessen JSON aus und weist per Warnung darauf hin.
++ - [**Aeon CLI**](GenesisAeonAdvancedAi/aeon_cli.py) – erzeugt symbolische Ergebnisse aus Zahlenfolgen, kann Leistungsdaten, CREP-Metriken, Fraktal-Graphen (``--graph``) und poetische Kommentare (``--poetry``) ausgeben. Fehlt PyYAML, gibt die CLI stattdessen JSON aus und weist per Warnung darauf hin.
+ ## 📦 Paketstruktur
+ 
+ ```bash

--- a/GenesisAeonZIPMEM/36d98b56c6ec1ccc8f0ad472d0ef3f3b5a9705e8/fragments/GenesisAeonAdvancedAi/aeon_cli.py.patch
+++ b/GenesisAeonZIPMEM/36d98b56c6ec1ccc8f0ad472d0ef3f3b5a9705e8/fragments/GenesisAeonAdvancedAi/aeon_cli.py.patch
@@ -1,0 +1,48 @@
+diff --git a/GenesisAeonAdvancedAi/aeon_cli.py b/GenesisAeonAdvancedAi/aeon_cli.py
+index f944892..b8a2ded 100644
+--- a/GenesisAeonAdvancedAi/aeon_cli.py
++++ b/GenesisAeonAdvancedAi/aeon_cli.py
+@@ -14,7 +14,11 @@ from .aeon_processor import (
+     fraktal_feedback_metrics,
+     fraktal_feedback_graph,
+ )
+-from .aeon_processor import generate_haiku
++from .aeon_processor import (
++    generate_haiku,
++    generate_poetic_commentary,
++    advanced_crep_eval,
++)
+ from .performance_monitor import monitor_performance
+ from .memory_store import store_result, load_results
+ from .sigil_loader import load_sigil, load_start_sigil
+@@ -73,6 +77,11 @@ def main(argv: List[str] | None = None) -> None:
+         action="store_true",
+         help="Generate a haiku describing the symbolic output",
+     )
++    parser.add_argument(
++        "--poetry",
++        action="store_true",
++        help="Generate a short poetic comment based on CREP metrics",
++    )
+     parser.add_argument(
+         "--metrics",
+         action="store_true",
+@@ -115,7 +124,7 @@ def main(argv: List[str] | None = None) -> None:
+         if args.graph:
+             result["graph"] = fraktal_feedback_graph(values, depth=args.depth)
+     else:
+-        if args.metrics:
++        if args.metrics or args.poetry or args.graph:
+             symbolic, score, metrics = fraktal_feedback_metrics(
+                 values, depth=args.depth
+             )
+@@ -136,6 +145,9 @@ def main(argv: List[str] | None = None) -> None:
+             result["sigil"] = sigil_data
+         if args.haiku:
+             result["haiku"] = generate_haiku(symbolic)
++        if args.poetry:
++            metrics = result.get("metrics") or advanced_crep_eval(symbolic)
++            result["poetry"] = generate_poetic_commentary(metrics)
+         if args.graph:
+             result["graph"] = fraktal_feedback_graph(values, depth=args.depth)
+ 

--- a/GenesisAeonZIPMEM/36d98b56c6ec1ccc8f0ad472d0ef3f3b5a9705e8/fragments/GenesisAeonAdvancedAi/aeon_processor.py.patch
+++ b/GenesisAeonZIPMEM/36d98b56c6ec1ccc8f0ad472d0ef3f3b5a9705e8/fragments/GenesisAeonAdvancedAi/aeon_processor.py.patch
@@ -1,0 +1,19 @@
+diff --git a/GenesisAeonAdvancedAi/aeon_processor.py b/GenesisAeonAdvancedAi/aeon_processor.py
+index f09a99a..06193f6 100644
+--- a/GenesisAeonAdvancedAi/aeon_processor.py
++++ b/GenesisAeonAdvancedAi/aeon_processor.py
+@@ -193,3 +193,14 @@ def generate_haiku(symbolic_data: Dict[str, Any]) -> str:
+         return "raindrops softly fall\npooling into quiet streams\nchange flows ever on"
+     # default case for ⚫ or unknown symbol
+     return "stillness all around\nshadows weave an empty path\nnight consumes the sound"
++
++
++
++def generate_poetic_commentary(metrics: Dict[str, float]) -> str:
++    """Return a short deterministic poetic line based on CREP metrics."""
++    avg = sum(metrics.values()) / len(metrics) if metrics else 0.0
++    if avg >= 0.8:
++        return "resonant patterns bloom"
++    if avg >= 0.5:
++        return "subtle waves converge"
++    return "quiet traces fade"

--- a/GenesisAeonZIPMEM/36d98b56c6ec1ccc8f0ad472d0ef3f3b5a9705e8/fragments/GenesisAeonAdvancedAi/test_aeon_processor.py.patch
+++ b/GenesisAeonZIPMEM/36d98b56c6ec1ccc8f0ad472d0ef3f3b5a9705e8/fragments/GenesisAeonAdvancedAi/test_aeon_processor.py.patch
@@ -1,0 +1,28 @@
+diff --git a/GenesisAeonAdvancedAi/test_aeon_processor.py b/GenesisAeonAdvancedAi/test_aeon_processor.py
+index 1505eba..bf2ea1f 100644
+--- a/GenesisAeonAdvancedAi/test_aeon_processor.py
++++ b/GenesisAeonAdvancedAi/test_aeon_processor.py
+@@ -1,6 +1,10 @@
+ import unittest
+ 
+-from GenesisAeonAdvancedAi.aeon_processor import assign_symbol, generate_haiku
++from GenesisAeonAdvancedAi.aeon_processor import (
++    assign_symbol,
++    generate_haiku,
++    generate_poetic_commentary,
++)
+ 
+ 
+ class TestAssignSymbol(unittest.TestCase):
+@@ -15,6 +19,11 @@ class TestAssignSymbol(unittest.TestCase):
+         haiku = generate_haiku(symbolic)
+         self.assertIn("golden light", haiku)
+ 
++    def test_poetic_commentary(self):
++        metrics = {"kohärenz": 0.9, "resonanz": 0.9, "emergenz": 0.9, "präsenz": 0.9}
++        comment = generate_poetic_commentary(metrics)
++        self.assertEqual(comment, "resonant patterns bloom")
++
+ 
+ if __name__ == "__main__":
+     unittest.main()

--- a/GenesisAeonZIPMEM/36d98b56c6ec1ccc8f0ad472d0ef3f3b5a9705e8/fragments/GenesisAeonAdvancedAi/test_cli.py.patch
+++ b/GenesisAeonZIPMEM/36d98b56c6ec1ccc8f0ad472d0ef3f3b5a9705e8/fragments/GenesisAeonAdvancedAi/test_cli.py.patch
@@ -1,0 +1,28 @@
+diff --git a/GenesisAeonAdvancedAi/test_cli.py b/GenesisAeonAdvancedAi/test_cli.py
+index 8c73564..1c813c7 100644
+--- a/GenesisAeonAdvancedAi/test_cli.py
++++ b/GenesisAeonAdvancedAi/test_cli.py
+@@ -131,3 +131,23 @@ class TestAeonCLI(unittest.TestCase):
+             data = json.loads(result.stdout)
+             self.assertIn("graph", data)
+             self.assertIn("nodes", data["graph"])
++
++    def test_poetry_flag(self):
++        with tempfile.TemporaryDirectory() as tmpdir:
++            input_path = Path(tmpdir) / "vals.txt"
++            input_path.write_text("0.4 0.5")
++            result = subprocess.run(
++                [
++                    sys.executable,
++                    "-m",
++                    "GenesisAeonAdvancedAi.aeon_cli",
++                    "--input",
++                    str(input_path),
++                    "--poetry",
++                ],
++                capture_output=True,
++                text=True,
++                check=True,
++            )
++            data = json.loads(result.stdout)
++            self.assertIn("poetry", data)

--- a/GenesisAeonZIPMEM/36d98b56c6ec1ccc8f0ad472d0ef3f3b5a9705e8/fragments/README.md.patch
+++ b/GenesisAeonZIPMEM/36d98b56c6ec1ccc8f0ad472d0ef3f3b5a9705e8/fragments/README.md.patch
@@ -1,0 +1,13 @@
+diff --git a/README.md b/README.md
+index 71eecbc..85a21b4 100644
+--- a/README.md
++++ b/README.md
+@@ -139,7 +139,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
+ - [**Share your Sigil** & **Remix my Solution**](docs/CommunityOnboarding.md) – Community-Features
+ - [**NumericToSymbolicAdapter**](GenesisAeonAdvancedAi/aeon_processor.py) – übersetzt Tensorwerte in Klang- und Farbcodes
+ - [**fraktal_feedback_graph**](GenesisAeonAdvancedAi/aeon_processor.py) – erstellt einen einfachen Graphen der Fraktal-Feedback-Schritte
+-- [**Aeon CLI**](GenesisAeonAdvancedAi/aeon_cli.py) – erzeugt symbolische Ergebnisse aus Zahlenfolgen, kann Leistungsdaten, CREP-Metriken und nun auch einen Fraktal-Graphen (``--graph``) ausgeben. Fehlt PyYAML, gibt die CLI stattdessen JSON aus und weist per Warnung darauf hin.
++ - [**Aeon CLI**](GenesisAeonAdvancedAi/aeon_cli.py) – erzeugt symbolische Ergebnisse aus Zahlenfolgen, kann Leistungsdaten, CREP-Metriken, Fraktal-Graphen (``--graph``) und poetische Kommentare (``--poetry``) ausgeben. Fehlt PyYAML, gibt die CLI stattdessen JSON aus und weist per Warnung darauf hin.
+ ## 📦 Paketstruktur
+ 
+ ```bash

--- a/GenesisAeonZIPMEM/36d98b56c6ec1ccc8f0ad472d0ef3f3b5a9705e8/meta.yaml
+++ b/GenesisAeonZIPMEM/36d98b56c6ec1ccc8f0ad472d0ef3f3b5a9705e8/meta.yaml
@@ -1,0 +1,14 @@
+commit: 36d98b56c6ec1ccc8f0ad472d0ef3f3b5a9705e8
+message: "feat: add poetic commentary option"
+patch: changes.patch
+fragments: fragments
+files:
+  - GenesisAeonAdvancedAi/aeon_cli.py
+  - GenesisAeonAdvancedAi/aeon_processor.py
+  - GenesisAeonAdvancedAi/test_aeon_processor.py
+  - GenesisAeonAdvancedAi/test_cli.py
+  - README.md
+environment:
+  node: v22.16.0
+  pnpm: 10.5.2
+instructions: Apply patch with git apply or review for reference.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
 - [**Share your Sigil** & **Remix my Solution**](docs/CommunityOnboarding.md) – Community-Features
 - [**NumericToSymbolicAdapter**](GenesisAeonAdvancedAi/aeon_processor.py) – übersetzt Tensorwerte in Klang- und Farbcodes
 - [**fraktal_feedback_graph**](GenesisAeonAdvancedAi/aeon_processor.py) – erstellt einen einfachen Graphen der Fraktal-Feedback-Schritte
-- [**Aeon CLI**](GenesisAeonAdvancedAi/aeon_cli.py) – erzeugt symbolische Ergebnisse aus Zahlenfolgen, kann Leistungsdaten, CREP-Metriken und nun auch einen Fraktal-Graphen (``--graph``) ausgeben. Fehlt PyYAML, gibt die CLI stattdessen JSON aus und weist per Warnung darauf hin.
+ - [**Aeon CLI**](GenesisAeonAdvancedAi/aeon_cli.py) – erzeugt symbolische Ergebnisse aus Zahlenfolgen, kann Leistungsdaten, CREP-Metriken, Fraktal-Graphen (``--graph``) und poetische Kommentare (``--poetry``) ausgeben. Fehlt PyYAML, gibt die CLI stattdessen JSON aus und weist per Warnung darauf hin.
 ## 📦 Paketstruktur
 
 ```bash


### PR DESCRIPTION
## Summary
- generate deterministic poetic comments
- expose `--poetry` option in aeon_cli
- document new CLI feature in README
- test poetic commentary and CLI flag
- store commit memory for this change

## Testing
- `python -m unittest discover GenesisAeonAdvancedAi`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685d08c6688c83228d4a26de6f848533