### PR TITLE
Add CREP mandala visualizer

### DIFF
--- a/GenesisAeonAdvancedAi/__init__.py
+++ b/GenesisAeonAdvancedAi/__init__.py
@@ -4,6 +4,7 @@ from .symbol_tools import assign_color, transform_to_symbol
 from .crep_eval import evaluate_crep
 from .aeon_logger import log_event
 from .aeon_processor import symbolic_manifestation
+from .mandala_visualizer import plot_crep_mandala
 
 __all__ = [
     "AeonAgent",
@@ -13,4 +14,5 @@ __all__ = [
     "evaluate_crep",
     "log_event",
     "symbolic_manifestation",
+    "plot_crep_mandala",
 ]

--- a/GenesisAeonAdvancedAi/feedback.json
+++ b/GenesisAeonAdvancedAi/feedback.json
@@ -1,5 +1,5 @@
 {
   "meta_commit_finalized": true,
-  "message": "Symbolic manifestation feature added; MetaCommit Phase 3 complete",
+  "message": "Mandala visualizer added; MetaCommit Phase 4 complete",
   "timestamp": "2025-06-26T09:14:30Z"
 }

--- a/GenesisAeonAdvancedAi/mandala_visualizer.py
+++ b/GenesisAeonAdvancedAi/mandala_visualizer.py
@@ -1,0 +1,24 @@
+"""Basic plotting utilities for CREP data."""
+
+from typing import Sequence
+import plotly.graph_objs as go
+
+
+def plot_crep_mandala(crep_values: Sequence[float], sigil_labels: Sequence[str] | None = None) -> "go.Figure":
+    """Return a polar chart figure for CREP metrics.
+
+    Parameters
+    ----------
+    crep_values:
+        Sequence of CREP metric values.
+    sigil_labels:
+        Optional labels to annotate each value.
+    """
+    values = list(map(float, crep_values))
+    angles = [i * 360 / len(values) for i in range(len(values))]
+    fig = go.Figure(
+        go.Scatterpolar(r=values, theta=angles, mode="lines+markers+text", text=sigil_labels or [])
+    )
+    fig.update_layout(polar=dict(radialaxis=dict(visible=True)))
+    return fig
+

--- a/GenesisAeonAdvancedAi/requirements.txt
+++ b/GenesisAeonAdvancedAi/requirements.txt
@@ -1,1 +1,3 @@
 pyyaml
+plotly==5.18.0
+

--- a/GenesisAeonAdvancedAi/test_mandala_visualizer.py
+++ b/GenesisAeonAdvancedAi/test_mandala_visualizer.py
@@ -1,0 +1,13 @@
+import unittest
+
+from GenesisAeonAdvancedAi.mandala_visualizer import plot_crep_mandala
+
+class TestMandalaVisualizer(unittest.TestCase):
+    def test_returns_figure(self):
+        fig = plot_crep_mandala([0.1, 0.5, 0.9], ["a", "b", "c"])
+        self.assertEqual(fig.data[0].mode, "lines+markers+text")
+        self.assertEqual(len(fig.data[0].r), 3)
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- create a simple Plotly-based mandala visualizer
- expose the visualizer via package `__init__`
- document progress in `feedback.json`
- add dependency on `plotly`
- test the new module

## Testing
- `pnpm run qa`
- `python -m unittest discover GenesisAeonAdvancedAi`

------
https://chatgpt.com/codex/tasks/task_e_685d108898f08322b395e439f9a6fe34