### PR TITLE
Add memory persistence to advanced agent

### DIFF
--- a/GenesisAeonAdvancedAi/advanced_agent.py
+++ b/GenesisAeonAdvancedAi/advanced_agent.py
@@ -1,7 +1,10 @@
 import argparse
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 import yaml
+
+from .memory_store import store_result
 
 
 def generate_basic_haiku(symbol: str) -> str:
@@ -30,6 +33,7 @@ class AdvancedAeonAgent:
         log_path: Optional[str] = None,
         state_path: Optional[str] = None,
         symbol_memory_path: Optional[str] = None,
+        memory_path: Optional[str] = None,
     ) -> None:
         self.name = name
         self.state: Dict[str, Any] = state or {}
@@ -38,6 +42,7 @@ class AdvancedAeonAgent:
         self.log_path = log_path or f"{self.name}_log.yaml"
         self.state_path = state_path or f"{self.name}_state.yaml"
         self.symbol_memory_path = symbol_memory_path or f"{self.name}_symbols.yaml"
+        self.memory_path = memory_path
 
     def act(self, input_data: Any) -> Dict[str, Any]:
         decision = self.process_input(input_data)
@@ -72,6 +77,8 @@ class AdvancedAeonAgent:
         self.history.append(log_entry)
         with open(self.log_path, "a", encoding="utf-8") as f:
             yaml.safe_dump([log_entry], f, allow_unicode=True)
+        if self.memory_path:
+            store_result(log_entry, Path(self.memory_path))
 
     def save_symbol_memory(self, path: Optional[str] = None) -> None:
         """Persist symbol memory to a YAML file."""
@@ -96,6 +103,10 @@ def main(argv: Optional[List[str]] = None) -> None:
         "--symbol-memory-file",
         help="Pfad für YAML-Datei zum Speichern des Symbolspeichers",
     )
+    parser.add_argument(
+        "--memory-file",
+        help="Pfad für JSON-Datei zum Persistieren aller Aktionen",
+    )
     parser.add_argument("--haiku", action="store_true", help="Gibt ein Haiku zum Ergebnis aus")
     args = parser.parse_args(argv)
 
@@ -105,6 +116,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         log_path=args.log_file,
         state_path=args.state_file,
         symbol_memory_path=args.symbol_memory_file,
+        memory_path=args.memory_file,
     )
     result = agent.act(args.input)
     dump_yaml(agent)

--- a/GenesisAeonAdvancedAi/feedback.md
+++ b/GenesisAeonAdvancedAi/feedback.md
@@ -4,3 +4,5 @@ Erweiterung: Aeon CLI unterstuetzt jetzt das Flag `--graph`, um einen Fraktal-Fe
 \n- Advanced agent allows custom log and state file paths via `--log-file` and `--state-file`.
 \n- Advanced agent outputs a deterministic haiku when invoked with `--haiku`.
 \n- Advanced agent now persists symbol memory via `--symbol-memory-file`.
+\n- Advanced agent persists action history via `--memory-file`.
+

--- a/GenesisAeonAdvancedAi/requirements.txt
+++ b/GenesisAeonAdvancedAi/requirements.txt
@@ -1,3 +1,4 @@
 pyyaml
 plotly==5.18.0
 
+flask

--- a/GenesisAeonAdvancedAi/test_advanced_agent.py
+++ b/GenesisAeonAdvancedAi/test_advanced_agent.py
@@ -14,13 +14,18 @@ class TestAdvancedAeonAgent(unittest.TestCase):
             cwd = os.getcwd()
             os.chdir(tmpdir)
             try:
-                agent = AdvancedAeonAgent("test_agent", {})
+                mem_path = Path("mem.json")
+                agent = AdvancedAeonAgent("test_agent", {}, memory_path=str(mem_path))
                 result = agent.act("data")
                 self.assertIn("symbol", result)
                 log_file = Path("test_agent_log.yaml")
                 self.assertTrue(log_file.exists())
                 data = list(yaml.safe_load_all(log_file.read_text()))
                 self.assertGreaterEqual(len(data), 1)
+                self.assertTrue(mem_path.exists())
+                import json
+                mem_data = json.loads(mem_path.read_text())
+                self.assertGreaterEqual(len(mem_data), 1)
             finally:
                 os.chdir(cwd)
 

--- a/GenesisAeonAdvancedAi/test_advanced_agent_cli.py
+++ b/GenesisAeonAdvancedAi/test_advanced_agent_cli.py
@@ -11,6 +11,7 @@ class TestAdvancedAgentCLI(unittest.TestCase):
             log_file = Path(tmpdir) / "custom_log.yaml"
             state_file = Path(tmpdir) / "custom_state.yaml"
             symbol_file = Path(tmpdir) / "symbols.yaml"
+            mem_file = Path(tmpdir) / "mem.json"
             subprocess.run(
                 [
                     sys.executable,
@@ -24,12 +25,15 @@ class TestAdvancedAgentCLI(unittest.TestCase):
                     str(state_file),
                     "--symbol-memory-file",
                     str(symbol_file),
+                    "--memory-file",
+                    str(mem_file),
                 ],
                 check=True,
             )
             self.assertTrue(log_file.exists())
             self.assertTrue(state_file.exists())
             self.assertTrue(symbol_file.exists())
+            self.assertTrue(mem_file.exists())
             import yaml
             data = yaml.safe_load(symbol_file.read_text())
             self.assertIsInstance(data, dict)


### PR DESCRIPTION
## Summary
- support saving action history via `--memory-file`
- update advanced agent tests for new memory option
- note feature in feedback file
- document Flask dependency for web tests

## Testing
- `pnpm test`
- `pytest GenesisAeonAdvancedAi`

------
https://chatgpt.com/codex/tasks/task_e_685d13cb66688322926804cb2a0b9892