### PR TITLE
Implement adaptive CREP threshold helper

### DIFF
--- a/GenesisAeonAdvancedAi/__init__.py
+++ b/GenesisAeonAdvancedAi/__init__.py
@@ -4,6 +4,7 @@ from .symbol_tools import assign_color, transform_to_symbol
 from .crep_eval import evaluate_crep
 from .aeon_logger import log_event
 from .aeon_processor import symbolic_manifestation
+from .adaptive_threshold import auto_adapt_crep_threshold
 from .mandala_visualizer import plot_crep_mandala
 
 __all__ = [
@@ -15,4 +16,5 @@ __all__ = [
     "log_event",
     "symbolic_manifestation",
     "plot_crep_mandala",
+    "auto_adapt_crep_threshold",
 ]

--- a/GenesisAeonAdvancedAi/adaptive_threshold.py
+++ b/GenesisAeonAdvancedAi/adaptive_threshold.py
@@ -1,0 +1,34 @@
+"""Adaptive CREP threshold utilities."""
+
+from __future__ import annotations
+
+from typing import Iterable, Dict, Any
+
+
+def auto_adapt_crep_threshold(memory_data: Iterable[Dict[str, Any]]) -> float:
+    """Return an adapted CREP threshold based on recent memory data.
+
+    The function looks at the last 10 entries in ``memory_data`` and
+    computes the mean CREP score. It accepts either the key ``"crep"``
+    or ``"crep_score"`` in each entry. The returned threshold follows a
+    simple rule set:
+
+    - mean < 0.4  -> 0.2
+    - mean > 0.7  -> 0.8
+    - otherwise   -> 0.5
+    """
+    scores: list[float] = []
+    for entry in list(memory_data)[-10:]:
+        if "crep" in entry:
+            scores.append(float(entry["crep"]))
+        elif "crep_score" in entry:
+            scores.append(float(entry["crep_score"]))
+    if not scores:
+        return 0.5
+
+    mean_score = sum(scores) / len(scores)
+    if mean_score < 0.4:
+        return 0.2
+    if mean_score > 0.7:
+        return 0.8
+    return 0.5

--- a/GenesisAeonAdvancedAi/feedback.json
+++ b/GenesisAeonAdvancedAi/feedback.json
@@ -1,5 +1,5 @@
 {
   "meta_commit_finalized": true,
-  "message": "Mandala visualizer added; MetaCommit Phase 4 complete",
-  "timestamp": "2025-06-26T09:14:30Z"
+  "message": "Adaptive CREP threshold added; MetaCommit Phase 5 complete",
+  "timestamp": "2025-06-26T09:56:11Z"
 }

--- a/GenesisAeonAdvancedAi/feedback.md
+++ b/GenesisAeonAdvancedAi/feedback.md
@@ -6,3 +6,4 @@ Erweiterung: Aeon CLI unterstuetzt jetzt das Flag `--graph`, um einen Fraktal-Fe
 \n- Advanced agent now persists symbol memory via `--symbol-memory-file`.
 \n- Advanced agent persists action history via `--memory-file`.
 
+- Adaptive CREP threshold helper `auto_adapt_crep_threshold` implemented.

--- a/GenesisAeonAdvancedAi/test_adaptive_threshold.py
+++ b/GenesisAeonAdvancedAi/test_adaptive_threshold.py
@@ -1,0 +1,20 @@
+import unittest
+from GenesisAeonAdvancedAi.adaptive_threshold import auto_adapt_crep_threshold
+
+
+class TestAutoAdaptCREPThreshold(unittest.TestCase):
+    def test_low_average_returns_low_threshold(self):
+        memory = [{"crep": 0.3} for _ in range(5)]
+        self.assertEqual(auto_adapt_crep_threshold(memory), 0.2)
+
+    def test_high_average_returns_high_threshold(self):
+        memory = [{"crep_score": 0.9} for _ in range(5)]
+        self.assertEqual(auto_adapt_crep_threshold(memory), 0.8)
+
+    def test_mid_average_returns_default(self):
+        memory = [{"crep": 0.5}, {"crep_score": 0.55}]
+        self.assertEqual(auto_adapt_crep_threshold(memory), 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `auto_adapt_crep_threshold` utility with simple score analysis
- export helper in package `__init__`
- provide tests for new helper
- document update in `feedback.md` and `feedback.json`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685d18735f048322b172865e2eaf4616