### PR TITLE
Add plugin loader utility

### DIFF
--- a/GenesisAeonAdvancedAi/__init__.py
+++ b/GenesisAeonAdvancedAi/__init__.py
@@ -6,6 +6,7 @@ from .aeon_logger import log_event
 from .aeon_processor import symbolic_manifestation
 from .adaptive_threshold import auto_adapt_crep_threshold
 from .mandala_visualizer import plot_crep_mandala
+from .plugin_loader import load_plugin_manifest, load_plugins
 
 __all__ = [
     "AeonAgent",
@@ -17,4 +18,6 @@ __all__ = [
     "symbolic_manifestation",
     "plot_crep_mandala",
     "auto_adapt_crep_threshold",
+    "load_plugin_manifest",
+    "load_plugins",
 ]

--- a/GenesisAeonAdvancedAi/plugin_loader.py
+++ b/GenesisAeonAdvancedAi/plugin_loader.py
@@ -1,0 +1,27 @@
+import yaml
+from pathlib import Path
+from typing import Dict, Any
+
+REQUIRED_FIELDS = {"id", "type", "entry"}
+
+
+def load_plugin_manifest(path: Path) -> Dict[str, Any]:
+    """Load a single plugin manifest YAML file."""
+    if not path.exists():
+        raise FileNotFoundError(f"Plugin manifest not found: {path}")
+    data = yaml.safe_load(path.read_text(encoding='utf-8'))
+    if not isinstance(data, dict):
+        raise ValueError("Plugin manifest must be a mapping")
+    missing = REQUIRED_FIELDS - data.keys()
+    if missing:
+        raise ValueError(f"Missing required fields: {', '.join(sorted(missing))}")
+    return data
+
+
+def load_plugins(directory: Path) -> Dict[str, Dict[str, Any]]:
+    """Load all plugin manifests from a directory."""
+    plugins: Dict[str, Dict[str, Any]] = {}
+    for path in directory.glob('*.yaml'):
+        manifest = load_plugin_manifest(path)
+        plugins[manifest['id']] = manifest
+    return plugins

--- a/GenesisAeonAdvancedAi/test_plugin_loader.py
+++ b/GenesisAeonAdvancedAi/test_plugin_loader.py
@@ -1,0 +1,44 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from GenesisAeonAdvancedAi.plugin_loader import (
+    load_plugin_manifest,
+    load_plugins,
+)
+
+
+class TestPluginLoader(unittest.TestCase):
+    def test_load_manifest(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "manifest.yaml"
+            path.write_text(
+                """id: test
+type: agent
+entry: main.py
+"""
+            )
+            data = load_plugin_manifest(path)
+            self.assertEqual(data["id"], "test")
+            self.assertEqual(data["type"], "agent")
+            self.assertEqual(data["entry"], "main.py")
+
+    def test_missing_required_field(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "manifest.yaml"
+            path.write_text("id: test")
+            with self.assertRaises(ValueError):
+                load_plugin_manifest(path)
+
+    def test_load_plugins_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p1 = Path(tmpdir) / "a.yaml"
+            p1.write_text("id: a\ntype: agent\nentry: a.py")
+            p2 = Path(tmpdir) / "b.yaml"
+            p2.write_text("id: b\ntype: tool\nentry: b.py")
+            plugins = load_plugins(Path(tmpdir))
+            self.assertEqual(set(plugins.keys()), {"a", "b"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- provide `plugin_loader` module for reading plugin manifests
- export loader functions in `__init__`
- test plugin loading logic

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm test:agents`
- `python -m unittest discover GenesisAeonAdvancedAi -v`

------
https://chatgpt.com/codex/tasks/task_e_685d1c5eefa08322846e183f62a62a67