### PR TITLE
Add archetype lookup utility

### DIFF
--- a/GenesisAeonAdvancedAi/__init__.py
+++ b/GenesisAeonAdvancedAi/__init__.py
@@ -7,6 +7,7 @@ from .aeon_processor import symbolic_manifestation
 from .adaptive_threshold import auto_adapt_crep_threshold
 from .mandala_visualizer import plot_crep_mandala
 from .plugin_loader import load_plugin_manifest, load_plugins
+from .archetype_tools import get_symbol
 
 __all__ = [
     "AeonAgent",
@@ -20,4 +21,5 @@ __all__ = [
     "auto_adapt_crep_threshold",
     "load_plugin_manifest",
     "load_plugins",
+    "get_symbol",
 ]

--- a/GenesisAeonAdvancedAi/archetype_tools.py
+++ b/GenesisAeonAdvancedAi/archetype_tools.py
@@ -1,0 +1,27 @@
+import yaml
+from pathlib import Path
+from typing import List, Tuple, Dict
+
+
+def load_archetypes(path: Path) -> List[Dict[str, object]]:
+    """Load archetype config from YAML file."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, list) else []
+
+
+def get_symbol(crep: float, context: str, config_path: Path | str = Path("archetypes.yaml")) -> Tuple[str, str]:
+    """Return symbol and meaning for given CREP value and context."""
+    path = Path(config_path)
+    if not path.exists():
+        return "⚫", "Unbestimmt"
+    archetypes = load_archetypes(path)
+    for entry in archetypes:
+        try:
+            if (
+                entry.get("context") == context
+                and float(entry.get("crep_min", 0)) <= crep <= float(entry.get("crep_max", 0))
+            ):
+                return entry.get("symbol", "⚫"), entry.get("meaning", "Unbestimmt")
+        except (TypeError, ValueError):
+            continue
+    return "⚫", "Unbestimmt"

--- a/GenesisAeonAdvancedAi/archetypes.yaml
+++ b/GenesisAeonAdvancedAi/archetypes.yaml
@@ -1,0 +1,10 @@
+- context: "stress"
+  crep_min: 0.0
+  crep_max: 0.2
+  symbol: "🕳️"
+  meaning: "Krise"
+- context: "growth"
+  crep_min: 0.7
+  crep_max: 1.0
+  symbol: "🌱"
+  meaning: "Wachstum"

--- a/GenesisAeonAdvancedAi/feedback.json
+++ b/GenesisAeonAdvancedAi/feedback.json
@@ -1,5 +1,5 @@
 {
   "meta_commit_finalized": true,
-  "message": "Adaptive CREP threshold added; MetaCommit Phase 5 complete",
-  "timestamp": "2025-06-26T09:56:11Z"
+  "message": "Archetype lookup utility implemented",
+  "timestamp": "2025-06-26T10:15:00Z"
 }

--- a/GenesisAeonAdvancedAi/feedback.md
+++ b/GenesisAeonAdvancedAi/feedback.md
@@ -5,5 +5,5 @@ Erweiterung: Aeon CLI unterstuetzt jetzt das Flag `--graph`, um einen Fraktal-Fe
 \n- Advanced agent outputs a deterministic haiku when invoked with `--haiku`.
 \n- Advanced agent now persists symbol memory via `--symbol-memory-file`.
 \n- Advanced agent persists action history via `--memory-file`.
-
 - Adaptive CREP threshold helper `auto_adapt_crep_threshold` implemented.
+\n- Archetype lookup utility `get_symbol` added with tests.

--- a/GenesisAeonAdvancedAi/test_archetype_tools.py
+++ b/GenesisAeonAdvancedAi/test_archetype_tools.py
@@ -1,0 +1,34 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from GenesisAeonAdvancedAi.archetype_tools import get_symbol
+
+
+class TestArchetypeTools(unittest.TestCase):
+    def test_match(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = Path(tmpdir) / "arch.yaml"
+            cfg.write_text(
+                """- context: test
+  crep_min: 0.0
+  crep_max: 0.5
+  symbol: X
+  meaning: Y
+"""
+            )
+            sym, meaning = get_symbol(0.2, "test", cfg)
+            self.assertEqual(sym, "X")
+            self.assertEqual(meaning, "Y")
+
+    def test_default(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = Path(tmpdir) / "arch.yaml"
+            cfg.write_text("[]")
+            sym, meaning = get_symbol(0.2, "none", cfg)
+            self.assertEqual(sym, "⚫")
+            self.assertEqual(meaning, "Unbestimmt")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `get_symbol` for archetype lookups
- export the helper via package `__init__`
- ship default `archetypes.yaml`
- document change in feedback files
- add tests for the new module

## Testing
- `pytest GenesisAeonAdvancedAi/test_archetype_tools.py`
- `pytest GenesisAeonAdvancedAi`

------
https://chatgpt.com/codex/tasks/task_e_685d1f5d27888322b2527539c00f036b