### PR TITLE
Add memory summary feature

### DIFF
--- a/GenesisAeonAdvancedAi/__init__.py
+++ b/GenesisAeonAdvancedAi/__init__.py
@@ -8,6 +8,7 @@ from .adaptive_threshold import auto_adapt_crep_threshold
 from .mandala_visualizer import plot_crep_mandala
 from .plugin_loader import load_plugin_manifest, load_plugins
 from .archetype_tools import get_symbol
+from .memory_store import store_result, load_results, summarize_memory
 
 __all__ = [
     "AeonAgent",
@@ -22,4 +23,8 @@ __all__ = [
     "load_plugin_manifest",
     "load_plugins",
     "get_symbol",
+    "store_result",
+    "load_results",
+    "summarize_memory",
 ]
+

--- a/GenesisAeonAdvancedAi/aeon_cli.py
+++ b/GenesisAeonAdvancedAi/aeon_cli.py
@@ -20,7 +20,7 @@ from .aeon_processor import (
     advanced_crep_eval,
 )
 from .performance_monitor import monitor_performance
-from .memory_store import store_result, load_results
+from .memory_store import store_result, load_results, summarize_memory
 from .sigil_loader import load_sigil, load_start_sigil
 from .trikaya import trikaya_state
 
@@ -56,6 +56,11 @@ def main(argv: List[str] | None = None) -> None:
         "--show-memory",
         action="store_true",
         help="Display stored memory results and exit (requires --memory)",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Print numeric averages of stored memory entries (requires --memory)",
     )
     parser.add_argument(
         "--sigil",
@@ -99,6 +104,13 @@ def main(argv: List[str] | None = None) -> None:
             parser.error("--show-memory requires --memory")
         results = load_results(args.memory)
         print(json.dumps(results, indent=2))
+        return
+
+    if args.summary:
+        if not args.memory:
+            parser.error("--summary requires --memory")
+        summary = summarize_memory(args.memory)
+        print(json.dumps(summary, indent=2))
         return
 
     values = list(args.values)
@@ -167,3 +179,4 @@ def main(argv: List[str] | None = None) -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/GenesisAeonAdvancedAi/feedback.json
+++ b/GenesisAeonAdvancedAi/feedback.json
@@ -1,5 +1,6 @@
 {
   "meta_commit_finalized": true,
-  "message": "Archetype lookup utility implemented",
-  "timestamp": "2025-06-26T10:15:00Z"
+  "message": "Memory summary and CLI flag added",
+  "timestamp": "2025-06-27T10:15:00Z"
 }
+

--- a/GenesisAeonAdvancedAi/feedback.md
+++ b/GenesisAeonAdvancedAi/feedback.md
@@ -7,3 +7,5 @@ Erweiterung: Aeon CLI unterstuetzt jetzt das Flag `--graph`, um einen Fraktal-Fe
 \n- Advanced agent persists action history via `--memory-file`.
 - Adaptive CREP threshold helper `auto_adapt_crep_threshold` implemented.
 \n- Archetype lookup utility `get_symbol` added with tests.
+- Memory summarization utility `summarize_memory` and `--summary` CLI flag implemented.
+

--- a/GenesisAeonAdvancedAi/memory_store.py
+++ b/GenesisAeonAdvancedAi/memory_store.py
@@ -30,3 +30,19 @@ def load_results(path: Path) -> List[Dict[str, Any]]:
         except json.JSONDecodeError:
             return []
     return []
+
+
+def summarize_memory(path: Path) -> Dict[str, float]:
+    """Return simple averages for numeric fields in stored results."""
+    results = load_results(path)
+    if not results:
+        return {}
+
+    sums: Dict[str, List[float]] = {}
+    for entry in results:
+        for key, value in entry.items():
+            if isinstance(value, (int, float)):
+                sums.setdefault(key, []).append(float(value))
+
+    return {k: sum(v) / len(v) for k, v in sums.items() if v}
+

--- a/GenesisAeonAdvancedAi/test_cli.py
+++ b/GenesisAeonAdvancedAi/test_cli.py
@@ -151,3 +151,29 @@ class TestAeonCLI(unittest.TestCase):
             )
             data = json.loads(result.stdout)
             self.assertIn("poetry", data)
+
+    def test_summary_flag(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "vals.txt"
+            input_path.write_text("0.1")
+            mem_file = Path(tmpdir) / "mem.json"
+            subprocess.run([
+                sys.executable,
+                "-m",
+                "GenesisAeonAdvancedAi.aeon_cli",
+                "--input",
+                str(input_path),
+                "--memory",
+                str(mem_file),
+            ], check=True)
+            result = subprocess.run([
+                sys.executable,
+                "-m",
+                "GenesisAeonAdvancedAi.aeon_cli",
+                "--summary",
+                "--memory",
+                str(mem_file),
+            ], capture_output=True, text=True, check=True)
+            data = json.loads(result.stdout)
+            self.assertIn("crep_score", data)
+

--- a/GenesisAeonAdvancedAi/test_memory_store.py
+++ b/GenesisAeonAdvancedAi/test_memory_store.py
@@ -2,7 +2,11 @@ import unittest
 import json
 import pathlib
 
-from GenesisAeonAdvancedAi.memory_store import store_result, load_results
+from GenesisAeonAdvancedAi.memory_store import (
+    store_result,
+    load_results,
+    summarize_memory,
+)
 
 
 class TestMemoryStore(unittest.TestCase):
@@ -30,6 +34,17 @@ class TestMemoryStore(unittest.TestCase):
         self.assertIsInstance(results[0], dict)
         path.unlink()
 
+    def test_summarize_memory(self):
+        path = pathlib.Path('temp_mem.json')
+        if path.exists():
+            path.unlink()
+        store_result({'crep_score': 1}, path)
+        store_result({'crep_score': 0}, path)
+        summary = summarize_memory(path)
+        self.assertAlmostEqual(summary.get('crep_score'), 0.5)
+        path.unlink()
+
 
 if __name__ == '__main__':
     unittest.main()
+


### PR DESCRIPTION
## Summary
- add `summarize_memory` helper for stored results
- export new helper from package
- extend `aeon_cli` with `--summary` flag
- document new feature in feedback files
- test memory summarization and CLI flag

## Testing
- `npm test`
- `npm run test:agents`


------
https://chatgpt.com/codex/tasks/task_e_685d23b5ae2c8322875807402b2c1574