### PR TITLE
Add memory summary endpoint

### DIFF
--- a/GenesisAeonAdvancedAi/__init__.py
+++ b/GenesisAeonAdvancedAi/__init__.py
@@ -8,7 +8,12 @@ from .adaptive_threshold import auto_adapt_crep_threshold
 from .mandala_visualizer import plot_crep_mandala
 from .plugin_loader import load_plugin_manifest, load_plugins
 from .archetype_tools import get_symbol
-from .memory_store import store_result, load_results, summarize_memory
+from .memory_store import (
+    store_result,
+    load_results,
+    summarize_memory,
+    summarize_entries,
+)
 
 __all__ = [
     "AeonAgent",
@@ -26,5 +31,6 @@ __all__ = [
     "store_result",
     "load_results",
     "summarize_memory",
+    "summarize_entries",
 ]
 

--- a/GenesisAeonAdvancedAi/aeon_web.py
+++ b/GenesisAeonAdvancedAi/aeon_web.py
@@ -3,6 +3,7 @@
 from flask import Flask, request, jsonify
 
 from .aeon_agent import AeonAgent
+from .memory_store import summarize_entries
 
 app = Flask(__name__)
 agent = AeonAgent()
@@ -13,6 +14,13 @@ def act() -> "flask.Response":
     data = request.json.get("input")
     action, record = agent.act(data or [])
     return jsonify({"action": action, "record": record})
+
+
+@app.route("/aeon/summary", methods=["GET"])
+def summary() -> "flask.Response":
+    """Return a summary of the agent's memory."""
+    data = summarize_entries(agent.memory)
+    return jsonify(data)
 
 
 if __name__ == "__main__":

--- a/GenesisAeonAdvancedAi/feedback.json
+++ b/GenesisAeonAdvancedAi/feedback.json
@@ -1,6 +1,6 @@
 {
   "meta_commit_finalized": true,
-  "message": "Memory summary and CLI flag added",
-  "timestamp": "2025-06-27T10:15:00Z"
+  "message": "Summary endpoint implemented",
+  "timestamp": "2025-06-26T13:11:08Z"
 }
 

--- a/GenesisAeonAdvancedAi/feedback.md
+++ b/GenesisAeonAdvancedAi/feedback.md
@@ -9,3 +9,4 @@ Erweiterung: Aeon CLI unterstuetzt jetzt das Flag `--graph`, um einen Fraktal-Fe
 \n- Archetype lookup utility `get_symbol` added with tests.
 - Memory summarization utility `summarize_memory` and `--summary` CLI flag implemented.
 
+- Web API exposes `/aeon/summary` for memory summaries using new `summarize_entries` helper.

--- a/GenesisAeonAdvancedAi/memory_store.py
+++ b/GenesisAeonAdvancedAi/memory_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Iterable
 
 
 def store_result(result: Dict[str, Any], path: Path) -> None:
@@ -32,12 +32,8 @@ def load_results(path: Path) -> List[Dict[str, Any]]:
     return []
 
 
-def summarize_memory(path: Path) -> Dict[str, float]:
-    """Return simple averages for numeric fields in stored results."""
-    results = load_results(path)
-    if not results:
-        return {}
-
+def summarize_entries(results: Iterable[Dict[str, Any]]) -> Dict[str, float]:
+    """Return average values for numeric fields in ``results``."""
     sums: Dict[str, List[float]] = {}
     for entry in results:
         for key, value in entry.items():
@@ -45,4 +41,13 @@ def summarize_memory(path: Path) -> Dict[str, float]:
                 sums.setdefault(key, []).append(float(value))
 
     return {k: sum(v) / len(v) for k, v in sums.items() if v}
+
+
+def summarize_memory(path: Path) -> Dict[str, float]:
+    """Return simple averages for numeric fields in stored results."""
+    results = load_results(path)
+    if not results:
+        return {}
+
+    return summarize_entries(results)
 

--- a/GenesisAeonAdvancedAi/test_aeon_web.py
+++ b/GenesisAeonAdvancedAi/test_aeon_web.py
@@ -12,6 +12,14 @@ class TestAeonWeb(unittest.TestCase):
             self.assertIn('action', data)
             self.assertIn('record', data)
 
+    def test_summary_endpoint(self):
+        with app.test_client() as client:
+            client.post('/aeon/act', json={'input': [0.2]})
+            res = client.get('/aeon/summary')
+            self.assertEqual(res.status_code, 200)
+            data = res.get_json()
+            self.assertIsInstance(data, dict)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/GenesisAeonAdvancedAi/test_memory_store.py
+++ b/GenesisAeonAdvancedAi/test_memory_store.py
@@ -6,6 +6,7 @@ from GenesisAeonAdvancedAi.memory_store import (
     store_result,
     load_results,
     summarize_memory,
+    summarize_entries,
 )
 
 
@@ -43,6 +44,15 @@ class TestMemoryStore(unittest.TestCase):
         summary = summarize_memory(path)
         self.assertAlmostEqual(summary.get('crep_score'), 0.5)
         path.unlink()
+
+    def test_summarize_entries(self):
+        entries = [
+            {"a": 1, "b": 2.0},
+            {"a": 3, "b": 4.0},
+        ]
+        result = summarize_entries(entries)
+        self.assertEqual(result["a"], 2.0)
+        self.assertEqual(result["b"], 3.0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- implement `summarize_entries` helper for in-memory averages
- expose `/aeon/summary` endpoint in Flask app
- export new helper through package init
- test the endpoint and helper
- log change in feedback docs

## Testing
- `pnpm run qa`
- `python -m unittest discover GenesisAeonAdvancedAi`

------
https://chatgpt.com/codex/tasks/task_e_685d45b4ea388322ac7436fcca9cdbf6