### PR TITLE
Implement tail results feature

### DIFF
--- a/GenesisAeonAdvancedAi/__init__.py
+++ b/GenesisAeonAdvancedAi/__init__.py
@@ -13,6 +13,7 @@ from .memory_store import (
     load_results,
     summarize_memory,
     summarize_entries,
+    tail_results,
 )
 
 __all__ = [
@@ -32,5 +33,6 @@ __all__ = [
     "load_results",
     "summarize_memory",
     "summarize_entries",
+    "tail_results",
 ]
 

--- a/GenesisAeonAdvancedAi/aeon_cli.py
+++ b/GenesisAeonAdvancedAi/aeon_cli.py
@@ -21,6 +21,7 @@ from .aeon_processor import (
 )
 from .performance_monitor import monitor_performance
 from .memory_store import store_result, load_results, summarize_memory
+from .memory_store import tail_results
 from .sigil_loader import load_sigil, load_start_sigil
 from .trikaya import trikaya_state
 
@@ -61,6 +62,12 @@ def main(argv: List[str] | None = None) -> None:
         "--summary",
         action="store_true",
         help="Print numeric averages of stored memory entries (requires --memory)",
+    )
+    parser.add_argument(
+        "--tail",
+        type=int,
+        metavar="N",
+        help="Display the last N memory entries (requires --memory)",
     )
     parser.add_argument(
         "--sigil",
@@ -111,6 +118,13 @@ def main(argv: List[str] | None = None) -> None:
             parser.error("--summary requires --memory")
         summary = summarize_memory(args.memory)
         print(json.dumps(summary, indent=2))
+        return
+
+    if args.tail is not None:
+        if not args.memory:
+            parser.error("--tail requires --memory")
+        entries = tail_results(args.memory, args.tail)
+        print(json.dumps(entries, indent=2))
         return
 
     values = list(args.values)

--- a/GenesisAeonAdvancedAi/feedback.json
+++ b/GenesisAeonAdvancedAi/feedback.json
@@ -1,6 +1,6 @@
 {
   "meta_commit_finalized": true,
-  "message": "Summary endpoint implemented",
-  "timestamp": "2025-06-26T13:11:08Z"
+  "message": "Tail results feature added",
+  "timestamp": "2025-06-26T13:45:52Z"
 }
 

--- a/GenesisAeonAdvancedAi/feedback.md
+++ b/GenesisAeonAdvancedAi/feedback.md
@@ -11,3 +11,4 @@ Erweiterung: Aeon CLI unterstuetzt jetzt das Flag `--graph`, um einen Fraktal-Fe
 
 - Web API exposes `/aeon/summary` for memory summaries using new `summarize_entries` helper.
 - Fraktal-Graph-Nodes enthalten jetzt Trikaya-Zustand.
+- Tail utility `tail_results` added with corresponding `--tail` CLI flag and tests.

--- a/GenesisAeonAdvancedAi/memory_store.py
+++ b/GenesisAeonAdvancedAi/memory_store.py
@@ -51,3 +51,19 @@ def summarize_memory(path: Path) -> Dict[str, float]:
 
     return summarize_entries(results)
 
+
+def tail_results(path: Path, n: int = 10) -> List[Dict[str, Any]]:
+    """Return the last ``n`` stored results.
+
+    Parameters
+    ----------
+    path:
+        Path to the JSON memory file.
+    n:
+        Number of entries to retrieve from the end of the file.
+    """
+    results = load_results(path)
+    if not results:
+        return []
+    return results[-n:]
+

--- a/GenesisAeonAdvancedAi/test_cli.py
+++ b/GenesisAeonAdvancedAi/test_cli.py
@@ -177,3 +177,39 @@ class TestAeonCLI(unittest.TestCase):
             data = json.loads(result.stdout)
             self.assertIn("crep_score", data)
 
+    def test_tail_flag(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "vals.txt"
+            input_path.write_text("0.1 0.2")
+            mem_file = Path(tmpdir) / "mem.json"
+            # store two entries
+            subprocess.run([
+                sys.executable,
+                "-m",
+                "GenesisAeonAdvancedAi.aeon_cli",
+                "--input",
+                str(input_path),
+                "--memory",
+                str(mem_file),
+            ], check=True)
+            subprocess.run([
+                sys.executable,
+                "-m",
+                "GenesisAeonAdvancedAi.aeon_cli",
+                "--input",
+                str(input_path),
+                "--memory",
+                str(mem_file),
+            ], check=True)
+            result = subprocess.run([
+                sys.executable,
+                "-m",
+                "GenesisAeonAdvancedAi.aeon_cli",
+                "--tail",
+                "1",
+                "--memory",
+                str(mem_file),
+            ], capture_output=True, text=True, check=True)
+            data = json.loads(result.stdout)
+            self.assertEqual(len(data), 1)
+

--- a/GenesisAeonAdvancedAi/test_memory_store.py
+++ b/GenesisAeonAdvancedAi/test_memory_store.py
@@ -7,6 +7,7 @@ from GenesisAeonAdvancedAi.memory_store import (
     load_results,
     summarize_memory,
     summarize_entries,
+    tail_results,
 )
 
 
@@ -53,6 +54,18 @@ class TestMemoryStore(unittest.TestCase):
         result = summarize_entries(entries)
         self.assertEqual(result["a"], 2.0)
         self.assertEqual(result["b"], 3.0)
+
+    def test_tail_results(self):
+        path = pathlib.Path("temp_mem.json")
+        if path.exists():
+            path.unlink()
+        for i in range(5):
+            store_result({"idx": i}, path)
+        tail = tail_results(path, 2)
+        self.assertEqual(len(tail), 2)
+        self.assertEqual(tail[0]["idx"], 3)
+        self.assertEqual(tail[1]["idx"], 4)
+        path.unlink()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add `tail_results` to fetch recent memory entries
- expose `tail_results` in package exports
- support `--tail` in `aeon_cli`
- document update in `feedback.md` and `feedback.json`
- test coverage for new feature in CLI and memory store

## Testing
- `npm test`
- `npm run lint`
- `python -m pytest GenesisAeonAdvancedAi`

------
https://chatgpt.com/codex/tasks/task_e_685d4e53beac8322b2a17c9a624b027d