### PR TITLE
Add archetype lookup feature to Aeon CLI

### DIFF
--- a/GenesisAeonAdvancedAi/aeon_cli.py
+++ b/GenesisAeonAdvancedAi/aeon_cli.py
@@ -24,6 +24,7 @@ from .memory_store import store_result, load_results, summarize_memory
 from .memory_store import tail_results
 from .sigil_loader import load_sigil, load_start_sigil
 from .trikaya import trikaya_state
+from .archetype_tools import get_symbol
 
 
 def dump_yaml(data: dict) -> str:
@@ -104,6 +105,16 @@ def main(argv: List[str] | None = None) -> None:
         action="store_true",
         help="Include a fractal feedback graph in the output",
     )
+    parser.add_argument(
+        "--archetype-context",
+        help="Lookup archetype symbol for the resulting CREP score using the given context",
+    )
+    parser.add_argument(
+        "--archetype-config",
+        type=Path,
+        default=Path("archetypes.yaml"),
+        help="Path to archetype config YAML file",
+    )
     args = parser.parse_args(argv)
 
     if args.show_memory:
@@ -176,6 +187,18 @@ def main(argv: List[str] | None = None) -> None:
             result["poetry"] = generate_poetic_commentary(metrics)
         if args.graph:
             result["graph"] = fraktal_feedback_graph(values, depth=args.depth)
+
+    crep_score = None
+    if args.perf:
+        _, crep_score = result.get("result", ({}, 0))
+    else:
+        crep_score = result.get("crep_score")
+
+    if args.archetype_context and crep_score is not None:
+        symbol, meaning = get_symbol(
+            float(crep_score), args.archetype_context, args.archetype_config
+        )
+        result["archetype"] = {"symbol": symbol, "meaning": meaning}
 
     if args.yaml:
         text_output = dump_yaml(result)

--- a/GenesisAeonAdvancedAi/feedback.md
+++ b/GenesisAeonAdvancedAi/feedback.md
@@ -12,3 +12,4 @@ Erweiterung: Aeon CLI unterstuetzt jetzt das Flag `--graph`, um einen Fraktal-Fe
 - Web API exposes `/aeon/summary` for memory summaries using new `summarize_entries` helper.
 - Fraktal-Graph-Nodes enthalten jetzt Trikaya-Zustand.
 - Tail utility `tail_results` added with corresponding `--tail` CLI flag and tests.
+- Aeon CLI supports `--archetype-context` to display matching archetype symbols.

--- a/GenesisAeonAdvancedAi/test_cli.py
+++ b/GenesisAeonAdvancedAi/test_cli.py
@@ -213,3 +213,31 @@ class TestAeonCLI(unittest.TestCase):
             data = json.loads(result.stdout)
             self.assertEqual(len(data), 1)
 
+    def test_archetype_context_flag(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "vals.txt"
+            input_path.write_text("0.8")
+            config_path = Path(tmpdir) / "arch.yaml"
+            config_path.write_text(
+                """- context: test
+  crep_min: 0.0
+  crep_max: 0.0
+  symbol: X
+  meaning: Y
+"""
+            )
+            result = subprocess.run([
+                sys.executable,
+                "-m",
+                "GenesisAeonAdvancedAi.aeon_cli",
+                "--input",
+                str(input_path),
+                "--archetype-context",
+                "test",
+                "--archetype-config",
+                str(config_path),
+            ], capture_output=True, text=True, check=True)
+            data = json.loads(result.stdout)
+            self.assertIn("archetype", data)
+            self.assertEqual(data["archetype"].get("symbol"), "X")
+


### PR DESCRIPTION
## Summary
- extend `aeon_cli` with `--archetype-context` and `--archetype-config`
- look up archetype information based on CREP score
- test new flag in CLI tests
- document the enhancement in `feedback.md`

## Testing
- `npm run lint` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: jest not found)*
- `python -m unittest discover GenesisAeonAdvancedAi`

------
https://chatgpt.com/codex/tasks/task_e_685d5397d5408322920bdd3a1e93861e