### PR TITLE
Add tail endpoint to Aeon web API

### DIFF
--- a/GenesisAeonAdvancedAi/aeon_web.py
+++ b/GenesisAeonAdvancedAi/aeon_web.py
@@ -3,7 +3,7 @@
 from flask import Flask, request, jsonify
 
 from .aeon_agent import AeonAgent
-from .memory_store import summarize_entries
+from .memory_store import summarize_entries, tail_results
 
 app = Flask(__name__)
 agent = AeonAgent()
@@ -21,6 +21,17 @@ def summary() -> "flask.Response":
     """Return a summary of the agent's memory."""
     data = summarize_entries(agent.memory)
     return jsonify(data)
+
+
+@app.route("/aeon/tail", methods=["GET"])
+def tail() -> "flask.Response":
+    """Return the last ``n`` memory entries."""
+    try:
+        n = int(request.args.get("n", "10"))
+    except ValueError:
+        n = 10
+    entries = agent.memory[-n:]
+    return jsonify(entries)
 
 
 if __name__ == "__main__":

--- a/GenesisAeonAdvancedAi/feedback.json
+++ b/GenesisAeonAdvancedAi/feedback.json
@@ -1,6 +1,6 @@
 {
   "meta_commit_finalized": true,
-  "message": "Tail results feature added",
-  "timestamp": "2025-06-26T13:45:52Z"
+  "message": "Added /aeon/tail web endpoint",
+  "timestamp": "2025-06-26T14:25:22Z"
 }
 

--- a/GenesisAeonAdvancedAi/feedback.md
+++ b/GenesisAeonAdvancedAi/feedback.md
@@ -13,3 +13,4 @@ Erweiterung: Aeon CLI unterstuetzt jetzt das Flag `--graph`, um einen Fraktal-Fe
 - Fraktal-Graph-Nodes enthalten jetzt Trikaya-Zustand.
 - Tail utility `tail_results` added with corresponding `--tail` CLI flag and tests.
 - Aeon CLI supports `--archetype-context` to display matching archetype symbols.
+- Web API exposes `/aeon/tail` endpoint to fetch recent memory entries.

--- a/GenesisAeonAdvancedAi/test_aeon_web.py
+++ b/GenesisAeonAdvancedAi/test_aeon_web.py
@@ -20,6 +20,16 @@ class TestAeonWeb(unittest.TestCase):
             data = res.get_json()
             self.assertIsInstance(data, dict)
 
+    def test_tail_endpoint(self):
+        with app.test_client() as client:
+            client.post('/aeon/act', json={'input': [0.3]})
+            client.post('/aeon/act', json={'input': [0.4]})
+            res = client.get('/aeon/tail?n=1')
+            self.assertEqual(res.status_code, 200)
+            data = res.get_json()
+            self.assertIsInstance(data, list)
+            self.assertEqual(len(data), 1)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- expose `/aeon/tail` in `aeon_web.py` for returning recent memory entries
- extend web test suite with `test_tail_endpoint`
- update feedback notes and JSON log

## Testing
- `pnpm install`
- `pnpm run qa`

------
https://chatgpt.com/codex/tasks/task_e_685d57a67c0083228608d8864ddf71ec