### PR TITLE
Add JSON support for plugin manifests

### DIFF
--- a/GenesisAeonAdvancedAi/feedback.json
+++ b/GenesisAeonAdvancedAi/feedback.json
@@ -1,6 +1,6 @@
 {
   "meta_commit_finalized": true,
-  "message": "Tail results feature added",
-  "timestamp": "2025-06-26T13:45:52Z"
+  "message": "Plugin loader supports JSON manifests",
+  "timestamp": "2025-06-26T14:43:51Z"
 }
 

--- a/GenesisAeonAdvancedAi/feedback.md
+++ b/GenesisAeonAdvancedAi/feedback.md
@@ -15,3 +15,4 @@ Erweiterung: Aeon CLI unterstuetzt jetzt das Flag `--graph`, um einen Fraktal-Fe
 - Aeon CLI supports `--archetype-context` to display matching archetype symbols.
 - Trend analysis via `trend_metric` added. CLI option `--trend-key` computes
   average change for a numeric field.
+\n- Plugin loader accepts JSON manifests in addition to YAML.

--- a/GenesisAeonAdvancedAi/plugin_loader.py
+++ b/GenesisAeonAdvancedAi/plugin_loader.py
@@ -1,3 +1,6 @@
+"""Utilities for loading plug-in manifests."""
+
+import json
 import yaml
 from pathlib import Path
 from typing import Dict, Any
@@ -6,10 +9,13 @@ REQUIRED_FIELDS = {"id", "type", "entry"}
 
 
 def load_plugin_manifest(path: Path) -> Dict[str, Any]:
-    """Load a single plugin manifest YAML file."""
+    """Load a single plugin manifest from YAML or JSON."""
     if not path.exists():
         raise FileNotFoundError(f"Plugin manifest not found: {path}")
-    data = yaml.safe_load(path.read_text(encoding='utf-8'))
+    if path.suffix == ".json":
+        data = json.loads(path.read_text(encoding="utf-8"))
+    else:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise ValueError("Plugin manifest must be a mapping")
     missing = REQUIRED_FIELDS - data.keys()
@@ -21,7 +27,8 @@ def load_plugin_manifest(path: Path) -> Dict[str, Any]:
 def load_plugins(directory: Path) -> Dict[str, Dict[str, Any]]:
     """Load all plugin manifests from a directory."""
     plugins: Dict[str, Dict[str, Any]] = {}
-    for path in directory.glob('*.yaml'):
-        manifest = load_plugin_manifest(path)
-        plugins[manifest['id']] = manifest
+    for pattern in ("*.yaml", "*.yml", "*.json"):
+        for path in directory.glob(pattern):
+            manifest = load_plugin_manifest(path)
+            plugins[manifest["id"]] = manifest
     return plugins

--- a/GenesisAeonAdvancedAi/test_plugin_loader.py
+++ b/GenesisAeonAdvancedAi/test_plugin_loader.py
@@ -23,6 +23,17 @@ entry: main.py
             self.assertEqual(data["type"], "agent")
             self.assertEqual(data["entry"], "main.py")
 
+    def test_load_manifest_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "manifest.json"
+            path.write_text(
+                '{"id": "test", "type": "agent", "entry": "main.py"}'
+            )
+            data = load_plugin_manifest(path)
+            self.assertEqual(data["id"], "test")
+            self.assertEqual(data["type"], "agent")
+            self.assertEqual(data["entry"], "main.py")
+
     def test_missing_required_field(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "manifest.yaml"
@@ -34,8 +45,8 @@ entry: main.py
         with tempfile.TemporaryDirectory() as tmpdir:
             p1 = Path(tmpdir) / "a.yaml"
             p1.write_text("id: a\ntype: agent\nentry: a.py")
-            p2 = Path(tmpdir) / "b.yaml"
-            p2.write_text("id: b\ntype: tool\nentry: b.py")
+            p2 = Path(tmpdir) / "b.json"
+            p2.write_text('{"id": "b", "type": "tool", "entry": "b.py"}')
             plugins = load_plugins(Path(tmpdir))
             self.assertEqual(set(plugins.keys()), {"a", "b"})
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/Age
 - [**AutoDoc & Manifest-Generator**](packages/crep-engine/autoDocGeneration.ts) – Dokumentation auf Knopfdruck
 - [**Plug-in-Architektur**](plugins/manifest.yaml) – GPT-Kommunikationsmodule, CLI-Tools
 - 🔗 [**GPTBridge (Go)**](go-bridge/pkg/gpt) – API- und Link-basierte GPT-Anbindung
-- [**Plugin-Registry & Dynamic Loader**](plugins/manifest.yaml) – `plugins/manifest.yaml` und `usePluginLoader`
+- [**Plugin-Registry & Dynamic Loader**](plugins/manifest.yaml) – `usePluginLoader` lädt jetzt YAML- und JSON-Manifeste
 - [**Objective2UI**](packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx) – generiert Layout-Vorschläge via GPT
 - [**Ethik-Governance & Heimkehr-Deklaration**](docs/sigils/sigillin_heimkehr.md) – Offene, poetische Ethik als Systembasis
 - [**Poesie & Automation**](aeon.sh) – Bash-Interface, automatisches Chronopoem, symbolisches Onboarding


### PR DESCRIPTION
## Summary
- allow `load_plugin_manifest` to parse YAML or JSON
- search for `.json` manifests when loading plugins
- test JSON plugin loading
- document this update in README and feedback
- update feedback.json with new entry

## Testing
- `pip install -r GenesisAeonAdvancedAi/requirements.txt`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d5c094f988322b1778440a39cef92