### PR TITLE
Update commit-memory workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,8 @@ autoGenerate:
   pact-depth-extension.yaml: true
 ```
 
+*Hinweis:* `pnpm store:commit-memory` wird nur beim ersten Commit einer Sitzung durch Husky ausgeführt. Eine Markerdatei `.zipmem_session` verhindert weitere Durchläufe.
+
 ### MetaPoetik
 "Ein Agent denkt nicht. Er erinnert sich an Bedeutung."  
 "Tiefe ist Bedingung. CREP ist Bewegung. Das Sigillin ist das Tor."  

--- a/README.md
+++ b/README.md
@@ -424,9 +424,10 @@ Aufgaben und Anweisungen aus laufenden Gesprächen werden in
 [`advancedconversations.json`](docs/sigils/advancedconversations.json)
 Es dient als Pendant zum Genesis ZIPMEM.
 Neue Fragmente werden im Ordner `GenesisAeonZIPMEM/` abgelegt, sortiert nach Chatnamen.
-Nach jedem Commit wird `pnpm store:commit-memory` automatisch ausgef\u00fchrt (Husky `post-commit`),
-um die \u00c4nderungen als Patch und `meta.yaml` unter `GenesisAeonZIPMEM/<commit>/` abzulegen.
-Die `meta.yaml` speichert nun auch Node- und pnpm-Versionen, um Abläufe leichter reproduzierbar zu machen.
+Beim **ersten** Commit einer Sitzung f\u00fchrt Husky `pnpm store:commit-memory` aus.
+Das Skript legt Patch und `meta.yaml` unter `GenesisAeonZIPMEM/<commit>/` an und erstellt eine Markerdatei `.zipmem_session`.
+Solange diese Datei existiert, wird das Skript bei weiteren Commits \u00fcbersprungen.
+Die `meta.yaml` enth\u00e4lt auch Node- und pnpm-Versionen, um Abläufe leichter reproduzierbar zu machen.
 gespeichert. Nutzen Sie die Helferskripte aus `packages/shared-utils`
 (`jsonFragmenter.*`), um daraus ToDos für `advancedToDo.yaml` und
 `advancedToDo.json` zu extrahieren.

--- a/dev-agents.md
+++ b/dev-agents.md
@@ -6,9 +6,10 @@ Weitere Hinweise:
 - Nutze **codex-sigil.yaml** als zentralen Arbeitsanker.
 - Folge dem Ablauf in **fraktal-zyklus.md** bei der Umsetzung deiner Aufgaben.
 - Feedback siehe feedbackcodex.json
-- F\u00fchre nach jedem Commit `pnpm store:commit-memory` aus, um einen Patch
-  samt `meta.yaml` im Ordner `GenesisAeonZIPMEM` abzulegen.
-  Die YAML-Datei enthält nun auch die eingesetzten Versionen von Node und pnpm.
+- Führe `pnpm store:commit-memory` nur beim **ersten** Commit einer Sitzung aus.
+  Dabei wird das Verzeichnis `GenesisAeonZIPMEM` angelegt und ein Marker `.zipmem_session` erzeugt.
+  Solange diese Datei existiert, kannst du den Schritt bei weiteren Commits überspringen.
+  Die `meta.yaml` enthält die eingesetzten Versionen von Node und pnpm.
 - Prüfe vor jedem Lauf, ob `metacommit.yaml` oder `metacommit.json` existieren.
   Befolge vorrangig die dort hinterlegten Schritte aus `feedbackcodex.md` und
   lösche die Dateien nach Abschluss der MetaCommit-Aufgaben.

--- a/scripts/__tests__/commit-memory.test.ts
+++ b/scripts/__tests__/commit-memory.test.ts
@@ -6,6 +6,8 @@ const { run } = require('../commit-memory');
 test('commit-memory writes meta and patch', async () => {
   const commit = execSync('git rev-parse HEAD').toString().trim();
   const dir = path.join(__dirname, '../../GenesisAeonZIPMEM', commit);
+  const flag = path.join(__dirname, '../../.zipmem_session');
+  if (fs.existsSync(flag)) fs.rmSync(flag);
   if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true, force: true });
   await run();
   const meta = path.join(dir, 'meta.yaml');

--- a/scripts/commit-memory.js
+++ b/scripts/commit-memory.js
@@ -8,6 +8,14 @@ const execAsync = promisify(exec);
 
 async function run() {
   const repoRoot = path.resolve(__dirname, '..');
+  const sessionFlag = path.join(repoRoot, '.zipmem_session');
+  try {
+    await fs.access(sessionFlag);
+    console.log('GenesisAeonZIPMEM already initialized for this session.');
+    return;
+  } catch {
+    // session flag absent -> first run
+  }
   const { stdout: commitStdout } = await execAsync('git rev-parse HEAD');
   const commit = commitStdout.trim();
   const memoryDir = path.join(repoRoot, 'GenesisAeonZIPMEM', commit);
@@ -72,6 +80,7 @@ async function run() {
     YAML.stringify(meta),
     'utf8'
   );
+  await fs.writeFile(sessionFlag, commit, 'utf8');
   console.log(`Commit memory stored in ${memoryDir}`);
 }
 


### PR DESCRIPTION
## Summary
- prevent repeated GenesisAeonZIPMEM generation in `commit-memory.js`
- update tests to reset session marker
- document new one-time behaviour in README, AGENTS.md and dev instructions

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685d650a795083229275aef0be53a725