### PR TITLE
Add statistics summary utilities and CLI support

### DIFF
--- a/GenesisAeonAdvancedAi/__init__.py
+++ b/GenesisAeonAdvancedAi/__init__.py
@@ -13,6 +13,8 @@ from .memory_store import (
     load_results,
     summarize_memory,
     summarize_entries,
+    summarize_stats,
+    summarize_stats_memory,
     tail_results,
     trend_metric,
 )
@@ -34,6 +36,8 @@ __all__ = [
     "load_results",
     "summarize_memory",
     "summarize_entries",
+    "summarize_stats",
+    "summarize_stats_memory",
     "tail_results",
     "trend_metric",
 ]

--- a/GenesisAeonAdvancedAi/aeon_cli.py
+++ b/GenesisAeonAdvancedAi/aeon_cli.py
@@ -24,6 +24,7 @@ from .memory_store import (
     store_result,
     load_results,
     summarize_memory,
+    summarize_stats_memory,
     tail_results,
     trend_metric,
 )
@@ -85,6 +86,11 @@ def main(argv: List[str] | None = None) -> None:
         default=5,
         metavar="N",
         help="Number of recent entries to consider for --trend-key",
+    )
+    parser.add_argument(
+        "--stats",
+        action="store_true",
+        help="Print mean and median statistics for numeric fields in memory (requires --memory)",
     )
     parser.add_argument(
         "--sigil",
@@ -159,6 +165,13 @@ def main(argv: List[str] | None = None) -> None:
             parser.error("--trend-key requires --memory")
         trend = trend_metric(args.memory, args.trend_key, args.trend_window)
         print(json.dumps({"trend": trend}, indent=2))
+        return
+
+    if args.stats:
+        if not args.memory:
+            parser.error("--stats requires --memory")
+        stats = summarize_stats_memory(args.memory)
+        print(json.dumps(stats, indent=2))
         return
 
     values = list(args.values)

--- a/GenesisAeonAdvancedAi/feedback.json
+++ b/GenesisAeonAdvancedAi/feedback.json
@@ -1,6 +1,6 @@
 {
   "meta_commit_finalized": true,
-  "message": "Plugin loader supports JSON manifests",
-  "timestamp": "2025-06-26T14:43:51Z"
+  "message": "Added memory stats utilities and --stats CLI flag",
+  "timestamp": "2025-06-26T15:35:11Z"
 }
 

--- a/GenesisAeonAdvancedAi/feedback.md
+++ b/GenesisAeonAdvancedAi/feedback.md
@@ -16,3 +16,4 @@ Erweiterung: Aeon CLI unterstuetzt jetzt das Flag `--graph`, um einen Fraktal-Fe
 - Trend analysis via `trend_metric` added. CLI option `--trend-key` computes
   average change for a numeric field.
 \n- Plugin loader accepts JSON manifests in addition to YAML.
+\n- Memory statistics via `summarize_stats` and `summarize_stats_memory` with `--stats` CLI flag.

--- a/GenesisAeonAdvancedAi/memory_store.py
+++ b/GenesisAeonAdvancedAi/memory_store.py
@@ -4,6 +4,7 @@ import json
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Iterable
+import statistics
 
 
 def store_result(result: Dict[str, Any], path: Path) -> None:
@@ -41,6 +42,31 @@ def summarize_entries(results: Iterable[Dict[str, Any]]) -> Dict[str, float]:
                 sums.setdefault(key, []).append(float(value))
 
     return {k: sum(v) / len(v) for k, v in sums.items() if v}
+
+
+def summarize_stats(results: Iterable[Dict[str, Any]]) -> Dict[str, Dict[str, float]]:
+    """Return mean and median for numeric fields in ``results``."""
+    values: Dict[str, List[float]] = {}
+    for entry in results:
+        for key, value in entry.items():
+            if isinstance(value, (int, float)):
+                values.setdefault(key, []).append(float(value))
+
+    stats = {}
+    for key, vals in values.items():
+        if vals:
+            mean = sum(vals) / len(vals)
+            med = statistics.median(vals)
+            stats[key] = {"mean": mean, "median": med}
+    return stats
+
+
+def summarize_stats_memory(path: Path) -> Dict[str, Dict[str, float]]:
+    """Return mean and median statistics for numeric fields stored in ``path``."""
+    results = load_results(path)
+    if not results:
+        return {}
+    return summarize_stats(results)
 
 
 def summarize_memory(path: Path) -> Dict[str, float]:

--- a/GenesisAeonAdvancedAi/test_cli.py
+++ b/GenesisAeonAdvancedAi/test_cli.py
@@ -272,3 +272,34 @@ class TestAeonCLI(unittest.TestCase):
             data = json.loads(result.stdout)
             self.assertIn("trend", data)
 
+    def test_stats_flag(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mem_file = Path(tmpdir) / "mem.json"
+            subprocess.run([
+                sys.executable,
+                "-m",
+                "GenesisAeonAdvancedAi.aeon_cli",
+                "0.1",
+                "--memory",
+                str(mem_file),
+            ], check=True)
+            subprocess.run([
+                sys.executable,
+                "-m",
+                "GenesisAeonAdvancedAi.aeon_cli",
+                "0.3",
+                "--memory",
+                str(mem_file),
+            ], check=True)
+            result = subprocess.run([
+                sys.executable,
+                "-m",
+                "GenesisAeonAdvancedAi.aeon_cli",
+                "--stats",
+                "--memory",
+                str(mem_file),
+            ], capture_output=True, text=True, check=True)
+            data = json.loads(result.stdout)
+            self.assertIn("crep_score", data)
+            self.assertIn("mean", data["crep_score"])
+

--- a/GenesisAeonAdvancedAi/test_memory_store.py
+++ b/GenesisAeonAdvancedAi/test_memory_store.py
@@ -7,6 +7,7 @@ from GenesisAeonAdvancedAi.memory_store import (
     load_results,
     summarize_memory,
     summarize_entries,
+    summarize_stats,
     tail_results,
     trend_metric,
 )
@@ -55,6 +56,16 @@ class TestMemoryStore(unittest.TestCase):
         result = summarize_entries(entries)
         self.assertEqual(result["a"], 2.0)
         self.assertEqual(result["b"], 3.0)
+
+    def test_summarize_stats(self):
+        entries = [
+            {"a": 1},
+            {"a": 3},
+            {"a": 5},
+        ]
+        stats = summarize_stats(entries)
+        self.assertEqual(stats["a"]["mean"], 3.0)
+        self.assertEqual(stats["a"]["median"], 3.0)
 
     def test_tail_results(self):
         path = pathlib.Path("temp_mem.json")


### PR DESCRIPTION
## Summary
- add `summarize_stats` utilities for mean & median calculation
- expose `summarize_stats_memory` via package init
- support `--stats` flag in `aeon_cli`
- extend tests for memory store and CLI
- update feedback files with new feature note

## Testing
- `python -m unittest discover GenesisAeonAdvancedAi`
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_685d67a612a88322912031e51099f727