### PR TITLE
Add volatility metric and CLI support

### DIFF
--- a/GenesisAeonAdvancedAi/__init__.py
+++ b/GenesisAeonAdvancedAi/__init__.py
@@ -17,6 +17,8 @@ from .memory_store import (
     summarize_stats_memory,
     tail_results,
     trend_metric,
+    volatility_metric,
+    volatility_metric_memory,
 )
 
 __all__ = [
@@ -40,5 +42,7 @@ __all__ = [
     "summarize_stats_memory",
     "tail_results",
     "trend_metric",
+    "volatility_metric",
+    "volatility_metric_memory",
 ]
 

--- a/GenesisAeonAdvancedAi/aeon_cli.py
+++ b/GenesisAeonAdvancedAi/aeon_cli.py
@@ -27,6 +27,7 @@ from .memory_store import (
     summarize_stats_memory,
     tail_results,
     trend_metric,
+    volatility_metric_memory,
 )
 from .sigil_loader import load_sigil, load_start_sigil
 from .trikaya import trikaya_state
@@ -91,6 +92,11 @@ def main(argv: List[str] | None = None) -> None:
         "--stats",
         action="store_true",
         help="Print mean and median statistics for numeric fields in memory (requires --memory)",
+    )
+    parser.add_argument(
+        "--volatility",
+        action="store_true",
+        help="Print standard deviation for numeric fields in memory (requires --memory)",
     )
     parser.add_argument(
         "--sigil",
@@ -172,6 +178,13 @@ def main(argv: List[str] | None = None) -> None:
             parser.error("--stats requires --memory")
         stats = summarize_stats_memory(args.memory)
         print(json.dumps(stats, indent=2))
+        return
+
+    if args.volatility:
+        if not args.memory:
+            parser.error("--volatility requires --memory")
+        volatility = volatility_metric_memory(args.memory)
+        print(json.dumps(volatility, indent=2))
         return
 
     values = list(args.values)

--- a/GenesisAeonAdvancedAi/feedback.md
+++ b/GenesisAeonAdvancedAi/feedback.md
@@ -17,3 +17,4 @@ Erweiterung: Aeon CLI unterstuetzt jetzt das Flag `--graph`, um einen Fraktal-Fe
   average change for a numeric field.
 \n- Plugin loader accepts JSON manifests in addition to YAML.
 \n- Memory statistics via `summarize_stats` and `summarize_stats_memory` with `--stats` CLI flag.
+- Volatility analysis via `volatility_metric_memory` with CLI flag `--volatility`.

--- a/GenesisAeonAdvancedAi/memory_store.py
+++ b/GenesisAeonAdvancedAi/memory_store.py
@@ -113,3 +113,30 @@ def trend_metric(path: Path, key: str, n: int = 5) -> float | None:
     diffs = [values[i] - values[i - 1] for i in range(1, len(values))]
     return sum(diffs) / len(diffs)
 
+
+def volatility_metric(results: Iterable[Dict[str, Any]]) -> Dict[str, float]:
+    """Return standard deviation for numeric fields in ``results``."""
+    values: Dict[str, List[float]] = {}
+    for entry in results:
+        for key, value in entry.items():
+            if isinstance(value, (int, float)):
+                values.setdefault(key, []).append(float(value))
+
+    volatilities: Dict[str, float] = {}
+    for key, vals in values.items():
+        if len(vals) > 1:
+            mean_val = sum(vals) / len(vals)
+            var = sum((v - mean_val) ** 2 for v in vals) / len(vals)
+            volatilities[key] = var ** 0.5
+        else:
+            volatilities[key] = 0.0
+    return volatilities
+
+
+def volatility_metric_memory(path: Path) -> Dict[str, float]:
+    """Return :func:`volatility_metric` for JSON data stored in ``path``."""
+    results = load_results(path)
+    if not results:
+        return {}
+    return volatility_metric(results)
+

--- a/GenesisAeonAdvancedAi/test_cli.py
+++ b/GenesisAeonAdvancedAi/test_cli.py
@@ -303,3 +303,34 @@ class TestAeonCLI(unittest.TestCase):
             self.assertIn("crep_score", data)
             self.assertIn("mean", data["crep_score"])
 
+    def test_volatility_flag(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mem_file = Path(tmpdir) / "mem.json"
+            subprocess.run([
+                sys.executable,
+                "-m",
+                "GenesisAeonAdvancedAi.aeon_cli",
+                "1",
+                "--memory",
+                str(mem_file),
+            ], check=True)
+            subprocess.run([
+                sys.executable,
+                "-m",
+                "GenesisAeonAdvancedAi.aeon_cli",
+                "3",
+                "--memory",
+                str(mem_file),
+            ], check=True)
+            result = subprocess.run([
+                sys.executable,
+                "-m",
+                "GenesisAeonAdvancedAi.aeon_cli",
+                "--volatility",
+                "--memory",
+                str(mem_file),
+            ], capture_output=True, text=True, check=True)
+            data = json.loads(result.stdout)
+            self.assertIn("crep_score", data)
+            self.assertGreater(data["crep_score"], 0)
+

--- a/GenesisAeonAdvancedAi/test_memory_store.py
+++ b/GenesisAeonAdvancedAi/test_memory_store.py
@@ -10,6 +10,8 @@ from GenesisAeonAdvancedAi.memory_store import (
     summarize_stats,
     tail_results,
     trend_metric,
+    volatility_metric,
+    volatility_metric_memory,
 )
 
 
@@ -87,6 +89,26 @@ class TestMemoryStore(unittest.TestCase):
         store_result({"score": 1}, path)
         trend = trend_metric(path, "score", 2)
         self.assertAlmostEqual(trend, 2.0)
+        path.unlink()
+
+    def test_volatility_metric(self):
+        entries = [
+            {"a": 1},
+            {"a": 3},
+            {"a": 5},
+        ]
+        vol = volatility_metric(entries)
+        self.assertAlmostEqual(vol["a"], 1.63299, places=5)
+
+    def test_volatility_metric_memory(self):
+        path = pathlib.Path("temp_mem.json")
+        if path.exists():
+            path.unlink()
+        store_result({"val": 1}, path)
+        store_result({"val": 5}, path)
+        vol = volatility_metric_memory(path)
+        self.assertIn("val", vol)
+        self.assertGreater(vol["val"], 0)
         path.unlink()
 
 


### PR DESCRIPTION
## Summary
- implement `volatility_metric` and `volatility_metric_memory`
- expose new helpers via package `__init__`
- add `--volatility` option to `aeon_cli`
- test new CLI option and helper functions
- document update in `feedback.md`

## Testing
- `pip install -q -r GenesisAeonAdvancedAi/requirements.txt`
- `pytest GenesisAeonAdvancedAi -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6aca0cbc8322b96ea3bdbd4116b1