### PR TITLE
Implement SealCore and relocate commit script

### DIFF
--- a/GenesisAeonZIPMEM/__init__.py
+++ b/GenesisAeonZIPMEM/__init__.py
@@ -1,0 +1,5 @@
+"""GenesisAeonZIPMEM package."""
+
+from .seal_core import SealCore
+
+__all__ = ["SealCore"]

--- a/GenesisAeonZIPMEM/commitMemory/commit-memory.js
+++ b/GenesisAeonZIPMEM/commitMemory/commit-memory.js
@@ -7,7 +7,7 @@ const YAML = require('yaml');
 const execAsync = promisify(exec);
 
 async function run() {
-  const repoRoot = path.resolve(__dirname, '..');
+  const repoRoot = path.resolve(__dirname, '..', '..');
   const sessionFlag = path.join(repoRoot, '.zipmem_session');
   try {
     await fs.access(sessionFlag);

--- a/GenesisAeonZIPMEM/feedback.json
+++ b/GenesisAeonZIPMEM/feedback.json
@@ -1,3 +1,3 @@
 {
-  "status": "MetaCommit in progress"
+  "status": "MetaCommit completed"
 }

--- a/GenesisAeonZIPMEM/feedback.md
+++ b/GenesisAeonZIPMEM/feedback.md
@@ -1,3 +1,4 @@
 # Feedback
 
 ZIPMEM MetaCommit läuft. Weitere Features werden integriert.
+SealCore module added and commit-memory script relocated.

--- a/GenesisAeonZIPMEM/seal_core.py
+++ b/GenesisAeonZIPMEM/seal_core.py
@@ -1,0 +1,59 @@
+"""Simplified SealCore module bridging AdvancedAI and SelfLearnAI."""
+
+from __future__ import annotations
+
+import logging
+from queue import Queue
+from typing import Any
+
+from .agents import symbol_mapper, crep_bridge
+
+
+class SealCore:
+    """Core loop for AeonSealAI."""
+
+    def __init__(self, input_queue: Queue | None = None) -> None:
+        self.input_queue: Queue[Any] = input_queue or Queue()
+        self.logger = logging.getLogger("SealCore")
+        if not self.logger.handlers:
+            handler = logging.StreamHandler()
+            self.logger.addHandler(handler)
+        self.logger.setLevel(logging.INFO)
+
+    def monitor_input(self) -> Any:
+        """Retrieve next item from the input queue."""
+        data = self.input_queue.get()
+        return data
+
+    def parse_to_symbols(self, data: Any) -> Any:
+        """Convert input data to symbolic representation."""
+        if isinstance(data, (list, tuple)):
+            return symbol_mapper.map_numeric_to_symbol(data)
+        if isinstance(data, str):
+            return symbol_mapper.map_text_to_glyph(data)
+        return data
+
+    def generate_resonance(self, symbols: Any) -> Any:
+        """Generate resonance response based on symbols."""
+        return {"resonance": symbols}
+
+    def evolve_behavior(self, symbols: Any) -> Any:
+        """Adapt symbols using CREP evaluation."""
+        scores = crep_bridge.evaluate_crep(symbols)
+        if scores.get("coherence", 1) < 0.5:
+            # placeholder for refactor trigger
+            symbols = f"refactored:{symbols}"
+        return symbols
+
+    def apply_feedback(self, response: Any) -> None:
+        """Handle feedback for response (stub)."""
+        self.logger.info("Feedback: %s", response)
+
+    def step(self) -> None:
+        """Execute one iteration of the core loop."""
+        data = self.monitor_input()
+        symbols = self.parse_to_symbols(data)
+        evolved = self.evolve_behavior(symbols)
+        response = self.generate_resonance(evolved)
+        self.apply_feedback(response)
+        self.logger.info("Processed input: %s -> %s", data, response)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "generate:next-sigil": "node scripts/generate-next-sigil.js",
     "aeon:transition": "node scripts/aeon-transition-workflow.js",
     "qa": "ts-node scripts/qa-test-runner.ts",
-    "store:commit-memory": "node scripts/commit-memory.js"
+    "store:commit-memory": "node GenesisAeonZIPMEM/commitMemory/commit-memory.js"
   },
   "dependencies": {
     "ajv": "^8.0.0",

--- a/scripts/__tests__/commit-memory.test.ts
+++ b/scripts/__tests__/commit-memory.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
-const { run } = require('../commit-memory');
+const { run } = require('../../GenesisAeonZIPMEM/commitMemory/commit-memory');
 
 test('commit-memory writes meta and patch', async () => {
   const commit = execSync('git rev-parse HEAD').toString().trim();


### PR DESCRIPTION
## Summary
- add a `SealCore` implementation inside `GenesisAeonZIPMEM`
- move commit-memory script into `GenesisAeonZIPMEM/commitMemory`
- update package script and tests to use the new location
- refresh feedback files

## Testing
- `pytest GenesisAeonZIPMEM/tests -q`
- `pnpm test -- scripts/__tests__/commit-memory.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_685d7b3fbecc8322b0d2c733ddfd223b