### PR TITLE
Update ZIPMEM commit storage

### DIFF
--- a/GenesisAeonZIPMEM/commitMemory/commit-memory.js
+++ b/GenesisAeonZIPMEM/commitMemory/commit-memory.js
@@ -22,6 +22,7 @@ async function run() {
     repoRoot,
     'GenesisAeonZIPMEM',
     'commitMemory',
+    'aeonCodexCommits',
     commit
   );
   try {

--- a/GenesisAeonZIPMEM/feedback.md
+++ b/GenesisAeonZIPMEM/feedback.md
@@ -2,3 +2,4 @@
 
 ZIPMEM MetaCommit läuft. Weitere Features werden integriert.
 SealCore module added and commit-memory script relocated.
+Commit memory now stored under aeonCodexCommits.

--- a/scripts/__tests__/commit-memory.test.ts
+++ b/scripts/__tests__/commit-memory.test.ts
@@ -7,7 +7,7 @@ test('commit-memory writes meta and patch', async () => {
   const commit = execSync('git rev-parse HEAD').toString().trim();
   const dir = path.join(
     __dirname,
-    '../../GenesisAeonZIPMEM/commitMemory',
+    '../../GenesisAeonZIPMEM/commitMemory/aeonCodexCommits',
     commit
   );
   const flag = path.join(__dirname, '../../.zipmem_session');


### PR DESCRIPTION
## Summary
- store commit patches under `aeonCodexCommits`
- update commit-memory Jest test accordingly
- note new path in feedback

## Testing
- `pytest GenesisAeonZIPMEM/tests -q`
- `npx jest scripts/__tests__/commit-memory.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_685d827dce9083229f08eced8750f316