### PR TITLE
Add self-learning modules and tests

### DIFF
--- a/GenesisAeonZIPMEM/__init__.py
+++ b/GenesisAeonZIPMEM/__init__.py
@@ -1,5 +1,17 @@
 """GenesisAeonZIPMEM package."""
 
 from .seal_core import SealCore
+from .self_organizing_memory import SelfOrganizingMemory
+from .dynamic_task_allocator import DynamicTaskAllocator
+from .fractal_agent import FractalAgent
+from .master_coordinator import MasterCoordinator
+from .advanced_ai_system import AdvancedAISelfLearnSystem
 
-__all__ = ["SealCore"]
+__all__ = [
+    "SealCore",
+    "SelfOrganizingMemory",
+    "DynamicTaskAllocator",
+    "FractalAgent",
+    "MasterCoordinator",
+    "AdvancedAISelfLearnSystem",
+]

--- a/GenesisAeonZIPMEM/advanced_ai_system.py
+++ b/GenesisAeonZIPMEM/advanced_ai_system.py
@@ -1,0 +1,45 @@
+"""High level AeonSealAI self learning loop."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, List, Dict
+
+from .seal_core import SealCore
+from .self_organizing_memory import SelfOrganizingMemory
+from .dynamic_task_allocator import DynamicTaskAllocator
+from .fractal_agent import FractalAgent
+from .master_coordinator import MasterCoordinator
+
+
+class AdvancedAISelfLearnSystem:
+    """Combine memory, sealcore and agents."""
+
+    def __init__(self) -> None:
+        self.memory = SelfOrganizingMemory()
+        self.sealcore = SealCore()
+        self.allocator = DynamicTaskAllocator()
+        self.agents = [FractalAgent(focus="CREP"), FractalAgent(focus="Symbolik")]
+        self.coordinator = MasterCoordinator(self.agents)
+
+    def estimate_crep(self) -> float:
+        return 0.5
+
+    def get_feedback(self) -> float:
+        return 0.5
+
+    def mainloop(self, feedback: float | None = None) -> Dict[str, Any]:
+        seal_snapshot = self.sealcore.evolve_behavior("\u25CB")  # simple call
+        todos = self.allocator.allocate([e.__dict__ for e in self.memory.entries])
+        self.coordinator.orchestrate([e.__dict__ for e in self.memory.entries], self.sealcore)
+        entry = {
+            "time": datetime.now().isoformat(),
+            "crep": self.estimate_crep(),
+            "feedback": feedback or self.get_feedback(),
+            "symbol": "\u25CB",
+            "strategy": "default",
+            "sealcore_snapshot": seal_snapshot,
+            "todos": todos,
+        }
+        self.memory.add(entry)
+        return entry

--- a/GenesisAeonZIPMEM/dynamic_task_allocator.py
+++ b/GenesisAeonZIPMEM/dynamic_task_allocator.py
@@ -1,0 +1,21 @@
+"""Allocate tasks dynamically based on CREP trends."""
+
+from __future__ import annotations
+
+from typing import Any, List, Dict
+
+
+class DynamicTaskAllocator:
+    """Simple task allocator influenced by average CREP."""
+
+    def allocate(self, memory: List[Dict[str, Any]]) -> List[str]:
+        window = memory[-10:]
+        if not window:
+            return ["Initialize"]
+        creps = [entry.get("crep", 0.0) for entry in window]
+        avg_crep = sum(creps) / len(creps)
+        if avg_crep < 0.4:
+            return ["FeedbackLoop", "Neue Symbolik testen"]
+        if avg_crep > 0.7:
+            return ["ClusterExpand", "CommunitySync"]
+        return ["StandardReview", "CREPMonitor"]

--- a/GenesisAeonZIPMEM/feedback.md
+++ b/GenesisAeonZIPMEM/feedback.md
@@ -3,3 +3,5 @@
 ZIPMEM MetaCommit läuft. Weitere Features werden integriert.
 SealCore module added and commit-memory script relocated.
 Commit memory now stored under aeonCodexCommits.
+
+Neue Module für SelfLearn-System implementiert (SelfOrganizingMemory, TaskAllocator, Coordinator).

--- a/GenesisAeonZIPMEM/fractal_agent.py
+++ b/GenesisAeonZIPMEM/fractal_agent.py
@@ -1,0 +1,18 @@
+"""Basic fractal agent for self learning."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+class FractalAgent:
+    """Simple agent skeleton."""
+
+    def __init__(self, focus: str) -> None:
+        self.focus = focus
+        self.state: Dict[str, Any] = {}
+
+    def step(self, memory: List[Dict[str, Any]], sealcore: Any) -> None:
+        """Placeholder review logic."""
+        self.state["last_memory"] = memory[-1] if memory else None
+        # Agents could modify sealcore or memory here

--- a/GenesisAeonZIPMEM/master_coordinator.py
+++ b/GenesisAeonZIPMEM/master_coordinator.py
@@ -1,0 +1,18 @@
+"""Master coordinator orchestrating fractal agents."""
+
+from __future__ import annotations
+
+from typing import Any, List, Dict
+
+from .fractal_agent import FractalAgent
+
+
+class MasterCoordinator:
+    """Coordinate multiple agents and aggregate learning."""
+
+    def __init__(self, agents: List[FractalAgent]) -> None:
+        self.agents = agents
+
+    def orchestrate(self, memory: List[Dict[str, Any]], sealcore: Any) -> None:
+        for agent in self.agents:
+            agent.step(memory, sealcore)

--- a/GenesisAeonZIPMEM/self_organizing_memory.py
+++ b/GenesisAeonZIPMEM/self_organizing_memory.py
@@ -1,0 +1,52 @@
+"""Self-organizing memory management for AeonSealAI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, List, Dict
+
+
+@dataclass
+class MemoryEntry:
+    time: str
+    crep: float
+    feedback: float | None = None
+    symbol: str | None = None
+    strategy: str | None = None
+    sealcore_snapshot: Dict[str, Any] | None = None
+    todos: List[str] | None = None
+    meta: Dict[str, Any] | None = None
+
+
+class SelfOrganizingMemory:
+    """Store memory entries and periodically review trends."""
+
+    def __init__(self) -> None:
+        self.entries: List[MemoryEntry] = []
+
+    def add(self, entry: Dict[str, Any]) -> None:
+        """Add a memory entry and trigger review every 10 items."""
+        complete = MemoryEntry(time=entry.get("time", datetime.now().isoformat()),
+                              crep=entry.get("crep", 0.0),
+                              feedback=entry.get("feedback"),
+                              symbol=entry.get("symbol"),
+                              strategy=entry.get("strategy"),
+                              sealcore_snapshot=entry.get("sealcore_snapshot"),
+                              todos=entry.get("todos"),
+                              meta=entry.get("meta"))
+        self.entries.append(complete)
+        if len(self.entries) % 10 == 0:
+            self.review()
+
+    def review(self) -> Dict[str, Any]:
+        """Return average CREP and symbol distribution of last 10 entries."""
+        window = self.entries[-10:]
+        if not window:
+            return {"avg_crep": 0.0, "symbol_counts": {}}
+        avg_crep = sum(e.crep for e in window) / len(window)
+        symbol_counts: Dict[str, int] = {}
+        for e in window:
+            sym = e.symbol or "\u25CB"
+            symbol_counts[sym] = symbol_counts.get(sym, 0) + 1
+        return {"avg_crep": avg_crep, "symbol_counts": symbol_counts}

--- a/GenesisAeonZIPMEM/tests/test_dynamic_task_allocator.py
+++ b/GenesisAeonZIPMEM/tests/test_dynamic_task_allocator.py
@@ -1,0 +1,15 @@
+from GenesisAeonZIPMEM.dynamic_task_allocator import DynamicTaskAllocator
+
+
+def test_allocate_low_crep():
+    allocator = DynamicTaskAllocator()
+    memory = [{"crep": 0.1}] * 10
+    tasks = allocator.allocate(memory)
+    assert "FeedbackLoop" in tasks
+
+
+def test_allocate_high_crep():
+    allocator = DynamicTaskAllocator()
+    memory = [{"crep": 0.9}] * 10
+    tasks = allocator.allocate(memory)
+    assert "ClusterExpand" in tasks

--- a/GenesisAeonZIPMEM/tests/test_self_organizing_memory.py
+++ b/GenesisAeonZIPMEM/tests/test_self_organizing_memory.py
@@ -1,0 +1,10 @@
+from GenesisAeonZIPMEM.self_organizing_memory import SelfOrganizingMemory
+
+
+def test_review_calculates_average():
+    mem = SelfOrganizingMemory()
+    for i in range(10):
+        mem.add({"crep": i / 10, "symbol": "\u25CB"})
+    result = mem.review()
+    assert abs(result["avg_crep"] - 0.45) < 1e-6
+    assert result["symbol_counts"]["\u25CB"] == 10


### PR DESCRIPTION
## Summary
- add self-organizing memory and dynamic task allocator modules
- implement fractal agent framework and master coordinator
- create advanced self learning system tying everything together
- expand feedback notes
- add tests for new modules

## Testing
- `pytest GenesisAeonZIPMEM/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_685d8fd03ba8832286aabd18d68920fa