### PR TITLE
Improve ZIPMEM SealCore integration

### DIFF
--- a/GenesisAeonZIPMEM/seal_core.py
+++ b/GenesisAeonZIPMEM/seal_core.py
@@ -12,7 +12,7 @@ from .agents import symbol_mapper, crep_bridge
 class SealCore:
     """Core loop for AeonSealAI."""
 
-    def __init__(self, input_queue: Queue | None = None) -> None:
+    def __init__(self, input_queue: Queue | None = None, config_path: str | None = None) -> None:
         self.input_queue: Queue[Any] = input_queue or Queue()
         self.logger = logging.getLogger("SealCore")
         if not self.logger.handlers:
@@ -23,11 +23,35 @@ class SealCore:
         self.strategy = "default"
         self.symbol_map: Dict[str, str] = {"default": "\u25CB", "current": "\u25CB"}
         self.thresholds: Dict[str, float] = {"crep_low": 0.2, "crep_high": 0.8}
+        self.meta: Dict[str, Any] = {}
+        if config_path:
+            self.load_config(config_path)
 
     def monitor_input(self) -> Any:
         """Retrieve next item from the input queue."""
         data = self.input_queue.get()
         return data
+
+    def load_config(self, path: str) -> None:
+        """Load configuration from a YAML file."""
+        import yaml
+
+        with open(path, "r", encoding="utf8") as f:
+            data = yaml.safe_load(f)
+        cfg = data.get("SealCore", data)
+        self.meta.update({k: cfg.get(k) for k in ["id", "version", "type", "description"] if k in cfg})
+        if "thresholds" in cfg:
+            self.thresholds.update(cfg["thresholds"])
+        if "symbol_map" in cfg:
+            self.symbol_map.update(cfg["symbol_map"])
+        if "strategy" in cfg:
+            self.strategy = cfg["strategy"]
+
+    @classmethod
+    def from_config(cls, path: str, input_queue: Queue | None = None) -> "SealCore":
+        """Instantiate SealCore from YAML config."""
+        obj = cls(input_queue=input_queue, config_path=path)
+        return obj
 
     def parse_to_symbols(self, data: Any) -> Any:
         """Convert input data to symbolic representation."""

--- a/GenesisAeonZIPMEM/tests/test_advanced_ai_system.py
+++ b/GenesisAeonZIPMEM/tests/test_advanced_ai_system.py
@@ -1,0 +1,8 @@
+from GenesisAeonZIPMEM.advanced_ai_system import AdvancedAISelfLearnSystem
+
+
+def test_mainloop_adds_entry():
+    system = AdvancedAISelfLearnSystem()
+    result = system.mainloop(feedback=0.6)
+    assert system.memory.entries
+    assert result["sealcore_snapshot"]

--- a/GenesisAeonZIPMEM/tests/test_fractal_agent.py
+++ b/GenesisAeonZIPMEM/tests/test_fractal_agent.py
@@ -1,0 +1,8 @@
+from GenesisAeonZIPMEM.fractal_agent import FractalAgent
+
+
+def test_agent_records_last_memory():
+    agent = FractalAgent(focus="test")
+    memory = [{"id": 1}, {"id": 2}]
+    agent.step(memory, None)
+    assert agent.state["last_memory"] == memory[-1]

--- a/GenesisAeonZIPMEM/tests/test_master_coordinator.py
+++ b/GenesisAeonZIPMEM/tests/test_master_coordinator.py
@@ -1,0 +1,12 @@
+from GenesisAeonZIPMEM.fractal_agent import FractalAgent
+from GenesisAeonZIPMEM.master_coordinator import MasterCoordinator
+
+
+def test_coordinator_calls_agents():
+    agent1 = FractalAgent(focus="a")
+    agent2 = FractalAgent(focus="b")
+    coord = MasterCoordinator([agent1, agent2])
+    memory = [{"foo": "bar"}]
+    coord.orchestrate(memory, None)
+    assert agent1.state["last_memory"] == memory[-1]
+    assert agent2.state["last_memory"] == memory[-1]

--- a/GenesisAeonZIPMEM/tests/test_seal_core.py
+++ b/GenesisAeonZIPMEM/tests/test_seal_core.py
@@ -29,3 +29,9 @@ def test_adapt_changes_strategy():
     snap = core.adapt(memory)
     assert snap["strategy"] == "growth"
     assert snap["active_symbol"] == "\U0001F331"
+
+
+def test_load_config_reads_meta():
+    path = "GenesisAeonZIPMEM/Codex-Instructions/SealCore.yaml"
+    core = SealCore(config_path=path)
+    assert core.meta.get("id") == "seal-core-alpha"


### PR DESCRIPTION
## Summary
- load SealCore YAML configuration via new `load_config` method
- add `from_config` factory
- include `meta` information inside `SealCore`
- extend SealCore tests and add tests for fractal agent, master coordinator and system loop

## Testing
- `pytest GenesisAeonZIPMEM/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_685d93637124832287e80915444c77cb