### PR TITLE
Fix commit memory path

### DIFF
--- a/GenesisAeonZIPMEM/Codex-Instructions/GenesisAeonZIPMEM-Struktur.md
+++ b/GenesisAeonZIPMEM/Codex-Instructions/GenesisAeonZIPMEM-Struktur.md
@@ -8,7 +8,7 @@ GenesisAeonZIPMEM/
 │   └── ...
 │
 ├── 📁 commitMemory/
-│   ├── aeonCodexCommits/
+│   ├── <commit-hash>/        # gespeicherte Commits
 │   ├── metaCommitPattern/
 │   └── crepRefactors/
 │

--- a/GenesisAeonZIPMEM/commitMemory/commit-memory.js
+++ b/GenesisAeonZIPMEM/commitMemory/commit-memory.js
@@ -22,7 +22,6 @@ async function run() {
     repoRoot,
     'GenesisAeonZIPMEM',
     'commitMemory',
-    'aeonCodexCommits',
     commit
   );
   try {

--- a/GenesisAeonZIPMEM/feedback.md
+++ b/GenesisAeonZIPMEM/feedback.md
@@ -2,6 +2,6 @@
 
 ZIPMEM MetaCommit läuft. Weitere Features werden integriert.
 SealCore module added and commit-memory script relocated.
-Commit memory now stored under aeonCodexCommits.
+Commit memory now stored direkt unter ``commitMemory/<commit-hash>``.
 
 Neue Module für SelfLearn-System implementiert (SelfOrganizingMemory, TaskAllocator, Coordinator).

--- a/scripts/__tests__/commit-memory.test.ts
+++ b/scripts/__tests__/commit-memory.test.ts
@@ -7,7 +7,7 @@ test('commit-memory writes meta and patch', async () => {
   const commit = execSync('git rev-parse HEAD').toString().trim();
   const dir = path.join(
     __dirname,
-    '../../GenesisAeonZIPMEM/commitMemory/aeonCodexCommits',
+    '../../GenesisAeonZIPMEM/commitMemory',
     commit
   );
   const flag = path.join(__dirname, '../../.zipmem_session');


### PR DESCRIPTION
## Summary
- update commit memory script to write to GenesisAeonZIPMEM/commitMemory/<hash>
- adjust docs and feedback
- update jest test path

## Testing
- `pytest GenesisAeonZIPMEM/tests`


------
https://chatgpt.com/codex/tasks/task_e_685d95858b648322aa95b8deda3e359c