### PR TITLE
Add conversation importer utilities

### DIFF
--- a/GenesisAeonZIPMEM/__init__.py
+++ b/GenesisAeonZIPMEM/__init__.py
@@ -6,6 +6,7 @@ from .dynamic_task_allocator import DynamicTaskAllocator
 from .fractal_agent import FractalAgent
 from .master_coordinator import MasterCoordinator
 from .advanced_ai_system import AdvancedAISelfLearnSystem
+from .conversation_importer import load_conversation_fragments, import_into_memory
 
 __all__ = [
     "SealCore",
@@ -14,4 +15,6 @@ __all__ = [
     "FractalAgent",
     "MasterCoordinator",
     "AdvancedAISelfLearnSystem",
+    "load_conversation_fragments",
+    "import_into_memory",
 ]

--- a/GenesisAeonZIPMEM/conversation_importer.py
+++ b/GenesisAeonZIPMEM/conversation_importer.py
@@ -1,0 +1,39 @@
+"""Utilities to import conversation fragments into memory."""
+
+from __future__ import annotations
+
+import os
+import yaml
+from typing import List, Dict
+
+from .self_organizing_memory import SelfOrganizingMemory
+
+
+def load_conversation_fragments(folder: str) -> List[Dict[str, any]]:
+    """Load YAML conversation fragments from *folder* sorted by filename."""
+    fragments: List[Dict[str, any]] = []
+    for fname in sorted(os.listdir(folder)):
+        if fname.endswith('.yaml'):
+            path = os.path.join(folder, fname)
+            with open(path, 'r', encoding='utf8') as f:
+                frag = yaml.safe_load(f)
+            if isinstance(frag, dict):
+                fragments.append(frag)
+    return fragments
+
+
+def import_into_memory(folder: str, memory: SelfOrganizingMemory) -> None:
+    """Import fragments from *folder* into *memory* as entries."""
+    fragments = load_conversation_fragments(folder)
+    for frag in fragments:
+        entry = {
+            'time': frag.get('timestamp'),
+            'crep': frag.get('crep', 0.5),
+            'feedback': frag.get('feedback'),
+            'symbol': frag.get('symbol'),
+            'strategy': frag.get('strategy'),
+            'sealcore_snapshot': frag.get('sealcore_snapshot'),
+            'todos': frag.get('todos'),
+            'meta': frag.get('meta'),
+        }
+        memory.add(entry)

--- a/GenesisAeonZIPMEM/feedback.md
+++ b/GenesisAeonZIPMEM/feedback.md
@@ -5,3 +5,4 @@ SealCore module added and commit-memory script relocated.
 Commit memory now stored direkt unter ``commitMemory/<commit-hash>``.
 
 Neue Module für SelfLearn-System implementiert (SelfOrganizingMemory, TaskAllocator, Coordinator).
+\nAdded conversation_importer utilities.

--- a/GenesisAeonZIPMEM/tests/test_conversation_importer.py
+++ b/GenesisAeonZIPMEM/tests/test_conversation_importer.py
@@ -1,0 +1,17 @@
+from GenesisAeonZIPMEM.conversation_importer import load_conversation_fragments, import_into_memory
+from GenesisAeonZIPMEM.self_organizing_memory import SelfOrganizingMemory
+
+
+def test_load_conversation_fragments():
+    folder = 'GenesisAeonZIPMEM/newadvancedconversations/2025-0626-PFADVERBUNDUNG'
+    frags = load_conversation_fragments(folder)
+    assert len(frags) >= 2
+    assert frags[0]['content']
+
+
+def test_import_into_memory():
+    folder = 'GenesisAeonZIPMEM/newadvancedconversations/2025-0626-PFADVERBUNDUNG'
+    mem = SelfOrganizingMemory()
+    import_into_memory(folder, mem)
+    assert mem.entries
+    assert mem.entries[0].time


### PR DESCRIPTION
## Summary
- expose new conversation importer utilities
- allow importing YAML fragments into SelfOrganizingMemory
- test the importer with example conversation data
- note update in feedback

## Testing
- `pytest -q GenesisAeonZIPMEM/tests`

------
https://chatgpt.com/codex/tasks/task_e_685d9883a43c8322b658a60ab559c213