### PR TITLE
Enhance AeonSealAI core modules

### DIFF
--- a/GenesisAeonZIPMEM/master_coordinator.py
+++ b/GenesisAeonZIPMEM/master_coordinator.py
@@ -12,7 +12,29 @@ class MasterCoordinator:
 
     def __init__(self, agents: List[FractalAgent]) -> None:
         self.agents = agents
+        self.performance_log: Dict[int, List[float]] = {id(a): [] for a in agents}
 
     def orchestrate(self, memory: List[Dict[str, Any]], sealcore: Any) -> None:
         for agent in self.agents:
             agent.step(memory, sealcore)
+
+    def log_agent_performance(self, agent_id: int, result: float) -> None:
+        """Record performance result for *agent_id*."""
+        self.performance_log.setdefault(agent_id, []).append(result)
+
+    def best_agent(self) -> FractalAgent | None:
+        """Return agent with highest average logged result."""
+        if not self.performance_log:
+            return None
+        best_id = max(
+            self.performance_log,
+            key=lambda k: (
+                sum(self.performance_log[k]) / len(self.performance_log[k])
+                if self.performance_log[k]
+                else 0
+            ),
+        )
+        for agent in self.agents:
+            if id(agent) == best_id:
+                return agent
+        return None

--- a/GenesisAeonZIPMEM/seal_core.py
+++ b/GenesisAeonZIPMEM/seal_core.py
@@ -88,6 +88,13 @@ class SealCore:
         }
         return snapshot
 
+    def update_from_feedback(self, feedback_score: float) -> None:
+        """Adjust thresholds based on sustained feedback."""
+        if feedback_score > 0.8:
+            self.thresholds["crep_high"] = min(1.0, self.thresholds["crep_high"] + 0.01)
+        elif feedback_score < 0.2:
+            self.thresholds["crep_low"] = max(0.0, self.thresholds["crep_low"] - 0.01)
+
     def to_yaml(self) -> str:
         """Return YAML representation of core state."""
         import yaml

--- a/GenesisAeonZIPMEM/tests/test_master_coordinator.py
+++ b/GenesisAeonZIPMEM/tests/test_master_coordinator.py
@@ -10,3 +10,12 @@ def test_coordinator_calls_agents():
     coord.orchestrate(memory, None)
     assert agent1.state["last_memory"] == memory[-1]
     assert agent2.state["last_memory"] == memory[-1]
+
+
+def test_best_agent_returns_highest_score():
+    agent1 = FractalAgent(focus="a")
+    agent2 = FractalAgent(focus="b")
+    coord = MasterCoordinator([agent1, agent2])
+    coord.log_agent_performance(id(agent1), 0.2)
+    coord.log_agent_performance(id(agent2), 0.8)
+    assert coord.best_agent() is agent2

--- a/GenesisAeonZIPMEM/tests/test_seal_core.py
+++ b/GenesisAeonZIPMEM/tests/test_seal_core.py
@@ -35,3 +35,13 @@ def test_load_config_reads_meta():
     path = "GenesisAeonZIPMEM/Codex-Instructions/SealCore.yaml"
     core = SealCore(config_path=path)
     assert core.meta.get("id") == "seal-core-alpha"
+
+
+def test_update_from_feedback_modifies_thresholds():
+    core = SealCore()
+    high_before = core.thresholds["crep_high"]
+    core.update_from_feedback(0.9)
+    assert core.thresholds["crep_high"] > high_before
+    low_before = core.thresholds["crep_low"]
+    core.update_from_feedback(0.1)
+    assert core.thresholds["crep_low"] < low_before


### PR DESCRIPTION
## Summary
- extend `SealCore` with adaptive threshold updates
- add performance tracking to `MasterCoordinator`
- test new coordinator methods
- test SealCore threshold adjustments

## Testing
- `pytest GenesisAeonZIPMEM/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_685da4004b908322bc34eec8a00a28a5