### PR TITLE
Enhance AeonSealAI with haiku memory entries

### DIFF
--- a/GenesisAeonZIPMEM/advanced_ai_system.py
+++ b/GenesisAeonZIPMEM/advanced_ai_system.py
@@ -11,6 +11,20 @@ from .dynamic_task_allocator import DynamicTaskAllocator
 from .fractal_agent import FractalAgent
 from .master_coordinator import MasterCoordinator
 
+def basic_haiku(symbol: str) -> str:
+    """Return a small deterministic haiku for *symbol* (borrowed from AdvancedAI)."""
+    if symbol == "\u0394":
+        return (
+            "change weaves its path\n"
+            "memory traces interlace\n"
+            "delta guides the flow"
+        )
+    return (
+        "nested loops unfold\n"
+        "reflections echo the core\n"
+        "nabla draws us in"
+    )
+
 
 class AdvancedAISelfLearnSystem:
     """Combine memory, sealcore and agents."""
@@ -40,6 +54,7 @@ class AdvancedAISelfLearnSystem:
             "strategy": seal_snapshot["strategy"],
             "sealcore_snapshot": seal_snapshot,
             "todos": todos,
+            "haiku": basic_haiku(seal_snapshot["active_symbol"]),
         }
         self.memory.add(entry)
         return entry

--- a/GenesisAeonZIPMEM/self_organizing_memory.py
+++ b/GenesisAeonZIPMEM/self_organizing_memory.py
@@ -16,6 +16,7 @@ class MemoryEntry:
     strategy: str | None = None
     sealcore_snapshot: Dict[str, Any] | None = None
     todos: List[str] | None = None
+    haiku: str | None = None
     meta: Dict[str, Any] | None = None
 
 
@@ -49,6 +50,7 @@ class SelfOrganizingMemory:
                               strategy=entry.get("strategy"),
                               sealcore_snapshot=entry.get("sealcore_snapshot"),
                               todos=entry.get("todos"),
+                              haiku=entry.get("haiku"),
                               meta=entry.get("meta"))
         self.entries.append(complete)
         if len(self.entries) % 10 == 0:

--- a/GenesisAeonZIPMEM/tests/test_advanced_ai_system.py
+++ b/GenesisAeonZIPMEM/tests/test_advanced_ai_system.py
@@ -6,3 +6,4 @@ def test_mainloop_adds_entry():
     result = system.mainloop(feedback=0.6)
     assert system.memory.entries
     assert result["sealcore_snapshot"]
+    assert isinstance(result["haiku"], str)

--- a/GenesisAeonZIPMEM/tests/test_self_organizing_memory.py
+++ b/GenesisAeonZIPMEM/tests/test_self_organizing_memory.py
@@ -12,9 +12,10 @@ def test_review_calculates_average():
 
 def test_snapshot_roundtrip(tmp_path):
     mem = SelfOrganizingMemory()
-    mem.add({"crep": 0.2, "symbol": "\u2605"})
+    mem.add({"crep": 0.2, "symbol": "\u2605", "haiku": "test"})
     path = tmp_path / "snap.yaml"
     mem.export_snapshot(str(path))
     new_mem = SelfOrganizingMemory()
     new_mem.import_snapshot(str(path))
     assert new_mem.entries[0].symbol == "\u2605"
+    assert new_mem.entries[0].haiku == "test"


### PR DESCRIPTION
## Summary
- extend `MemoryEntry` with `haiku`
- add small haiku generator in `AdvancedAISelfLearnSystem`
- store haikus in memory entries
- adjust tests for new field

## Testing
- `pytest GenesisAeonZIPMEM/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_685da816c4a4832283ac613a5e1c74cf