### PR TITLE
Add Python neural network demo for Aeon ZIPMEM

### DIFF
--- a/GenesisAeonZIPMEM/README_R.md
+++ b/GenesisAeonZIPMEM/README_R.md
@@ -3,3 +3,5 @@
 This folder contains example R code illustrating basic neural network training, as referenced in the Codex instructions.
 
 `neural_network_demo.R` demonstrates a simple multilayer perceptron on the built-in `iris` dataset using the `neuralnet` package.
+
+For Python users, `neural_network_demo.py` provides an equivalent example with `scikit-learn`.

--- a/GenesisAeonZIPMEM/neural_network_demo.py
+++ b/GenesisAeonZIPMEM/neural_network_demo.py
@@ -1,0 +1,24 @@
+import numpy as np
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+from sklearn.neural_network import MLPClassifier
+from sklearn.preprocessing import StandardScaler
+
+
+def train_iris_mlp(random_state: int = 245):
+    """Train a small MLP on the iris dataset and return accuracy."""
+    data = load_iris()
+    X_train, X_test, y_train, y_test = train_test_split(
+        data.data, data.target, test_size=0.2, random_state=random_state
+    )
+    scaler = StandardScaler()
+    X_train = scaler.fit_transform(X_train)
+    X_test = scaler.transform(X_test)
+    clf = MLPClassifier(hidden_layer_sizes=(4, 2), max_iter=1000, random_state=random_state)
+    clf.fit(X_train, y_train)
+    return clf.score(X_test, y_test)
+
+
+if __name__ == "__main__":
+    acc = train_iris_mlp()
+    print(f"Accuracy: {acc:.2%}")

--- a/GenesisAeonZIPMEM/tests/test_neural_network_demo.py
+++ b/GenesisAeonZIPMEM/tests/test_neural_network_demo.py
@@ -1,0 +1,6 @@
+from GenesisAeonZIPMEM.neural_network_demo import train_iris_mlp
+
+
+def test_train_iris_mlp_accuracy():
+    acc = train_iris_mlp(random_state=1)
+    assert 0.7 <= acc <= 1.0


### PR DESCRIPTION
## Summary
- add neural_network_demo.py using scikit-learn
- test neural network accuracy
- note demo in README

## Testing
- `pytest GenesisAeonZIPMEM/tests -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685db3cc9c188322b86b1c1c589daa02