### PR TITLE
Add AeonSealAI system

### DIFF
--- a/GenesisAeonZIPMEM/__init__.py
+++ b/GenesisAeonZIPMEM/__init__.py
@@ -6,6 +6,7 @@ from .dynamic_task_allocator import DynamicTaskAllocator
 from .fractal_agent import FractalAgent
 from .master_coordinator import MasterCoordinator
 from .advanced_ai_system import AdvancedAISelfLearnSystem
+from .aeon_seal_ai import AeonSealAI
 from .conversation_importer import load_conversation_fragments, import_into_memory
 
 __all__ = [
@@ -15,6 +16,7 @@ __all__ = [
     "FractalAgent",
     "MasterCoordinator",
     "AdvancedAISelfLearnSystem",
+    "AeonSealAI",
     "load_conversation_fragments",
     "import_into_memory",
 ]

--- a/GenesisAeonZIPMEM/aeon_seal_ai.py
+++ b/GenesisAeonZIPMEM/aeon_seal_ai.py
@@ -1,0 +1,37 @@
+"""AeonSealAI system combining AdvancedAeonAgent with SealCore."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+
+from GenesisAeonAdvancedAi.advanced_agent import AdvancedAeonAgent, generate_basic_haiku
+
+from .advanced_ai_system import AdvancedAISelfLearnSystem
+
+
+class AeonSealAI(AdvancedAISelfLearnSystem):
+    """Self-learning AI that wraps an AdvancedAeonAgent and SealCore."""
+
+    def __init__(self, agent_name: str = "aeon_seal") -> None:
+        super().__init__()
+        self.agent = AdvancedAeonAgent(agent_name)
+
+    def process(self, input_data: Any, feedback: float | None = None) -> Dict[str, Any]:
+        """Process *input_data* through the agent and store a memory entry."""
+        result = self.agent.act(input_data)
+        seal_snapshot = self.sealcore.adapt([e.__dict__ for e in self.memory.entries])
+        todos = self.allocator.allocate([e.__dict__ for e in self.memory.entries])
+        self.coordinator.orchestrate([e.__dict__ for e in self.memory.entries], self.sealcore)
+        entry = {
+            "time": datetime.now().isoformat(),
+            "crep": self.estimate_crep(),
+            "feedback": feedback or self.get_feedback(),
+            "symbol": result["symbol"],
+            "strategy": seal_snapshot["strategy"],
+            "sealcore_snapshot": seal_snapshot,
+            "todos": todos,
+            "haiku": generate_basic_haiku(result["symbol"]),
+        }
+        self.memory.add(entry)
+        return entry

--- a/GenesisAeonZIPMEM/tests/test_aeon_seal_ai.py
+++ b/GenesisAeonZIPMEM/tests/test_aeon_seal_ai.py
@@ -1,0 +1,9 @@
+from GenesisAeonZIPMEM.aeon_seal_ai import AeonSealAI
+
+
+def test_process_creates_memory_entry():
+    ai = AeonSealAI()
+    result = ai.process("hello", feedback=0.7)
+    assert ai.memory.entries
+    assert result["sealcore_snapshot"]
+    assert isinstance(result["haiku"], str)


### PR DESCRIPTION
## Summary
- introduce `AeonSealAI` combining `AdvancedAeonAgent` with the existing self‑learning loop
- expose the new class from the package
- cover behaviour with unit test

## Testing
- `pytest -q GenesisAeonZIPMEM/tests/test_aeon_seal_ai.py`
- `pytest -q GenesisAeonZIPMEM/tests`

------
https://chatgpt.com/codex/tasks/task_e_685db8b9d0808322b2d8ee78e495185c