### PR TITLE
Add depth bundle exporter utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ Alle relevanten Änderungen dieses Projekts werden in diesem Dokument festgehalt
 ## [Unreleased]
 - Verfeinerte Symbolzuordnung in `aeon_processor.assign_symbol`
   für differenziertere Ausgabe.
+- Neues Skript `export-depth-bundle.ts` generiert Depth-Bundle und Index.

--- a/docs/agents/DepthBundleExporter.md
+++ b/docs/agents/DepthBundleExporter.md
@@ -10,5 +10,5 @@
 
 ## Example usage
 ```bash
-node export-depth-bundle.ts --out ./exports
+pnpm export_depth_bundle ./exports
 ```

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "symbolzeit:run": "node scripts/symbolzeit-runner.js",
     "generate:next-sigil": "node scripts/generate-next-sigil.js",
     "aeon:transition": "node scripts/aeon-transition-workflow.js",
+    "export_depth_bundle": "ts-node scripts/export-depth-bundle.ts",
     "qa": "ts-node scripts/qa-test-runner.ts",
     "store:commit-memory": "node GenesisAeonZIPMEM/commitMemory/commit-memory.js"
   },

--- a/scripts/__tests__/export-depth-bundle.test.ts
+++ b/scripts/__tests__/export-depth-bundle.test.ts
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+const script = path.join(__dirname, '../export-depth-bundle.ts');
+const outDir = path.join(__dirname, '../../tmp-depth');
+
+beforeAll(() => {
+  if (fs.existsSync(outDir)) fs.rmSync(outDir, { recursive: true, force: true });
+});
+
+afterAll(() => {
+  if (fs.existsSync(outDir)) fs.rmSync(outDir, { recursive: true, force: true });
+});
+
+test('export-depth-bundle generates bundle and index', () => {
+  execSync(`ts-node ${script} ${outDir}`);
+  const bundle = path.join(outDir, 'sigillin_depth_bundle.sigil.json');
+  const index = path.join(outDir, 'depth_index.md');
+  expect(fs.existsSync(bundle)).toBe(true);
+  expect(fs.existsSync(index)).toBe(true);
+});

--- a/scripts/export-depth-bundle.ts
+++ b/scripts/export-depth-bundle.ts
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+import { globSync } from 'glob';
+
+interface BundleEntry {
+  file: string;
+  content: string;
+}
+
+function exportDepthBundle(outDir: string) {
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+  const sigilFiles = globSync('docs/sigils/**/*.{yaml,yml,json,sigil.json}');
+  const bundle: BundleEntry[] = sigilFiles.map((f) => ({
+    file: f,
+    content: fs.readFileSync(f, 'utf8'),
+  }));
+  const bundlePath = path.join(outDir, 'sigillin_depth_bundle.sigil.json');
+  fs.writeFileSync(bundlePath, JSON.stringify(bundle, null, 2));
+  const indexPath = path.join(outDir, 'depth_index.md');
+  const indexLines = bundle.map((b) => `- ${b.file}`).join('\n');
+  fs.writeFileSync(indexPath, '# Depth Bundle Index\n' + indexLines + '\n');
+  console.log(`Bundle written to ${bundlePath}`);
+  console.log(`Index written to ${indexPath}`);
+}
+
+const outDir = process.argv[2] || 'exports';
+exportDepthBundle(outDir);


### PR DESCRIPTION
## Summary
- add `export-depth-bundle.ts` script and accompanying test
- document DepthBundleExporter usage
- expose `export_depth_bundle` npm script
- note new script in changelog

## Testing
- `pnpm run qa`
- `pnpm export_depth_bundle exports`

------
https://chatgpt.com/codex/tasks/task_e_685dc59df39c8322b0c815289d431d04