### PR TITLE
Update TODOs and sample sendemail hook

### DIFF
--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -76,7 +76,7 @@ todos:
     status: offen
   - id: todo-26
     beschreibung: "sigillin-validator.ts zur Prüfung von Sigillin-Dateien gemäß Schema erstellen"
-    status: offen
+    status: erledigt
   - id: todo-27
     beschreibung: "generate-readmes.ts zur automatischen Erstellung von Modul-Readmes implementieren"
     status: offen
@@ -190,7 +190,7 @@ todos:
     status: offen
   - id: todo-64
     beschreibung: "Dokumentationslinks je Agent in Agents.md ergänzen"
-    status: offen
+    status: erledigt
   - id: todo-65
     beschreibung: "depth-sigil-generator.ts zur Erstellung von Sigillin-Dateien aus Tiefenwerten entwickeln"
     status: offen

--- a/scripts/sendemail-validate.sample
+++ b/scripts/sendemail-validate.sample
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# Custom sendemail validation hook for UnifiedMandala
+# Applies incoming patches in a temporary worktree and runs lint/tests
+
+validate_patch() {
+    file="$1"
+    git am -3 "$file" >/dev/null || return
+    pnpm lint >/dev/null && pnpm test >/dev/null
+}
+
+validate_cover_letter() {
+    file="$1"
+    grep -qi "Signed-off-by:" "$file" || {
+        echo "Cover letter missing Signed-off-by line" >&2
+        return 1
+    }
+}
+
+validate_series() {
+    echo "Series validation complete"
+}
+
+# main
+if [ "$GIT_SENDEMAIL_FILE_COUNTER" = 1 ]; then
+    remote=$(git config --default origin --get sendemail.validateRemote)
+    ref=$(git config --default HEAD --get sendemail.validateRemoteRef)
+    worktree=$(mktemp --tmpdir -d sendemail-validate.XXXXXXX)
+    git worktree add -fd --checkout "$worktree" "refs/remotes/$remote/$ref" || exit 1
+    git config --replace-all sendemail.validateWorktree "$worktree"
+else
+    worktree=$(git config --get sendemail.validateWorktree)
+fi || { echo "sendemail-validate: error: failed to prepare worktree" >&2; exit 1; }
+
+unset GIT_DIR GIT_WORK_TREE
+cd "$worktree" || exit 1
+
+if grep -q "^diff --git " "$1"; then
+    validate_patch "$1" || exit 1
+else
+    validate_cover_letter "$1" || exit 1
+fi
+
+if [ "$GIT_SENDEMAIL_FILE_COUNTER" = "$GIT_SENDEMAIL_FILE_TOTAL" ]; then
+    git config --unset-all sendemail.validateWorktree
+    trap 'git worktree remove -ff "$worktree"' EXIT
+    validate_series || exit 1
+fi


### PR DESCRIPTION
## Summary
- mark finished tasks in `ToDo.yaml`
- add `scripts/sendemail-validate.sample` with lint/test checks

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685dc9d65204832288ba3571c3d46476