### PR TITLE
Enhance AeonUniversalMembrane typing and tests

### DIFF
--- a/packages/aeon-neural-membrane/__tests__/aeonUniversalMembrane.test.ts
+++ b/packages/aeon-neural-membrane/__tests__/aeonUniversalMembrane.test.ts
@@ -1,8 +1,9 @@
 import { AeonUniversalMembrane } from '../aeonUniversalMembrane';
 import { CREPSignature } from '../crepAdapter';
+import { NeuronMembrane } from '../neuronMembrane';
 
 test('train and predict through universal membrane', () => {
-  const mem = new AeonUniversalMembrane(2);
+  const mem = new AeonUniversalMembrane(undefined, 2);
   const data: [number, number][] = [
     [115, 66],
     [175, 78]
@@ -16,7 +17,7 @@ test('train and predict through universal membrane', () => {
 });
 
 test('harmonize reflects on high energy', () => {
-  const mem = new AeonUniversalMembrane(0);
+  const mem = new AeonUniversalMembrane(undefined, 0);
   const data: [number, number][] = [
     [115, 66],
     [175, 78]
@@ -26,5 +27,30 @@ test('harmonize reflects on high energy', () => {
   expect(res.energy).toBeGreaterThan(0);
   expect(typeof res.tone).toBe('string');
   expect(mem.depth).toBeGreaterThan(0); // increased due to threshold 0
+});
+
+test('trainAsync resolves and predicts', async () => {
+  const mem = new AeonUniversalMembrane(undefined, 0);
+  const data: [number, number][] = [
+    [10, 20],
+    [30, 40]
+  ];
+  const answers = [0, 1];
+  const crep: CREPSignature = { coherence: 5, resonance: 5, emergence: 5, poetics: 5 };
+  await mem.trainAsync(data, answers, crep);
+  expect(typeof mem.predict(10, 20)).toBe('number');
+});
+
+test('constructor accepts injected membrane', () => {
+  const base = new NeuronMembrane();
+  const mem = new AeonUniversalMembrane(base, 0);
+  expect(mem.depth).toBe(1);
+});
+
+test('harmonize throws on mismatched data', () => {
+  const mem = new AeonUniversalMembrane(undefined, 0);
+  expect(() =>
+    mem.harmonize([[1, 2]], [1, 0], 'hi')
+  ).toThrow('harmonize: Data und Answers m');
 });
 

--- a/packages/aeon-neural-membrane/__tests__/cycle.test.ts
+++ b/packages/aeon-neural-membrane/__tests__/cycle.test.ts
@@ -4,7 +4,7 @@ const data: [number, number][] = [[115, 66], [175, 78]];
 const answers = [1, 0];
 
 it('runs self reflect cycle', () => {
-  const mem = new AeonUniversalMembrane(1);
+  const mem = new AeonUniversalMembrane(undefined, 1);
   mem.selfReflectCycle(3, data, answers, 'hello', 0);
   expect(mem.getHistory().length).toBe(3);
   expect(mem.depth).toBeGreaterThan(1);

--- a/packages/aeon-neural-membrane/__tests__/resonance.test.ts
+++ b/packages/aeon-neural-membrane/__tests__/resonance.test.ts
@@ -1,7 +1,7 @@
 import { AeonUniversalMembrane } from '../aeonUniversalMembrane';
 
 test('scanResonance lists energy for each reflection', () => {
-  const mem = new AeonUniversalMembrane(2);
+  const mem = new AeonUniversalMembrane(undefined, 2);
   const res = mem.scanResonance();
   expect(res.length).toBe(mem.depth);
   expect(res[0]).toHaveProperty('energy');
@@ -9,7 +9,7 @@ test('scanResonance lists energy for each reflection', () => {
 });
 
 test('resonanceMap includes layer index', () => {
-  const mem = new AeonUniversalMembrane(3);
+  const mem = new AeonUniversalMembrane(undefined, 3);
   const map = mem.resonanceMap();
   expect(map.length).toBe(mem.depth);
   expect(map[0]).toHaveProperty('layer');

--- a/packages/aeon-neural-membrane/aeonUniversalMembrane.ts
+++ b/packages/aeon-neural-membrane/aeonUniversalMembrane.ts
@@ -9,6 +9,18 @@ import { scanEnergy } from './nukleonScanner';
 /**
  * AeonUniversalMembrane kombiniert die Spiegel-Funktion der NeuronMembrane
  * mit CREP-basiertem Selbsttraining und Nukleon/Sonifier-Feedback.
+ *
+ * Beispiel:
+ * ```ts
+ * import { AeonUniversalMembrane } from './aeonUniversalMembrane';
+ * import { CREPSignature } from './crepAdapter';
+ *
+ * const crep: CREPSignature = { coherence: 6, resonance: 6, emergence: 6, poetics: 6 };
+ * const mem = new AeonUniversalMembrane();
+ * mem.train([[1, 2]], [0], crep);
+ * const res = mem.harmonize([[1, 2]], [0], 'Hallo KI');
+ * console.log(res.energy, res.tone);
+ * ```
  */
 export interface HistoryEntry {
   energy: number;
@@ -23,8 +35,8 @@ export class AeonUniversalMembrane {
     this.history.push(entry);
   }
 
-  constructor(reflections = 1) {
-    this.mem = new NeuronMembrane();
+  constructor(mem: NeuronMembrane = new NeuronMembrane(), reflections = 1) {
+    this.mem = mem;
     if (reflections > 0) this.mem.reflect(reflections);
     if (this.mem.getNetworks().length === 0) {
       throw new Error('AeonUniversalMembrane: keine Netzwerke initialisiert');
@@ -51,9 +63,21 @@ export class AeonUniversalMembrane {
    * anschließend alle Spiegelungen.
    */
   train(data: [number, number][], answers: number[], crep: CREPSignature): void {
+    if (data.length !== answers.length) {
+      throw new Error('train: Data und Answers m\u00fcssen gleich lang sein');
+    }
     const base = this.mem.getNetworks()[0];
     selfTrain(base, data, answers, crep, 5);
     depthSync(this.mem, data);
+  }
+
+  /** Asynchrone Variante von train */
+  async trainAsync(
+    data: [number, number][],
+    answers: number[],
+    crep: CREPSignature
+  ): Promise<void> {
+    this.train(data, answers, crep);
   }
 
   /**
@@ -78,6 +102,12 @@ export class AeonUniversalMembrane {
     text: string,
     energyThreshold = 5
   ): { conv: ConvoMemory; energy: number; tone: string; depth: number } {
+    if (!text.trim()) {
+      throw new Error('harmonize: Text darf nicht leer sein');
+    }
+    if (data.length !== answers.length) {
+      throw new Error('harmonize: Data und Answers m\u00fcssen gleich lang sein');
+    }
     const conv = extractConvoMemory(text);
     const base = this.mem.getNetworks()[0];
     selfTrain(base, data, answers, conv.crepSignature, 5);

--- a/packages/agents/AeonMembraneAgent.ts
+++ b/packages/agents/AeonMembraneAgent.ts
@@ -11,7 +11,7 @@ export class AeonMembraneAgent implements Agent {
   private kiAgent?: AeonKIResonanzAgent;
 
   constructor(reflections = 1, kiAgent?: AeonKIResonanzAgent) {
-    this.mem = new AeonUniversalMembrane(reflections);
+    this.mem = new AeonUniversalMembrane(undefined, reflections);
     this.kiAgent = kiAgent;
     withFSM(this);
   }


### PR DESCRIPTION
## Summary
- inject NeuronMembrane dependency into AeonUniversalMembrane
- add async `trainAsync` and stricter argument validation
- document usage example in AeonUniversalMembrane
- update AeonMembraneAgent for new constructor
- extend unit tests for new behaviour

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685e6907caf08322bf8c7407b8b9ea2e