### PR TITLE
Improve AeonUniversalMembrane robustness

### DIFF
--- a/packages/aeon-neural-membrane/__tests__/aeonUniversalMembrane.test.ts
+++ b/packages/aeon-neural-membrane/__tests__/aeonUniversalMembrane.test.ts
@@ -1,6 +1,11 @@
 import { AeonUniversalMembrane } from '../aeonUniversalMembrane';
 import { CREPSignature } from '../crepAdapter';
 import { NeuronMembrane } from '../neuronMembrane';
+import * as trainer from '../selfTrainer';
+import * as syncer from '../depthSync';
+
+jest.mock('../selfTrainer');
+jest.mock('../depthSync');
 
 test('train and predict through universal membrane', () => {
   const mem = new AeonUniversalMembrane(undefined, 2);
@@ -23,13 +28,15 @@ test('harmonize reflects on high energy', () => {
     [175, 78]
   ];
   const answers = [1, 0];
-  const res = mem.harmonize(data, answers, 'hello world', 0);
+  const res = mem.harmonize({ data, answers, text: 'hello world', energyThreshold: 0 });
   expect(res.energy).toBeGreaterThan(0);
   expect(typeof res.tone).toBe('string');
   expect(mem.depth).toBeGreaterThan(0); // increased due to threshold 0
 });
 
 test('trainAsync resolves and predicts', async () => {
+  (trainer.selfTrain as jest.Mock).mockClear();
+  (syncer.depthSync as jest.Mock).mockClear();
   const mem = new AeonUniversalMembrane(undefined, 0);
   const data: [number, number][] = [
     [10, 20],
@@ -38,6 +45,8 @@ test('trainAsync resolves and predicts', async () => {
   const answers = [0, 1];
   const crep: CREPSignature = { coherence: 5, resonance: 5, emergence: 5, poetics: 5 };
   await mem.trainAsync(data, answers, crep);
+  expect((trainer.selfTrain as jest.Mock).mock.calls.length).toBe(1);
+  expect((syncer.depthSync as jest.Mock).mock.calls.length).toBe(1);
   expect(typeof mem.predict(10, 20)).toBe('number');
 });
 
@@ -50,7 +59,18 @@ test('constructor accepts injected membrane', () => {
 test('harmonize throws on mismatched data', () => {
   const mem = new AeonUniversalMembrane(undefined, 0);
   expect(() =>
-    mem.harmonize([[1, 2]], [1, 0], 'hi')
+    mem.harmonize({ data: [[1, 2]], answers: [1, 0], text: 'hi' })
   ).toThrow('harmonize: Data und Answers m');
+});
+
+test('analyzeConversation fails without signature', () => {
+  jest.resetModules();
+  jest.doMock('../../nukleon-scanner', () => ({
+    extractConvoMemory: () => ({ text: 'x', crepSignature: undefined })
+  }));
+  const { AeonUniversalMembrane: Mem } = require('../aeonUniversalMembrane');
+  const mem = new Mem(undefined, 0);
+  expect(() => mem.analyzeConversation('x')).toThrow('fehlende CREP');
+  jest.dontMock('../../nukleon-scanner');
 });
 

--- a/packages/aeon-neural-membrane/__tests__/cycle.test.ts
+++ b/packages/aeon-neural-membrane/__tests__/cycle.test.ts
@@ -5,7 +5,7 @@ const answers = [1, 0];
 
 it('runs self reflect cycle', () => {
   const mem = new AeonUniversalMembrane(undefined, 1);
-  mem.selfReflectCycle(3, data, answers, 'hello', 0);
+  mem.selfReflectCycle(3, { data, answers, text: 'hello', energyThreshold: 0 });
   expect(mem.getHistory().length).toBe(3);
   expect(mem.depth).toBeGreaterThan(1);
 });

--- a/packages/aeon-neural-membrane/__tests__/resonance.test.ts
+++ b/packages/aeon-neural-membrane/__tests__/resonance.test.ts
@@ -15,3 +15,12 @@ test('resonanceMap includes layer index', () => {
   expect(map[0]).toHaveProperty('layer');
   expect(map[1].layer).toBe(1);
 });
+
+test('resonance lengths adjust after reflection', () => {
+  const mem = new AeonUniversalMembrane(undefined, 1);
+  mem.harmonize({ data: [[1, 2]], answers: [0], text: 'x', energyThreshold: 0 });
+  const scan = mem.scanResonance();
+  const map = mem.resonanceMap();
+  expect(scan.length).toBe(mem.depth);
+  expect(map.length).toBe(mem.depth);
+});

--- a/packages/aeon-neural-membrane/aeonUniversalMembrane.ts
+++ b/packages/aeon-neural-membrane/aeonUniversalMembrane.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import { NeuronMembrane } from './neuronMembrane';
 import { depthSync } from './depthSync';
 import { selfTrain } from './selfTrainer';
@@ -27,16 +28,58 @@ export interface HistoryEntry {
   tone: string;
   depth: number;
 }
+
+export interface HarmonizeOptions {
+  data: [number, number][];
+  answers: number[];
+  text: string;
+  energyThreshold?: number;
+}
+
+export interface HarmonyResult {
+  conv: ConvoMemory;
+  energy: number;
+  tone: string;
+  depth: number;
+}
+
+export interface AeonUniversalOptions {
+  persistHistory?: boolean;
+  historyPath?: string;
+  maxDepth?: number;
+}
+
+const DEFAULT_OPTIONS: Required<AeonUniversalOptions> = {
+  persistHistory: false,
+  historyPath: 'aeon-history.json',
+  maxDepth: 10
+};
 export class AeonUniversalMembrane {
   private mem: NeuronMembrane;
   private history: HistoryEntry[] = [];
+  private opts: Required<AeonUniversalOptions>;
 
   private logHistory(entry: HistoryEntry) {
     this.history.push(entry);
+    if (this.opts.persistHistory) {
+      this.saveHistoryToFile();
+    }
   }
 
-  constructor(mem: NeuronMembrane = new NeuronMembrane(), reflections = 1) {
+  private saveHistoryToFile() {
+    fs.writeFileSync(
+      this.opts.historyPath,
+      JSON.stringify(this.history, null, 2)
+    );
+  }
+
+  constructor(
+    mem: NeuronMembrane = new NeuronMembrane(),
+    reflections = 1,
+    options: AeonUniversalOptions = {}
+  ) {
     this.mem = mem;
+    this.opts = { ...DEFAULT_OPTIONS, ...options };
     if (reflections > 0) this.mem.reflect(reflections);
     if (this.mem.getNetworks().length === 0) {
       throw new Error('AeonUniversalMembrane: keine Netzwerke initialisiert');
@@ -77,7 +120,22 @@ export class AeonUniversalMembrane {
     answers: number[],
     crep: CREPSignature
   ): Promise<void> {
-    this.train(data, answers, crep);
+    if (data.length !== answers.length) {
+      throw new Error('trainAsync: Data und Answers m\u00fcssen gleich lang sein');
+    }
+    const base = this.mem.getNetworks()[0];
+    await new Promise<void>(resolve =>
+      setTimeout(() => {
+        selfTrain(base, data, answers, crep, 5);
+        resolve();
+      }, 0)
+    );
+    await new Promise<void>(resolve =>
+      setTimeout(() => {
+        depthSync(this.mem, data);
+        resolve();
+      }, 0)
+    );
   }
 
   /**
@@ -96,32 +154,33 @@ export class AeonUniversalMembrane {
    * Vollständiger Selbstreflexionszyklus. Trainiert anhand des
    * Gesprächs-Textes und erzeugt bei hoher Energie eine neue Spiegelung.
    */
-  harmonize(
-    data: [number, number][],
-    answers: number[],
-    text: string,
-    energyThreshold = 5
-  ): { conv: ConvoMemory; energy: number; tone: string; depth: number } {
-    if (!text.trim()) {
-      throw new Error('harmonize: Text darf nicht leer sein');
-    }
-    if (data.length !== answers.length) {
-      throw new Error('harmonize: Data und Answers m\u00fcssen gleich lang sein');
-    }
-    const conv = extractConvoMemory(text);
-    const base = this.mem.getNetworks()[0];
-    selfTrain(base, data, answers, conv.crepSignature, 5);
-    depthSync(this.mem, data);
+  harmonize(options: HarmonizeOptions): HarmonyResult {
+    const { data, answers, text, energyThreshold = 5 } = options;
+    try {
+      if (!text.trim()) {
+        throw new Error('harmonize: Text darf nicht leer sein');
+      }
+      if (data.length !== answers.length) {
+        throw new Error('harmonize: Data und Answers m\u00fcssen gleich lang sein');
+      }
+      const conv = extractConvoMemory(text);
+      const base = this.mem.getNetworks()[0];
+      selfTrain(base, data, answers, conv.crepSignature, 5);
+      depthSync(this.mem, data);
 
-    const energy = scanEnergy(base);
-    const depthFactor = this.mem.depth || 1;
-    const tone = memoryToTone(energy / (10 * depthFactor));
-    if (energy / depthFactor > energyThreshold) {
-      this.mem.reflect();
+      const energy = scanEnergy(base);
+      const depthFactor = this.mem.depth || 1;
+      const tone = memoryToTone(energy / (10 * depthFactor));
+      if (this.mem.depth < this.opts.maxDepth && energy / depthFactor > energyThreshold) {
+        this.mem.reflect();
+      }
+      const result = { conv, energy, tone, depth: this.mem.depth };
+      this.logHistory({ energy, tone, depth: this.mem.depth });
+      return result;
+    } catch (err) {
+      console.error('harmonize failed', err);
+      throw err;
     }
-    const result = { conv, energy, tone, depth: this.mem.depth };
-    this.logHistory({ energy, tone, depth: this.mem.depth });
-    return result;
   }
 
   /**
@@ -129,19 +188,11 @@ export class AeonUniversalMembrane {
    */
   selfReflectCycle(
     iterations: number,
-    data: [number, number][],
-    answers: number[],
-    text: string,
-    energyThreshold = 5,
-  ): { conv: ConvoMemory; energy: number; tone: string; depth: number } {
-    let last = undefined as unknown as {
-      conv: ConvoMemory;
-      energy: number;
-      tone: string;
-      depth: number;
-    };
+    options: HarmonizeOptions
+  ): HarmonyResult {
+    let last = undefined as unknown as HarmonyResult;
     for (let i = 0; i < iterations; i++) {
-      last = this.harmonize(data, answers, text, energyThreshold);
+      last = this.harmonize(options);
     }
     return last;
   }


### PR DESCRIPTION
## Summary
- extend AeonUniversalMembrane with async training, depth limits and persistence
- refactor harmonize/selfReflectCycle to use option objects
- add maxDepth and history persistence features
- update tests for new API

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_685e811425d08322b07fe9424c30f1c5