### PR TITLE
Implement plugin layer with loader and example

### DIFF
--- a/.registry/plugins.json
+++ b/.registry/plugins.json
@@ -1,0 +1,3 @@
+{
+  "poeticResonance": ["1.0.2"]
+}

--- a/plugins/poeticResonance/manifest.yaml
+++ b/plugins/poeticResonance/manifest.yaml
@@ -1,0 +1,10 @@
+name: "poeticResonance"
+type: "agent"
+description: "Generiert poetische CREP-Feedback-Haikus."
+version: "1.0.2"
+author: "AeonDev"
+entry: "poeticResonance.js"
+apiVersion: "1.0"
+permissions:
+  - "read:history"
+  - "emit:sigil_alert"

--- a/plugins/poeticResonance/poeticResonance.js
+++ b/plugins/poeticResonance/poeticResonance.js
@@ -1,0 +1,4 @@
+module.exports.initialize = function(context) {
+  const { logger } = context;
+  logger && logger('poeticResonance initialized');
+};

--- a/public/plugins.html
+++ b/public/plugins.html
@@ -1,0 +1,20 @@
+<div id="plugin-list"></div>
+<script>
+  fetch('/api/plugins')
+    .then(r => r.json())
+    .then(list => {
+      const container = document.getElementById('plugin-list');
+      list.forEach(m => {
+        const btn = document.createElement('button');
+        btn.textContent = `${m.name} (${m.version}) – ${m.type}`;
+        btn.onclick = () => {
+          fetch('/api/plugin/activate', {
+            method: 'POST',
+            body: JSON.stringify({ name: m.name }),
+            headers: { 'Content-Type': 'application/json' }
+          });
+        };
+        container.appendChild(btn);
+      });
+    });
+</script>

--- a/services/ghost-shell/server.ts
+++ b/services/ghost-shell/server.ts
@@ -4,10 +4,14 @@ import { Server } from 'socket.io';
 import { socketAuth } from './auth';
 import * as ws from "ws";
 import { collectDefaultMetrics, register } from 'prom-client';
+import { listPlugins, getPlugin } from '../plugin-loader';
+import path from 'path';
 
 export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: boolean = true) {
   collectDefaultMetrics();
   const app = express();
+
+  app.use(express.static(path.join(__dirname, '..', 'public')));
 
   app.get('/healthz', (_req, res) => {
     res.json({ ok: true });
@@ -16,6 +20,24 @@ export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: 
   app.get('/metrics', async (_req, res) => {
     res.set('Content-Type', register.contentType);
     res.end(await register.metrics());
+  });
+
+  app.get('/api/plugins', (_req, res) => {
+    res.json(listPlugins());
+  });
+
+  app.post('/api/plugin/activate', express.json(), (req, res) => {
+    const { name } = req.body;
+    try {
+      const plugin = getPlugin(name);
+      if (!plugin || typeof plugin.initialize !== 'function') {
+        throw new Error('Invalid plugin');
+      }
+      plugin.initialize({ io, logger: console.log, getPlugin });
+      res.sendStatus(204);
+    } catch (e: any) {
+      res.status(400).json({ error: e.message });
+    }
   });
 
   const server = http.createServer(app);

--- a/services/plugin-loader.ts
+++ b/services/plugin-loader.ts
@@ -1,0 +1,73 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { EventEmitter } from 'events';
+import vm from 'vm';
+
+export interface PluginManifest {
+  name: string;
+  type: string;
+  description: string;
+  version: string;
+  author: string;
+  entry: string;
+  apiVersion: string;
+  permissions: string[];
+}
+
+const CORE_API_VERSION = '1.0';
+const PLUGIN_DIR = path.join(__dirname, '..', 'plugins');
+const manifests = new Map<string, PluginManifest>();
+const modules = new Map<string, any>();
+const emitter = new EventEmitter();
+
+function loadPlugin(name: string) {
+  const manifestPath = path.join(PLUGIN_DIR, name, 'manifest.yaml');
+  const content = fs.readFileSync(manifestPath, 'utf8');
+  const manifest = yaml.load(content) as PluginManifest;
+  if (manifest.apiVersion !== CORE_API_VERSION) {
+    throw new Error(`Plugin ${name} expects API ${manifest.apiVersion}, core is ${CORE_API_VERSION}`);
+  }
+  manifests.set(name, manifest);
+  const entryPath = path.join(PLUGIN_DIR, name, manifest.entry);
+  const code = fs.readFileSync(entryPath, 'utf8');
+  const sandbox: any = { module: { exports: {} }, exports: {}, require, console };
+  vm.createContext(sandbox);
+  vm.runInContext(code, sandbox, { filename: entryPath });
+  modules.set(name, sandbox.module.exports || sandbox.exports);
+  emitter.emit('loaded', name);
+  console.log(`🔌 Loaded plugin ${name}@${manifest.version}`);
+}
+
+function watch() {
+  fs.watch(PLUGIN_DIR, { recursive: true }, (event, filename) => {
+    if (!filename?.endsWith('manifest.yaml')) return;
+    const name = path.basename(path.dirname(path.join(PLUGIN_DIR, filename)));
+    try {
+      loadPlugin(name);
+    } catch (err) {
+      console.error(err);
+    }
+  });
+}
+
+fs.readdirSync(PLUGIN_DIR).forEach(dir => {
+  if (fs.existsSync(path.join(PLUGIN_DIR, dir, 'manifest.yaml'))) {
+    try {
+      loadPlugin(dir);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+});
+if (process.env.NODE_ENV !== 'test') {
+  watch();
+}
+
+export function getPlugin(name: string) {
+  return modules.get(name);
+}
+export function listPlugins() {
+  return Array.from(manifests.values());
+}
+export { emitter as pluginEvents };

--- a/tests/pluginLoader.test.ts
+++ b/tests/pluginLoader.test.ts
@@ -1,0 +1,16 @@
+/* @jest-environment node */
+import { listPlugins, getPlugin } from '../services/plugin-loader';
+
+describe('Plugin Loader', () => {
+  it('should list at least one plugin', () => {
+    const all = listPlugins();
+    expect(all.length).toBeGreaterThan(0);
+  });
+
+  it('should load plugin entry point', () => {
+    const manifest = listPlugins()[0];
+    const plugin = getPlugin(manifest.name);
+    expect(plugin).toBeDefined();
+    expect(typeof plugin.initialize).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- add plugin manifest and plugin loader service with hot-reload support
- expose plugin management endpoints in ghost-shell server
- provide example plugin `poeticResonance`
- track plugin versions
- basic UI page for plugin activation
- unit tests for plugin loader

## Testing
- `npm install --silent`
- `npx jest --runInBand tests/pluginLoader.test.ts services/ghost-shell/server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_686281f2d3208322926aad0d583eb8f9