### PR TITLE
Add mandalaHaiku plugin with UI trigger

### DIFF
--- a/apps/sharedream-interface/components/MandalaPluginList.tsx
+++ b/apps/sharedream-interface/components/MandalaPluginList.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { io as ioClient } from 'socket.io-client';
+
+export default function MandalaPluginList() {
+  const socketRef = React.useRef<any>();
+
+  const activate = () => {
+    if (!socketRef.current) {
+      socketRef.current = ioClient();
+      socketRef.current.on('haiku_response', (data: any) => {
+        console.log('Haiku received:', data.haiku);
+      });
+    }
+    socketRef.current.emit('sigil_alert', {
+      id: 'aeon:2025-0626-HIGH-ENERGY',
+      crep: {}
+    });
+  };
+
+  return (
+    <div>
+      <button onClick={activate}>Activate mandalaHaiku</button>
+    </div>
+  );
+}

--- a/apps/sharedream-interface/pages/index.tsx
+++ b/apps/sharedream-interface/pages/index.tsx
@@ -1,10 +1,12 @@
 import GPTBridgeUI from '../components/GPTBridgeUI';
+import MandalaPluginList from '../components/MandalaPluginList';
 
 export default function Home() {
   return (
     <div>
       <h1>Sharedream Interface</h1>
       <GPTBridgeUI />
+      <MandalaPluginList />
     </div>
   );
 }

--- a/plugins/mandalaHaiku/mandalaHaiku.js
+++ b/plugins/mandalaHaiku/mandalaHaiku.js
@@ -1,0 +1,23 @@
+module.exports = {
+  initialize({ io, logger }) {
+    logger && logger('mandalaHaiku initialized');
+    io.on('connection', (socket) => {
+      socket.on('sigil_alert', (alert) => {
+        if (alert.id === 'aeon:2025-0626-HIGH-ENERGY') {
+          const haiku = generateHaiku(alert.crep);
+          socket.emit('haiku_response', { haiku });
+          logger && logger(`Emitted haiku: ${haiku}`);
+        }
+      });
+    });
+    function generateHaiku() {
+      const templates = [
+        'Leuchtendes Sigil – / Träger von Klang und Tiefen / Mandala erwacht',
+        'Im Resonanzfeld / tanzt das Echo stiller Kraft / Haiku verweht nie',
+        'Dreifach-Welle ruft / Poetik in Codes geschrieben / Herz findet Klang'
+      ];
+      const idx = Math.floor(Math.random() * templates.length);
+      return templates[idx];
+    }
+  }
+};

--- a/plugins/mandalaHaiku/manifest.yaml
+++ b/plugins/mandalaHaiku/manifest.yaml
@@ -1,0 +1,10 @@
+name: "mandalaHaiku"
+type: "agent"
+description: "Generiert poetische Haikus bei High-Energy-Sigil-Alerts."
+version: "1.0.0"
+author: "AeonDev"
+entry: "mandalaHaiku.js"
+apiVersion: "1.0"
+permissions:
+  - "listen:sigil_alert"
+  - "emit:haiku_response"

--- a/tests/mandalaHaiku.test.ts
+++ b/tests/mandalaHaiku.test.ts
@@ -1,0 +1,22 @@
+/* @jest-environment node */
+import { getPlugin } from '../services/plugin-loader';
+import { EventEmitter } from 'events';
+
+describe('mandalaHaiku plugin', () => {
+  it('emits haiku_response on high-energy alert', (done) => {
+    const plugin = getPlugin('mandalaHaiku');
+    expect(plugin).toBeDefined();
+
+    const socket = new EventEmitter();
+    const io = { on: (_evt: string, handler: any) => handler(socket) } as any;
+    const logs: string[] = [];
+    plugin.initialize({ io, logger: (msg: string) => logs.push(msg) });
+
+    socket.on('haiku_response', (data: any) => {
+      expect(typeof data.haiku).toBe('string');
+      done();
+    });
+
+    socket.emit('sigil_alert', { id: 'aeon:2025-0626-HIGH-ENERGY', crep: {} });
+  });
+});


### PR DESCRIPTION
## Summary
- implement new mandalaHaiku plugin reacting to high-energy sigil alerts
- provide manifest for plugin loader
- expose activation button in frontend via MandalaPluginList component
- show plugin list on Sharedream Interface home page
- cover plugin with Jest test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686289e087ac8322b909ea4eb9d3e97e