### PR TITLE
Add Prometheus metrics for API routes

### DIFF
--- a/packages/core/routes/haiku.test.ts
+++ b/packages/core/routes/haiku.test.ts
@@ -5,10 +5,18 @@ import request from 'supertest';
 import express from 'express';
 import jwt from 'jsonwebtoken';
 import haikuRoutes from './haiku';
+import metricsRoutes from './metrics';
+import { register } from '../../../services/metrics';
 
 const SECRET = 'test-secret';
 const token = jwt.sign({ id: 'u1' }, SECRET);
-const app = express().use('/api/haiku', haikuRoutes(SECRET));
+const app = express();
+app.use(metricsRoutes);
+app.use('/api/haiku', haikuRoutes(SECRET));
+
+beforeEach(() => {
+  register.resetMetrics();
+});
 
 describe('Haiku vote API', () => {
   it('POST /api/haiku/vote stores vote', async () => {
@@ -17,5 +25,14 @@ describe('Haiku vote API', () => {
       .set('Authorization', `Bearer ${token}`)
       .send({ haiku: 'test', delta: 1 });
     expect(res.status).toBe(204);
+  });
+
+  it('increments haiku_votes_total metric', async () => {
+    await request(app)
+      .post('/api/haiku/vote')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ haiku: 'test', delta: 1 });
+    const res = await request(app).get('/metrics');
+    expect(res.text).toContain('haiku_votes_total 1');
   });
 });

--- a/packages/core/routes/haiku.ts
+++ b/packages/core/routes/haiku.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import rateLimit from 'express-rate-limit';
 import jwt from 'jsonwebtoken';
+import { haikuVoteCounter } from '../../../services/metrics';
 
 interface JwtUser {
   id: string;
@@ -30,6 +31,7 @@ export default function haikuRoutes(secret: string) {
   router.post('/vote', auth(secret), limiter, express.json(), (req, res) => {
     const { haiku, delta } = req.body;
     store.push({ haiku, delta, ts: Date.now() });
+    haikuVoteCounter.inc();
     res.sendStatus(204);
   });
 

--- a/packages/core/routes/metrics.ts
+++ b/packages/core/routes/metrics.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+import { register } from '../../../services/metrics';
+
+const router = express.Router();
+
+router.get('/metrics', async (_req, res) => {
+  res.set('Content-Type', register.contentType);
+  res.end(await register.metrics());
+});
+
+export default router;

--- a/packages/core/routes/patterns.test.ts
+++ b/packages/core/routes/patterns.test.ts
@@ -5,17 +5,21 @@ import request from 'supertest';
 import express from 'express';
 import jwt from 'jsonwebtoken';
 import patternRoutes from './patterns';
+import metricsRoutes from './metrics';
+import { register } from '../../../services/metrics';
 import fs from 'fs';
 
 const SECRET = 'test-secret';
 const token = jwt.sign({ id: 'u1' }, SECRET);
 const app = express();
+app.use(metricsRoutes);
 app.use('/patterns', patternRoutes(SECRET));
 
 beforeEach(() => {
   if (fs.existsSync('plugins/mandalaHaiku/customPatterns.json')) {
     fs.writeFileSync('plugins/mandalaHaiku/customPatterns.json', '[]');
   }
+  register.resetMetrics();
 });
 
 describe('Community-Pattern API', () => {
@@ -32,5 +36,14 @@ describe('Community-Pattern API', () => {
       .send({ pattern: 'Ein neuer poetischer Kreis erwacht im Licht.' });
     expect(res.status).toBe(201);
     expect(res.body.message).toBe('Pattern added');
+  });
+
+  it('increments patterns_created_total metric', async () => {
+    await request(app)
+      .post('/patterns')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ pattern: 'Ein neuer poetischer Kreis erwacht im Licht.' });
+    const res = await request(app).get('/metrics');
+    expect(res.text).toContain('patterns_created_total 1');
   });
 });

--- a/packages/core/routes/patterns.ts
+++ b/packages/core/routes/patterns.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import rateLimit from 'express-rate-limit';
 import jwt from 'jsonwebtoken';
+import { patternCreateCounter } from '../../../services/metrics';
 
 export interface JwtUser {
   id: string;
@@ -46,6 +47,7 @@ export default function patternRoutes(secret: string) {
       : [];
     list.push(pattern);
     fs.writeFileSync(PATTERN_FILE, JSON.stringify(list, null, 2), 'utf8');
+    patternCreateCounter.inc();
     res.status(201).json({ message: 'Pattern added' });
   });
 

--- a/services/crep-metrics.ts
+++ b/services/crep-metrics.ts
@@ -1,3 +1,5 @@
+import { recordABVariant } from './metrics';
+
 export function sendABMetric(variant: 'A' | 'B') {
-  console.log(`A/B layout variant: ${variant}`);
+  recordABVariant(variant);
 }

--- a/services/metrics.ts
+++ b/services/metrics.ts
@@ -1,0 +1,27 @@
+import { Counter, collectDefaultMetrics, Registry } from 'prom-client';
+
+export const register = new Registry();
+collectDefaultMetrics({ register });
+
+export const patternCreateCounter = new Counter({
+  name: 'patterns_created_total',
+  help: 'Number of patterns created',
+  registers: [register]
+});
+
+export const haikuVoteCounter = new Counter({
+  name: 'haiku_votes_total',
+  help: 'Number of haiku votes',
+  registers: [register]
+});
+
+const abVariantCounter = new Counter({
+  name: 'layout_variant_total',
+  help: 'Count of AB layout variants',
+  labelNames: ['variant'],
+  registers: [register]
+});
+
+export function recordABVariant(variant: 'A' | 'B') {
+  abVariantCounter.labels(variant).inc();
+}


### PR DESCRIPTION
## Summary
- create shared Prometheus registry and counters
- expose `/metrics` route
- emit metrics for pattern creations and haiku votes
- track AB layout metrics
- test metrics behaviour

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6862971efe14832290641bd4c314d340