### PR TITLE
Add Prometheus metrics and observability docs

### DIFF
--- a/docs/Observability.md
+++ b/docs/Observability.md
@@ -1,0 +1,23 @@
+# Observability
+
+UnifiedMandala exposes runtime metrics that can be scraped by Prometheus and visualised in Grafana.
+
+## Metrics Endpoint
+
+Start the development server via:
+
+```bash
+pnpm dev
+```
+
+Prometheus can then scrape `http://localhost:3000/metrics`.
+
+The endpoint is provided by `prom-client` and includes default Node.js process metrics.
+
+## Grafana Dashboard
+
+1. Install Prometheus and Grafana locally.
+2. Add your running Prometheus instance as a data source in Grafana.
+3. Create a new dashboard or import an existing one and query metrics like `process_cpu_user_seconds_total`.
+
+A minimal example dashboard configuration is available at `docs/observability/grafana-dashboard.json`.

--- a/docs/observability/grafana-dashboard.json
+++ b/docs/observability/grafana-dashboard.json
@@ -1,0 +1,13 @@
+{
+  "title": "UnifiedMandala Metrics",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "CPU Usage",
+      "targets": [{
+        "expr": "process_cpu_user_seconds_total",
+        "interval": "1m"
+      }]
+    }
+  ]
+}

--- a/packages/core/routes/metrics.test.ts
+++ b/packages/core/routes/metrics.test.ts
@@ -1,0 +1,18 @@
+/** @jest-environment node */
+import { TextEncoder } from 'util';
+// polyfill for Node versions lacking TextEncoder
+(global as any).TextEncoder = TextEncoder;
+import request from 'supertest';
+import express from 'express';
+import metrics from './metrics';
+
+const app = express();
+app.use(metrics);
+
+describe('metrics route', () => {
+  it('returns default metrics', async () => {
+    const res = await request(app).get('/metrics');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('process_cpu_user_seconds_total');
+  });
+});

--- a/packages/core/routes/metrics.ts
+++ b/packages/core/routes/metrics.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+import { collectDefaultMetrics, register } from 'prom-client';
+
+collectDefaultMetrics();
+
+const router = express.Router();
+
+router.get('/metrics', async (_req, res) => {
+  res.set('Content-Type', register.contentType);
+  res.end(await register.metrics());
+});
+
+export default router;

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -1,10 +1,12 @@
 import express from 'express';
 import healthz from '../packages/core/routes/healthz';
 import metaScores from '../packages/core/routes/metaScores';
+import metrics from '../packages/core/routes/metrics';
 
 const app = express();
 app.use(healthz);
 app.use(metaScores);
+app.use(metrics);
 
 const port = Number(process.env.PORT) || 3000;
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- expose Prometheus metrics through new `metrics` route
- mount the metrics endpoint in the dev server
- add tests for the metrics route
- document observability setup with Prometheus/Grafana
- provide a sample Grafana dashboard configuration

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6862971efe14832290641bd4c314d340