### PR TITLE
Add Prometheus metrics and Grafana setup

### DIFF
--- a/ci/monitoring/README.md
+++ b/ci/monitoring/README.md
@@ -1,0 +1,5 @@
+# Monitoring Stack
+
+This directory contains configuration files for a simple Prometheus and Grafana setup.
+
+Run `docker compose up` in this folder to start both services. Prometheus scrapes metrics from the Node server at port 3000 and Grafana exposes dashboards on port 3001.

--- a/ci/monitoring/docker-compose.yml
+++ b/ci/monitoring/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3001:3000"
+    volumes:
+      - ./grafana:/var/lib/grafana/dashboards
+    environment:
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning

--- a/ci/monitoring/grafana/dashboard.json
+++ b/ci/monitoring/grafana/dashboard.json
@@ -1,0 +1,21 @@
+{
+  "dashboard": {
+    "uid": "mandala-metrics",
+    "title": "Mandala Metrics",
+    "panels": [
+      {
+        "type": "graph",
+        "title": "HTTP Requests",
+        "targets": [
+          {
+            "expr": "sum(rate(http_requests_total[1m])) by (route)",
+            "legendFormat": "{{route}}"
+          }
+        ],
+        "datasource": "Prometheus"
+      }
+    ],
+    "schemaVersion": 30,
+    "version": 1
+  }
+}

--- a/ci/monitoring/prometheus.yml
+++ b/ci/monitoring/prometheus.yml
@@ -1,0 +1,4 @@
+scrape_configs:
+  - job_name: mandala
+    static_configs:
+      - targets: ['host.docker.internal:3000']

--- a/packages/core/middleware/metrics.ts
+++ b/packages/core/middleware/metrics.ts
@@ -1,0 +1,31 @@
+import { collectDefaultMetrics, Counter, Histogram, register } from 'prom-client';
+import { Request, Response, NextFunction } from 'express';
+
+collectDefaultMetrics();
+
+const httpRequestCounter = new Counter({
+  name: 'http_requests_total',
+  help: 'Total number of HTTP requests',
+  labelNames: ['method', 'route', 'status'] as const,
+});
+
+const httpRequestDuration = new Histogram({
+  name: 'http_request_duration_seconds',
+  help: 'Duration of HTTP requests in seconds',
+  labelNames: ['method', 'route', 'status'] as const,
+});
+
+export function metricsMiddleware(req: Request, res: Response, next: NextFunction) {
+  const end = httpRequestDuration.startTimer({ method: req.method, route: req.path });
+  res.on('finish', () => {
+    const status = res.statusCode;
+    httpRequestCounter.labels(req.method, req.path, String(status)).inc();
+    end({ status: String(status) });
+  });
+  next();
+}
+
+export function metricsEndpoint(_req: Request, res: Response) {
+  res.set('Content-Type', register.contentType);
+  register.metrics().then(m => res.end(m));
+}

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -1,10 +1,13 @@
 import express from 'express';
 import healthz from '../packages/core/routes/healthz';
 import metaScores from '../packages/core/routes/metaScores';
+import { metricsMiddleware, metricsEndpoint } from '../packages/core/middleware/metrics';
 
 const app = express();
+app.use(metricsMiddleware);
 app.use(healthz);
 app.use(metaScores);
+app.get('/metrics', metricsEndpoint);
 
 const port = Number(process.env.PORT) || 3000;
 app.listen(port, () => {

--- a/services/ghost-shell/server.ts
+++ b/services/ghost-shell/server.ts
@@ -3,13 +3,14 @@ import http from 'http';
 import { Server } from 'socket.io';
 import { socketAuth } from './auth';
 import * as ws from "ws";
-import { collectDefaultMetrics, register } from 'prom-client';
+import { register } from 'prom-client';
 import { listPlugins, getPlugin } from '../plugin-loader';
+import { metricsMiddleware, metricsEndpoint } from '../../packages/core/middleware/metrics';
 import path from 'path';
 
 export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: boolean = true) {
-  collectDefaultMetrics();
   const app = express();
+  app.use(metricsMiddleware);
 
   app.use(express.static(path.join(__dirname, '..', 'public')));
 
@@ -17,10 +18,7 @@ export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: 
     res.json({ ok: true });
   });
 
-  app.get('/metrics', async (_req, res) => {
-    res.set('Content-Type', register.contentType);
-    res.end(await register.metrics());
-  });
+  app.get('/metrics', metricsEndpoint);
 
   app.get('/api/plugins', (_req, res) => {
     res.json(listPlugins());


### PR DESCRIPTION
## Summary
- expose Prometheus metrics for GhostShell server and dev server
- add metrics middleware using `prom-client`
- provide docker compose stack and dashboard for Prometheus/Grafana

## Testing
- `pnpm lint` *(fails: AeonMembraneAgent.ts TS2554)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6862971efe14832290641bd4c314d340