### PR TITLE
GhostShell session store and nginx config

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2118,5 +2118,17 @@
     "task": "Parse Markdown task lists and append to advancedToDo files",
     "test": "scripts/__tests__/parse-md-todo.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add GhostShell NGINX config",
+    "path": "config/nginx/ghostshell.conf",
+    "task": "Provide NGINX reverse proxy for clustered GhostShellAgent",
+    "test": ""
+  },
+  {
+    "commit": "Implement GhostShell session store",
+    "path": "services/ghost-shell/session-store.ts",
+    "task": "Track WebSocket message history per client",
+    "test": "services/ghost-shell/session-store.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3977,3 +3977,11 @@
   task: Parse Markdown task lists and append to advancedToDo files
   test: scripts/__tests__/parse-md-todo.test.ts
   status: done
+- commit: Add GhostShell NGINX config
+  path: config/nginx/ghostshell.conf
+  task: Provide NGINX reverse proxy for clustered GhostShellAgent
+  test: ""
+- commit: Implement GhostShell session store
+  path: services/ghost-shell/session-store.ts
+  task: Track WebSocket message history per client
+  test: services/ghost-shell/session-store.test.ts

--- a/config/nginx/ghostshell.conf
+++ b/config/nginx/ghostshell.conf
@@ -1,0 +1,14 @@
+upstream ghostshell {
+    server 127.0.0.1:3000;
+    server 127.0.0.1:3001;
+}
+server {
+    listen 80;
+    location / {
+        proxy_pass http://ghostshell;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+}

--- a/services/ghost-shell/server.ts
+++ b/services/ghost-shell/server.ts
@@ -9,6 +9,7 @@ import pino from 'pino';
 import { listPlugins, getPlugin } from '../plugin-loader';
 import { metricsMiddleware, metricsEndpoint } from '../../packages/core/middleware/metrics';
 import path from 'path';
+import { addSession, getSession, removeSession } from './session-store';
 
 export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: boolean = true) {
   const app = express();
@@ -58,7 +59,17 @@ export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: 
       }
     });
     io.on("connection", (socket) => {
-      socket.on("echo", (msg) => socket.emit("echo", msg));
+      addSession(socket.id);
+      socket.on("user_message", (msg) => {
+        const session = getSession(socket.id);
+        if (session) {
+          session.history.push(msg);
+        }
+        socket.emit("echo", msg);
+      });
+      socket.on("disconnect", () => {
+        removeSession(socket.id);
+      });
     });
   }
 

--- a/services/ghost-shell/session-store.test.ts
+++ b/services/ghost-shell/session-store.test.ts
@@ -1,0 +1,15 @@
+import { addSession, getSession, removeSession } from './session-store';
+
+describe('session store', () => {
+  it('tracks sessions and history', () => {
+    addSession('1');
+    const session = getSession('1');
+    expect(session).toBeDefined();
+    if (session) {
+      session.history.push('hello');
+    }
+    expect(getSession('1')?.history).toEqual(['hello']);
+    removeSession('1');
+    expect(getSession('1')).toBeUndefined();
+  });
+});

--- a/services/ghost-shell/session-store.ts
+++ b/services/ghost-shell/session-store.ts
@@ -1,0 +1,17 @@
+export interface Session {
+  history: any[];
+}
+
+const sessions = new Map<string, Session>();
+
+export function addSession(id: string): void {
+  sessions.set(id, { history: [] });
+}
+
+export function getSession(id: string): Session | undefined {
+  return sessions.get(id);
+}
+
+export function removeSession(id: string): void {
+  sessions.delete(id);
+}


### PR DESCRIPTION
## Summary
- add NGINX config for GhostShell
- implement simple in-memory session store for GhostShell service
- wire session store into server
- add tests for session store
- track tasks in advancedToDo files

## Testing
- `pnpm install --ignore-scripts`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6862b4aecdcc83228bd57c54a3e36d0c