### PR TITLE
Implement GhostShell metrics and room support

### DIFF
--- a/services/ghost-shell/metrics.test.ts
+++ b/services/ghost-shell/metrics.test.ts
@@ -1,0 +1,14 @@
+import { connectionCounter, responseLatencyGauge, recordConnection, recordLatency } from './metrics';
+
+describe('ghost-shell metrics', () => {
+  it('tracks connections and latency', async () => {
+    const before = (await connectionCounter.get()).values[0]?.value ?? 0;
+    recordConnection();
+    const after = (await connectionCounter.get()).values[0]?.value ?? 0;
+    expect(after).toBe(before + 1);
+
+    recordLatency(42);
+    const latency = (await responseLatencyGauge.get()).values[0]?.value;
+    expect(latency).toBe(42);
+  });
+});

--- a/services/ghost-shell/metrics.ts
+++ b/services/ghost-shell/metrics.ts
@@ -1,0 +1,19 @@
+import { Counter, Gauge } from 'prom-client';
+
+export const connectionCounter = new Counter({
+  name: 'ghost_connections_total',
+  help: 'Total WS connections'
+});
+
+export const responseLatencyGauge = new Gauge({
+  name: 'ghost_response_latency_ms',
+  help: 'Response latency ms'
+});
+
+export function recordConnection(): void {
+  connectionCounter.inc();
+}
+
+export function recordLatency(ms: number): void {
+  responseLatencyGauge.set(ms);
+}

--- a/services/ghost-shell/rooms.test.ts
+++ b/services/ghost-shell/rooms.test.ts
@@ -1,0 +1,20 @@
+import { joinRoom, sendRoomMessage, leaveAll, getRoomMembers } from './rooms';
+
+describe('rooms', () => {
+  it('handles join and messaging', () => {
+    const socket: any = { id: 's1', join: jest.fn(), emit: jest.fn() };
+    const emitMock = jest.fn();
+    const io: any = { to: jest.fn(() => ({ emit: emitMock })) };
+
+    joinRoom(socket, 'r1');
+    expect(socket.join).toHaveBeenCalledWith('r1');
+    expect(getRoomMembers('r1')).toEqual(['s1']);
+
+    sendRoomMessage(io, 'r1', 'hello');
+    expect(io.to).toHaveBeenCalledWith('r1');
+    expect(emitMock).toHaveBeenCalledWith('room_response', 'hello');
+
+    leaveAll(socket);
+    expect(getRoomMembers('r1')).toEqual([]);
+  });
+});

--- a/services/ghost-shell/rooms.ts
+++ b/services/ghost-shell/rooms.ts
@@ -1,0 +1,28 @@
+import { Server, Socket } from 'socket.io';
+
+const rooms = new Map<string, Set<string>>();
+
+export function joinRoom(socket: Socket, roomId: string): void {
+  socket.join(roomId);
+  if (!rooms.has(roomId)) {
+    rooms.set(roomId, new Set());
+  }
+  rooms.get(roomId)!.add(socket.id);
+}
+
+export function sendRoomMessage(io: Server, roomId: string, msg: any): void {
+  io.to(roomId).emit('room_response', msg);
+}
+
+export function leaveAll(socket: Socket): void {
+  rooms.forEach((members, roomId) => {
+    members.delete(socket.id);
+    if (members.size === 0) {
+      rooms.delete(roomId);
+    }
+  });
+}
+
+export function getRoomMembers(roomId: string): string[] {
+  return Array.from(rooms.get(roomId) || []);
+}

--- a/services/ghost-shell/server.ts
+++ b/services/ghost-shell/server.ts
@@ -10,6 +10,8 @@ import { listPlugins, getPlugin } from '../plugin-loader';
 import { metricsMiddleware, metricsEndpoint } from '../../packages/core/middleware/metrics';
 import path from 'path';
 import { addSession, getSession, removeSession } from './session-store';
+import { recordConnection, recordLatency } from './metrics';
+import { joinRoom, sendRoomMessage, leaveAll } from './rooms';
 
 export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: boolean = true) {
   const app = express();
@@ -60,15 +62,29 @@ export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: 
     });
     io.on("connection", (socket) => {
       addSession(socket.id);
+      recordConnection();
+
+      socket.on("join_room", (roomId: string) => {
+        joinRoom(socket, roomId);
+      });
+
+      socket.on("room_message", ({ roomId, msg }) => {
+        sendRoomMessage(io!, roomId, msg);
+      });
+
       socket.on("user_message", (msg) => {
+        const start = Date.now();
         const session = getSession(socket.id);
         if (session) {
           session.history.push(msg);
         }
         socket.emit("echo", msg);
+        recordLatency(Date.now() - start);
       });
+
       socket.on("disconnect", () => {
         removeSession(socket.id);
+        leaveAll(socket);
       });
     });
   }


### PR DESCRIPTION
## Summary
- add Prometheus metrics helpers for GhostShell
- track websocket metrics and room events in `server.ts`
- implement simple in-memory room management
- test metrics and room helpers

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6862d5006bf08322a0be7f0a8591ff0e