### PR TITLE
Implement conversation watcher for GhostShellAgent

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2165,7 +2165,8 @@
     "commit": "Add fragment watcher",
     "path": "services/ghost-shell/watchers/chokidar.ts",
     "task": "Trigger runSelfLearn when new conversation fragments arrive",
-    "test": "services/ghost-shell/watchers/chokidar.test.ts"
+    "test": "services/ghost-shell/watchers/chokidar.test.ts",
+    "status": "done"
   },
   {
     "commit": "Implement adaptive scheduler",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4009,6 +4009,7 @@
   path: services/ghost-shell/watchers/chokidar.ts
   task: Trigger runSelfLearn when new conversation fragments arrive
   test: services/ghost-shell/watchers/chokidar.test.ts
+  status: done
 - commit: Implement adaptive scheduler
   path: services/ghost-shell/scheduler.ts
   task: Adjust self learning interval by fragment count

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "feat: agents diagram generation",
-  "fractalStep": "agents-diagram",
+  "lastCommit": "feat: add conversation watcher",
+  "fractalStep": "self-learn-trigger",
   "openBranches": [
     "work"
   ],

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "ajv": "^8.0.0",
     "ajv-formats": "^3.0.1",
+    "chokidar": "^4.0.3",
     "commander": "^11.0.0",
     "d3": "^7.8.5",
     "express": "^4.19.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.17.1)
+      chokidar:
+        specifier: ^4.0.3
+        version: 4.0.3
       commander:
         specifier: ^11.0.0
         version: 11.1.0
@@ -1770,6 +1773,10 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
 
   chromium-bidi@0.11.0:
     resolution: {integrity: sha512-6CJWHkNRoyZyjV9Rwv2lYONZf1Xm0IuDyNq97nwSsxxP3wf5Bwy15K5rOvVKMtJ127jJBmxFUanSAOjgFRxgrA==}
@@ -3627,6 +3634,10 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
 
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
@@ -6188,6 +6199,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   chromium-bidi@0.11.0(devtools-protocol@0.0.1367902):
     dependencies:
       devtools-protocol: 0.0.1367902
@@ -8317,6 +8332,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  readdirp@4.1.2: {}
 
   real-require@0.2.0: {}
 

--- a/services/ghost-shell/runSelfLearn.ts
+++ b/services/ghost-shell/runSelfLearn.ts
@@ -1,0 +1,4 @@
+export function runSelfLearn() {
+  // Placeholder for advanced self-learning logic
+  console.log('runSelfLearn triggered');
+}

--- a/services/ghost-shell/server.ts
+++ b/services/ghost-shell/server.ts
@@ -10,8 +10,15 @@ import { listPlugins, getPlugin } from '../plugin-loader';
 import { metricsMiddleware, metricsEndpoint } from '../../packages/core/middleware/metrics';
 import path from 'path';
 import { addSession, getSession, removeSession } from './session-store';
+import { runSelfLearn } from './runSelfLearn';
+import { watchConversations } from './watchers/chokidar';
 
-export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: boolean = true) {
+export function startServer(
+  port = 3000,
+  secret = 'ghost-secret',
+  enableSocket: boolean = true,
+  watchDir?: string
+) {
   const app = express();
   const logger = pino({ level: 'info' });
   const wsLimiter = new RateLimiterMemory({ points: 10, duration: 60 });
@@ -76,6 +83,10 @@ export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: 
   server.listen(port, () => {
     logger.info(`GhostShellAgent listening on ${port}`);
   });
+
+  if (watchDir) {
+    watchConversations(watchDir, runSelfLearn);
+  }
 
   return { app, io, server };
 }

--- a/services/ghost-shell/watchers/chokidar.test.ts
+++ b/services/ghost-shell/watchers/chokidar.test.ts
@@ -1,0 +1,10 @@
+/* @jest-environment node */
+import { watchConversations } from './chokidar';
+
+test('runs callback on add event', done => {
+  const watcher = watchConversations('/tmp', () => {
+    watcher.close();
+    done();
+  });
+  (watcher as any).emit('add', '/tmp/test.json');
+});

--- a/services/ghost-shell/watchers/chokidar.ts
+++ b/services/ghost-shell/watchers/chokidar.ts
@@ -1,0 +1,9 @@
+import chokidar from 'chokidar';
+
+export function watchConversations(dir: string, onNew: () => void) {
+  const watcher = chokidar.watch(`${dir}/*.json`, { ignoreInitial: true });
+  watcher.on('add', () => {
+    onNew();
+  });
+  return watcher;
+}


### PR DESCRIPTION
## Summary
- watch conversation folder with chokidar and trigger `runSelfLearn`
- integrate watcher option in `startServer`
- add stub `runSelfLearn`
- cover watcher with unit test
- track progress in advanced ToDo lists
- record progress in `advancedprogress.json`
- add chokidar dependency

## Testing
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_6862d5006bf08322a0be7f0a8591ff0e