### PR TITLE
Add GhostShell watcher and scheduler

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2165,25 +2165,29 @@
     "commit": "Add fragment watcher",
     "path": "services/ghost-shell/watchers/chokidar.ts",
     "task": "Trigger runSelfLearn when new conversation fragments arrive",
-    "test": "services/ghost-shell/watchers/chokidar.test.ts"
+    "test": "services/ghost-shell/watchers/chokidar.test.ts",
+    "status": "done"
   },
   {
     "commit": "Implement adaptive scheduler",
     "path": "services/ghost-shell/scheduler.ts",
     "task": "Adjust self learning interval by fragment count",
-    "test": "services/ghost-shell/scheduler.test.ts"
+    "test": "services/ghost-shell/scheduler.test.ts",
+    "status": "done"
   },
   {
     "commit": "Emit sigil alerts",
     "path": "services/ghost-shell/sigil-alerts.ts",
     "task": "Emit websocket event when energy threshold exceeded",
-    "test": "services/ghost-shell/sigil-alerts.test.ts"
+    "test": "services/ghost-shell/sigil-alerts.test.ts",
+    "status": "done"
   },
   {
     "commit": "Client handler for sigil alerts",
     "path": "public/js/sigil-alert-handler.js",
     "task": "Display pulsating sigil overlay on alert events",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Add GhostShell room support",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4009,18 +4009,22 @@
   path: services/ghost-shell/watchers/chokidar.ts
   task: Trigger runSelfLearn when new conversation fragments arrive
   test: services/ghost-shell/watchers/chokidar.test.ts
+  status: done
 - commit: Implement adaptive scheduler
   path: services/ghost-shell/scheduler.ts
   task: Adjust self learning interval by fragment count
   test: services/ghost-shell/scheduler.test.ts
+  status: done
 - commit: Emit sigil alerts
   path: services/ghost-shell/sigil-alerts.ts
   task: Emit websocket event when energy threshold exceeded
   test: services/ghost-shell/sigil-alerts.test.ts
+  status: done
 - commit: Client handler for sigil alerts
   path: public/js/sigil-alert-handler.js
   task: Display pulsating sigil overlay on alert events
   test: ""
+  status: done
 - commit: Add GhostShell room support
   path: services/ghost-shell/rooms.ts
   task: Manage join_room and room_message events for collaborative sessions

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "ajv": "^8.0.0",
     "ajv-formats": "^3.0.1",
+    "chokidar": "^3.5.3",
     "commander": "^11.0.0",
     "d3": "^7.8.5",
     "express": "^4.19.2",
@@ -61,6 +62,7 @@
     "@mermaid-js/mermaid-cli": "^11.6.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@types/chokidar": "^2.1.7",
     "@types/d3": "^7.4.3",
     "@types/express": "^4.17.21",
     "@types/express-rate-limit": "^6.0.2",

--- a/public/js/sigil-alert-handler.js
+++ b/public/js/sigil-alert-handler.js
@@ -1,0 +1,9 @@
+export function registerSigilHandler(socket) {
+  socket.on('sigil_alert', sigil => {
+    const el = document.createElement('div');
+    el.className = `sigil ${sigil.effect}`;
+    el.textContent = sigil.id;
+    document.body.appendChild(el);
+    setTimeout(() => el.remove(), 5000);
+  });
+}

--- a/scripts/self-learn.ts
+++ b/scripts/self-learn.ts
@@ -1,0 +1,3 @@
+export async function runSelfLearn(): Promise<void> {
+  console.log('runSelfLearn triggered');
+}

--- a/services/ghost-shell/scheduler.test.ts
+++ b/services/ghost-shell/scheduler.test.ts
@@ -1,0 +1,19 @@
+import { scheduleAdaptive, getInterval } from './scheduler';
+
+jest.useFakeTimers();
+
+describe('adaptive scheduler', () => {
+  it('adjusts interval after first run', async () => {
+    const counts = [11];
+    const getCount = jest.fn().mockImplementation(() => Promise.resolve(counts.shift() || 0));
+    const run = jest.fn().mockResolvedValue(undefined);
+
+    scheduleAdaptive(getCount, run);
+
+    expect(getInterval()).toBe(6 * 3600 * 1000);
+
+    jest.advanceTimersByTime(6 * 3600 * 1000);
+    await Promise.resolve();
+    expect(getInterval()).toBe(2 * 3600 * 1000);
+  });
+});

--- a/services/ghost-shell/scheduler.ts
+++ b/services/ghost-shell/scheduler.ts
@@ -1,0 +1,17 @@
+let intervalMs = 6 * 3600 * 1000;
+
+export function getInterval() {
+  return intervalMs;
+}
+
+export function scheduleAdaptive(
+  countFn: () => Promise<number>,
+  run: () => Promise<void>
+) {
+  setTimeout(async () => {
+    const newCount = await countFn();
+    intervalMs = newCount > 10 ? 2 * 3600 * 1000 : 12 * 3600 * 1000;
+    await run();
+    scheduleAdaptive(countFn, run);
+  }, intervalMs);
+}

--- a/services/ghost-shell/sigil-alerts.test.ts
+++ b/services/ghost-shell/sigil-alerts.test.ts
@@ -1,0 +1,15 @@
+import { emitSigilAlert } from './sigil-alerts';
+
+describe('sigil alerts', () => {
+  it('emits alert when threshold exceeded', () => {
+    const socket: any = { emit: jest.fn() };
+    emitSigilAlert(socket, { energy: 0.9 }, 0.8);
+    expect(socket.emit).toHaveBeenCalledWith('sigil_alert', expect.objectContaining({ id: 'aeon:2025-0626-HIGH-ENERGY' }));
+  });
+
+  it('does nothing below threshold', () => {
+    const socket: any = { emit: jest.fn() };
+    emitSigilAlert(socket, { energy: 0.5 }, 0.8);
+    expect(socket.emit).not.toHaveBeenCalled();
+  });
+});

--- a/services/ghost-shell/sigil-alerts.ts
+++ b/services/ghost-shell/sigil-alerts.ts
@@ -1,0 +1,14 @@
+import { Socket } from 'socket.io';
+
+export function emitSigilAlert(
+  socket: Socket,
+  result: { energy: number },
+  threshold = 0.8
+) {
+  if (result.energy > threshold) {
+    socket.emit('sigil_alert', {
+      id: 'aeon:2025-0626-HIGH-ENERGY',
+      effect: 'pulse-red',
+    });
+  }
+}

--- a/services/ghost-shell/watchers/chokidar.test.ts
+++ b/services/ghost-shell/watchers/chokidar.test.ts
@@ -1,0 +1,20 @@
+import chokidar from 'chokidar';
+import { watchFragments } from './chokidar';
+import { runSelfLearn } from '../../../scripts/self-learn';
+
+jest.mock('chokidar');
+jest.mock('../../../scripts/self-learn');
+
+describe('fragment watcher', () => {
+  it('triggers runSelfLearn on new file', () => {
+    const onMock = jest.fn();
+    (chokidar.watch as any as jest.Mock).mockReturnValue({ on: onMock });
+
+    watchFragments('test/*.json');
+
+    expect(chokidar.watch).toHaveBeenCalledWith('test/*.json', { ignoreInitial: true });
+    const handler = onMock.mock.calls[0][1];
+    handler('new.json');
+    expect(runSelfLearn).toHaveBeenCalled();
+  });
+});

--- a/services/ghost-shell/watchers/chokidar.ts
+++ b/services/ghost-shell/watchers/chokidar.ts
@@ -1,0 +1,10 @@
+import chokidar from 'chokidar';
+import { runSelfLearn } from '../../../scripts/self-learn';
+
+export function watchFragments(pattern = 'newadvancedconversations/*.json') {
+  const watcher = chokidar.watch(pattern, { ignoreInitial: true });
+  watcher.on('add', () => {
+    runSelfLearn();
+  });
+  return watcher;
+}


### PR DESCRIPTION
## Summary
- extend GhostShell agent with fragment watcher, adaptive scheduler and sigil alerts
- add client handler for sigil alerts
- document completion in advancedToDo files
- include chokidar dependency

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6862d894219c8322a1e3e98e4af5e536