### PR TITLE
Add pino logger module and cluster tests

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2242,5 +2242,17 @@
     "path": ".github/dependabot.yml",
     "task": "Keep npm and Docker dependencies up to date",
     "test": ""
+  },
+  {
+    "commit": "Add VR integration",
+    "path": "public/vr",
+    "task": "Implement immersive ritual environment using A-Frame/WebXR",
+    "test": ""
+  },
+  {
+    "commit": "Implement blockchain manifest verification",
+    "path": "services/plugin-verification",
+    "task": "Verify plugin manifests via blockchain ledger",
+    "test": ""
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4061,3 +4061,11 @@
   path: .github/dependabot.yml
   task: Keep npm and Docker dependencies up to date
   test: ""
+- commit: Add VR integration
+  path: public/vr
+  task: Implement immersive ritual environment using A-Frame/WebXR
+  test: ""
+- commit: Implement blockchain manifest verification
+  path: services/plugin-verification
+  task: Verify plugin manifests via blockchain ledger
+  test: ""

--- a/services/ghost-shell/cluster.test.ts
+++ b/services/ghost-shell/cluster.test.ts
@@ -1,0 +1,37 @@
+import cluster from 'cluster';
+import os from 'os';
+
+jest.mock('./server', () => ({ startServer: jest.fn() }));
+
+jest.mock('cluster');
+jest.mock('os');
+
+describe('ghost-shell cluster', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('forks workers when primary', () => {
+    (cluster as any).isPrimary = true;
+    const forkMock = jest.fn();
+    const onMock = jest.fn();
+    (cluster as any).fork = forkMock;
+    (cluster as any).on = onMock;
+    (os.cpus as jest.Mock).mockReturnValue([{}, {}]);
+
+    jest.isolateModules(() => {
+      require('./cluster');
+    });
+
+    expect(forkMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('starts server when worker', () => {
+    (cluster as any).isPrimary = false;
+    const startServerMock = require('./server').startServer as jest.Mock;
+    jest.isolateModules(() => {
+      require('./cluster');
+    });
+    expect(startServerMock).toHaveBeenCalled();
+  });
+});

--- a/services/ghost-shell/cluster.ts
+++ b/services/ghost-shell/cluster.ts
@@ -1,11 +1,10 @@
 import cluster from 'cluster';
 import os from 'os';
 import { startServer } from './server';
-import pino from 'pino';
+import { logger } from './logger';
 
 const basePort = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
 const secret = process.env.SECRET || 'ghost-secret';
-const logger = pino({ level: 'info' });
 
 if (cluster.isPrimary) {
   const cpus = os.cpus().length;

--- a/services/ghost-shell/logger.test.ts
+++ b/services/ghost-shell/logger.test.ts
@@ -1,0 +1,7 @@
+import { logger } from './logger';
+
+describe('logger', () => {
+  it('defaults to info level', () => {
+    expect(logger.level).toBe('info');
+  });
+});

--- a/services/ghost-shell/logger.ts
+++ b/services/ghost-shell/logger.ts
@@ -1,0 +1,10 @@
+import pino from 'pino';
+
+const level = process.env.LOG_LEVEL || 'info';
+
+export const logger = pino({
+  level,
+  transport: process.env.NODE_ENV === 'development'
+    ? { target: 'pino-pretty' }
+    : undefined,
+});

--- a/services/ghost-shell/server.ts
+++ b/services/ghost-shell/server.ts
@@ -5,7 +5,7 @@ import { socketAuth } from './auth';
 import * as ws from 'ws';
 import { register } from 'prom-client';
 import { RateLimiterMemory } from 'rate-limiter-flexible';
-import pino from 'pino';
+import { logger } from './logger';
 import { listPlugins, getPlugin } from '../plugin-loader';
 import { metricsMiddleware, metricsEndpoint } from '../../packages/core/middleware/metrics';
 import path from 'path';
@@ -15,7 +15,6 @@ import { joinRoom, sendRoomMessage, leaveAll } from './rooms';
 
 export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: boolean = true) {
   const app = express();
-  const logger = pino({ level: 'info' });
   const wsLimiter = new RateLimiterMemory({ points: 10, duration: 60 });
 
   app.use(metricsMiddleware);


### PR DESCRIPTION
## Summary
- centralize GhostShell logging in a new `logger` module
- use the logger in the server and cluster entry points
- add jest tests for cluster startup and the logger
- record follow-up tasks for VR/WebXR integration and blockchain manifest verification

## Testing
- `npx jest --runInBand --no-colors` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ddff4018832294a1971f506573a3