### PR TITLE
Implement GhostShell logger and ratelimiter

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2133,33 +2133,38 @@
   },
   {
     "commit": "Add GhostShell cluster manager",
-    "path": "services/ghost-shell/cluster.js",
+    "path": "services/ghost-shell/cluster.ts",
     "task": "Start Node.js cluster of GhostShellAgent workers using `cluster` API",
-    "test": "services/ghost-shell/cluster.test.ts"
+    "test": "services/ghost-shell/cluster.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add WebSocket JWT middleware",
     "path": "services/ghost-shell/auth.ts",
     "task": "Verify tokens on websocket connections",
-    "test": "services/ghost-shell/auth.test.ts"
+    "test": "services/ghost-shell/auth.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add GhostShell rate limiter",
     "path": "services/ghost-shell/ratelimit.ts",
     "task": "Limit incoming socket events with rate-limiter-flexible",
-    "test": "services/ghost-shell/ratelimit.test.ts"
+    "test": "services/ghost-shell/ratelimit.test.ts",
+    "status": "done"
   },
   {
     "commit": "Expose GhostShell Prometheus metrics",
     "path": "services/ghost-shell/metrics.ts",
     "task": "Export connection counter and latency gauge",
-    "test": "services/ghost-shell/metrics.test.ts"
+    "test": "services/ghost-shell/metrics.test.ts",
+    "status": "done"
   },
   {
     "commit": "Integrate Pino logger",
     "path": "services/ghost-shell/logger.ts",
     "task": "Provide structured logging for GhostShellAgent",
-    "test": "services/ghost-shell/logger.test.ts"
+    "test": "services/ghost-shell/logger.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add fragment watcher",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3986,25 +3986,30 @@
   task: Track WebSocket message history per client
   test: services/ghost-shell/session-store.test.ts
 - commit: Add GhostShell cluster manager
-  path: services/ghost-shell/cluster.js
+  path: services/ghost-shell/cluster.ts
   task: Start Node.js cluster of GhostShellAgent workers using `cluster` API
   test: services/ghost-shell/cluster.test.ts
+  status: done
 - commit: Add WebSocket JWT middleware
   path: services/ghost-shell/auth.ts
   task: Verify tokens on websocket connections
   test: services/ghost-shell/auth.test.ts
+  status: done
 - commit: Add GhostShell rate limiter
   path: services/ghost-shell/ratelimit.ts
   task: Limit incoming socket events with rate-limiter-flexible
   test: services/ghost-shell/ratelimit.test.ts
+  status: done
 - commit: Expose GhostShell Prometheus metrics
   path: services/ghost-shell/metrics.ts
   task: Export connection counter and latency gauge
   test: services/ghost-shell/metrics.test.ts
+  status: done
 - commit: Integrate Pino logger
   path: services/ghost-shell/logger.ts
   task: Provide structured logging for GhostShellAgent
   test: services/ghost-shell/logger.test.ts
+  status: done
 - commit: Add fragment watcher
   path: services/ghost-shell/watchers/chokidar.ts
   task: Trigger runSelfLearn when new conversation fragments arrive

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "husky": "^9.0.0",
     "jest": "^30.0.2",
     "jest-environment-jsdom": "30.0.0-beta.3",
+    "pino-pretty": "^13.0.0",
     "supertest": "^7.1.1",
     "test-exclude": "^7.0.1",
     "ts-jest": "^29.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.17.1)
+      chokidar:
+        specifier: ^3.5.3
+        version: 3.6.0
       commander:
         specifier: ^11.0.0
         version: 11.1.0
@@ -93,6 +96,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/chokidar':
+        specifier: ^2.1.7
+        version: 2.1.7
       '@types/d3':
         specifier: ^7.4.3
         version: 7.4.3
@@ -147,6 +153,9 @@ importers:
       jest-environment-jsdom:
         specifier: 30.0.0-beta.3
         version: 30.0.0-beta.3
+      pino-pretty:
+        specifier: ^13.0.0
+        version: 13.0.0
       supertest:
         specifier: ^7.1.1
         version: 7.1.1
@@ -1080,6 +1089,10 @@ packages:
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
+  '@types/chokidar@2.1.7':
+    resolution: {integrity: sha512-A7/MFHf6KF7peCzjEC1BBTF8jpmZTokb3vr/A0NxRGfwRLK3Ws+Hq6ugVn6cJIMfM6wkCak/aplWrxbTcu8oig==}
+    deprecated: This is a stub types definition. chokidar provides its own type definitions, so you do not need this installed.
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -1823,6 +1836,9 @@ packages:
     resolution: {integrity: sha512-5z9FbYTZPAo8iKsNEqRNv+OlpBbDcoE+SY9GjLfDUHEfcNNV7tS9eSAlFHEaub/r5tBL9LtskAeq1l9SaoZ5tQ==}
     engines: {node: '>=18'}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -2088,6 +2104,9 @@ packages:
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
+
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
@@ -2376,6 +2395,9 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
 
+  fast-copy@3.0.2:
+    resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2565,6 +2587,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
@@ -2934,6 +2959,10 @@ packages:
       react:
         optional: true
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3189,6 +3218,9 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3394,6 +3426,10 @@ packages:
 
   pino-abstract-transport@2.0.0:
     resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-pretty@13.0.0:
+    resolution: {integrity: sha512-cQBBIVG3YajgoUjo1FdKVRX6t9XPxwB9lcNJVD5GCnNM4Y6T12YYx8c6zEejxQsU0wrg9TwmDulcE9LR7qcJqA==}
+    hasBin: true
 
   pino-std-serializers@6.2.2:
     resolution: {integrity: sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==}
@@ -3714,6 +3750,9 @@ packages:
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -5408,6 +5447,10 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
 
+  '@types/chokidar@2.1.7':
+    dependencies:
+      chokidar: 3.6.0
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 20.17.57
@@ -6230,6 +6273,8 @@ snapshots:
     dependencies:
       color-name: 2.0.0
 
+  colorette@2.0.20: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -6499,6 +6544,8 @@ snapshots:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
+
+  dateformat@4.6.3: {}
 
   dayjs@1.11.13: {}
 
@@ -6806,6 +6853,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-copy@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-equals@5.2.2: {}
@@ -7007,6 +7056,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  help-me@5.0.0: {}
 
   highlight.js@10.7.3: {}
 
@@ -7602,6 +7653,8 @@ snapshots:
       '@types/react': 18.3.23
       react: 19.1.0
 
+  joycon@3.1.1: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -7859,6 +7912,8 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
+  minimist@1.2.8: {}
+
   minipass@7.1.2: {}
 
   mitt@3.0.1: {}
@@ -8031,6 +8086,22 @@ snapshots:
   pino-abstract-transport@2.0.0:
     dependencies:
       split2: 4.2.0
+
+  pino-pretty@13.0.0:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 3.0.2
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pump: 3.0.3
+      secure-json-parse: 2.7.0
+      sonic-boom: 4.2.0
+      strip-json-comments: 3.1.1
 
   pino-std-serializers@6.2.2: {}
 
@@ -8420,6 +8491,8 @@ snapshots:
       loose-envify: 1.4.0
 
   scheduler@0.26.0: {}
+
+  secure-json-parse@2.7.0: {}
 
   semver@6.3.1: {}
 

--- a/services/ghost-shell/cluster.ts
+++ b/services/ghost-shell/cluster.ts
@@ -1,11 +1,10 @@
 import cluster from 'cluster';
 import os from 'os';
 import { startServer } from './server';
-import pino from 'pino';
+import { logger } from './logger';
 
 const basePort = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
 const secret = process.env.SECRET || 'ghost-secret';
-const logger = pino({ level: 'info' });
 
 if (cluster.isPrimary) {
   const cpus = os.cpus().length;

--- a/services/ghost-shell/logger.test.ts
+++ b/services/ghost-shell/logger.test.ts
@@ -1,0 +1,8 @@
+import { logger } from './logger';
+
+describe('logger', () => {
+  it('creates a pino logger', () => {
+    expect(logger).toBeDefined();
+    expect(typeof logger.info).toBe('function');
+  });
+});

--- a/services/ghost-shell/logger.ts
+++ b/services/ghost-shell/logger.ts
@@ -1,0 +1,8 @@
+import pino from 'pino';
+
+export const logger = pino({
+  level: 'info',
+  ...(process.env.NODE_ENV !== 'test'
+    ? { transport: { target: 'pino-pretty' } }
+    : {}),
+});

--- a/services/ghost-shell/ratelimit.test.ts
+++ b/services/ghost-shell/ratelimit.test.ts
@@ -1,0 +1,22 @@
+import { rateLimit } from './ratelimit';
+
+const socketFactory = (addr: string) => ({ handshake: { address: addr } }) as any;
+
+describe('rate limit', () => {
+  it('allows under limit', async () => {
+    const socket = socketFactory('1');
+    let called = false;
+    await rateLimit(socket, () => { called = true; });
+    expect(called).toBe(true);
+  });
+
+  it('blocks over limit', async () => {
+    const socket = socketFactory('2');
+    for (let i = 0; i < 10; i++) {
+      await rateLimit(socket, () => {});
+    }
+    let err: Error | null = null;
+    await rateLimit(socket, (e?: Error) => { err = e || null; });
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/services/ghost-shell/ratelimit.ts
+++ b/services/ghost-shell/ratelimit.ts
@@ -1,0 +1,13 @@
+import { RateLimiterMemory } from 'rate-limiter-flexible';
+import { Socket } from 'socket.io';
+
+const limiter = new RateLimiterMemory({ points: 10, duration: 60 });
+
+export async function rateLimit(socket: Socket, next: (err?: Error) => void) {
+  try {
+    await limiter.consume(socket.handshake.address);
+    next();
+  } catch {
+    next(new Error('Too many requests'));
+  }
+}

--- a/services/ghost-shell/server.ts
+++ b/services/ghost-shell/server.ts
@@ -3,9 +3,8 @@ import http from 'http';
 import { Server } from 'socket.io';
 import { socketAuth } from './auth';
 import * as ws from 'ws';
-import { register } from 'prom-client';
-import { RateLimiterMemory } from 'rate-limiter-flexible';
-import pino from 'pino';
+import { rateLimit } from './ratelimit';
+import { logger } from './logger';
 import { listPlugins, getPlugin } from '../plugin-loader';
 import { metricsMiddleware, metricsEndpoint } from '../../packages/core/middleware/metrics';
 import path from 'path';
@@ -15,8 +14,6 @@ import { joinRoom, sendRoomMessage, leaveAll } from './rooms';
 
 export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: boolean = true) {
   const app = express();
-  const logger = pino({ level: 'info' });
-  const wsLimiter = new RateLimiterMemory({ points: 10, duration: 60 });
 
   app.use(metricsMiddleware);
 
@@ -52,14 +49,7 @@ export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: 
   if (enableSocket) {
     io = new Server(server, { cors: { origin: "*" }, wsEngine: ws.Server });
     io.use(socketAuth(secret));
-    io.use(async (_socket, next) => {
-      try {
-        await wsLimiter.consume(_socket.handshake.address);
-        next();
-      } catch {
-        next(new Error('Too many requests'));
-      }
-    });
+    io.use(rateLimit);
     io.on("connection", (socket) => {
       addSession(socket.id);
       recordConnection();


### PR DESCRIPTION
## Summary
- add pino-based logger module with optional pretty transport
- create rate limiter middleware for Socket.IO
- integrate new modules into GhostShell server and cluster
- update advanced TODO lists
- install `pino-pretty` in workspace

## Testing
- `pnpm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6862ddff4018832294a1971f506573a3