### PR TITLE
Implement ghost shell scheduler integration

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2136,7 +2136,7 @@
     "path": "services/ghost-shell/cluster.ts",
     "task": "Start Node.js cluster of GhostShellAgent workers using `cluster` API",
     "test": "services/ghost-shell/cluster.test.ts",
-    "status": "done"
+    "status": "todo"
   },
   {
     "commit": "Add WebSocket JWT middleware",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3989,7 +3989,7 @@
   path: services/ghost-shell/cluster.ts
   task: Start Node.js cluster of GhostShellAgent workers using `cluster` API
   test: services/ghost-shell/cluster.test.ts
-  status: done
+  status: todo
 - commit: Add WebSocket JWT middleware
   path: services/ghost-shell/auth.ts
   task: Verify tokens on websocket connections

--- a/services/ghost-shell/server.ts
+++ b/services/ghost-shell/server.ts
@@ -11,6 +11,11 @@ import path from 'path';
 import { addSession, getSession, removeSession } from './session-store';
 import { recordConnection, recordLatency } from './metrics';
 import { joinRoom, sendRoomMessage, leaveAll } from './rooms';
+import { watchFragments } from './watchers/chokidar';
+import { scheduleAdaptive } from './scheduler';
+import { runSelfLearn } from '../../scripts/self-learn';
+import { emitSigilAlert } from './sigil-alerts';
+import { glob } from 'glob';
 
 export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: boolean = true) {
   const app = express();
@@ -69,6 +74,7 @@ export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: 
           session.history.push(msg);
         }
         socket.emit("echo", msg);
+        emitSigilAlert(socket, { energy: Math.random() });
         recordLatency(Date.now() - start);
       });
 
@@ -82,6 +88,21 @@ export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: 
   server.listen(port, () => {
     logger.info(`GhostShellAgent listening on ${port}`);
   });
+
+  const fragmentsPattern = path.join(
+    __dirname,
+    '..',
+    '..',
+    'GenesisAeonZIPMEM',
+    'newadvancedconversations',
+    '**',
+    '*.yaml'
+  );
+  watchFragments(fragmentsPattern);
+  scheduleAdaptive(
+    () => glob(fragmentsPattern).then((files) => files.length),
+    runSelfLearn
+  );
 
   return { app, io, server };
 }


### PR DESCRIPTION
## Summary
- integrate fragment watching and adaptive scheduling with GhostShell server
- emit sigil alerts on user messages
- update advanced task status for cluster manager
- remove unfinished cluster tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6862ed8a794c8322a01db9e2553f20fd