### PR TITLE
Verify plugin manifests before activation

### DIFF
--- a/services/ghost-shell/server.test.ts
+++ b/services/ghost-shell/server.test.ts
@@ -18,4 +18,11 @@ describe('ghost-shell server', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ ok: true });
   });
+
+  it('rejects invalid plugin manifest', async () => {
+    const res = await request(`http://localhost:${PORT}`)
+      .post('/api/plugin/activate')
+      .send({ name: 'mandalaHaiku' });
+    expect(res.status).toBe(400);
+  });
 });

--- a/services/ghost-shell/server.ts
+++ b/services/ghost-shell/server.ts
@@ -6,6 +6,7 @@ import * as ws from 'ws';
 import { rateLimit } from './ratelimit';
 import { logger } from './logger';
 import { listPlugins, getPlugin } from '../plugin-loader';
+import { verifyPluginManifest } from './blockchain-trust';
 import { metricsMiddleware, metricsEndpoint } from '../../packages/core/middleware/metrics';
 import path from 'path';
 import { addSession, getSession, removeSession } from './session-store';
@@ -38,8 +39,12 @@ export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: 
     const { name } = req.body;
     try {
       const plugin = getPlugin(name);
-      if (!plugin || typeof plugin.initialize !== 'function') {
+      const manifest = listPlugins().find((p) => p.name === name) as any;
+      if (!plugin || typeof plugin.initialize !== 'function' || !manifest) {
         throw new Error('Invalid plugin');
+      }
+      if (!verifyPluginManifest(manifest)) {
+        throw new Error('Manifest verification failed');
       }
       plugin.initialize({ io, logger: (msg: string) => logger.info(msg), getPlugin });
       res.sendStatus(204);


### PR DESCRIPTION
## Summary
- verify plugin manifests using `verifyPluginManifest` before calling plugin `initialize`
- reject activation when verification fails
- test verification failure handling

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6864107ffcac8322a32ccddba7f7d77b