### PR TITLE
Add readiness endpoint for ghost-shell

### DIFF
--- a/charts/ghostshell/templates/deployment.yaml
+++ b/charts/ghostshell/templates/deployment.yaml
@@ -17,3 +17,11 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           ports:
             - containerPort: 3000
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 3000

--- a/services/ghost-shell/server.test.ts
+++ b/services/ghost-shell/server.test.ts
@@ -19,6 +19,12 @@ describe('ghost-shell server', () => {
     expect(res.body).toEqual({ ok: true });
   });
 
+  it('responds to readyz', async () => {
+    const res = await request(`http://localhost:${PORT}`).get('/readyz');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ready: true });
+  });
+
   it('rejects invalid plugin manifest', async () => {
     const res = await request(`http://localhost:${PORT}`)
       .post('/api/plugin/activate')

--- a/services/ghost-shell/server.ts
+++ b/services/ghost-shell/server.ts
@@ -20,6 +20,7 @@ import { glob } from 'glob';
 
 export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: boolean = true) {
   const app = express();
+  let ready = false;
 
   app.use(metricsMiddleware);
 
@@ -27,6 +28,10 @@ export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: 
 
   app.get('/healthz', (_req, res) => {
     res.json({ ok: true });
+  });
+
+  app.get('/readyz', (_req, res) => {
+    res.json({ ready });
   });
 
   app.get('/metrics', metricsEndpoint);
@@ -91,6 +96,7 @@ export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: 
   }
 
   server.listen(port, () => {
+    ready = true;
     logger.info(`GhostShellAgent listening on ${port}`);
   });
 


### PR DESCRIPTION
## Summary
- add a `/readyz` route in `startServer` indicating Socket.io readiness
- expose readiness and liveness probes in the deployment chart
- test `/readyz` handler

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68641238aaec8322b4d89c6e365d654e