### PR TITLE
Parameterize ghostshell ports

### DIFF
--- a/config/nginx/ghostshell.conf
+++ b/config/nginx/ghostshell.conf
@@ -1,6 +1,6 @@
 upstream ghostshell {
-    server 127.0.0.1:3000;
-    server 127.0.0.1:3001;
+    server 127.0.0.1:${PORT_BASE:-3000};
+    server 127.0.0.1:${PORT_NEXT:-3001};
 }
 server {
     listen 80;

--- a/docs/architecture/ghost-shell-agent.md
+++ b/docs/architecture/ghost-shell-agent.md
@@ -9,3 +9,14 @@ Diese Komponente stellt einen skalierbaren WebSocket-Dienst bereit. Sie nutzt da
 * Strukturierte Logs mit `pino`
 * Prometheus-Metriken unter `/metrics`
 * Beispielhafter Echo-Channel
+
+## Konfigurationsvariablen
+
+Das mitgelieferte `ghostshell.conf` verwendet Platzhalter, die zur Laufzeit 
+mit Umgebungsvariablen ersetzt werden können.
+
+| Variable   | Beschreibung                                             | Standard |
+|-----------|-----------------------------------------------------------|----------|
+| `PORT_BASE` | Port des ersten Node.js-Workers im Upstream              | `3000`   |
+| `PORT_NEXT` | Port des zweiten Node.js-Workers im Upstream             | `3001`   |
+


### PR DESCRIPTION
## Summary
- parameterize ghostshell upstream ports via environment variables
- document PORT_BASE and PORT_NEXT in Ghost Shell agent docs

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6864137da3d88322b4bc56ca9496c27e