### PR TITLE
Restrict plugin sandbox imports

### DIFF
--- a/services/plugin-loader.ts
+++ b/services/plugin-loader.ts
@@ -21,6 +21,26 @@ const manifests = new Map<string, PluginManifest>();
 const modules = new Map<string, any>();
 const emitter = new EventEmitter();
 
+const ALLOWED_MODULES = new Set([
+  'fs',
+  'path',
+  'events',
+  'prom-client'
+]);
+
+function createSandboxRequire(pluginDir: string) {
+  return function sandboxRequire(mod: string) {
+    if (mod.startsWith('./') || mod.startsWith('../')) {
+      const resolved = require.resolve(path.join(pluginDir, mod));
+      return require(resolved);
+    }
+    if (!ALLOWED_MODULES.has(mod)) {
+      throw new Error(`Module ${mod} is not allowed in plugin sandbox`);
+    }
+    return require(mod);
+  };
+}
+
 function loadPlugin(name: string) {
   const manifestPath = path.join(PLUGIN_DIR, name, 'manifest.yaml');
   const content = fs.readFileSync(manifestPath, 'utf8');
@@ -29,9 +49,11 @@ function loadPlugin(name: string) {
     throw new Error(`Plugin ${name} expects API ${manifest.apiVersion}, core is ${CORE_API_VERSION}`);
   }
   manifests.set(name, manifest);
-  const entryPath = path.join(PLUGIN_DIR, name, manifest.entry);
+  const pluginDir = path.join(PLUGIN_DIR, name);
+  const entryPath = path.join(pluginDir, manifest.entry);
   const code = fs.readFileSync(entryPath, 'utf8');
-  const sandbox: any = { module: { exports: {} }, exports: {}, require, console, pluginMeta: manifest };
+  const sandboxRequire = createSandboxRequire(pluginDir);
+  const sandbox: any = { module: { exports: {} }, exports: {}, require: sandboxRequire, console, pluginMeta: manifest };
   vm.createContext(sandbox);
   vm.runInContext(code, sandbox, { filename: entryPath });
   modules.set(name, sandbox.module.exports || sandbox.exports);

--- a/tests/pluginSandbox.test.ts
+++ b/tests/pluginSandbox.test.ts
@@ -1,0 +1,47 @@
+/* @jest-environment node */
+import fs from 'fs';
+import path from 'path';
+
+describe('Plugin Sandbox', () => {
+  const pluginsDir = path.join(__dirname, '..', 'plugins');
+  const tmpPluginDir = path.join(pluginsDir, 'sandboxTest');
+
+  beforeAll(() => {
+    fs.mkdirSync(tmpPluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpPluginDir, 'manifest.yaml'),
+      [
+        'name: "sandboxTest"',
+        'type: "agent"',
+        'description: "sandbox"',
+        'version: "1.0.0"',
+        'author: "tester"',
+        'entry: "index.js"',
+        'apiVersion: "1.0"',
+        'permissions: []'
+      ].join('\n')
+    );
+    fs.writeFileSync(
+      path.join(tmpPluginDir, 'index.js'),
+      "const cp = require('child_process'); module.exports = {}"
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpPluginDir, { recursive: true, force: true });
+  });
+
+  it('blocks unauthorized imports', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.resetModules();
+    process.env.NODE_ENV = 'test';
+    const loader = require('../services/plugin-loader');
+    const plugin = loader.getPlugin('sandboxTest');
+    expect(plugin).toBeUndefined();
+    expect(spy).toHaveBeenCalled();
+    const err = spy.mock.calls[0][0];
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toMatch(/not allowed/);
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- restrict available modules in plugin sandbox
- add error on disallowed imports
- test blocking of unauthorized imports

## Testing
- `pnpm exec jest`

------
https://chatgpt.com/codex/tasks/task_e_686417d099c083228733c67d2ac7072c