### PR TITLE
Dynamic GhostShell NGINX config generation

### DIFF
--- a/DeployRoadMap.md
+++ b/DeployRoadMap.md
@@ -74,6 +74,12 @@ server {
 sudo ln -s /etc/nginx/sites-available/mandala.conf /etc/nginx/sites-enabled/
 sudo nginx -t && sudo systemctl reload nginx
 
+Bei einem GhostShellAgent im Cluster-Modus musst du alle Worker-Ports an Nginx
+weiterleiten. Erzeuge die Upstream-Datei mit
+`pnpm generate:ghostshell-nginx` (Variablen `PORT_BASE` und `WORKER_COUNT` oder
+`PORT_RANGE` setzen) und binde sie anschließend unter
+`/etc/nginx/conf.d/ghostshell.conf` ein.
+
 SSL aktivieren (Let’s Encrypt):
 
     sudo apt install certbot python3-certbot-nginx

--- a/docs/architecture/ghost-shell-agent.md
+++ b/docs/architecture/ghost-shell-agent.md
@@ -19,4 +19,10 @@ mit Umgebungsvariablen ersetzt werden können.
 |-----------|-----------------------------------------------------------|----------|
 | `PORT_BASE` | Port des ersten Node.js-Workers im Upstream              | `3000`   |
 | `PORT_NEXT` | Port des zweiten Node.js-Workers im Upstream             | `3001`   |
+| `WORKER_COUNT` | Anzahl der Worker-Prozesse bei automatischer Generierung | CPUs |
+| `PORT_RANGE` | Portbereich aller Worker, z. B. `3000-3007`              | - |
+
+Die Nginx-Konfiguration kann mit `pnpm generate:ghostshell-nginx` aus diesen
+Variablen erzeugt werden. Dabei wird für jeden Worker-Port ein Eintrag im
+Upstream-Block generiert.
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "qa": "ts-node scripts/qa-test-runner.ts",
     "ghost-shell:cluster": "ts-node services/ghost-shell/cluster.ts",
     "ghost-shell:server": "ts-node services/ghost-shell/server.ts",
+    "generate:ghostshell-nginx": "ts-node scripts/generate-ghostshell-nginx.ts",
     "store:commit-memory": "node GenesisAeonZIPMEM/commitMemory/commit-memory.js",
     "generate:changelog": "node scripts/generate-changelog.js"
   },

--- a/scripts/generate-ghostshell-nginx.ts
+++ b/scripts/generate-ghostshell-nginx.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import os from 'os';
+
+function getPorts(): number[] {
+  const range = process.env.PORT_RANGE;
+  if (range) {
+    const [startStr, endStr] = range.split('-');
+    const start = parseInt(startStr, 10);
+    const end = parseInt(endStr, 10);
+    if (isNaN(start) || isNaN(end) || end < start) {
+      throw new Error('Invalid PORT_RANGE format. Use START-END');
+    }
+    const ports: number[] = [];
+    for (let p = start; p <= end; p++) ports.push(p);
+    return ports;
+  }
+  const base = parseInt(process.env.PORT_BASE || '3000', 10);
+  const count = parseInt(process.env.WORKER_COUNT || String(os.cpus().length), 10);
+  return Array.from({ length: count }, (_, i) => base + i);
+}
+
+function generateConfig(ports: number[]) {
+  let upstream = 'upstream ghostshell {\n';
+  for (const p of ports) {
+    upstream += `    server 127.0.0.1:${p};\n`;
+  }
+  upstream += '}\n';
+  return `${upstream}server {\n    listen 80;\n    location / {\n        proxy_pass http://ghostshell;\n        proxy_http_version 1.1;\n        proxy_set_header Upgrade $http_upgrade;\n        proxy_set_header Connection "upgrade";\n        proxy_set_header Host $host;\n    }\n}\n`;
+}
+
+try {
+  const ports = getPorts();
+  const conf = generateConfig(ports);
+  const out = process.argv[2] || 'config/nginx/ghostshell.conf';
+  fs.writeFileSync(out, conf);
+  console.log(`Generated ${out} for ports: ${ports.join(', ')}`);
+} catch (err) {
+  console.error((err as Error).message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add script to build NGINX upstream configuration based on cluster workers
- document the new script and variables in `ghost-shell-agent` docs
- mention proxy setup in deployment guide
- expose new `generate:ghostshell-nginx` script in `package.json`

## Testing
- `pnpm test`
- `pnpm vitest run`
- `(cd go-agent && go test ./cmd/... ./internal/... ./pkg/... ./test)`
- `(cd go-bridge && go test ./cmd/... ./pkg/... ./api/... ./test)`
- `(cd services/vector-indexer && go test ./...)`


------
https://chatgpt.com/codex/tasks/task_e_68641df28c908322b98868909d7ed945