### PR TITLE
Add cancellable handle to scheduler

### DIFF
--- a/services/ghost-shell/scheduler.test.ts
+++ b/services/ghost-shell/scheduler.test.ts
@@ -16,4 +16,22 @@ describe('adaptive scheduler', () => {
     await Promise.resolve();
     expect(getInterval()).toBe(2 * 3600 * 1000);
   });
+
+  it('can cancel future schedules', async () => {
+    const counts = [11, 0];
+    const getCount = jest.fn().mockImplementation(() => Promise.resolve(counts.shift() || 0));
+    const run = jest.fn().mockResolvedValue(undefined);
+
+    const handle = scheduleAdaptive(getCount, run);
+
+    jest.advanceTimersByTime(6 * 3600 * 1000);
+    await Promise.resolve();
+
+    handle.cancel();
+
+    jest.advanceTimersByTime(24 * 3600 * 1000);
+    await Promise.resolve();
+
+    expect(run).toHaveBeenCalledTimes(1);
+  });
 });

--- a/services/ghost-shell/scheduler.ts
+++ b/services/ghost-shell/scheduler.ts
@@ -8,10 +8,28 @@ export function scheduleAdaptive(
   countFn: () => Promise<number>,
   run: () => Promise<void>
 ) {
-  setTimeout(async () => {
-    const newCount = await countFn();
-    intervalMs = newCount > 10 ? 2 * 3600 * 1000 : 12 * 3600 * 1000;
-    await run();
-    scheduleAdaptive(countFn, run);
-  }, intervalMs);
+  let timeout: NodeJS.Timeout | undefined;
+  let cancelled = false;
+
+  const schedule = () => {
+    timeout = setTimeout(async () => {
+      const newCount = await countFn();
+      intervalMs = newCount > 10 ? 2 * 3600 * 1000 : 12 * 3600 * 1000;
+      await run();
+      if (!cancelled) {
+        schedule();
+      }
+    }, intervalMs);
+  };
+
+  schedule();
+
+  return {
+    cancel() {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      cancelled = true;
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- allow cancelling of adaptive scheduler loops
- test that schedules stop running after cancellation

## Testing
- `npm test`
- `npx jest services/ghost-shell/scheduler.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68642d26274c83228a1bd71cff6a0279