### PR TITLE
Implement TTL for session store

### DIFF
--- a/services/ghost-shell/session-store.test.ts
+++ b/services/ghost-shell/session-store.test.ts
@@ -1,15 +1,32 @@
-import { addSession, getSession, removeSession } from './session-store';
+import {
+  addSession,
+  addHistory,
+  configureSessionStore,
+  getSession,
+  pruneSessions,
+  removeSession,
+} from './session-store';
+
+jest.useFakeTimers();
 
 describe('session store', () => {
-  it('tracks sessions and history', () => {
+  beforeEach(() => {
+    configureSessionStore({ ttlMs: 1000, maxHistory: 2 });
+  });
+
+  it('tracks sessions and prunes history', () => {
     addSession('1');
-    const session = getSession('1');
-    expect(session).toBeDefined();
-    if (session) {
-      session.history.push('hello');
-    }
-    expect(getSession('1')?.history).toEqual(['hello']);
+    addHistory('1', 'a');
+    addHistory('1', 'b');
+    addHistory('1', 'c');
+    expect(getSession('1')?.history).toEqual(['b', 'c']);
     removeSession('1');
-    expect(getSession('1')).toBeUndefined();
+  });
+
+  it('expires sessions after ttl', () => {
+    addSession('2');
+    jest.advanceTimersByTime(1500);
+    pruneSessions();
+    expect(getSession('2')).toBeUndefined();
   });
 });

--- a/services/ghost-shell/session-store.ts
+++ b/services/ghost-shell/session-store.ts
@@ -1,17 +1,65 @@
 export interface Session {
   history: any[];
+  lastActive: number;
 }
+
+let ttlMs = 60 * 60 * 1000; // 1 hour default
+let maxHistory = 50;
 
 const sessions = new Map<string, Session>();
 
+export function configureSessionStore(options: {
+  ttlMs?: number;
+  maxHistory?: number;
+} = {}): void {
+  if (options.ttlMs !== undefined) {
+    ttlMs = options.ttlMs;
+  }
+  if (options.maxHistory !== undefined) {
+    maxHistory = options.maxHistory;
+  }
+}
+
 export function addSession(id: string): void {
-  sessions.set(id, { history: [] });
+  sessions.set(id, { history: [], lastActive: Date.now() });
 }
 
 export function getSession(id: string): Session | undefined {
-  return sessions.get(id);
+  const session = sessions.get(id);
+  if (!session) {
+    return undefined;
+  }
+  if (Date.now() - session.lastActive > ttlMs) {
+    sessions.delete(id);
+    return undefined;
+  }
+  return session;
+}
+
+export function addHistory(id: string, entry: any): void {
+  let session = getSession(id);
+  if (!session) {
+    addSession(id);
+    session = sessions.get(id)!;
+  }
+  session.lastActive = Date.now();
+  session.history.push(entry);
+  if (session.history.length > maxHistory) {
+    session.history = session.history.slice(-maxHistory);
+  }
 }
 
 export function removeSession(id: string): void {
   sessions.delete(id);
+}
+
+export function pruneSessions(): void {
+  const now = Date.now();
+  for (const [id, session] of sessions.entries()) {
+    if (now - session.lastActive > ttlMs) {
+      sessions.delete(id);
+    } else if (session.history.length > maxHistory) {
+      session.history = session.history.slice(-maxHistory);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- expire session data using TTL
- limit session history size
- expose configuration for TTL and max history
- test session store TTL and history pruning

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686431e907448322b75a1336584d7407