### PR TITLE
Add leave_room helper and event

### DIFF
--- a/services/ghost-shell/rooms.test.ts
+++ b/services/ghost-shell/rooms.test.ts
@@ -1,4 +1,4 @@
-import { joinRoom, sendRoomMessage, leaveAll, getRoomMembers } from './rooms';
+import { joinRoom, sendRoomMessage, leaveAll, leaveRoom, getRoomMembers } from './rooms';
 
 describe('rooms', () => {
   it('handles join and messaging', () => {
@@ -16,5 +16,20 @@ describe('rooms', () => {
 
     leaveAll(socket);
     expect(getRoomMembers('r1')).toEqual([]);
+  });
+
+  it('removes a socket from a single room', () => {
+    const socket: any = { id: 's2', join: jest.fn(), leave: jest.fn() };
+
+    joinRoom(socket, 'roomA');
+    joinRoom(socket, 'roomB');
+
+    leaveRoom(socket, 'roomA');
+
+    expect(socket.leave).toHaveBeenCalledWith('roomA');
+    expect(getRoomMembers('roomA')).toEqual([]);
+    expect(getRoomMembers('roomB')).toEqual(['s2']);
+
+    leaveAll(socket);
   });
 });

--- a/services/ghost-shell/rooms.ts
+++ b/services/ghost-shell/rooms.ts
@@ -14,6 +14,17 @@ export function sendRoomMessage(io: Server, roomId: string, msg: any): void {
   io.to(roomId).emit('room_response', msg);
 }
 
+export function leaveRoom(socket: Socket, roomId: string): void {
+  socket.leave(roomId);
+  const members = rooms.get(roomId);
+  if (members) {
+    members.delete(socket.id);
+    if (members.size === 0) {
+      rooms.delete(roomId);
+    }
+  }
+}
+
 export function leaveAll(socket: Socket): void {
   rooms.forEach((members, roomId) => {
     members.delete(socket.id);

--- a/services/ghost-shell/server.ts
+++ b/services/ghost-shell/server.ts
@@ -11,7 +11,7 @@ import { metricsMiddleware, metricsEndpoint } from '../../packages/core/middlewa
 import path from 'path';
 import { addSession, getSession, removeSession } from './session-store';
 import { recordConnection, recordLatency } from './metrics';
-import { joinRoom, sendRoomMessage, leaveAll } from './rooms';
+import { joinRoom, sendRoomMessage, leaveAll, leaveRoom } from './rooms';
 import { watchFragments } from './watchers/chokidar';
 import { scheduleAdaptive } from './scheduler';
 import { runSelfLearn } from '../../scripts/self-learn';
@@ -71,6 +71,10 @@ export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: 
 
       socket.on("join_room", (roomId: string) => {
         joinRoom(socket, roomId);
+      });
+
+      socket.on("leave_room", (roomId: string) => {
+        leaveRoom(socket, roomId);
       });
 
       socket.on("room_message", ({ roomId, msg }) => {


### PR DESCRIPTION
## Summary
- support removing a socket from a specific room
- listen for `leave_room` event in Ghost Shell server
- test the leaveRoom helper

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68643fa8361c8322869f0de15eb06569