### PR TITLE
Add GhostShell Lambda@Edge deployment

### DIFF
--- a/aws/lambda-edge/handler.ts
+++ b/aws/lambda-edge/handler.ts
@@ -1,0 +1,12 @@
+import { startServer } from '../../services/ghost-shell/server';
+
+let initialized = false;
+
+export async function handler(event: any) {
+  if (!initialized) {
+    const secret = process.env.SECRET || 'ghost-secret';
+    startServer(3000, secret, false);
+    initialized = true;
+  }
+  return event.Records[0].cf.request;
+}

--- a/aws/lambda-edge/template.yaml
+++ b/aws/lambda-edge/template.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  GhostShellEdgeFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: GhostShellEdge
+      Handler: handler.handler
+      Runtime: nodejs20.x
+      Role: arn:aws:iam::123456789012:role/lambda-edge-role
+      Code:
+        S3Bucket: YOUR_BUCKET
+        S3Key: ghostshell-edge.zip

--- a/ci/agent.yml
+++ b/ci/agent.yml
@@ -14,3 +14,5 @@ jobs:
       - name: Run Go tests
         run: |
           go test ./services/vector-indexer
+      - name: Package Lambda@Edge
+        run: ./scripts/package-lambda-edge.sh

--- a/scripts/package-lambda-edge.sh
+++ b/scripts/package-lambda-edge.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DIST="$ROOT/dist/aws/lambda-edge"
+ZIP="$ROOT/ghostshell-edge.zip"
+
+pnpm run build
+
+cd "$DIST"
+zip -r "$ZIP" .
+
+echo "Lambda package created at $ZIP"
+
+if [ -n "${LAMBDA_FUNCTION_NAME:-}" ] && command -v aws >/dev/null 2>&1; then
+  aws lambda update-function-code --function-name "$LAMBDA_FUNCTION_NAME" --zip-file "fileb://$ZIP"
+fi

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
   "include": [
     "packages/**/*",
     "services/**/*",
-    "scripts/**/*.ts"
+    "scripts/**/*.ts",
+    "aws/**/*"
   ]
 }


### PR DESCRIPTION
## Summary
- create `aws/lambda-edge` for Lambda@Edge support
- add minimal handler starting GhostShell
- include CloudFormation template for deployment
- script for packaging and optional upload
- run packaging script in CI
- compile AWS code in tsconfig

## Testing
- `./scripts/run-all-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6864c18458fc8322b8a8ed605db98c54