### PR TITLE
Fix lingering Jest handles

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,5 +4,6 @@ module.exports = {
   testPathIgnorePatterns: ['/dist/', '/packages/agents/__tests__/'],
   moduleNameMapper: {
     '^yaml$': '<rootDir>/node_modules/yaml/dist/index.js'
-  }
+  },
+  detectOpenHandles: true
 };

--- a/services/ghost-shell/server.test.ts
+++ b/services/ghost-shell/server.test.ts
@@ -7,10 +7,12 @@ const PORT = 4010;
 const SECRET = 'test-secret';
 
 describe('ghost-shell server', () => {
-  const { server } = startServer(PORT, SECRET, false);
+  const { server, watcher, scheduler } = startServer(PORT, SECRET, false, false);
 
   afterAll(() => {
     server.close();
+    watcher?.close();
+    scheduler?.cancel();
   });
 
   it('responds to healthz', async () => {

--- a/services/ghost-shell/server.ts
+++ b/services/ghost-shell/server.ts
@@ -18,7 +18,12 @@ import { runSelfLearn } from '../../scripts/self-learn';
 import { emitSigilAlert } from './sigil-alerts';
 import { glob } from 'glob';
 
-export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: boolean = true) {
+export function startServer(
+  port = 3000,
+  secret = 'ghost-secret',
+  enableSocket: boolean = true,
+  enableBackground: boolean = true
+) {
   const app = express();
   let ready = false;
 
@@ -104,20 +109,24 @@ export function startServer(port = 3000, secret = 'ghost-secret', enableSocket: 
     logger.info(`GhostShellAgent listening on ${port}`);
   });
 
-  const fragmentsPattern = path.join(
-    __dirname,
-    '..',
-    '..',
-    'GenesisAeonZIPMEM',
-    'newadvancedconversations',
-    '**',
-    '*.yaml'
-  );
-  watchFragments(fragmentsPattern);
-  scheduleAdaptive(
-    () => glob(fragmentsPattern).then((files) => files.length),
-    runSelfLearn
-  );
+  let watcher: ReturnType<typeof watchFragments> | undefined;
+  let scheduler: ReturnType<typeof scheduleAdaptive> | undefined;
+  if (enableBackground) {
+    const fragmentsPattern = path.join(
+      __dirname,
+      '..',
+      '..',
+      'GenesisAeonZIPMEM',
+      'newadvancedconversations',
+      '**',
+      '*.yaml'
+    );
+    watcher = watchFragments(fragmentsPattern);
+    scheduler = scheduleAdaptive(
+      () => glob(fragmentsPattern).then((files) => files.length),
+      runSelfLearn
+    );
+  }
 
-  return { app, io, server };
+  return { app, io, server, watcher, scheduler };
 }


### PR DESCRIPTION
## Summary
- enable `detectOpenHandles` in Jest configuration
- add optional `enableBackground` flag to `startServer`
- close watchers and timers in server test

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6864c8394f5c8322b37118fc5ddd2270