### PR TITLE
Fix agent test patterns

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   transform: { '^.+\\.tsx?$': ['<rootDir>/node_modules/ts-jest', {}] },
   testEnvironment: 'jsdom',
-  testPathIgnorePatterns: ['/dist/', '/packages/agents/__tests__/'],
+  testPathIgnorePatterns: ['/dist/'],
   moduleNameMapper: {
     '^yaml$': '<rootDir>/node_modules/yaml/dist/index.js'
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['packages/agents/**/*.spec.ts'],
+    include: ['packages/agents/**/*.{test,spec}.ts'],
     environment: 'node'
   }
 });


### PR DESCRIPTION
## Summary
- support both `.spec.ts` and `.test.ts` in Vitest config
- allow Jest to see agent test folder by adjusting ignore patterns

## Testing
- `pnpm test:agents` *(fails: ReferenceError test is not defined)*
- `pnpm test` *(fails: Manifest verification failed)*

------
https://chatgpt.com/codex/tasks/task_e_6864d1aad3b08322840f8c937fafc2fe