### PR TITLE
Expose neurons accessor

### DIFF
--- a/packages/aeon-neural-membrane/nukleonScanner.ts
+++ b/packages/aeon-neural-membrane/nukleonScanner.ts
@@ -4,7 +4,7 @@ import { Network } from '../simple-neural-net';
  * Summiert absolute Gewichte aller Neuronen als einfache Energie-Messung.
  */
 export function scanEnergy(net: Network): number {
-  const neurons = (net as any).neurons as any[];
+  const neurons = net.neurons as any[];
   let sum = 0;
   for (const n of neurons) {
     sum += Math.abs(n.weight1);

--- a/packages/aeon-neural-membrane/selfTrainer.ts
+++ b/packages/aeon-neural-membrane/selfTrainer.ts
@@ -16,7 +16,7 @@ export function selfTrain(
     net.train(data, answers, 1);
     // einfache Backprop-Näherung: leichtes Nachjustieren zur Mitte
     const preds = data.map(d => net.predict(d[0], d[1]));
-    const neurons = (net as any).neurons as any[];
+    const neurons = net.neurons as any[];
     for (const n of neurons) {
       n.weight1 -= rate * (preds[0] - answers[0]) * data[0][0];
       (n as any).weight2 -= rate * (preds[0] - answers[0]) * data[0][1];

--- a/packages/simple-neural-net/Network.ts
+++ b/packages/simple-neural-net/Network.ts
@@ -2,14 +2,19 @@ import { Neuron } from './Neuron';
 import { sigmoid, meanSquareLoss } from './util';
 
 export class Network {
-  private neurons: Neuron[] = [
+  private _neurons: Neuron[] = [
     new Neuron(), new Neuron(), new Neuron(), // input
     new Neuron(), new Neuron(), // hidden
     new Neuron() // output
   ];
 
+  /** Access internal neurons array for advanced inspection. */
+  get neurons(): Neuron[] {
+    return this._neurons;
+  }
+
   predict(input1: number, input2: number): number {
-    const n = this.neurons;
+    const n = this._neurons;
     return n[5].compute(
       n[4].compute(
         n[2].compute(input1, input2, sigmoid),
@@ -28,7 +33,7 @@ export class Network {
   train(data: [number, number][], answers: number[], epochs = 1000) {
     let bestLoss: number | null = null;
     for (let epoch = 0; epoch < epochs; epoch++) {
-      const neuron = this.neurons[epoch % this.neurons.length];
+      const neuron = this._neurons[epoch % this._neurons.length];
       neuron.mutate();
 
       const predictions = data.map(d => this.predict(d[0], d[1]));


### PR DESCRIPTION
## Summary
- add `neurons` getter in `Network`
- use the accessor in aeon-neural-membrane modules

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Vitest cannot be imported in a CommonJS module)*
- `pnpm test:agents` *(fails: test files missing globals)*

------
https://chatgpt.com/codex/tasks/task_e_6864d309fea883228ee9e2844a15b7b3