### PR TITLE
Add error handling for runSelfLearn in chokidar watcher

### DIFF
--- a/services/ghost-shell/watchers/chokidar.ts
+++ b/services/ghost-shell/watchers/chokidar.ts
@@ -1,10 +1,15 @@
 import chokidar from 'chokidar';
 import { runSelfLearn } from '../../../scripts/self-learn';
+import { logger } from '../logger';
 
 export function watchFragments(pattern = 'newadvancedconversations/*.json') {
   const watcher = chokidar.watch(pattern, { ignoreInitial: true });
-  watcher.on('add', () => {
-    runSelfLearn();
+  watcher.on('add', async () => {
+    try {
+      await runSelfLearn();
+    } catch (err) {
+      logger.error(err);
+    }
   });
   return watcher;
 }


### PR DESCRIPTION
## Summary
- add logger import and wrap `runSelfLearn` in a try/catch

## Testing
- `pnpm test` *(fails: Manifest verification failed)*

------
https://chatgpt.com/codex/tasks/task_e_6864d61a63d8832282eca5da2c9b739a