### PR TITLE
Add metrics endpoint test

### DIFF
--- a/services/ghost-shell/server.test.ts
+++ b/services/ghost-shell/server.test.ts
@@ -33,4 +33,10 @@ describe('ghost-shell server', () => {
       .send({ name: 'mandalaHaiku' });
     expect(res.status).toBe(400);
   });
+
+  it('exposes prometheus metrics', async () => {
+    const res = await request(`http://localhost:${PORT}`).get('/metrics');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('ghost_connections_total');
+  });
 });


### PR DESCRIPTION
## Summary
- extend `ghost-shell` server tests to check `/metrics` output

## Testing
- `pnpm test` *(fails: Vitest cannot be imported in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_6864dd12cc2883229758aee2e851931b