### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: pnpm install
+      - run: node scripts/generate-changelog.js
+      - name: Bump version and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          npm version patch -m "chore(release): %s"
+      - name: Push changes
+        run: git push --follow-tags

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1187,7 +1187,8 @@
     "commit": "Automate release tagging",
     "path": ".github/workflows/release.yaml",
     "task": "Tag new version when merging into main",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Add changelog generator",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -835,6 +835,7 @@
   path: .github/workflows/release.yaml
   task: Tag new version when merging into main
   test: ''
+  status: done
 - commit: Add changelog generator
   path: scripts/generate-changelog.js
   task: Generate CHANGELOG.md from commit messages


### PR DESCRIPTION
## Summary
- add GitHub Actions release workflow to automate tagging
- mark `Automate release tagging` in advancedToDo lists as complete

## Testing
- `pnpm test` *(fails: Vitest cannot be imported in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_6864e1588c148322a81989fa1024a1e3