### PR TITLE
Implement plugin registry admin UI

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1202,6 +1202,7 @@
     "path": "apps/plugin-registry",
     "task": "Manage plugin review, blacklist and version lock",
     "test": ""
+    "status": "done"
   },
   {
     "commit": "Setup backup script",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -845,6 +845,7 @@
   path: apps/plugin-registry
   task: Manage plugin review, blacklist and version lock
   test: ''
+  status: done
 - commit: Setup backup script
   path: scripts/backup.sh
   task: Backup patterns, votes and sessions to S3 or Minio

--- a/apps/plugin-registry/components/PluginList.test.tsx
+++ b/apps/plugin-registry/components/PluginList.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PluginList from './PluginList';
+
+describe('PluginList', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve([
+            { name: 'mandalaHaiku', version: '1.1.0', approved: false, blacklisted: false },
+          ]),
+      })
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('renders plugin names', async () => {
+    await act(async () => {
+      render(<PluginList />);
+    });
+    expect(await screen.findByText(/mandalaHaiku/)).toBeInTheDocument();
+  });
+});

--- a/apps/plugin-registry/components/PluginList.tsx
+++ b/apps/plugin-registry/components/PluginList.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+
+interface PluginInfo {
+  name: string;
+  version: string;
+  approved: boolean;
+  blacklisted: boolean;
+  versionLock?: string | null;
+}
+
+export default function PluginList() {
+  const [plugins, setPlugins] = useState<PluginInfo[]>([]);
+
+  const fetchPlugins = () => {
+    fetch('/api/plugins')
+      .then((res) => res.json())
+      .then(setPlugins);
+  };
+
+  useEffect(fetchPlugins, []);
+
+  const act = (url: string, name: string, body: any = {}) => {
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, ...body }),
+    }).then(fetchPlugins);
+  };
+
+  return (
+    <div>
+      <h2>Plugin Registry</h2>
+      <ul>
+        {plugins.map((p) => (
+          <li key={p.name}>
+            {p.name} ({p.version}){' '}
+            {p.approved ? '✅' : ''}
+            {p.blacklisted ? '🚫' : ''}
+            {p.versionLock ? `🔒 ${p.versionLock}` : ''}
+            <button onClick={() => act('/api/approve', p.name)}>Approve</button>
+            <button onClick={() => act('/api/blacklist', p.name)}>Blacklist</button>
+            <button
+              onClick={() => {
+                const v = prompt('Lock to version', p.version);
+                if (v) act('/api/lock-version', p.name, { version: v });
+              }}
+            >
+              Lock Version
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/plugin-registry/lib/registry.ts
+++ b/apps/plugin-registry/lib/registry.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+
+const REGISTRY_PATH = path.join(process.cwd(), 'plugins', 'registry.json');
+
+export interface RegistryEntry {
+  approved?: boolean;
+  blacklisted?: boolean;
+  versionLock?: string | null;
+}
+
+export function readRegistry(): Record<string, RegistryEntry> {
+  if (!fs.existsSync(REGISTRY_PATH)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8')) as Record<string, RegistryEntry>;
+  } catch {
+    return {};
+  }
+}
+
+export function writeRegistry(reg: Record<string, RegistryEntry>) {
+  fs.writeFileSync(REGISTRY_PATH, JSON.stringify(reg, null, 2));
+}

--- a/apps/plugin-registry/pages/api/approve.ts
+++ b/apps/plugin-registry/pages/api/approve.ts
@@ -1,0 +1,11 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { readRegistry, writeRegistry } from '../../lib/registry';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { name } = req.body;
+  const reg = readRegistry();
+  reg[name] = { ...(reg[name] || {}), approved: true, blacklisted: false };
+  writeRegistry(reg);
+  res.status(204).end();
+}

--- a/apps/plugin-registry/pages/api/blacklist.ts
+++ b/apps/plugin-registry/pages/api/blacklist.ts
@@ -1,0 +1,11 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { readRegistry, writeRegistry } from '../../lib/registry';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { name } = req.body;
+  const reg = readRegistry();
+  reg[name] = { ...(reg[name] || {}), blacklisted: true, approved: false };
+  writeRegistry(reg);
+  res.status(204).end();
+}

--- a/apps/plugin-registry/pages/api/lock-version.ts
+++ b/apps/plugin-registry/pages/api/lock-version.ts
@@ -1,0 +1,11 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { readRegistry, writeRegistry } from '../../lib/registry';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { name, version } = req.body;
+  const reg = readRegistry();
+  reg[name] = { ...(reg[name] || {}), versionLock: version };
+  writeRegistry(reg);
+  res.status(204).end();
+}

--- a/apps/plugin-registry/pages/api/plugins.ts
+++ b/apps/plugin-registry/pages/api/plugins.ts
@@ -1,0 +1,14 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { listPlugins } from '../../../../services/plugin-loader';
+import { readRegistry } from '../../lib/registry';
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  const registry = readRegistry();
+  const plugins = listPlugins().map((p) => ({
+    ...p,
+    approved: registry[p.name]?.approved || false,
+    blacklisted: registry[p.name]?.blacklisted || false,
+    versionLock: registry[p.name]?.versionLock || null,
+  }));
+  res.status(200).json(plugins);
+}

--- a/apps/plugin-registry/pages/index.tsx
+++ b/apps/plugin-registry/pages/index.tsx
@@ -1,0 +1,10 @@
+import PluginList from '../components/PluginList';
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Plugin Registry</h1>
+      <PluginList />
+    </div>
+  );
+}

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -1,0 +1,4 @@
+{
+  "mandalaHaiku": { "approved": true, "blacklisted": false, "versionLock": "1.1.0" },
+  "poeticResonance": { "approved": false, "blacklisted": false }
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js app `plugin-registry`
- list plugins with approve/blacklist/version lock controls
- expose minimal API endpoints reading/writing `plugins/registry.json`
- mark plugin registry task as done in advancedToDo files

## Testing
- `pnpm install --ignore-scripts`
- `pnpm test` *(fails: Vitest cannot be imported in a CommonJS module; server test timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6864e77fb48c832286e820f5f5fcb801