### PR TITLE
Implement session persistence for ghost-shell

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -9,7 +9,7 @@ ARCHIVE="$DEST/backup-$TIMESTAMP.tar.gz"
 FILES=()
 [ -f plugins/mandalaHaiku/customPatterns.json ] && FILES+=("plugins/mandalaHaiku/customPatterns.json")
 [ -f data/haikuVotes.json ] && FILES+=("data/haikuVotes.json")
-[ -f services/ghost-shell/sessions.json ] && FILES+=("services/ghost-shell/sessions.json")
+[ -f services/ghost-shell/sessions.json ] && FILES+=("services/ghost-shell/sessions.json") # session persistence
 
 if [ ${#FILES[@]} -eq 0 ]; then
   echo "Nothing to backup" >&2

--- a/services/ghost-shell/session-store.test.ts
+++ b/services/ghost-shell/session-store.test.ts
@@ -1,17 +1,39 @@
-import {
-  addSession,
-  addHistory,
-  configureSessionStore,
-  getSession,
-  pruneSessions,
-  removeSession,
-} from './session-store';
+import fs from 'fs';
+
+let addSession: any;
+let addHistory: any;
+let configureSessionStore: any;
+let getSession: any;
+let pruneSessions: any;
+let removeSession: any;
+let stopSessionPersistence: any;
 
 jest.useFakeTimers();
 
 describe('session store', () => {
   beforeEach(() => {
+    jest.resetModules();
+    jest.isolateModules(() => {
+      const mod = require('./session-store');
+      addSession = mod.addSession;
+      addHistory = mod.addHistory;
+      configureSessionStore = mod.configureSessionStore;
+      getSession = mod.getSession;
+      pruneSessions = mod.pruneSessions;
+      removeSession = mod.removeSession;
+      stopSessionPersistence = mod.stopSessionPersistence;
+    });
     configureSessionStore({ ttlMs: 1000, maxHistory: 2 });
+    if (fs.existsSync('services/ghost-shell/sessions.json')) {
+      fs.unlinkSync('services/ghost-shell/sessions.json');
+    }
+  });
+
+  afterEach(() => {
+    stopSessionPersistence();
+    if (fs.existsSync('services/ghost-shell/sessions.json')) {
+      fs.unlinkSync('services/ghost-shell/sessions.json');
+    }
   });
 
   it('tracks sessions and prunes history', () => {
@@ -28,5 +50,26 @@ describe('session store', () => {
     jest.advanceTimersByTime(1500);
     pruneSessions();
     expect(getSession('2')).toBeUndefined();
+  });
+
+  it('persists sessions to disk', () => {
+    addSession('persist');
+    jest.advanceTimersByTime(31000);
+    const data = JSON.parse(
+      fs.readFileSync('services/ghost-shell/sessions.json', 'utf8')
+    );
+    expect(data.persist).toBeDefined();
+  });
+
+  it('loads sessions from disk on startup', () => {
+    fs.writeFileSync(
+      'services/ghost-shell/sessions.json',
+      JSON.stringify({ loadme: { history: [], lastActive: Date.now() } })
+    );
+    jest.isolateModules(() => {
+      const mod = require('./session-store');
+      expect(mod.getSession('loadme')).toBeDefined();
+      mod.stopSessionPersistence();
+    });
   });
 });

--- a/services/ghost-shell/session-store.ts
+++ b/services/ghost-shell/session-store.ts
@@ -6,7 +6,50 @@ export interface Session {
 let ttlMs = 60 * 60 * 1000; // 1 hour default
 let maxHistory = 50;
 
+import fs from 'fs';
+import path from 'path';
+
+const SESSIONS_FILE = path.join(__dirname, 'sessions.json');
+
 const sessions = new Map<string, Session>();
+
+function loadSessions() {
+  if (fs.existsSync(SESSIONS_FILE)) {
+    try {
+      const data = JSON.parse(fs.readFileSync(SESSIONS_FILE, 'utf8')) as Record<string, Session>;
+      for (const [id, session] of Object.entries(data)) {
+        sessions.set(id, session);
+      }
+    } catch {
+      // ignore corrupted files
+    }
+  }
+}
+
+function saveSessions() {
+  const obj: Record<string, Session> = {};
+  for (const [id, session] of sessions.entries()) {
+    obj[id] = session;
+  }
+  fs.writeFileSync(SESSIONS_FILE, JSON.stringify(obj));
+}
+
+let persistenceTimer: NodeJS.Timeout | null = null;
+
+export function startSessionPersistence(intervalMs = 30000) {
+  if (persistenceTimer) return;
+  persistenceTimer = setInterval(saveSessions, intervalMs);
+}
+
+export function stopSessionPersistence() {
+  if (persistenceTimer) {
+    clearInterval(persistenceTimer);
+    persistenceTimer = null;
+  }
+}
+
+loadSessions();
+startSessionPersistence();
 
 export function configureSessionStore(options: {
   ttlMs?: number;


### PR DESCRIPTION
## Summary
- persist ghost-shell sessions in `sessions.json`
- restore sessions on startup and start periodic persistence
- test persistence behaviour of the session store
- add comment in backup script ensuring sessions file is archived

## Testing
- `pnpm test`
- `pnpm run test:agents`

------
https://chatgpt.com/codex/tasks/task_e_6864eb62c4b8832280f177ec68cfa283