### PR TITLE
Add missing token auth test

### DIFF
--- a/services/ghost-shell/auth.test.ts
+++ b/services/ghost-shell/auth.test.ts
@@ -33,4 +33,15 @@ describe('ghost-shell auth', () => {
 
     expect(next).toHaveBeenCalledWith(expect.any(Error));
   });
+
+  it('calls next with error when token missing', () => {
+    verify.mockImplementation(() => { throw new Error('missing'); });
+
+    const socket: any = { handshake: { auth: {} } };
+    const next = jest.fn();
+
+    socketAuth('secret')(socket, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
 });


### PR DESCRIPTION
## Summary
- cover socketAuth for when the token isn't provided

## Testing
- `pnpm test` *(fails: Vitest cannot be imported in a CommonJS module, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6864ee4058108322b68900ddc2f17b5c