### PR TITLE
Update advanced ToDo with simulation and GPT team tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2535,4 +2535,22 @@
     "task": "s für v0.7 wurden priorisiert markiert. Bereit für den nächsten Schritt – möchtest du direkt mit der Planung der Generativen Mutation, Clusteranalyse oder Meta-Annotation beginnen?",
     "test": ""
   }
+  ,{
+    "commit": "Add NullfeldSimulation module",
+    "path": "packages/universum-simulationen/NullfeldSimulation.ts",
+    "task": "Implement NullfeldSimulation with gravitational forces, membrane curvature and energy conversion",
+    "test": "packages/universum-simulationen/NullfeldSimulation.test.ts"
+  },
+  {
+    "commit": "Add Nullfeld visualization components",
+    "path": "packages/universum-simulationen/NullfeldVisualization.ts",
+    "task": "Visualize membrane curvature, galaxy map and dark matter distribution",
+    "test": "packages/universum-simulationen/NullfeldVisualization.test.ts"
+  },
+  {
+    "commit": "Integrate new GPT teams from Zukunft conversation",
+    "path": "packages/agents",
+    "task": "Register PädagogikGPT, FutureTechScoutGPT, OptimizerGPT and StateMatterGPT teams",
+    "test": "packages/agents/__tests__/TeamIntegration.test.ts"
+  }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4264,3 +4264,15 @@
     möchtest du direkt mit der Planung der Generativen Mutation, Clusteranalyse
     oder Meta-Annotation beginnen?
   test: ""
+- commit: Add NullfeldSimulation module
+  path: packages/universum-simulationen/NullfeldSimulation.ts
+  task: Implement NullfeldSimulation with gravitational forces, membrane curvature and energy conversion
+  test: packages/universum-simulationen/NullfeldSimulation.test.ts
+- commit: Add Nullfeld visualization components
+  path: packages/universum-simulationen/NullfeldVisualization.ts
+  task: Visualize membrane curvature, galaxy map and dark matter distribution
+  test: packages/universum-simulationen/NullfeldVisualization.test.ts
+- commit: Integrate new GPT teams from Zukunft conversation
+  path: packages/agents
+  task: Register PädagogikGPT, FutureTechScoutGPT, OptimizerGPT and StateMatterGPT teams
+  test: packages/agents/__tests__/TeamIntegration.test.ts


### PR DESCRIPTION
## Summary
- expand `advancedToDo.json` and `advancedToDo.yaml` with tasks derived from conversations
  - Nullfeld simulation module and visualizations
  - GPT team integrations from the "Zukunft von GPT" discussion

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651a30cc8483228022820d9f73528d