### PR TITLE
Update advanced ToDo with simulation tasks

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-02, in der Zeit des Morgen.
+Am 2025-07-02, in der Zeit des Tag.
 
-Symbolphase: Initiation (Fokus: C)
+Symbolphase: Aktivierung (Fokus: R)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2534,8 +2534,8 @@
     "path": "",
     "task": "s für v0.7 wurden priorisiert markiert. Bereit für den nächsten Schritt – möchtest du direkt mit der Planung der Generativen Mutation, Clusteranalyse oder Meta-Annotation beginnen?",
     "test": ""
-  }
-  ,{
+  },
+  {
     "commit": "Add NullfeldSimulation module",
     "path": "packages/universum-simulationen/NullfeldSimulation.ts",
     "task": "Implement NullfeldSimulation with gravitational forces, membrane curvature and energy conversion",
@@ -2552,5 +2552,29 @@
     "path": "packages/agents",
     "task": "Register PädagogikGPT, FutureTechScoutGPT, OptimizerGPT and StateMatterGPT teams",
     "test": "packages/agents/__tests__/TeamIntegration.test.ts"
+  },
+  {
+    "commit": "feat: implement particle time-dilation module",
+    "path": "packages/universum-simulationen/ParticleTimeDilation.ts",
+    "task": "Simulate time dilation, energy conversion and gas formation",
+    "test": "packages/universum-simulationen/ParticleTimeDilation.test.ts"
+  },
+  {
+    "commit": "chore: scaffold Wissenschaftliche Versuche project",
+    "path": "packages/wissenschaftliche-versuche",
+    "task": "Create WVH folder with module placeholders",
+    "test": "packages/wissenschaftliche-versuche/__tests__/scaffold.test.ts"
+  },
+  {
+    "commit": "feat: add MasterGPTBridge orchestrator",
+    "path": "packages/agents/MasterGPTBridge.ts",
+    "task": "Orchestrate systems autonomously when captain absent",
+    "test": "packages/agents/__tests__/MasterGPTBridge.test.ts"
+  },
+  {
+    "commit": "feat: integrate FutureTechFramework",
+    "path": "packages/agents/FutureTechFramework.ts",
+    "task": "Launch Genesis FutureTech systems with orchestration",
+    "test": "packages/agents/__tests__/FutureTechFramework.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4266,7 +4266,8 @@
   test: ""
 - commit: Add NullfeldSimulation module
   path: packages/universum-simulationen/NullfeldSimulation.ts
-  task: Implement NullfeldSimulation with gravitational forces, membrane curvature and energy conversion
+  task: Implement NullfeldSimulation with gravitational forces, membrane curvature
+    and energy conversion
   test: packages/universum-simulationen/NullfeldSimulation.test.ts
 - commit: Add Nullfeld visualization components
   path: packages/universum-simulationen/NullfeldVisualization.ts
@@ -4274,5 +4275,22 @@
   test: packages/universum-simulationen/NullfeldVisualization.test.ts
 - commit: Integrate new GPT teams from Zukunft conversation
   path: packages/agents
-  task: Register PädagogikGPT, FutureTechScoutGPT, OptimizerGPT and StateMatterGPT teams
+  task: Register PädagogikGPT, FutureTechScoutGPT, OptimizerGPT and StateMatterGPT
+    teams
   test: packages/agents/__tests__/TeamIntegration.test.ts
+- commit: "feat: implement particle time-dilation module"
+  path: packages/universum-simulationen/ParticleTimeDilation.ts
+  task: Simulate time dilation, energy conversion and gas formation
+  test: packages/universum-simulationen/ParticleTimeDilation.test.ts
+- commit: "chore: scaffold Wissenschaftliche Versuche project"
+  path: packages/wissenschaftliche-versuche
+  task: Create WVH folder with module placeholders
+  test: packages/wissenschaftliche-versuche/__tests__/scaffold.test.ts
+- commit: "feat: add MasterGPTBridge orchestrator"
+  path: packages/agents/MasterGPTBridge.ts
+  task: Orchestrate systems autonomously when captain absent
+  test: packages/agents/__tests__/MasterGPTBridge.test.ts
+- commit: "feat: integrate FutureTechFramework"
+  path: packages/agents/FutureTechFramework.ts
+  task: Launch Genesis FutureTech systems with orchestration
+  test: packages/agents/__tests__/FutureTechFramework.test.ts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: update progress files",
+  "lastCommit": "chore: update todo formatting",
   "fractalStep": "sync",
   "openBranches": [
     "work"


### PR DESCRIPTION
## Summary
- add advanced simulation and orchestrator tasks to ToDo lists
- regenerate Chronopoem and progress files

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68651eabfd5c832296b0656020542f7d