### PR TITLE
Add advanced tasks from conversations

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2594,5 +2594,53 @@
     "path": "packages/agents/OvernightWorkerAgent.ts",
     "task": "Maintain nightly analysis and orchestrate progress",
     "test": "packages/agents/__tests__/OvernightWorkerAgent.test.ts"
+  },
+  {
+    "commit": "feat: add NullmembranQuantization module",
+    "path": "packages/universum-simulationen/modules/nullmembran_quantization.py",
+    "task": "Implement start conditions and binary reproduction",
+    "test": "packages/universum-simulationen/__tests__/nullmembran_quantization.test.py"
+  },
+  {
+    "commit": "feat: add FieldQuantization module",
+    "path": "packages/universum-simulationen/modules/field_quantization.py",
+    "task": "Simulate two-dimensional fields and dynamic quantum states",
+    "test": "packages/universum-simulationen/__tests__/field_quantization.test.py"
+  },
+  {
+    "commit": "feat: add ParticleForce module",
+    "path": "packages/universum-simulationen/modules/particle_force.py",
+    "task": "Kernel for stable particles and basic forces",
+    "test": "packages/universum-simulationen/__tests__/particle_force.test.py"
+  },
+  {
+    "commit": "feat: add FusionEvolution module",
+    "path": "packages/universum-simulationen/modules/fusion_evolution.py",
+    "task": "Compute fusion processes and heavier elements",
+    "test": "packages/universum-simulationen/__tests__/fusion_evolution.test.py"
+  },
+  {
+    "commit": "feat: add Consciousness module",
+    "path": "packages/universum-simulationen/modules/consciousness.py",
+    "task": "Model biochemical processes and neural networks",
+    "test": "packages/universum-simulationen/__tests__/consciousness.test.py"
+  },
+  {
+    "commit": "feat: add GermanGrammarAssistant agent",
+    "path": "packages/agents/GermanGrammarAssistant.ts",
+    "task": "Assist users with text corrections from conversation",
+    "test": "packages/agents/__tests__/GermanGrammarAssistant.test.ts"
+  },
+  {
+    "commit": "feat: add SimulationOrchestrator agent",
+    "path": "packages/agents/SimulationOrchestrator.ts",
+    "task": "Orchestrate universum simulation modules with overnight worker",
+    "test": "packages/agents/__tests__/SimulationOrchestrator.test.ts"
+  },
+  {
+    "commit": "feat: extend FutureKIAgent",
+    "path": "packages/agents/FutureKIAgent.ts",
+    "task": "Integrate predictions from Zukunft von KI conversation",
+    "test": "packages/agents/__tests__/FutureKIAgent.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4306,3 +4306,35 @@
   path: packages/agents/OvernightWorkerAgent.ts
   task: Maintain nightly analysis and orchestrate progress
   test: packages/agents/__tests__/OvernightWorkerAgent.test.ts
+- commit: "feat: add NullmembranQuantization module"
+  path: packages/universum-simulationen/modules/nullmembran_quantization.py
+  task: Implement start conditions and binary reproduction
+  test: packages/universum-simulationen/__tests__/nullmembran_quantization.test.py
+- commit: "feat: add FieldQuantization module"
+  path: packages/universum-simulationen/modules/field_quantization.py
+  task: Simulate two-dimensional fields and dynamic quantum states
+  test: packages/universum-simulationen/__tests__/field_quantization.test.py
+- commit: "feat: add ParticleForce module"
+  path: packages/universum-simulationen/modules/particle_force.py
+  task: Kernel for stable particles and basic forces
+  test: packages/universum-simulationen/__tests__/particle_force.test.py
+- commit: "feat: add FusionEvolution module"
+  path: packages/universum-simulationen/modules/fusion_evolution.py
+  task: Compute fusion processes and heavier elements
+  test: packages/universum-simulationen/__tests__/fusion_evolution.test.py
+- commit: "feat: add Consciousness module"
+  path: packages/universum-simulationen/modules/consciousness.py
+  task: Model biochemical processes and neural networks
+  test: packages/universum-simulationen/__tests__/consciousness.test.py
+- commit: "feat: add GermanGrammarAssistant agent"
+  path: packages/agents/GermanGrammarAssistant.ts
+  task: Assist users with text corrections from conversation
+  test: packages/agents/__tests__/GermanGrammarAssistant.test.ts
+- commit: "feat: add SimulationOrchestrator agent"
+  path: packages/agents/SimulationOrchestrator.ts
+  task: Orchestrate universum simulation modules with overnight worker
+  test: packages/agents/__tests__/SimulationOrchestrator.test.ts
+- commit: "feat: extend FutureKIAgent"
+  path: packages/agents/FutureKIAgent.ts
+  task: Integrate predictions from Zukunft von KI conversation
+  test: packages/agents/__tests__/FutureKIAgent.test.ts


### PR DESCRIPTION
## Summary
- parse conversations for universum simulation ideas
- add tasks for simulation modules and new agents

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686527d9b8ec832280079728bc7fcdb6