### PR TITLE
Add document generator and teamboard tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2642,5 +2642,17 @@
     "path": "packages/agents/FutureKIAgent.ts",
     "task": "Integrate predictions from Zukunft von KI conversation",
     "test": "packages/agents/__tests__/FutureKIAgent.test.ts"
+  },
+  {
+    "commit": "feat: add DocumentGenerator agent",
+    "path": "packages/agents/DocumentGenerator.ts",
+    "task": "Compile nightly scientific reports from conversation data",
+    "test": "packages/agents/__tests__/DocumentGenerator.test.ts"
+  },
+  {
+    "commit": "feat: add TeamboardManager module",
+    "path": "packages/agents/TeamboardManager.ts",
+    "task": "Manage specialized GPT teams and persistent teamboard docs",
+    "test": "packages/agents/__tests__/TeamboardManager.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4338,3 +4338,11 @@
   path: packages/agents/FutureKIAgent.ts
   task: Integrate predictions from Zukunft von KI conversation
   test: packages/agents/__tests__/FutureKIAgent.test.ts
+- commit: "feat: add DocumentGenerator agent"
+  path: packages/agents/DocumentGenerator.ts
+  task: Compile nightly scientific reports from conversation data
+  test: packages/agents/__tests__/DocumentGenerator.test.ts
+- commit: "feat: add TeamboardManager module"
+  path: packages/agents/TeamboardManager.ts
+  task: Manage specialized GPT teams and persistent teamboard docs
+  test: packages/agents/__tests__/TeamboardManager.test.ts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #473 from GenesisAeon/codex/durchsuche-chats-und-erstelle-todos-für-agenten-systeme",
+  "lastCommit": "docs: add document generator and teamboard tasks",
   "fractalStep": "sync",
   "openBranches": [
     "work"


### PR DESCRIPTION
## Summary
- note document generator and teamboard manager modules in advanced todo files
- update progress tracking

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68652c2ba0688322b34ae5aa9df2c7d7