### PR TITLE
Add advanced simulation tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2756,5 +2756,41 @@
     "path": "packages/agents/PathkeeperGPT.ts",
     "task": "Maintain publication strategy and update docs",
     "test": "packages/agents/__tests__/PathkeeperGPT.test.ts"
+  },
+  {
+    "commit": "feat: add FiniteElementSolver module",
+    "path": "packages/universum-simulationen/modules/FiniteElementSolver.ts",
+    "task": "Solve field equations using finite element methods",
+    "test": "packages/universum-simulationen/__tests__/FiniteElementSolver.test.ts"
+  },
+  {
+    "commit": "feat: add MonteCarloTester module",
+    "path": "packages/universum-simulationen/modules/MonteCarloTester.ts",
+    "task": "Run Monte-Carlo sampling for quantization modules",
+    "test": "packages/universum-simulationen/__tests__/MonteCarloTester.test.ts"
+  },
+  {
+    "commit": "feat: add SimHostGPT agent",
+    "path": "packages/agents/SimHostGPT.ts",
+    "task": "Coordinate Monte-Carlo tests and visualize scenarios",
+    "test": "packages/agents/__tests__/SimHostGPT.test.ts"
+  },
+  {
+    "commit": "feat: add ForgeGPT agent",
+    "path": "packages/agents/ForgeGPT.ts",
+    "task": "Research model architectures for future GPT evolution",
+    "test": "packages/agents/__tests__/ForgeGPT.test.ts"
+  },
+  {
+    "commit": "feat: add ResearchGPTHub agent",
+    "path": "packages/agents/ResearchGPTHub.ts",
+    "task": "Aggregate research notes and generate reports",
+    "test": "packages/agents/__tests__/ResearchGPTHub.test.ts"
+  },
+  {
+    "commit": "feat: add TextSimplifier agent",
+    "path": "packages/agents/TextSimplifier.ts",
+    "task": "Provide dyslexia-friendly rephrasing for users",
+    "test": "packages/agents/__tests__/TextSimplifier.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4414,3 +4414,27 @@
   path: packages/agents/PathkeeperGPT.ts
   task: Maintain publication strategy and update docs
   test: packages/agents/__tests__/PathkeeperGPT.test.ts
+- commit: "feat: add FiniteElementSolver module"
+  path: packages/universum-simulationen/modules/FiniteElementSolver.ts
+  task: Solve field equations using finite element methods
+  test: packages/universum-simulationen/__tests__/FiniteElementSolver.test.ts
+- commit: "feat: add MonteCarloTester module"
+  path: packages/universum-simulationen/modules/MonteCarloTester.ts
+  task: Run Monte-Carlo sampling for quantization modules
+  test: packages/universum-simulationen/__tests__/MonteCarloTester.test.ts
+- commit: "feat: add SimHostGPT agent"
+  path: packages/agents/SimHostGPT.ts
+  task: Coordinate Monte-Carlo tests and visualize scenarios
+  test: packages/agents/__tests__/SimHostGPT.test.ts
+- commit: "feat: add ForgeGPT agent"
+  path: packages/agents/ForgeGPT.ts
+  task: Research model architectures for future GPT evolution
+  test: packages/agents/__tests__/ForgeGPT.test.ts
+- commit: "feat: add ResearchGPTHub agent"
+  path: packages/agents/ResearchGPTHub.ts
+  task: Aggregate research notes and generate reports
+  test: packages/agents/__tests__/ResearchGPTHub.test.ts
+- commit: "feat: add TextSimplifier agent"
+  path: packages/agents/TextSimplifier.ts
+  task: Provide dyslexia-friendly rephrasing for users
+  test: packages/agents/__tests__/TextSimplifier.test.ts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "docs(todo): add tasks from advanced conversations",
+  "lastCommit": "chore: refresh progress metadata",
   "fractalStep": "sync",
   "openBranches": [
     "work"


### PR DESCRIPTION
## Summary
- append simulation and agent tasks in `advancedToDo.json`
- mirror tasks in `advancedToDo.yaml`
- refresh progress metadata

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68653d1e50ac8322b79f3a36b234ad2b