### PR TITLE
Add SimHost orchestration tools

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2894,5 +2894,35 @@
     "path": "packages/unifiedmandala-ui/components/SoforthilfeOverlay.tsx",
     "task": "Implement emergency overlay with focus trap and keyboard handling",
     "test": "packages/unifiedmandala-ui/components/__tests__/SoforthilfeOverlay.test.tsx"
+  },
+  {
+    "commit": "feat: add SimHostCore for universe simulations",
+    "path": "packages/universum-simulationen/SimHostCore.ts",
+    "task": "Provide base class to register and run simulation modules",
+    "test": "packages/universum-simulationen/SimHostCore.test.ts"
+  },
+  {
+    "commit": "feat: add sound resonance module",
+    "path": "packages/universum-simulationen/SoundResonanceModule.ts",
+    "task": "Generate wave-based resonance data",
+    "test": "packages/universum-simulationen/SoundResonanceModule.test.ts"
+  },
+  {
+    "commit": "feat: add pyramid node simulation",
+    "path": "packages/universum-simulationen/PyramidNodeSimulation.ts",
+    "task": "Energy log modelling for AEON pyramid simulation",
+    "test": "packages/universum-simulationen/PyramidNodeSimulation.test.ts"
+  },
+  {
+    "commit": "feat: add SimHostOrchestrator agent",
+    "path": "packages/agents/SimHostOrchestrator.ts",
+    "task": "Orchestrate simulation modules via SimHostCore",
+    "test": "packages/agents/SimHostOrchestrator.test.ts"
+  },
+  {
+    "commit": "feat: implement Sigil formula engine",
+    "path": "packages/genesis-sigillin-core/SigilFormulaEngine.ts",
+    "task": "Extract keywords from invocation formulas",
+    "test": "packages/genesis-sigillin-core/SigilFormulaEngine.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4506,3 +4506,23 @@
   path: packages/unifiedmandala-ui/components/SoforthilfeOverlay.tsx
   task: Implement emergency overlay with focus trap and keyboard handling
   test: packages/unifiedmandala-ui/components/__tests__/SoforthilfeOverlay.test.tsx
+- commit: "feat: add SimHostCore for universe simulations"
+  path: packages/universum-simulationen/SimHostCore.ts
+  task: Provide base class to register and run simulation modules
+  test: packages/universum-simulationen/SimHostCore.test.ts
+- commit: "feat: add sound resonance module"
+  path: packages/universum-simulationen/SoundResonanceModule.ts
+  task: Generate wave-based resonance data
+  test: packages/universum-simulationen/SoundResonanceModule.test.ts
+- commit: "feat: add pyramid node simulation"
+  path: packages/universum-simulationen/PyramidNodeSimulation.ts
+  task: Energy log modelling for AEON pyramid simulation
+  test: packages/universum-simulationen/PyramidNodeSimulation.test.ts
+- commit: "feat: add SimHostOrchestrator agent"
+  path: packages/agents/SimHostOrchestrator.ts
+  task: Orchestrate simulation modules via SimHostCore
+  test: packages/agents/SimHostOrchestrator.test.ts
+- commit: "feat: implement Sigil formula engine"
+  path: packages/genesis-sigillin-core/SigilFormulaEngine.ts
+  task: Extract keywords from invocation formulas
+  test: packages/genesis-sigillin-core/SigilFormulaEngine.test.ts

--- a/packages/agents/SimHostOrchestrator.test.ts
+++ b/packages/agents/SimHostOrchestrator.test.ts
@@ -1,0 +1,9 @@
+import { SimHostOrchestrator } from './SimHostOrchestrator';
+import { SimulationModule } from '../universum-simulationen/SimHostCore';
+
+test('orchestrates simulation modules', () => {
+  const orchestrator = new SimHostOrchestrator();
+  const mod: SimulationModule = { run: () => 'ok' };
+  orchestrator.register(mod);
+  expect(orchestrator.run()).toEqual(['ok']);
+});

--- a/packages/agents/SimHostOrchestrator.ts
+++ b/packages/agents/SimHostOrchestrator.ts
@@ -1,0 +1,13 @@
+import { SimulationModule, SimHostCore } from '../universum-simulationen/SimHostCore';
+
+export class SimHostOrchestrator {
+  private core = new SimHostCore();
+
+  register(module: SimulationModule): void {
+    this.core.register(module);
+  }
+
+  run(): unknown[] {
+    return this.core.runAll();
+  }
+}

--- a/packages/genesis-sigillin-core/SigilFormulaEngine.test.ts
+++ b/packages/genesis-sigillin-core/SigilFormulaEngine.test.ts
@@ -1,0 +1,6 @@
+import { extractKeywords } from './SigilFormulaEngine';
+
+test('extracts keywords from formula', () => {
+  const res = extractKeywords('Im Zentrum des Netzes ruht ein Knoten.');
+  expect(res).toContain('Zentrum');
+});

--- a/packages/genesis-sigillin-core/SigilFormulaEngine.ts
+++ b/packages/genesis-sigillin-core/SigilFormulaEngine.ts
@@ -1,0 +1,6 @@
+export function extractKeywords(formula: string): string[] {
+  return formula
+    .replace(/[^a-zA-Z0-9\s]/g, '')
+    .split(/\s+/)
+    .filter(Boolean);
+}

--- a/packages/genesis-sigillin-core/index.ts
+++ b/packages/genesis-sigillin-core/index.ts
@@ -3,3 +3,4 @@ export * from './SigillinParser';
 export * from './SigillinActivationManager';
 export * from './SigillinSuggestionEngine';
 export * from './SigillinSyncManager';
+export * from './SigilFormulaEngine';

--- a/packages/universum-simulationen/PyramidNodeSimulation.test.ts
+++ b/packages/universum-simulationen/PyramidNodeSimulation.test.ts
@@ -1,0 +1,7 @@
+import { pyramidNodeSimulation } from './PyramidNodeSimulation';
+
+test('produces increasing energy values', () => {
+  const res = pyramidNodeSimulation(3);
+  expect(res.length).toBe(3);
+  expect(res[1].energy).toBeGreaterThan(res[0].energy);
+});

--- a/packages/universum-simulationen/PyramidNodeSimulation.ts
+++ b/packages/universum-simulationen/PyramidNodeSimulation.ts
@@ -1,0 +1,14 @@
+export interface PyramidStep {
+  time: number;
+  energy: number;
+}
+
+export function pyramidNodeSimulation(steps: number): PyramidStep[] {
+  const result: PyramidStep[] = [];
+  let energy = 1;
+  for (let t = 0; t < steps; t++) {
+    energy += Math.log(t + 1);
+    result.push({ time: t, energy });
+  }
+  return result;
+}

--- a/packages/universum-simulationen/SimHostCore.test.ts
+++ b/packages/universum-simulationen/SimHostCore.test.ts
@@ -1,0 +1,10 @@
+import { SimHostCore, SimulationModule } from './SimHostCore';
+
+test('runs registered modules', () => {
+  const core = new SimHostCore();
+  const results: number[] = [];
+  const mod: SimulationModule = { run: () => { results.push(1); return 1; } };
+  core.register(mod);
+  expect(core.runAll()).toEqual([1]);
+  expect(results).toEqual([1]);
+});

--- a/packages/universum-simulationen/SimHostCore.ts
+++ b/packages/universum-simulationen/SimHostCore.ts
@@ -1,0 +1,15 @@
+export interface SimulationModule {
+  run(): unknown;
+}
+
+export class SimHostCore {
+  private modules: SimulationModule[] = [];
+
+  register(module: SimulationModule): void {
+    this.modules.push(module);
+  }
+
+  runAll(): unknown[] {
+    return this.modules.map((m) => m.run());
+  }
+}

--- a/packages/universum-simulationen/SoundResonanceModule.test.ts
+++ b/packages/universum-simulationen/SoundResonanceModule.test.ts
@@ -1,0 +1,7 @@
+import { soundResonance } from './SoundResonanceModule';
+
+test('generates resonance values', () => {
+  const data = soundResonance(2 * Math.PI, 1, 5);
+  expect(data.length).toBe(5);
+  expect(data[0]).toBeCloseTo(0);
+});

--- a/packages/universum-simulationen/SoundResonanceModule.ts
+++ b/packages/universum-simulationen/SoundResonanceModule.ts
@@ -1,0 +1,7 @@
+export function soundResonance(freq: number, amp: number, steps: number): number[] {
+  const result: number[] = [];
+  for (let i = 0; i < steps; i++) {
+    result.push(Math.sin((i / steps) * freq) * amp);
+  }
+  return result;
+}

--- a/packages/universum-simulationen/index.ts
+++ b/packages/universum-simulationen/index.ts
@@ -1,1 +1,6 @@
 export * from './UniversePulseSimulator';
+export * from './EmotionalResonanceSimulator';
+export * from './InteractiveNarrativeEngine';
+export * from './SimHostCore';
+export * from './SoundResonanceModule';
+export * from './PyramidNodeSimulation';


### PR DESCRIPTION
## Summary
- implement `SimHostCore` to manage simulation modules
- create `SimHostOrchestrator` agent using the core
- add `SoundResonanceModule` and `PyramidNodeSimulation`
- add `SigilFormulaEngine`
- export new modules and track tasks in advancedToDo

## Testing
- `pnpm test` *(fails: jest not found)*
- `pnpm test:agents` *(fails: vitest not found)*
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68654b95e35c8322b43fffbeb79dff82