### PR TITLE
Add advanced simulation and agent tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2925,4 +2925,35 @@
     "task": "Extract keywords from invocation formulas",
     "test": "packages/genesis-sigillin-core/SigilFormulaEngine.test.ts"
   }
+  ,
+  {
+    "commit": "feat: add VacuumEnergyFluctuation module",
+    "path": "packages/universum-simulationen/VacuumEnergyFluctuation.ts",
+    "task": "Model vacuum energy and zero-point fluctuations from conversation",
+    "test": "packages/universum-simulationen/VacuumEnergyFluctuation.test.ts"
+  },
+  {
+    "commit": "feat: add ZeroOneTransitionModel module",
+    "path": "packages/universum-simulationen/ZeroOneTransitionModel.ts",
+    "task": "Simulate transitions between vacuum 0 and matter 1 states",
+    "test": "packages/universum-simulationen/ZeroOneTransitionModel.test.ts"
+  },
+  {
+    "commit": "feat: add FeedbackCollectorGPT agent",
+    "path": "packages/agents/FeedbackCollectorGPT.ts",
+    "task": "Collect GPT interactions for training dataset generation",
+    "test": "packages/agents/__tests__/FeedbackCollectorGPT.test.ts"
+  },
+  {
+    "commit": "feat: add TrainerGPT agent",
+    "path": "packages/agents/TrainerGPT.ts",
+    "task": "Analyze feedback logs and trigger fine-tuning jobs",
+    "test": "packages/agents/__tests__/TrainerGPT.test.ts"
+  },
+  {
+    "commit": "feat: add ProjectReportGenerator agent",
+    "path": "packages/agents/ProjectReportGenerator.ts",
+    "task": "Generate structured project reports from overnight results",
+    "test": "packages/agents/__tests__/ProjectReportGenerator.test.ts"
+  }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4526,3 +4526,23 @@
   path: packages/genesis-sigillin-core/SigilFormulaEngine.ts
   task: Extract keywords from invocation formulas
   test: packages/genesis-sigillin-core/SigilFormulaEngine.test.ts
+- commit: "feat: add VacuumEnergyFluctuation module"
+  path: packages/universum-simulationen/VacuumEnergyFluctuation.ts
+  task: Model vacuum energy and zero-point fluctuations from conversation
+  test: packages/universum-simulationen/VacuumEnergyFluctuation.test.ts
+- commit: "feat: add ZeroOneTransitionModel module"
+  path: packages/universum-simulationen/ZeroOneTransitionModel.ts
+  task: Simulate transitions between vacuum 0 and matter 1 states
+  test: packages/universum-simulationen/ZeroOneTransitionModel.test.ts
+- commit: "feat: add FeedbackCollectorGPT agent"
+  path: packages/agents/FeedbackCollectorGPT.ts
+  task: Collect GPT interactions for training dataset generation
+  test: packages/agents/__tests__/FeedbackCollectorGPT.test.ts
+- commit: "feat: add TrainerGPT agent"
+  path: packages/agents/TrainerGPT.ts
+  task: Analyze feedback logs and trigger fine-tuning jobs
+  test: packages/agents/__tests__/TrainerGPT.test.ts
+- commit: "feat: add ProjectReportGenerator agent"
+  path: packages/agents/ProjectReportGenerator.ts
+  task: Generate structured project reports from overnight results
+  test: packages/agents/__tests__/ProjectReportGenerator.test.ts


### PR DESCRIPTION
## Summary
- extend advancedToDo.json with new modules and agents derived from archived conversations
- mirror tasks in advancedToDo.yaml

## Testing
- `pnpm test` *(fails: jest not found)*
- `pnpm vitest run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686550dfcad48322b7898182c0a1dfba