### PR TITLE
Add wallet integration and matter balance tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2924,8 +2924,7 @@
     "path": "packages/genesis-sigillin-core/SigilFormulaEngine.ts",
     "task": "Extract keywords from invocation formulas",
     "test": "packages/genesis-sigillin-core/SigilFormulaEngine.test.ts"
-  }
-  ,
+  },
   {
     "commit": "feat: add VacuumEnergyFluctuation module",
     "path": "packages/universum-simulationen/VacuumEnergyFluctuation.ts",
@@ -2955,5 +2954,17 @@
     "path": "packages/agents/ProjectReportGenerator.ts",
     "task": "Generate structured project reports from overnight results",
     "test": "packages/agents/__tests__/ProjectReportGenerator.test.ts"
+  },
+  {
+    "commit": "feat: add CryptoWalletIntegration service",
+    "path": "packages/universum-simulationen/modules/CryptoWalletIntegration.ts",
+    "task": "Provide wallet interface for simulation contributions",
+    "test": "packages/universum-simulationen/__tests__/CryptoWalletIntegration.test.ts"
+  },
+  {
+    "commit": "feat: add DarkMatterWhiteMatterBalancer module",
+    "path": "packages/universum-simulationen/modules/DarkMatterWhiteMatterBalancer.ts",
+    "task": "Balance cold dark matter and hot white matter dynamics",
+    "test": "packages/universum-simulationen/__tests__/DarkMatterWhiteMatterBalancer.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4546,3 +4546,12 @@
   path: packages/agents/ProjectReportGenerator.ts
   task: Generate structured project reports from overnight results
   test: packages/agents/__tests__/ProjectReportGenerator.test.ts
+
+- commit: "feat: add CryptoWalletIntegration service"
+  path: packages/universum-simulationen/modules/CryptoWalletIntegration.ts
+  task: Provide wallet interface for simulation contributions
+  test: packages/universum-simulationen/__tests__/CryptoWalletIntegration.test.ts
+- commit: "feat: add DarkMatterWhiteMatterBalancer module"
+  path: packages/universum-simulationen/modules/DarkMatterWhiteMatterBalancer.ts
+  task: Balance cold dark matter and hot white matter dynamics
+  test: packages/universum-simulationen/__tests__/DarkMatterWhiteMatterBalancer.test.ts


### PR DESCRIPTION
## Summary
- add CryptoWalletIntegration service task for universum simulation
- add DarkMatterWhiteMatterBalancer module task

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865564a29008322b59190adc8666d8a