### PR TITLE
Add NachtAtmo and RaumzeitLichtmodell

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2966,5 +2966,17 @@
     "path": "packages/universum-simulationen/modules/DarkMatterWhiteMatterBalancer.ts",
     "task": "Balance cold dark matter and hot white matter dynamics",
     "test": "packages/universum-simulationen/__tests__/DarkMatterWhiteMatterBalancer.test.ts"
+  },
+  {
+    "commit": "feat: add NachtAtmo simulation module",
+    "path": "packages/universum-simulationen/NachtAtmo.ts",
+    "task": "Render layered starfield with parallax for Resonarium night scenes",
+    "test": "packages/universum-simulationen/NachtAtmo.test.ts"
+  },
+  {
+    "commit": "feat: add RaumzeitLichtmodell module",
+    "path": "packages/universum-simulationen/RaumzeitLichtmodell.ts",
+    "task": "Model overlapping light paths to explore local spacetime effects",
+    "test": "packages/universum-simulationen/RaumzeitLichtmodell.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4555,3 +4555,11 @@
   path: packages/universum-simulationen/modules/DarkMatterWhiteMatterBalancer.ts
   task: Balance cold dark matter and hot white matter dynamics
   test: packages/universum-simulationen/__tests__/DarkMatterWhiteMatterBalancer.test.ts
+- commit: "feat: add NachtAtmo simulation module"
+  path: packages/universum-simulationen/NachtAtmo.ts
+  task: Render layered starfield with parallax for Resonarium night scenes
+  test: packages/universum-simulationen/NachtAtmo.test.ts
+- commit: "feat: add RaumzeitLichtmodell module"
+  path: packages/universum-simulationen/RaumzeitLichtmodell.ts
+  task: Model overlapping light paths to explore local spacetime effects
+  test: packages/universum-simulationen/RaumzeitLichtmodell.test.ts

--- a/packages/universum-simulationen/NachtAtmo.test.ts
+++ b/packages/universum-simulationen/NachtAtmo.test.ts
@@ -1,0 +1,8 @@
+import { generateNachtAtmo } from './NachtAtmo';
+
+test('generateNachtAtmo returns correct amount of stars', () => {
+  const stars = generateNachtAtmo(2, 5, 100, 100);
+  expect(stars.length).toBe(10);
+  expect(stars.every(s => s.x >= 0 && s.x <= 100)).toBe(true);
+  expect(stars.every(s => s.layer < 2)).toBe(true);
+});

--- a/packages/universum-simulationen/NachtAtmo.ts
+++ b/packages/universum-simulationen/NachtAtmo.ts
@@ -1,0 +1,23 @@
+export interface Star {
+  x: number;
+  y: number;
+  layer: number;
+}
+
+/**
+ * Generate layered star positions for a simple night atmosphere simulation.
+ * Each layer represents a parallax depth.
+ */
+export function generateNachtAtmo(layers: number, starsPerLayer: number, width: number, height: number): Star[] {
+  const stars: Star[] = [];
+  for (let layer = 0; layer < layers; layer++) {
+    for (let i = 0; i < starsPerLayer; i++) {
+      stars.push({
+        x: Math.random() * width,
+        y: Math.random() * height,
+        layer
+      });
+    }
+  }
+  return stars;
+}

--- a/packages/universum-simulationen/RaumzeitLichtmodell.test.ts
+++ b/packages/universum-simulationen/RaumzeitLichtmodell.test.ts
@@ -1,0 +1,7 @@
+import { computeLightOverlap } from './RaumzeitLichtmodell';
+
+test('computeLightOverlap returns grid with expected size', () => {
+  const grid = computeLightOverlap([{ x: 0, y: 0, intensity: 1 }], 3);
+  expect(grid.length).toBe(3);
+  expect(grid[0].length).toBe(3);
+});

--- a/packages/universum-simulationen/RaumzeitLichtmodell.ts
+++ b/packages/universum-simulationen/RaumzeitLichtmodell.ts
@@ -1,0 +1,28 @@
+export interface LightSource {
+  x: number;
+  y: number;
+  intensity: number;
+}
+
+/**
+ * Compute additive light overlap grid from multiple light sources.
+ * The result can be used to approximate local spacetime interference.
+ */
+export function computeLightOverlap(sources: LightSource[], gridSize: number): number[][] {
+  const grid: number[][] = [];
+  for (let y = 0; y < gridSize; y++) {
+    const row: number[] = [];
+    for (let x = 0; x < gridSize; x++) {
+      let value = 0;
+      for (const s of sources) {
+        const dx = x - s.x;
+        const dy = y - s.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        value += s.intensity / (1 + dist);
+      }
+      row.push(value);
+    }
+    grid.push(row);
+  }
+  return grid;
+}


### PR DESCRIPTION
## Summary
- implement `generateNachtAtmo` for starfield generation
- implement `computeLightOverlap` for spacetime light model
- document new modules in advancedToDo

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68655b9908688322a5561bcd642bea62