### PR TITLE
Add tasks from chat insights

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -3075,4 +3075,53 @@
     "task": "Outline consciousness development theory",
     "test": ""
   }
+],
+{
+  "commit": "feat: add Nullmembran simulation module",
+  "path": "simulations/universe-sim/modules/nullmembran.go",
+  "task": "Implement Nullmembran & first quantization simulation stage",
+  "test": "simulations/universe-sim/modules/nullmembran_test.go"
+},
+{
+  "commit": "feat: add FelderQuantisierung module",
+  "path": "simulations/universe-sim/modules/felder_quantisierung.go",
+  "task": "Simulate two-dimensional fields and quantization",
+  "test": "simulations/universe-sim/modules/felder_quantisierung_test.go"
+},
+{
+  "commit": "feat: add ParticlesForces module",
+  "path": "simulations/universe-sim/modules/particles_forces.go",
+  "task": "Model stable particles and fundamental forces",
+  "test": "simulations/universe-sim/modules/particles_forces_test.go"
+},
+{
+  "commit": "feat: add FusionEvolution module",
+  "path": "simulations/universe-sim/modules/fusion_evolution.go",
+  "task": "Implement element fusion and chemical evolution",
+  "test": "simulations/universe-sim/modules/fusion_evolution_test.go"
+},
+{
+  "commit": "feat: add ConsciousnessSim module",
+  "path": "simulations/universe-sim/modules/consciousness_sim.go",
+  "task": "Simulate information processing and emergence of consciousness",
+  "test": "simulations/universe-sim/modules/consciousness_sim_test.go"
+},
+{
+  "commit": "feat: add NightShiftOrchestrator agent",
+  "path": "packages/agents/nightshift-orchestrator.ts",
+  "task": "Coordinate overnight processing and auto-resume cycles",
+  "test": "packages/agents/__tests__/nightshift-orchestrator.test.ts"
+},
+{
+  "commit": "feat: add MasterGPTCoordinator agent",
+  "path": "packages/agents/mastergpt-coordinator.ts",
+  "task": "Delegate strategic plans to sub-agents based on future GPT scenarios",
+  "test": "packages/agents/__tests__/mastergpt-coordinator.test.ts"
+},
+{
+  "commit": "feat: add StyleAdapter utility",
+  "path": "packages/tools/style_adapter.ts",
+  "task": "Adapt assistant responses to user language and style preferences",
+  "test": "packages/tools/__tests__/style_adapter.test.ts"
+}
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4626,3 +4626,35 @@
   path: docs/WVH/Bewusstseinsentwicklung.md
   task: Outline consciousness development theory
   test: ""
+- commit: "feat: add Nullmembran simulation module"
+  path: simulations/universe-sim/modules/nullmembran.go
+  task: Implement Nullmembran & first quantization simulation stage
+  test: simulations/universe-sim/modules/nullmembran_test.go
+- commit: "feat: add FelderQuantisierung module"
+  path: simulations/universe-sim/modules/felder_quantisierung.go
+  task: Simulate two-dimensional fields and quantization
+  test: simulations/universe-sim/modules/felder_quantisierung_test.go
+- commit: "feat: add ParticlesForces module"
+  path: simulations/universe-sim/modules/particles_forces.go
+  task: Model stable particles and fundamental forces
+  test: simulations/universe-sim/modules/particles_forces_test.go
+- commit: "feat: add FusionEvolution module"
+  path: simulations/universe-sim/modules/fusion_evolution.go
+  task: Implement element fusion and chemical evolution
+  test: simulations/universe-sim/modules/fusion_evolution_test.go
+- commit: "feat: add ConsciousnessSim module"
+  path: simulations/universe-sim/modules/consciousness_sim.go
+  task: Simulate information processing and emergence of consciousness
+  test: simulations/universe-sim/modules/consciousness_sim_test.go
+- commit: "feat: add NightShiftOrchestrator agent"
+  path: packages/agents/nightshift-orchestrator.ts
+  task: Coordinate overnight processing and auto-resume cycles
+  test: packages/agents/__tests__/nightshift-orchestrator.test.ts
+- commit: "feat: add MasterGPTCoordinator agent"
+  path: packages/agents/mastergpt-coordinator.ts
+  task: Delegate strategic plans to sub-agents based on future GPT scenarios
+  test: packages/agents/__tests__/mastergpt-coordinator.test.ts
+- commit: "feat: add StyleAdapter utility"
+  path: packages/tools/style_adapter.ts
+  task: Adapt assistant responses to user language and style preferences
+  test: packages/tools/__tests__/style_adapter.test.ts


### PR DESCRIPTION
## Summary
- capture tasks from conversations in `advancedToDo.json` and `advancedToDo.yaml`

## Testing
- `pnpm lint` *(fails: Cannot find type definition file for 'jest')*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686569912e648322b6e93c49d1417b72