### PR TITLE
Add tasks from advanced conversations

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -3200,5 +3200,29 @@
     "path": "packages/unifiedmandala-ui/components/InteraktiveModuleGUI.tsx",
     "task": "Interactive UI for simulation modules",
     "test": "packages/unifiedmandala-ui/components/InteraktiveModuleGUI.test.tsx"
+  },
+  {
+    "commit": "feat: add NullfeldWellenModul",
+    "path": "packages/universum-simulationen/NullfeldWellenModul.ts",
+    "task": "Simulate null field wave equations for universe model",
+    "test": "packages/universum-simulationen/NullfeldWellenModul.test.ts"
+  },
+  {
+    "commit": "feat: add VirtuelleTeilchenFusion module",
+    "path": "packages/universum-simulationen/VirtuelleTeilchenFusion.ts",
+    "task": "Model virtual particle fusion dynamics",
+    "test": "packages/universum-simulationen/VirtuelleTeilchenFusion.test.ts"
+  },
+  {
+    "commit": "feat: add MasterGPTOchestrator agent",
+    "path": "packages/agents/MasterGPTOchestrator.ts",
+    "task": "Coordinate specialized GPT teams for simulations",
+    "test": "packages/agents/MasterGPTOchestrator.test.ts"
+  },
+  {
+    "commit": "feat: add ProjektberichtGenesisSystem doc",
+    "path": "docs/research/Projektbericht_GenesisSystem.md",
+    "task": "Summarize project state and scientific findings",
+    "test": "docs/research/Projektbericht_GenesisSystem.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4710,3 +4710,19 @@
   path: packages/unifiedmandala-ui/components/InteraktiveModuleGUI.tsx
   task: Interactive UI for simulation modules
   test: packages/unifiedmandala-ui/components/InteraktiveModuleGUI.test.tsx
+- commit: "feat: add NullfeldWellenModul"
+  path: packages/universum-simulationen/NullfeldWellenModul.ts
+  task: Simulate null field wave equations for universe model
+  test: packages/universum-simulationen/NullfeldWellenModul.test.ts
+- commit: "feat: add VirtuelleTeilchenFusion module"
+  path: packages/universum-simulationen/VirtuelleTeilchenFusion.ts
+  task: Model virtual particle fusion dynamics
+  test: packages/universum-simulationen/VirtuelleTeilchenFusion.test.ts
+- commit: "feat: add MasterGPTOchestrator agent"
+  path: packages/agents/MasterGPTOchestrator.ts
+  task: Coordinate specialized GPT teams for simulations
+  test: packages/agents/MasterGPTOchestrator.test.ts
+- commit: "feat: add ProjektberichtGenesisSystem doc"
+  path: docs/research/Projektbericht_GenesisSystem.md
+  task: Summarize project state and scientific findings
+  test: docs/research/Projektbericht_GenesisSystem.test.ts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "chore: finalize progress update",
-  "fractalStep": "sync",
+  "lastCommit": "Merge pull request #492 from GenesisAeon/codex/durchsuche-und-analysiere-chats-für-agenten-tools",
+  "fractalStep": "work",
   "openBranches": [
     "work"
   ],


### PR DESCRIPTION
## Summary
- add Nullfeld-based simulation tasks and MasterGPT orchestration
- record new project report doc in advanced todo lists
- update progress tracker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68657c1d7e4483229bf020854183102f