### PR TITLE
Update advanced todos from chat insights

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -3296,5 +3296,23 @@
     "path": "docs/teamboards/SocietyGPT_Teamboard.md",
     "task": "Outline roles and milestones for societal narrative agents",
     "test": "docs/teamboards/SocietyGPT_Teamboard.test.ts"
+  },
+  {
+    "commit": "feat: implement LegasthenieHelper",
+    "path": "packages/helpers/LegasthenieHelper.ts",
+    "task": "Adaptive text formatter for users with dyslexia",
+    "test": "packages/helpers/LegasthenieHelper.test.ts"
+  },
+  {
+    "commit": "feat: add OvernightProgressReporter",
+    "path": "packages/agents/OvernightProgressReporter.ts",
+    "task": "Summarize nightly agent activity for next-day review",
+    "test": "packages/agents/OvernightProgressReporter.test.ts"
+  },
+  {
+    "commit": "docs: add Genesis_Veröffentlichungsstrategie",
+    "path": "docs/public/Genesis_Veröffentlichungsstrategie.md",
+    "task": "Outline publication strategy and required modules",
+    "test": "docs/public/Genesis_Veröffentlichungsstrategie.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4774,3 +4774,15 @@
   path: docs/teamboards/SocietyGPT_Teamboard.md
   task: Outline roles and milestones for societal narrative agents
   test: docs/teamboards/SocietyGPT_Teamboard.test.ts
+- commit: "feat: implement LegasthenieHelper"
+  path: packages/helpers/LegasthenieHelper.ts
+  task: Adaptive text formatter for users with dyslexia
+  test: packages/helpers/LegasthenieHelper.test.ts
+- commit: "feat: add OvernightProgressReporter"
+  path: packages/agents/OvernightProgressReporter.ts
+  task: Summarize nightly agent activity for next-day review
+  test: packages/agents/OvernightProgressReporter.test.ts
+- commit: "docs: add Genesis_Veröffentlichungsstrategie"
+  path: docs/public/Genesis_Veröffentlichungsstrategie.md
+  task: Outline publication strategy and required modules
+  test: docs/public/Genesis_Veröffentlichungsstrategie.test.ts


### PR DESCRIPTION
## Summary
- extend advancedToDo list with new tasks:
  - LegasthenieHelper utility
  - OvernightProgressReporter agent
  - publication strategy document
- keep YAML/JSON in sync

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68658502a0048322bdc72e6df9a06486