### PR TITLE
Implement GenesisGPTGateway agent

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -3288,6 +3288,7 @@
   {
     "commit": "feat: add GenesisGPTGateway",
     "path": "packages/agents/GenesisGPTGateway.ts",
+    "status": "done",
     "task": "Invoke specialized GPT modules via share links",
     "test": "packages/agents/GenesisGPTGateway.test.ts"
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4768,6 +4768,7 @@
   test: docs/future/FutureAI_Vision.test.ts
 - commit: "feat: add GenesisGPTGateway"
   path: packages/agents/GenesisGPTGateway.ts
+  status: done
   task: Invoke specialized GPT modules via share links
   test: packages/agents/GenesisGPTGateway.test.ts
 - commit: "docs: add SocietyGPT Teamboard blueprint"

--- a/packages/agents/GenesisGPTGateway.test.ts
+++ b/packages/agents/GenesisGPTGateway.test.ts
@@ -1,0 +1,11 @@
+import { GenesisGPTGateway } from './GenesisGPTGateway';
+
+describe('GenesisGPTGateway', () => {
+  it('fetches share link', async () => {
+    const text = 'response data';
+    const mockFetch = jest.fn().mockResolvedValue({ ok: true, status: 200, text: jest.fn().mockResolvedValue(text) });
+    const agent = new GenesisGPTGateway({ fetch: mockFetch as any });
+    await agent.handle({ id: '1', description: 'test', shareLink: 'http://example.com' });
+    expect(mockFetch).toHaveBeenCalledWith('http://example.com');
+  });
+});

--- a/packages/agents/GenesisGPTGateway.ts
+++ b/packages/agents/GenesisGPTGateway.ts
@@ -1,0 +1,28 @@
+import fetch from 'node-fetch';
+import { Agent, Task } from '../core/interfaces';
+import { withFSM } from '../core/fsmMixin';
+
+export interface GPTGatewayOptions {
+  fetch?: typeof fetch;
+}
+
+export class GenesisGPTGateway implements Agent {
+  id = 'GenesisGPTGateway';
+  layer: 'Gateway' = 'Gateway';
+
+  constructor(private options: GPTGatewayOptions = {}) {
+    withFSM(this);
+  }
+
+  async handle(task: Task): Promise<void> {
+    const url = (task as any).shareLink || (task as any).link;
+    if (!url) throw new Error('shareLink is required');
+    const f = this.options.fetch || fetch;
+    const res = await f(url);
+    if (!('ok' in res) || !res.ok) {
+      throw new Error(`request failed: ${res.status}`);
+    }
+    const text = await (res as any).text();
+    console.log(`\u2728 GenesisGPTGateway fetched: ${text.slice(0, 30)}`);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "packages/**/*",
     "services/**/*",
     "scripts/**/*.ts",
-    "aws/**/*"
+    "aws/**/*",
+    "types/**/*.d.ts"
   ]
 }

--- a/types/node-fetch.d.ts
+++ b/types/node-fetch.d.ts
@@ -1,0 +1,9 @@
+declare module 'node-fetch' {
+  interface Response {
+    ok: boolean;
+    status: number;
+    text(): Promise<string>;
+  }
+  function fetch(url: string, init?: Record<string, any>): Promise<Response>;
+  export default fetch;
+}


### PR DESCRIPTION
## Summary
- implement `GenesisGPTGateway` to invoke GPT modules via share links
- test gateway agent
- mark `GenesisGPTGateway` task as done
- include custom type declarations for `node-fetch`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68658e9805188322a4ca907c8d7e2439