### PR TITLE
Implement helper and reporter modules

### DIFF
--- a/packages/agents/OvernightProgressReporter.test.ts
+++ b/packages/agents/OvernightProgressReporter.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import { OvernightProgressReporter } from './OvernightProgressReporter';
+
+const OUTPUT = 'tmp-overnight.log';
+
+describe('OvernightProgressReporter', () => {
+  afterEach(() => {
+    if (fs.existsSync(OUTPUT)) fs.unlinkSync(OUTPUT);
+  });
+
+  it('records task summaries', async () => {
+    const agent = new OvernightProgressReporter(OUTPUT);
+    await agent.handle({ id: 't1', summary: 'done' } as any);
+    const content = fs.readFileSync(OUTPUT, 'utf8');
+    expect(content.trim()).toBe('t1:done');
+  });
+});

--- a/packages/agents/OvernightProgressReporter.ts
+++ b/packages/agents/OvernightProgressReporter.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import { Agent, Task } from '../core/interfaces';
+import { withFSM } from '../core/fsmMixin';
+
+interface ProgressEvent {
+  id: string;
+  summary: string;
+}
+
+export class OvernightProgressReporter implements Agent {
+  id = 'OvernightProgressReporter';
+  layer: 'Reporter' = 'Reporter';
+  private events: ProgressEvent[] = [];
+
+  constructor(private output = 'overnight-report.log') {
+    withFSM(this);
+  }
+
+  async handle(task: Task): Promise<void> {
+    const summary = (task as any).summary || (task as any).description || '';
+    this.events.push({ id: task.id, summary });
+    const lines = this.events.map(e => `${e.id}:${e.summary}`);
+    fs.writeFileSync(this.output, lines.join('\n'));
+    console.log(`\uD83C\uDF19 OvernightProgressReporter logged ${task.id}`);
+  }
+}

--- a/packages/helpers/LegasthenieHelper.test.ts
+++ b/packages/helpers/LegasthenieHelper.test.ts
@@ -1,0 +1,15 @@
+import { formatForDyslexia } from './LegasthenieHelper';
+
+describe('formatForDyslexia', () => {
+  it('wraps text with dyslexia friendly styles', () => {
+    const out = formatForDyslexia('Hallo Welt');
+    expect(out).toContain('OpenDyslexic');
+    expect(out).toContain('Hallo Welt');
+    expect(out.startsWith('<span')).toBe(true);
+  });
+
+  it('inserts syllable separators', () => {
+    const out = formatForDyslexia('Hallo', { syllableSeparator: '-' });
+    expect(out).toContain('Hal-lo');
+  });
+});

--- a/packages/helpers/LegasthenieHelper.ts
+++ b/packages/helpers/LegasthenieHelper.ts
@@ -1,0 +1,28 @@
+export interface FormatOptions {
+  letterSpacing?: number;
+  fontFamily?: string;
+  syllableSeparator?: string;
+}
+
+export function formatForDyslexia(text: string, options: FormatOptions = {}): string {
+  const { letterSpacing = 0.15, fontFamily = 'OpenDyslexic, Arial', syllableSeparator } = options;
+  let processed = text;
+  if (syllableSeparator) {
+    const vowel = /[aeiouäöüAEIOUÄÖÜyY]/;
+    let idx = -1;
+    for (let i = 0; i < text.length - 1; i++) {
+      if (vowel.test(text[i])) {
+        idx = i + 1;
+        if (idx < text.length && !vowel.test(text[idx])) {
+          idx += 1;
+        }
+        break;
+      }
+    }
+    if (idx !== -1) {
+      processed = text.slice(0, idx) + syllableSeparator + text.slice(idx);
+    }
+  }
+  const style = `font-family:${fontFamily};letter-spacing:${letterSpacing}em;`;
+  return `<span style="${style}">${processed}</span>`;
+}

--- a/packages/helpers/index.ts
+++ b/packages/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './LegasthenieHelper';


### PR DESCRIPTION
## Summary
- add `LegasthenieHelper` with simple text formatter
- provide `OvernightProgressReporter` agent for nightly summaries
- include unit tests for new modules

## Testing
- `npx vitest run packages/agents/OvernightProgressReporter.test.ts`
- `npx jest packages/helpers/LegasthenieHelper.test.ts`
- `pnpm test` *(fails: Vitest cannot be imported in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68661b6f15a883229a0a8bc20febf32b