### PR TITLE
Add pyramid simulation modules

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -3252,43 +3252,50 @@
     "commit": "feat: add MaterialModul for pyramid simulation",
     "path": "packages/universum-simulationen/MaterialModul.ts",
     "task": "Analyse thermal conduction and resonance of pyramid materials",
-    "test": "packages/universum-simulationen/MaterialModul.test.ts"
+    "test": "packages/universum-simulationen/MaterialModul.test.ts",
+    "status": "done"
   },
   {
     "commit": "feat: add MassVerhaeltnisModul",
     "path": "packages/universum-simulationen/MassVerhaeltnisModul.ts",
     "task": "Compute ratios like golden ratio and Fibonacci in pyramid measurements",
-    "test": "packages/universum-simulationen/MassVerhaeltnisModul.test.ts"
+    "test": "packages/universum-simulationen/MassVerhaeltnisModul.test.ts",
+    "status": "done"
   },
   {
     "commit": "feat: add KammerTopologie module",
     "path": "packages/universum-simulationen/KammerTopologie.ts",
     "task": "Map chamber topology to modern memory architecture",
-    "test": "packages/universum-simulationen/KammerTopologie.test.ts"
+    "test": "packages/universum-simulationen/KammerTopologie.test.ts",
+    "status": "done"
   },
   {
     "commit": "feat: add KlangRaumModul",
     "path": "packages/universum-simulationen/KlangRaumModul.ts",
     "task": "Simulate king chamber acoustics for CREP resonance",
-    "test": "packages/universum-simulationen/KlangRaumModul.test.ts"
+    "test": "packages/universum-simulationen/KlangRaumModul.test.ts",
+    "status": "done"
   },
   {
     "commit": "feat: add KanalVerbindungModul",
     "path": "packages/universum-simulationen/KanalVerbindungModul.ts",
     "task": "Model ventilation channels as data pipelines",
-    "test": "packages/universum-simulationen/KanalVerbindungModul.test.ts"
+    "test": "packages/universum-simulationen/KanalVerbindungModul.test.ts",
+    "status": "done"
   },
   {
     "commit": "feat: add SternausrichtungModul",
     "path": "packages/universum-simulationen/SternausrichtungModul.ts",
     "task": "Calculate star alignment for energy synchronization",
-    "test": "packages/universum-simulationen/SternausrichtungModul.test.ts"
+    "test": "packages/universum-simulationen/SternausrichtungModul.test.ts",
+    "status": "done"
   },
   {
     "commit": "feat: add HieroglyphenParser",
     "path": "packages/universum-simulationen/HieroglyphenParser.ts",
     "task": "Translate hieroglyph patterns into symbolic commands",
-    "test": "packages/universum-simulationen/HieroglyphenParser.test.ts"
+    "test": "packages/universum-simulationen/HieroglyphenParser.test.ts",
+    "status": "done"
   },
   {
     "commit": "feat: implement MemoryMeshSystem",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4753,30 +4753,37 @@
   path: packages/universum-simulationen/MaterialModul.ts
   task: Analyse thermal conduction and resonance of pyramid materials
   test: packages/universum-simulationen/MaterialModul.test.ts
+  status: done
 - commit: "feat: add MassVerhaeltnisModul"
   path: packages/universum-simulationen/MassVerhaeltnisModul.ts
   task: Compute ratios like golden ratio and Fibonacci in pyramid measurements
   test: packages/universum-simulationen/MassVerhaeltnisModul.test.ts
+  status: done
 - commit: "feat: add KammerTopologie module"
   path: packages/universum-simulationen/KammerTopologie.ts
   task: Map chamber topology to modern memory architecture
   test: packages/universum-simulationen/KammerTopologie.test.ts
+  status: done
 - commit: "feat: add KlangRaumModul"
   path: packages/universum-simulationen/KlangRaumModul.ts
   task: Simulate king chamber acoustics for CREP resonance
   test: packages/universum-simulationen/KlangRaumModul.test.ts
+  status: done
 - commit: "feat: add KanalVerbindungModul"
   path: packages/universum-simulationen/KanalVerbindungModul.ts
   task: Model ventilation channels as data pipelines
   test: packages/universum-simulationen/KanalVerbindungModul.test.ts
+  status: done
 - commit: "feat: add SternausrichtungModul"
   path: packages/universum-simulationen/SternausrichtungModul.ts
   task: Calculate star alignment for energy synchronization
   test: packages/universum-simulationen/SternausrichtungModul.test.ts
+  status: done
 - commit: "feat: add HieroglyphenParser"
   path: packages/universum-simulationen/HieroglyphenParser.ts
   task: Translate hieroglyph patterns into symbolic commands
   test: packages/universum-simulationen/HieroglyphenParser.test.ts
+  status: done
 - commit: "feat: implement MemoryMeshSystem"
   path: packages/universum-simulationen/MemoryMeshSystem.ts
   task: Core engine for memory mesh simulation across modules

--- a/packages/agents/ReplayController.test.ts
+++ b/packages/agents/ReplayController.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { describe, it, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { ReplayController } from './ReplayController';
 import { AeonMemory } from '../core/AeonMemory';
@@ -9,6 +10,6 @@ test('logs replay message', () => {
   const c = new ReplayController(1000);
   c.start();
   vi.advanceTimersByTime(1000);
-  expect((console.log as vi.Mock).mock.calls[0][0]).toContain('t1');
+  expect((console.log as ReturnType<typeof vi.fn>).mock.calls[0][0]).toContain('t1');
   vi.useRealTimers();
 });

--- a/packages/universum-simulationen/HieroglyphenParser.test.ts
+++ b/packages/universum-simulationen/HieroglyphenParser.test.ts
@@ -1,0 +1,5 @@
+import { parseGlyphs } from './HieroglyphenParser';
+
+test('splits glyphs by whitespace', () => {
+  expect(parseGlyphs('A B C')).toEqual(['A', 'B', 'C']);
+});

--- a/packages/universum-simulationen/HieroglyphenParser.ts
+++ b/packages/universum-simulationen/HieroglyphenParser.ts
@@ -1,0 +1,3 @@
+export function parseGlyphs(input: string): string[] {
+  return input.split(/\s+/).map(g => g.trim()).filter(Boolean);
+}

--- a/packages/universum-simulationen/KammerTopologie.test.ts
+++ b/packages/universum-simulationen/KammerTopologie.test.ts
@@ -1,0 +1,9 @@
+import { mapToMemory, Chamber } from './KammerTopologie';
+
+test('maps chambers to memory ids', () => {
+  const chambers: Chamber[] = [
+    { name: 'king', coordinates: [0, 0, 0] },
+    { name: 'queen', coordinates: [1, 1, 1] }
+  ];
+  expect(mapToMemory(chambers)).toEqual({ king: 'mem_0', queen: 'mem_1' });
+});

--- a/packages/universum-simulationen/KammerTopologie.ts
+++ b/packages/universum-simulationen/KammerTopologie.ts
@@ -1,0 +1,12 @@
+export interface Chamber {
+  name: string;
+  coordinates: [number, number, number];
+}
+
+export function mapToMemory(chambers: Chamber[]): Record<string, string> {
+  const memoryMap: Record<string, string> = {};
+  chambers.forEach((c, idx) => {
+    memoryMap[c.name] = `mem_${idx}`;
+  });
+  return memoryMap;
+}

--- a/packages/universum-simulationen/KanalVerbindungModul.test.ts
+++ b/packages/universum-simulationen/KanalVerbindungModul.test.ts
@@ -1,0 +1,6 @@
+import { channelLatency, Channel } from './KanalVerbindungModul';
+
+test('computes latency based on length', () => {
+  const ch: Channel = { name: 'vent', length: 5 };
+  expect(channelLatency(ch)).toBe(5);
+});

--- a/packages/universum-simulationen/KanalVerbindungModul.ts
+++ b/packages/universum-simulationen/KanalVerbindungModul.ts
@@ -1,0 +1,9 @@
+export interface Channel {
+  name: string;
+  length: number;
+}
+
+export function channelLatency(channel: Channel): number {
+  const velocity = 1; // normalized units per second
+  return channel.length / velocity;
+}

--- a/packages/universum-simulationen/KlangRaumModul.test.ts
+++ b/packages/universum-simulationen/KlangRaumModul.test.ts
@@ -1,0 +1,5 @@
+import { resonanceFrequency } from './KlangRaumModul';
+
+test('calculates resonance frequency', () => {
+  expect(resonanceFrequency(2)).toBeCloseTo(343 / 4);
+});

--- a/packages/universum-simulationen/KlangRaumModul.ts
+++ b/packages/universum-simulationen/KlangRaumModul.ts
@@ -1,0 +1,4 @@
+export function resonanceFrequency(length: number): number {
+  const speedOfSound = 343; // m/s
+  return speedOfSound / (2 * length);
+}

--- a/packages/universum-simulationen/MassVerhaeltnisModul.test.ts
+++ b/packages/universum-simulationen/MassVerhaeltnisModul.test.ts
@@ -1,0 +1,9 @@
+import { goldenRatio, fibonacci } from './MassVerhaeltnisModul';
+
+test('computes golden ratio multiplication', () => {
+  expect(goldenRatio(1)).toBeCloseTo(1.618, 3);
+});
+
+test('computes fibonacci numbers', () => {
+  expect(fibonacci(5)).toBe(5);
+});

--- a/packages/universum-simulationen/MassVerhaeltnisModul.ts
+++ b/packages/universum-simulationen/MassVerhaeltnisModul.ts
@@ -1,0 +1,13 @@
+export function goldenRatio(value: number): number {
+  const phi = (1 + Math.sqrt(5)) / 2;
+  return value * phi;
+}
+
+export function fibonacci(n: number): number {
+  if (n <= 1) return n;
+  let a = 0, b = 1;
+  for (let i = 2; i <= n; i++) {
+    [a, b] = [b, a + b];
+  }
+  return b;
+}

--- a/packages/universum-simulationen/MaterialModul.test.ts
+++ b/packages/universum-simulationen/MaterialModul.test.ts
@@ -1,0 +1,11 @@
+import { analyzeMaterial, Material } from './MaterialModul';
+
+test('calculates conduction and resonance score', () => {
+  const mats: Material[] = [
+    { name: 'limestone', conductivity: 2, resonance: 3, thickness: 0.5 },
+    { name: 'granite', conductivity: 1.5, resonance: 4, thickness: 1 }
+  ];
+  const res = analyzeMaterial(mats);
+  expect(res[0]).toEqual({ name: 'limestone', conduction: 1, resonanceScore: 6 });
+  expect(res[1].conduction).toBeCloseTo(1.5);
+});

--- a/packages/universum-simulationen/MaterialModul.ts
+++ b/packages/universum-simulationen/MaterialModul.ts
@@ -1,0 +1,20 @@
+export interface Material {
+  name: string;
+  conductivity: number; // thermal conductivity factor
+  resonance: number; // resonance coefficient
+  thickness: number; // in meters
+}
+
+export interface MaterialAnalysis {
+  name: string;
+  conduction: number;
+  resonanceScore: number;
+}
+
+export function analyzeMaterial(layers: Material[]): MaterialAnalysis[] {
+  return layers.map(layer => ({
+    name: layer.name,
+    conduction: layer.conductivity * layer.thickness,
+    resonanceScore: layer.resonance / (layer.thickness || 1)
+  }));
+}

--- a/packages/universum-simulationen/SternausrichtungModul.test.ts
+++ b/packages/universum-simulationen/SternausrichtungModul.test.ts
@@ -1,0 +1,6 @@
+import { isAligned, StarAlignment } from './SternausrichtungModul';
+
+test('detects alignment within threshold', () => {
+  const a: StarAlignment = { star: 'Sirius', azimuth: 0.5 };
+  expect(isAligned(a)).toBe(true);
+});

--- a/packages/universum-simulationen/SternausrichtungModul.ts
+++ b/packages/universum-simulationen/SternausrichtungModul.ts
@@ -1,0 +1,9 @@
+export interface StarAlignment {
+  star: string;
+  azimuth: number;
+}
+
+export function isAligned(alignment: StarAlignment, threshold = 1): boolean {
+  const target = 0; // reference azimuth
+  return Math.abs(alignment.azimuth - target) <= threshold;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "jsx": "react-jsx",
-    "types": ["node", "jest"]
+    "types": ["node", "jest", "vitest"]
   },
   "include": [
     "packages/**/*",


### PR DESCRIPTION
## Summary
- implement MaterialModul and MassVerhaeltnisModul for simulation
- create KammerTopologie, KlangRaumModul, KanalVerbindungModul,
  SternausrichtungModul and HieroglyphenParser
- add unit tests for all new modules
- update todo files marking these tasks as done
- fix ReplayController test and include vitest types in tsconfig

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Vitest cannot be imported in a CommonJS module)*
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_6866426b1da48322910c208b24c35ad6