### PR TITLE
Add PyramidInit CLI and ToDo update

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -911,7 +911,7 @@
     "commit": "Document learning modules",
     "path": "docs/learning-modules.md",
     "task": "Describe workflows from advancedconversations_snippet.json",
-    "test": ""
+    "test": "",
     "status": "done"
   },
   {
@@ -3556,8 +3556,7 @@
     "path": "",
     "task": "c & Manifest-Generator – Dokumentation auf Knopfdruck",
     "test": ""
-  }
-,
+  },
   {
     "commit": "Implement PyramidConfig and loader",
     "path": "packages/unifiedmandala-ui/pyramid/PyramidConfig.ts",
@@ -3575,5 +3574,11 @@
     "path": "packages/unifiedmandala-ui/hooks/usePyramidAudio.ts",
     "task": "Generate phi/pi tones based on layer weights",
     "test": "packages/unifiedmandala-ui/hooks/usePyramidAudio.test.ts"
+  },
+  {
+    "commit": "Add PyramidInit CLI and config generator",
+    "path": "packages/cli-tools/PyramidInit.ts",
+    "task": "Generate default pyramid config via CLI",
+    "test": "packages/cli-tools/PyramidInit.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -5421,10 +5421,10 @@
   path: ""
   task: c & Manifest-Generator – Dokumentation auf Knopfdruck
   test: ""
-
 - commit: Implement PyramidConfig and loader
   path: packages/unifiedmandala-ui/pyramid/PyramidConfig.ts
-  task: Provide configuration interface for pyramid layers and loader with AJV validation
+  task: Provide configuration interface for pyramid layers and loader with AJV
+    validation
   test: packages/unifiedmandala-ui/pyramid/PyramidConfig.test.ts
 - commit: Implement interactive PyramidView component
   path: packages/unifiedmandala-ui/components/PyramidView.tsx
@@ -5434,3 +5434,7 @@
   path: packages/unifiedmandala-ui/hooks/usePyramidAudio.ts
   task: Generate phi/pi tones based on layer weights
   test: packages/unifiedmandala-ui/hooks/usePyramidAudio.test.ts
+- commit: Add PyramidInit CLI and config generator
+  path: packages/cli-tools/PyramidInit.ts
+  task: Generate default pyramid config via CLI
+  test: packages/cli-tools/PyramidInit.test.ts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #505 from GenesisAeon/codex/implementiere-ai-ui-suite-nach-planung",
+  "lastCommit": "Update progress and todo after commit",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/packages/cli-tools/PyramidInit.test.ts
+++ b/packages/cli-tools/PyramidInit.test.ts
@@ -1,0 +1,11 @@
+import fs from 'fs';
+import { createDefaultPyramidConfig } from './PyramidInit';
+
+test('creates config file', () => {
+  const file = 'test.pyramid.json';
+  createDefaultPyramidConfig(file);
+  const content = fs.readFileSync(file, 'utf-8');
+  const cfg = JSON.parse(content);
+  expect(cfg.layers.length).toBe(3);
+  fs.unlinkSync(file);
+});

--- a/packages/cli-tools/PyramidInit.ts
+++ b/packages/cli-tools/PyramidInit.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+import { PyramidConfig } from '../unifiedmandala-ui/pyramid/PyramidConfig';
+
+export function createDefaultPyramidConfig(output = 'pyramid.config.json'): void {
+  const config: PyramidConfig = {
+    layers: [
+      { name: 'base', weight: 1, color: '#FFD700' },
+      { name: 'middle', weight: 0.618, color: '#FF8C00' },
+      { name: 'apex', weight: 0.382, color: '#FF4500' }
+    ]
+  };
+  fs.writeFileSync(path.resolve(output), JSON.stringify(config, null, 2));
+}
+
+if (require.main === module) {
+  const [, , file] = process.argv;
+  createDefaultPyramidConfig(file);
+  console.log('Created', file || 'pyramid.config.json');
+}


### PR DESCRIPTION
## Summary
- add `PyramidInit` CLI for generating a default pyramid config
- create unit test for the CLI
- record new task in advancedToDo YAML and JSON

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Vitest cannot be imported in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_686656e2f7988322ba5433a91cffb8d6