### PR TITLE
Add PyramidUtils helper functions

### DIFF
--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -16,3 +16,4 @@ export * from './hooks/useCREPManager';
 export * from './hooks/useCREPHistory';
 export { SymbolzeitManager } from '../aeon-shell/SymbolzeitManager';
 export { runCommand as AeonShellBridge } from '../aeon-shell/AeonShellBridge';
+export * from './utils/PyramidUtils';

--- a/packages/unifiedmandala-ui/utils/PyramidUtils.test.ts
+++ b/packages/unifiedmandala-ui/utils/PyramidUtils.test.ts
@@ -1,0 +1,13 @@
+import { generateLayer, mirrorLayers } from './PyramidUtils';
+
+test('generateLayer creates nodes', () => {
+  const layer = generateLayer(3, 'X');
+  expect(layer).toHaveLength(3);
+  expect(layer[0].symbol).toBe('X');
+});
+
+test('mirrorLayers flips y position', () => {
+  const layer = [{ position: [1, 2, 3] as [number, number, number], symbol: 'A' }];
+  const mirrored = mirrorLayers([layer]);
+  expect(mirrored[0][0].position).toEqual([1, -2, 3]);
+});

--- a/packages/unifiedmandala-ui/utils/PyramidUtils.ts
+++ b/packages/unifiedmandala-ui/utils/PyramidUtils.ts
@@ -1,0 +1,22 @@
+export interface PyramidNode {
+  position: [number, number, number];
+  symbol: string;
+}
+
+export type PyramidLayerNodes = PyramidNode[];
+
+export function generateLayer(size: number, symbol: string): PyramidLayerNodes {
+  return Array.from({ length: size }, (_, i) => ({
+    position: [i, i, 0],
+    symbol,
+  }));
+}
+
+export function mirrorLayers(layers: PyramidLayerNodes[]): PyramidLayerNodes[] {
+  return layers.map(layer =>
+    layer.map(node => ({
+      ...node,
+      position: [node.position[0], -node.position[1], node.position[2]],
+    }))
+  );
+}


### PR DESCRIPTION
## Summary
- add new utility module for pyramid components
- export new utilities
- add accompanying tests

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Vitest cannot be imported in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68679c1189c883228e097ae9d254ff75