### PR TITLE
Add plugin manifest generator

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,7 +1,7 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-03, in der Zeit des Morgen.
+Am 2025-07-04, in der Zeit des Morgen.
 
 Symbolphase: Initiation (Fokus: C)
 

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Update progress and todo after commit",
+  "lastCommit": "feat(scripts): add plugin manifest generator",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/scripts/__tests__/generate-plugin-manifest.test.ts
+++ b/scripts/__tests__/generate-plugin-manifest.test.ts
@@ -1,0 +1,12 @@
+import fs from 'fs';
+import path from 'path';
+const { generatePluginManifest } = require('../generate-plugin-manifest');
+
+test('generates combined plugin manifest', () => {
+  const out = path.join(__dirname, '../../plugins/test-manifest.yaml');
+  generatePluginManifest(out);
+  const text = fs.readFileSync(out, 'utf8');
+  expect(text).toContain('mandalaHaiku');
+  expect(text).toContain('poeticResonance');
+  fs.unlinkSync(out);
+});

--- a/scripts/generate-plugin-manifest.ts
+++ b/scripts/generate-plugin-manifest.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env ts-node
+import fs from 'fs';
+import path from 'path';
+import YAML from 'yaml';
+
+export function generatePluginManifest(outFile = path.join(__dirname, '../plugins/generated-manifest.yaml')): void {
+  const pluginsDir = path.join(__dirname, '../plugins');
+  const entries = fs.readdirSync(pluginsDir).filter((f) => {
+    const p = path.join(pluginsDir, f);
+    return fs.statSync(p).isDirectory();
+  });
+  const manifest: { plugins: any[] } = { plugins: [] };
+  for (const dir of entries) {
+    const mf = path.join(pluginsDir, dir, 'manifest.yaml');
+    if (!fs.existsSync(mf)) continue;
+    const data = YAML.parse(fs.readFileSync(mf, 'utf8')) as any;
+    manifest.plugins.push({
+      name: data.name,
+      version: data.version,
+      entry: path.relative(path.dirname(outFile), path.join(pluginsDir, dir, data.entry || 'index.js')),
+      description: data.description,
+      type: data.type,
+    });
+  }
+  fs.writeFileSync(outFile, YAML.stringify(manifest));
+}
+
+if (require.main === module) {
+  const [, , out] = process.argv;
+  generatePluginManifest(out);
+  console.log('Generated', out || 'plugins/generated-manifest.yaml');
+}


### PR DESCRIPTION
## Summary
- add a `generate-plugin-manifest` script and tests
- update progress artifacts via commit hooks

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Test Suites: 44 failed, 231 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6867a0055ee88322bbd663b0a064bcea