### PR TITLE
Add CODEX Pyramid Init Sigil todo

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -3593,5 +3593,12 @@
     "task": "Implement final planning instructions for Pyramid Suite",
     "test": "packages/cli-tools/PyramidInit.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Integrate CODEX Pyramid Init Sigil",
+    "path": "docs/sigils/newadvancedconversations.json",
+    "task": "Register CODEX-PYRAMID-INIT anchor and update planning meta",
+    "test": "packages/cli-tools/PyramidInit.test.ts",
+    "status": "todo"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -5449,3 +5449,8 @@
   task: Implement final planning instructions for Pyramid Suite
   test: packages/cli-tools/PyramidInit.test.ts
   status: done
+- commit: Integrate CODEX Pyramid Init Sigil
+  path: docs/sigils/newadvancedconversations.json
+  task: Register CODEX-PYRAMID-INIT anchor and update planning meta
+  test: packages/cli-tools/PyramidInit.test.ts
+  status: todo


### PR DESCRIPTION
## Summary
- update advancedToDo files with new CODEX-PYRAMID-INIT task from the latest planning blueprint

## Testing
- `pnpm test` *(fails: Vitest cannot be imported in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_6867d1166e048322b7ebfd484132195e