### PR TITLE
Add playCREPTone utility

### DIFF
--- a/packages/crep-engine/playCREPTone.test.ts
+++ b/packages/crep-engine/playCREPTone.test.ts
@@ -1,0 +1,15 @@
+import { playCREPTone } from './playCREPTone';
+
+test('plays tone at frequency', () => {
+  const start = jest.fn();
+  const stop = jest.fn();
+  const connect = jest.fn();
+  const oscillator = { frequency: { value: 0 }, connect, start, stop };
+  globalThis.AudioContext = function () {
+    return { createOscillator: () => oscillator, destination: {}, currentTime: 0 } as any;
+  } as any;
+  playCREPTone(2);
+  expect(oscillator.frequency.value).toBe(880);
+  expect(start).toHaveBeenCalled();
+  expect(stop).toHaveBeenCalled();
+});

--- a/packages/crep-engine/playCREPTone.ts
+++ b/packages/crep-engine/playCREPTone.ts
@@ -1,0 +1,9 @@
+export function playCREPTone(value: number) {
+  if (typeof window === 'undefined') return;
+  const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+  const osc = ctx.createOscillator();
+  osc.frequency.value = 440 * value;
+  osc.connect(ctx.destination);
+  osc.start();
+  osc.stop(ctx.currentTime + 0.2);
+}


### PR DESCRIPTION
## Summary
- implement `playCREPTone` in `crep-engine`
- add unit test for new utility

## Testing
- `pnpm exec jest`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68680005690c832292b977798a1f2b34