### PR TITLE
Add Sonification module and tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -3600,5 +3600,12 @@
     "task": "Register CODEX-PYRAMID-INIT anchor and update planning meta",
     "test": "packages/cli-tools/PyramidInit.test.ts",
     "status": "todo"
+  },
+  {
+    "commit": "Add Sonification module",
+    "path": "packages/visuals/Sonification.ts",
+    "task": "Provide playCREPTone function using Web Audio API",
+    "test": "packages/visuals/__tests__/Sonification.test.ts",
+    "status": "todo"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -5454,3 +5454,8 @@
   task: Register CODEX-PYRAMID-INIT anchor and update planning meta
   test: packages/cli-tools/PyramidInit.test.ts
   status: todo
+- commit: Add Sonification module
+  path: packages/visuals/Sonification.ts
+  task: Provide playCREPTone function using Web Audio API
+  test: packages/visuals/__tests__/Sonification.test.ts
+  status: todo

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #516 from GenesisAeon/codex/implementiere-ai-ui-suite-nach-blueprint",
+  "lastCommit": "feat: add Sonification module",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/packages/visuals/Sonification.ts
+++ b/packages/visuals/Sonification.ts
@@ -1,0 +1,9 @@
+export function playCREPTone(crep: number) {
+  const AudioCtx = (typeof window !== 'undefined' && (window.AudioContext || (window as any).webkitAudioContext)) || AudioContext;
+  const ctx = new AudioCtx();
+  const osc = ctx.createOscillator();
+  osc.frequency.value = 440 * crep;
+  osc.connect(ctx.destination);
+  osc.start();
+  osc.stop(ctx.currentTime + 1);
+}

--- a/packages/visuals/__tests__/Sonification.test.ts
+++ b/packages/visuals/__tests__/Sonification.test.ts
@@ -1,0 +1,12 @@
+import { playCREPTone } from '../Sonification';
+
+test('plays tone without throwing', () => {
+  globalThis.AudioContext = function () {
+    return {
+      createOscillator: () => ({ connect: jest.fn(), start: jest.fn(), stop: jest.fn(), frequency: { value: 0 } }),
+      destination: {},
+      currentTime: 0
+    } as any;
+  } as any;
+  playCREPTone(1);
+});

--- a/packages/visuals/index.ts
+++ b/packages/visuals/index.ts
@@ -1,1 +1,3 @@
 export * from './MandalaGraph';
+export * from './RealTimeCREPSonification';
+export * from './Sonification';


### PR DESCRIPTION
## Summary
- implement `playCREPTone` in new `Sonification` utility
- test tone playback with mock `AudioContext`
- export new module in visuals index
- track the task in advancedToDo lists

## Testing
- `pnpm install`
- `pnpm test` *(fails: Vitest cannot be imported in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_686803f55abc8322bd88b29dd327f374