### PR TITLE
feat(ui): extend PyramidConfig schema

### DIFF
--- a/packages/unifiedmandala-ui/pyramid/PyramidConfig.test.ts
+++ b/packages/unifiedmandala-ui/pyramid/PyramidConfig.test.ts
@@ -1,8 +1,15 @@
 import { loadPyramidConfig } from './PyramidConfig';
 
 test('loads valid config', () => {
-  const cfg = loadPyramidConfig({ layers: [{ name: 'base', weight: 1 }] });
+  const cfg = loadPyramidConfig({
+    layers: [{ name: 'base', weight: 1 }],
+    totalLayers: 1,
+    nodesPerLayer: 1,
+    weightFactors: { coherence: 1, resonance: 1, emergence: 1, poetics: 1 }
+  });
   expect(cfg.layers[0].name).toBe('base');
+  expect(cfg.totalLayers).toBe(1);
+  expect(cfg.weightFactors?.coherence).toBe(1);
 });
 
 test('throws on invalid config', () => {

--- a/packages/unifiedmandala-ui/pyramid/PyramidConfig.ts
+++ b/packages/unifiedmandala-ui/pyramid/PyramidConfig.ts
@@ -8,6 +8,17 @@ export interface PyramidLayer {
 
 export interface PyramidConfig {
   layers: PyramidLayer[];
+  /** total number of layers in the pyramid */
+  totalLayers?: number;
+  /** number of nodes per layer */
+  nodesPerLayer?: number;
+  /** weight factors used for CREP based computations */
+  weightFactors?: {
+    coherence: number;
+    resonance: number;
+    emergence: number;
+    poetics: number;
+  };
 }
 
 const schema = {
@@ -25,6 +36,19 @@ const schema = {
         required: ['name', 'weight'],
         additionalProperties: false
       }
+    },
+    totalLayers: { type: 'number' },
+    nodesPerLayer: { type: 'number' },
+    weightFactors: {
+      type: 'object',
+      properties: {
+        coherence: { type: 'number' },
+        resonance: { type: 'number' },
+        emergence: { type: 'number' },
+        poetics: { type: 'number' }
+      },
+      required: ['coherence', 'resonance', 'emergence', 'poetics'],
+      additionalProperties: false
     }
   },
   required: ['layers'],


### PR DESCRIPTION
## Summary
- extend `PyramidConfig` interface with `totalLayers`, `nodesPerLayer` and `weightFactors`
- update JSON schema accordingly
- cover new schema fields in tests

## Testing
- `pnpm test packages/unifiedmandala-ui/pyramid/PyramidConfig.test.ts`
- `pnpm lint`
- `pnpm test` *(fails: Vitest cannot be imported in CommonJS modules)*

------
https://chatgpt.com/codex/tasks/task_e_686806f22c70832285ee5ad5c784ab9f