### PR TITLE
Add PyramidWeighting module and update ToDos

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -3628,5 +3628,12 @@
     "task": "Provide fallback synthesizer and visual markers on audio errors",
     "test": "packages/visuals/__tests__/Sonification.test.ts",
     "status": "todo"
+  },
+  {
+    "commit": "feat: add PyramidWeighting module",
+    "path": "packages/unifiedmandala-ui/pyramid/PyramidWeighting.ts",
+    "task": "compute layer weights using PHI, PI and E constants",
+    "test": "packages/unifiedmandala-ui/pyramid/PyramidWeighting.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -5474,3 +5474,8 @@
   task: Provide fallback synthesizer and visual markers on audio errors
   test: packages/visuals/__tests__/Sonification.test.ts
   status: todo
+- commit: "feat: add PyramidWeighting module"
+  path: packages/unifiedmandala-ui/pyramid/PyramidWeighting.ts
+  task: compute layer weights using PHI, PI and E constants
+  test: packages/unifiedmandala-ui/pyramid/PyramidWeighting.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add Sonification module",
+  "lastCommit": "chore: sync todo files",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/packages/unifiedmandala-ui/pyramid/PyramidWeighting.test.ts
+++ b/packages/unifiedmandala-ui/pyramid/PyramidWeighting.test.ts
@@ -1,0 +1,9 @@
+import { generateWeights, PHI } from './PyramidWeighting';
+
+test('generateWeights returns increasing weights', () => {
+  const weights = generateWeights(3);
+  expect(weights.length).toBe(3);
+  expect(weights[1]).toBeGreaterThan(weights[0]);
+  expect(weights[2]).toBeGreaterThan(weights[1]);
+});
+

--- a/packages/unifiedmandala-ui/pyramid/PyramidWeighting.ts
+++ b/packages/unifiedmandala-ui/pyramid/PyramidWeighting.ts
@@ -1,0 +1,11 @@
+export const PHI = (1 + Math.sqrt(5)) / 2;
+
+export function generateWeights(totalLayers: number): number[] {
+  const weights: number[] = [];
+  const factor = Math.PI / Math.E;
+  for (let i = 0; i < totalLayers; i++) {
+    const weight = Math.pow(PHI, i) / factor;
+    weights.push(Number(weight.toFixed(6)));
+  }
+  return weights;
+}


### PR DESCRIPTION
## Summary
- implement `generateWeights` using PHI, PI and E
- test new weight generation
- document new task in advancedToDo lists
- record latest commit in progress tracking

## Testing
- `pnpm test`
- `pnpm test:agents`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68680cc6ed008322881ce9dca4482849