### PR TITLE
Extract fractal tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -3635,5 +3635,73 @@
     "task": "compute layer weights using PHI, PI and E constants",
     "test": "packages/unifiedmandala-ui/pyramid/PyramidWeighting.test.ts",
     "status": "done"
+  },
+  {
+    "sprint": "MetaScore",
+    "commit": "feat: implement AestheticsLayer and EthicsLayer modules",
+    "path": "packages/layers/",
+    "description": "Add AestheticsLayer.ts and EthicsLayer.ts to compute and emit layer scores",
+    "test_or_story": "packages/agents/__tests__/MetaScoreComposer.spec.ts; MetaScoreHeatmap.stories.tsx",
+    "responsible": "Core Team",
+    "dependencies": [],
+    "self_check": true
+  },
+  {
+    "sprint": "Collaboration",
+    "commit": "feat: add CollaborativeEditor and federation routes",
+    "path": "packages/unifiedmandala-ui/components/; packages/core/routes/federation.ts",
+    "description": "Implement collaborative markdown editor with Automerge and federation API endpoints",
+    "test_or_story": "CollaborativeEditor.story.tsx; SyncStatus component",
+    "responsible": "UI Team",
+    "dependencies": [
+      "MetaScore"
+    ],
+    "self_check": true
+  },
+  {
+    "sprint": "Federation",
+    "commit": "feat: implement Automerge-based federation and SyncStatus UI",
+    "path": "packages/core/routes/federation.ts; packages/unifiedmandala-ui/components/SyncStatus.tsx",
+    "description": "Add federation push/pull API and sync status indicator",
+    "test_or_story": "SyncStatus.story.tsx",
+    "responsible": "Integration Team",
+    "dependencies": [
+      "Collaboration"
+    ],
+    "self_check": true
+  },
+  {
+    "sprint": "MetaLearner",
+    "commit": "feat: add MetaLearnerAgent and scheduled GitHub Action",
+    "path": "packages/agents/MetaLearnerAgent.ts; .github/workflows/meta-learner.yml",
+    "description": "Implement agent to suggest layer weight optimizations and schedule periodic runs",
+    "test_or_story": "MetaLearnerAgent.spec.ts",
+    "responsible": "AI Team",
+    "dependencies": [
+      "MetaScore"
+    ],
+    "self_check": true
+  },
+  {
+    "sprint": "Security",
+    "commit": "chore: setup mTLS scripts and Kong JWT gateway",
+    "path": "scripts/gen-certs.sh; config/kong.yml",
+    "description": "Provide certificate generation and API gateway JWT configuration",
+    "test_or_story": "N/A",
+    "responsible": "DevOps Team",
+    "dependencies": [],
+    "self_check": true
+  },
+  {
+    "sprint": "UI",
+    "commit": "feat: integrate OpenTelemetry metrics and Storybook CI",
+    "path": "packages/core/tracing.ts; .github/workflows/storybook-deploy.yml",
+    "description": "Add tracing setup and deploy Storybook via GitHub Actions",
+    "test_or_story": "Tracing.story.tsx",
+    "responsible": "Ops Team",
+    "dependencies": [
+      "Security"
+    ],
+    "self_check": true
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -5479,3 +5479,59 @@
   task: compute layer weights using PHI, PI and E constants
   test: packages/unifiedmandala-ui/pyramid/PyramidWeighting.test.ts
   status: done
+- sprint: MetaScore
+  commit: "feat: implement AestheticsLayer and EthicsLayer modules"
+  path: packages/layers/
+  description: Add AestheticsLayer.ts and EthicsLayer.ts to compute and emit layer scores
+  test_or_story: packages/agents/__tests__/MetaScoreComposer.spec.ts;
+    MetaScoreHeatmap.stories.tsx
+  responsible: Core Team
+  dependencies: []
+  self_check: true
+- sprint: Collaboration
+  commit: "feat: add CollaborativeEditor and federation routes"
+  path: packages/unifiedmandala-ui/components/; packages/core/routes/federation.ts
+  description: Implement collaborative markdown editor with Automerge and
+    federation API endpoints
+  test_or_story: CollaborativeEditor.story.tsx; SyncStatus component
+  responsible: UI Team
+  dependencies:
+    - MetaScore
+  self_check: true
+- sprint: Federation
+  commit: "feat: implement Automerge-based federation and SyncStatus UI"
+  path: packages/core/routes/federation.ts;
+    packages/unifiedmandala-ui/components/SyncStatus.tsx
+  description: Add federation push/pull API and sync status indicator
+  test_or_story: SyncStatus.story.tsx
+  responsible: Integration Team
+  dependencies:
+    - Collaboration
+  self_check: true
+- sprint: MetaLearner
+  commit: "feat: add MetaLearnerAgent and scheduled GitHub Action"
+  path: packages/agents/MetaLearnerAgent.ts; .github/workflows/meta-learner.yml
+  description: Implement agent to suggest layer weight optimizations and schedule
+    periodic runs
+  test_or_story: MetaLearnerAgent.spec.ts
+  responsible: AI Team
+  dependencies:
+    - MetaScore
+  self_check: true
+- sprint: Security
+  commit: "chore: setup mTLS scripts and Kong JWT gateway"
+  path: scripts/gen-certs.sh; config/kong.yml
+  description: Provide certificate generation and API gateway JWT configuration
+  test_or_story: N/A
+  responsible: DevOps Team
+  dependencies: []
+  self_check: true
+- sprint: UI
+  commit: "feat: integrate OpenTelemetry metrics and Storybook CI"
+  path: packages/core/tracing.ts; .github/workflows/storybook-deploy.yml
+  description: Add tracing setup and deploy Storybook via GitHub Actions
+  test_or_story: Tracing.story.tsx
+  responsible: Ops Team
+  dependencies:
+    - Security
+  self_check: true

--- a/scripts/extract-fractal-todo.js
+++ b/scripts/extract-fractal-todo.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const YAML = require('yaml');
+
+const convFile = path.join(__dirname, '../docs/sigils/newadvancedconversations.json');
+const yamlFile = path.join(__dirname, '../advancedToDo.yaml');
+const jsonFile = path.join(__dirname, '../advancedToDo.json');
+
+const data = JSON.parse(fs.readFileSync(convFile, 'utf8'));
+let block = null;
+for (const conv of data) {
+  for (const node of Object.values(conv.mapping)) {
+    const part = node.message?.content?.parts?.[0]; if(typeof part!=="string") continue;
+    if (part && part.includes('advancedToDo.yaml')) {
+      const m = part.match(/```yaml[^`]*advancedToDo:[\s\S]*?```/);
+      if (m) { block = m[0]; break; }
+    }
+  }
+  if (block) break;
+}
+if (!block) {
+  console.error('No advancedToDo block found');
+  process.exit(1);
+}
+const yamlContent = block.replace(/```yaml\n?|```/g, '');
+let parsed;
+try {
+  parsed = YAML.parse(yamlContent);
+} catch (err) {
+  console.error('Failed to parse YAML:', err);
+  process.exit(1);
+}
+const newEntries = parsed.advancedToDo || [];
+function loadYaml(file){
+  if(fs.existsSync(file)) return YAML.parse(fs.readFileSync(file,'utf8'))||[];
+  return [];
+}
+function loadJson(file){
+  if(fs.existsSync(file)) return JSON.parse(fs.readFileSync(file,'utf8'))||[];
+  return [];
+}
+function merge(existing, add){
+  const commits=new Set(existing.map(e=>e.commit));
+  for(const e of add){
+    if(!commits.has(e.commit)){existing.push(e);commits.add(e.commit);}
+  }
+  return existing;
+}
+const yamlData=merge(loadYaml(yamlFile), JSON.parse(JSON.stringify(newEntries)));
+const jsonData=merge(loadJson(jsonFile), JSON.parse(JSON.stringify(newEntries)));
+fs.writeFileSync(yamlFile, YAML.stringify(yamlData));
+fs.writeFileSync(jsonFile, JSON.stringify(jsonData,null,2));
+console.log(`Appended ${newEntries.length} tasks to advancedToDo.`);


### PR DESCRIPTION
## Summary
- parse newadvancedconversations.json for `advancedToDo` entries
- append parsed tasks to advancedToDo lists
- add helper script `extract-fractal-todo.js`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Vitest cannot be imported in CommonJS modules)*

------
https://chatgpt.com/codex/tasks/task_e_68690c03e388832288cb0a68546537bf