### PR TITLE
Add fractal anchor tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -3859,5 +3859,103 @@
     "path": "",
     "task": "\"` erzeugt spontane `ReflectionNotice` |",
     "test": ""
+  },
+  {
+    "commit": "Add todoSigilUpdater module",
+    "path": "packages/shared-utils/todoSigilUpdater.ts",
+    "task": "Update status in ToDo Sigil files",
+    "test": "packages/shared-utils/todoSigilUpdater.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Add todoCommentScanner tool",
+    "path": "packages/shared-utils/todoCommentScanner.ts",
+    "task": "Scan repository for TODO comments and produce summary",
+    "test": "packages/shared-utils/todoCommentScanner.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Add conversationProgress tracker",
+    "path": "packages/agents/conversationProgress.ts",
+    "task": "Mark processed conversation fragments to avoid duplication",
+    "test": "packages/agents/__tests__/conversationProgress.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Extend selfAnalyzer module",
+    "path": "packages/shared-utils/selfAnalyzer.ts",
+    "task": "Provide repository statistics like file counts and test coverage",
+    "test": "packages/shared-utils/selfAnalyzer.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Create GespraechsfallGenerator utility",
+    "path": "packages/shared-utils/GespraechsfallGenerator.ts",
+    "task": "Generate conversation protocols from transcripts",
+    "test": "packages/shared-utils/GespraechsfallGenerator.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Implement loadSymbolphasen helper",
+    "path": "config/loadSymbolphasen.ts",
+    "task": "Read symbolphasen.yaml and expose phase data",
+    "test": "config/loadSymbolphasen.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Add simple RestClient module",
+    "path": "packages/shared-utils/RestClient.ts",
+    "task": "Provide minimal HTTP/HTTPS client for tests and scripts",
+    "test": "packages/shared-utils/RestClient.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Add todoSigilUpdater module",
+    "path": "packages/shared-utils/todoSigilUpdater.ts",
+    "task": "Update status in ToDo Sigil files",
+    "test": "packages/shared-utils/todoSigilUpdater.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Add todoCommentScanner tool",
+    "path": "packages/shared-utils/todoCommentScanner.ts",
+    "task": "Scan repository for TODO comments and produce summary",
+    "test": "packages/shared-utils/todoCommentScanner.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Add conversationProgress tracker",
+    "path": "packages/agents/conversationProgress.ts",
+    "task": "Mark processed conversation fragments to avoid duplication",
+    "test": "packages/agents/__tests__/conversationProgress.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Extend selfAnalyzer module",
+    "path": "packages/shared-utils/selfAnalyzer.ts",
+    "task": "Provide repository statistics like file counts and test coverage",
+    "test": "packages/shared-utils/selfAnalyzer.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Create GespraechsfallGenerator utility",
+    "path": "packages/shared-utils/GespraechsfallGenerator.ts",
+    "task": "Generate conversation protocols from transcripts",
+    "test": "packages/shared-utils/GespraechsfallGenerator.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Implement loadSymbolphasen helper",
+    "path": "config/loadSymbolphasen.ts",
+    "task": "Read symbolphasen.yaml and expose phase data",
+    "test": "config/loadSymbolphasen.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Add simple RestClient module",
+    "path": "packages/shared-utils/RestClient.ts",
+    "task": "Provide minimal HTTP/HTTPS client for tests and scripts",
+    "test": "packages/shared-utils/RestClient.test.ts",
+    "status": "todo"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -5846,3 +5846,38 @@
   path: ""
   task: '"` erzeugt spontane `ReflectionNotice` |'
   test: ""
+- commit: Add todoSigilUpdater module
+  path: packages/shared-utils/todoSigilUpdater.ts
+  task: Update status in ToDo Sigil files
+  test: packages/shared-utils/todoSigilUpdater.test.ts
+  status: todo
+- commit: Add todoCommentScanner tool
+  path: packages/shared-utils/todoCommentScanner.ts
+  task: Scan repository for TODO comments and produce summary
+  test: packages/shared-utils/todoCommentScanner.test.ts
+  status: todo
+- commit: Add conversationProgress tracker
+  path: packages/agents/conversationProgress.ts
+  task: Mark processed conversation fragments to avoid duplication
+  test: packages/agents/__tests__/conversationProgress.test.ts
+  status: todo
+- commit: Extend selfAnalyzer module
+  path: packages/shared-utils/selfAnalyzer.ts
+  task: Provide repository statistics like file counts and test coverage
+  test: packages/shared-utils/selfAnalyzer.test.ts
+  status: todo
+- commit: Create GespraechsfallGenerator utility
+  path: packages/shared-utils/GespraechsfallGenerator.ts
+  task: Generate conversation protocols from transcripts
+  test: packages/shared-utils/GespraechsfallGenerator.test.ts
+  status: todo
+- commit: Implement loadSymbolphasen helper
+  path: config/loadSymbolphasen.ts
+  task: Read symbolphasen.yaml and expose phase data
+  test: config/loadSymbolphasen.test.ts
+  status: todo
+- commit: Add simple RestClient module
+  path: packages/shared-utils/RestClient.ts
+  task: Provide minimal HTTP/HTTPS client for tests and scripts
+  test: packages/shared-utils/RestClient.test.ts
+  status: todo


### PR DESCRIPTION
## Summary
- append new modules from the aeon fractal anchor conversation to advancedToDo lists

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Vitest cannot be imported in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68691b0655ec832292f32f5e6f3f62e3