### PR TITLE
Add fractal anchor ToDos

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,7 +1,7 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-04, in der Zeit des Tag.
+Am 2025-07-05, in der Zeit des Tag.
 
 Symbolphase: Aktivierung (Fokus: R)
 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -3957,5 +3957,19 @@
     "task": "Provide minimal HTTP/HTTPS client for tests and scripts",
     "test": "packages/shared-utils/RestClient.test.ts",
     "status": "todo"
+  },
+  {
+    "commit": "Implement MetaRunner script for fractal tasks",
+    "path": "scripts/metaRunner.ts",
+    "task": "Run tasks recursively using fractal anchor reference",
+    "test": "scripts/__tests__/metaRunner.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Add MetaRunner blueprint YAML",
+    "path": "docs/sigils/metaRunnerBlueprint.yaml",
+    "task": "Outline structure for fractal task pipelines referenced by anchor",
+    "test": "",
+    "status": "todo"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -5881,3 +5881,13 @@
   task: Provide minimal HTTP/HTTPS client for tests and scripts
   test: packages/shared-utils/RestClient.test.ts
   status: todo
+- commit: Implement MetaRunner script for fractal tasks
+  path: scripts/metaRunner.ts
+  task: Run tasks recursively using fractal anchor reference
+  test: scripts/__tests__/metaRunner.test.ts
+  status: todo
+- commit: Add MetaRunner blueprint YAML
+  path: docs/sigils/metaRunnerBlueprint.yaml
+  task: Outline structure for fractal task pipelines referenced by anchor
+  test: ""
+  status: todo

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #525 from GenesisAeon/lew4y4-codex/erstelle-todos-aus-newadvancedconversations.json",
+  "lastCommit": "Add fractal anchor file and MetaRunner tasks",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/docs/sigils/aeon-2025-0705-fractal-anchor.yaml
+++ b/docs/sigils/aeon-2025-0705-fractal-anchor.yaml
@@ -1,0 +1,16 @@
+sigillin_id: aeon:2025-0705-FRACTAL-ANCHOR
+anchorType: "fractal-entry"
+update_time: "2025-07-05T14:00:00+02:00"
+responsible: "aeon"
+description: |
+  Dieses Sigil markiert den Einstiegspunkt für den Fraktallauf über mehrere MetaCommits.
+  - Extraktion und Abstraktion von ToDos im Repo
+  - Kombination vorhandener und neuer Technik für maximale Modernität
+  - Phasen:
+    1. Initiales Setup & Auslesen
+    2. Implementierung & Validierung
+    3. Optimierung, Fehleranalyse & Deployment
+context:
+  - "Repo: GenesisAeonAdvancedAi"
+  - "MetaCommit: recursive-task-runner"
+refLink: "docs/sigils/aeon-2025-0705-fractal-anchor.yaml"

--- a/docs/sigils/metaRunnerBlueprint.yaml
+++ b/docs/sigils/metaRunnerBlueprint.yaml
@@ -1,0 +1,8 @@
+fractal_anchor: aeon:2025-0705-FRACTAL-ANCHOR
+steps:
+  - id: scan-todos
+    desc: "scan repository and update ToDos"
+  - id: run-validators
+    desc: "execute lint and test steps"
+  - id: deploy-phase
+    desc: "deploy artifacts and update progress"


### PR DESCRIPTION
## Summary
- add fractal anchor sigil
- draft MetaRunner blueprint
- add MetaRunner tasks to advancedToDo lists
- update CHRONOPOEM and progress

## Testing
- `npx jest` *(fails: Vitest cannot be imported in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68692960c71c8322a82c9d0b8e4cc560