### PR TITLE
Add advanced tasks from fractal conversations

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4097,5 +4097,40 @@
     "task": "Configure Jest, Cypress and K8s manifests",
     "test": "tests/fractal-ci.test.ts",
     "status": "todo"
+  },
+  {
+    "commit": "Add AutoDocManifest generator script",
+    "path": "scripts/autoDocManifest.ts",
+    "task": "Generate docs and manifest from code comments",
+    "test": "scripts/__tests__/autoDocManifest.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Split advanced conversations into fragments",
+    "path": "scripts/split-advanced-conversations.js",
+    "task": "Split newadvancedconversations.json into conversation fragments",
+    "test": "scripts/__tests__/split-advanced-conversations.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Archive outdated tasks",
+    "path": "GenesisAeonZIPMEM/archived-todos",
+    "task": "Move solved TODOs and workflow docs to ZIPMEM archive",
+    "test": "",
+    "status": "todo"
+  },
+  {
+    "commit": "Create Sigilcards UI prototype",
+    "path": "packages/unifiedmandala-ui/components/SigilCard.tsx",
+    "task": "Render first Sigilcard for deployment planning",
+    "test": "packages/unifiedmandala-ui/components/SigilCard.test.tsx",
+    "status": "todo"
+  },
+  {
+    "commit": "Draft dev-agent system blueprint",
+    "path": "docs/agents/dev-agent-blueprint.md",
+    "task": "Describe dev-agent architecture and update codexwork.yaml",
+    "test": "",
+    "status": "todo"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -5981,3 +5981,28 @@
   task: Configure Jest, Cypress and K8s manifests
   test: tests/fractal-ci.test.ts
   status: todo
+- commit: Add AutoDocManifest generator script
+  path: scripts/autoDocManifest.ts
+  task: Generate docs and manifest from code comments
+  test: scripts/__tests__/autoDocManifest.test.ts
+  status: todo
+- commit: Split advanced conversations into fragments
+  path: scripts/split-advanced-conversations.js
+  task: Split newadvancedconversations.json into conversation fragments
+  test: scripts/__tests__/split-advanced-conversations.test.ts
+  status: todo
+- commit: Archive outdated tasks
+  path: GenesisAeonZIPMEM/archived-todos
+  task: Move solved TODOs and workflow docs to ZIPMEM archive
+  test: ""
+  status: todo
+- commit: Create Sigilcards UI prototype
+  path: packages/unifiedmandala-ui/components/SigilCard.tsx
+  task: Render first Sigilcard for deployment planning
+  test: packages/unifiedmandala-ui/components/SigilCard.test.tsx
+  status: todo
+- commit: Draft dev-agent system blueprint
+  path: docs/agents/dev-agent-blueprint.md
+  task: Describe dev-agent architecture and update codexwork.yaml
+  test: ""
+  status: todo


### PR DESCRIPTION
## Summary
- add new tasks derived from `newadvancedconversations.json`
- mirror entries in both JSON and YAML todo lists

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869513b97208322b2a6002de09ddbdc