### PR TITLE
Add Aeon Seal blueprint and autodoc tool

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-05, in der Zeit des Tag.
+Am 2025-07-05, in der Zeit des Abend.
 
-Symbolphase: Aktivierung (Fokus: R)
+Symbolphase: Integration (Fokus: E)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4145,27 +4145,27 @@
     "path": "packages/agents/ZIPMEMManagementAgent.ts",
     "task": "Map conversation fragments, detect links, and reorganize GenesisAeonZIPMEM",
     "test": "packages/agents/ZIPMEMManagementAgent.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add AeonSealAI integration blueprint",
     "path": "docs/aeon-seal-ai/blueprint.md",
     "task": "Outline SelfLearnAI Seal integration with GenesisAeon system",
     "test": "",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Expand pyramid blueprint docs",
     "path": "docs/blueprints/aeon-ui-pyramid.md",
     "task": "Add error management, performance, accessibility, config schema, testing and deployment sections",
     "test": "",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add autodoc generator script",
     "path": "scripts/autodoc-generator.js",
     "task": "Convert code comments to Markdown docs",
     "test": "scripts/__tests__/autodoc-generator.test.ts",
-    "status": "todo"
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6021,15 +6021,15 @@
   path: docs/aeon-seal-ai/blueprint.md
   task: Outline SelfLearnAI Seal integration with GenesisAeon system
   test: ""
-  status: todo
+  status: done
 - commit: Expand pyramid blueprint docs
   path: docs/blueprints/aeon-ui-pyramid.md
   task: Add error management, performance, accessibility, config schema, testing
     and deployment sections
   test: ""
-  status: todo
+  status: done
 - commit: Add autodoc generator script
   path: scripts/autodoc-generator.js
   task: Convert code comments to Markdown docs
   test: scripts/__tests__/autodoc-generator.test.ts
-  status: todo
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: update advanced todo from fractal anchor",
+  "lastCommit": "feat: add aeon seal blueprint and autodoc generator",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/docs/aeon-seal-ai/blueprint.md
+++ b/docs/aeon-seal-ai/blueprint.md
@@ -1,0 +1,13 @@
+# AeonSealAI Integration Blueprint
+
+This document outlines how the SelfLearnAI Seal connects with the GenesisAeon system.
+
+## Overview
+- Secure seal registration using Sigillin identifiers.
+- CREP engine hooks validate contributions.
+
+## Integration Steps
+1. Register the seal in `AeonSigillinVault`.
+2. Exchange keys via the Genesis API.
+3. Verify seal payloads during CREP evaluation.
+

--- a/docs/blueprints/aeon-ui-pyramid.md
+++ b/docs/blueprints/aeon-ui-pyramid.md
@@ -1,0 +1,23 @@
+# Aeon UI Pyramid Blueprint
+
+This blueprint expands the Pyramid UI planning with additional operational notes.
+
+## Error Management
+- Provide fallbacks when rendering fails.
+- Log audio errors via the Sonification module.
+
+## Performance
+- Measure FPS and load times via OpenTelemetry.
+
+## Accessibility
+- Use high-contrast colors and ARIA labels for interactive nodes.
+
+## Config Schema
+- Document `pyramid.config.yaml` defaults and options.
+
+## Testing
+- Add Vitest suites for hooks and Cypress end-to-end tests.
+
+## Deployment
+- Offer a Docker Compose setup for quick start.
+

--- a/scripts/__tests__/autodoc-generator.test.ts
+++ b/scripts/__tests__/autodoc-generator.test.ts
@@ -1,0 +1,14 @@
+import fs from 'fs';
+import path from 'path';
+import { generateDocs } from '../autodoc-generator';
+
+test('generates markdown from comments', () => {
+  const tmpSrc = path.join(__dirname, '__tmp.ts');
+  const outDir = path.join(__dirname, '__out');
+  fs.writeFileSync(tmpSrc, `/**\n * Example comment\n * second line\n */\nexport function x() {}`);
+  const outFile = generateDocs(tmpSrc, outDir);
+  const result = fs.readFileSync(outFile!, 'utf8');
+  expect(result).toContain('Example comment');
+  fs.rmSync(tmpSrc);
+  fs.rmSync(outDir, { recursive: true, force: true });
+});

--- a/scripts/autodoc-generator.js
+++ b/scripts/autodoc-generator.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+function extractComments(file) {
+  const content = fs.readFileSync(file, 'utf8');
+  const regex = /\/\*\*([\s\S]*?)\*\//g;
+  const docs = [];
+  let match;
+  while ((match = regex.exec(content))) {
+    const cleaned = match[1].split('\n').map(l => l.replace(/^\s*\* ?/, '')).join('\n').trim();
+    if (cleaned) docs.push(cleaned);
+  }
+  return docs.join('\n\n');
+}
+
+function generateDocs(file, outDir) {
+  const md = extractComments(file);
+  if (!md) return null;
+  const base = path.basename(file, path.extname(file));
+  const outFile = path.join(outDir, `${base}.md`);
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(outFile, md);
+  return outFile;
+}
+
+if (require.main === module) {
+  const [src, outDir = path.join('docs', 'autodoc')] = process.argv.slice(2);
+  if (!src) {
+    console.error('Usage: node autodoc-generator.js <file> [outDir]');
+    process.exit(1);
+  }
+  const out = generateDocs(src, outDir);
+  if (out) console.log('Generated', out);
+}
+
+module.exports = { generateDocs };


### PR DESCRIPTION
## Summary
- add AeonSealAI integration blueprint
- document extended Aeon UI pyramid notes
- create autodoc generator utility and tests
- mark related advanced tasks as done
- update progress logs

## Testing
- `pnpm install`
- `pnpm test` *(fails: Vitest cannot be imported, plus other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6869714f5ec4832297abe2435a4ecbe0