### PR TITLE
Add simple agent engine to universe simulation

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "Merge pull request #536 from GenesisAeon/codex/implementiere-neue-features-aus-advancedtodo",
-  "fractalStep": "implementiert",
+  "lastCommit": "chore(progress): finalize commit metadata",
+  "fractalStep": "sync",
   "openBranches": [
     "work"
   ],

--- a/simulations/universe-sim/pkg/agent/engine.go
+++ b/simulations/universe-sim/pkg/agent/engine.go
@@ -1,0 +1,50 @@
+package agent
+
+import (
+	core "github.com/GenesisAeon/unified-mandala/universe-sim/pkg/core"
+)
+
+// Event represents a simulation event triggered by an agent.
+type Event struct {
+	Name string
+}
+
+// Agent performs an action on the simulation state and returns an event.
+type Agent interface {
+	Act(s *core.State) Event
+}
+
+// Engine coordinates agents and applies their actions to the state.
+type Engine struct {
+	agents []Agent
+}
+
+// NewEngine creates a new Engine instance.
+func NewEngine(agents ...Agent) *Engine {
+	return &Engine{agents: agents}
+}
+
+// Step executes one step for all agents and returns produced events.
+func (e *Engine) Step(s *core.State) []Event {
+	events := make([]Event, len(e.agents))
+	for i, a := range e.agents {
+		events[i] = a.Act(s)
+	}
+	return events
+}
+
+// MoveAgent increases the position of the first entity by a fixed velocity.
+type MoveAgent struct {
+	VX, VY float64
+}
+
+// Act applies the movement to the first entity and returns an event.
+func (m MoveAgent) Act(s *core.State) Event {
+	if len(s.Entities) == 0 {
+		return Event{Name: "noop"}
+	}
+	e := &s.Entities[0]
+	e.Position.X += m.VX
+	e.Position.Y += m.VY
+	return Event{Name: "moved"}
+}

--- a/simulations/universe-sim/test/agent_rules_test.go
+++ b/simulations/universe-sim/test/agent_rules_test.go
@@ -1,0 +1,21 @@
+package test
+
+import (
+	"testing"
+
+	agent "github.com/GenesisAeon/unified-mandala/universe-sim/pkg/agent"
+	core "github.com/GenesisAeon/unified-mandala/universe-sim/pkg/core"
+)
+
+func TestMoveAgent(t *testing.T) {
+	s := core.NewState(1)
+	s.Entities[0].Velocity = core.Vector{X: 0, Y: 0}
+	eng := agent.NewEngine(agent.MoveAgent{VX: 1, VY: -1})
+	events := eng.Step(s)
+	if s.Entities[0].Position.X != 1 || s.Entities[0].Position.Y != -1 {
+		t.Fatalf("position not updated: %+v", s.Entities[0].Position)
+	}
+	if len(events) != 1 || events[0].Name != "moved" {
+		t.Fatalf("unexpected events: %+v", events)
+	}
+}


### PR DESCRIPTION
## Summary
- create `MoveAgent` and `Engine` for universe simulator
- add corresponding test
- keep progress metadata in sync

## Testing
- `pnpm lint` *(fails: Cannot find name 'organize')*
- `pnpm test` *(fails: multiple Vitest ESM import errors)*

------
https://chatgpt.com/codex/tasks/task_e_6869784d8fd08322b265c42c87c673ac