### PR TITLE
Add open tasks CLI command

### DIFF
--- a/packages/cli-tools/OpenTaskLister.test.ts
+++ b/packages/cli-tools/OpenTaskLister.test.ts
@@ -1,0 +1,11 @@
+import fs from 'fs';
+import { getOpenTasks } from './OpenTaskLister';
+
+test('getOpenTasks filters tasks with status todo', () => {
+  const tmp = 'tmp_open_tasks.yaml';
+  fs.writeFileSync(tmp, '- task: a\n  status: todo\n- task: b\n  status: done\n');
+  const tasks = getOpenTasks(tmp);
+  expect(tasks).toHaveLength(1);
+  expect(tasks[0].task).toBe('a');
+  fs.unlinkSync(tmp);
+});

--- a/packages/cli-tools/OpenTaskLister.ts
+++ b/packages/cli-tools/OpenTaskLister.ts
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import YAML from 'yaml';
+
+export interface AdvancedTodoEntry {
+  commit: string;
+  path: string;
+  task: string;
+  test?: string;
+  status?: string;
+}
+
+export function loadAdvancedTodo(file: string): AdvancedTodoEntry[] {
+  try {
+    const data = fs.readFileSync(file, 'utf8');
+    const list = YAML.parse(data);
+    return Array.isArray(list) ? (list as AdvancedTodoEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function getOpenTasks(file: string): AdvancedTodoEntry[] {
+  return loadAdvancedTodo(file).filter(t => t.status === 'todo');
+}

--- a/packages/cli-tools/README.md
+++ b/packages/cli-tools/README.md
@@ -6,5 +6,6 @@ Sammlung von Befehlen zur Arbeit mit Sigillin- und CREP-Daten.
 - **export-doc.js** – Exportiert CREP-Historie als Markdown
 - **sigillin-archive.js** – Erstellt poetisches Archiv aller Sigillin-Dateien
 - **sigillin-cli.js todo-sigil** – erzeugt `docs/sigils/todo-sigil.yaml` aus Aufgabenlisten
+- **sigillin-cli.js list-open-tasks** – listet offene Tasks aus `advancedToDo.yaml`
 
 - **SigillinValidator.ts** – Prüft eine Sigillin-Datei gegen das Schema

--- a/packages/cli-tools/sigillin-cli.js
+++ b/packages/cli-tools/sigillin-cli.js
@@ -144,6 +144,27 @@ program
   });
 
 program
+  .command('list-open-tasks [file]')
+  .description('Listet offene Tasks aus advancedToDo.yaml')
+  .action((file = '../../advancedToDo.yaml') => {
+    const path = require('path');
+    let getOpenTasks;
+    try {
+      ({ getOpenTasks } = require('../../dist/cli-tools/OpenTaskLister.js'));
+    } catch {
+      ({ getOpenTasks } = require('./OpenTaskLister'));
+    }
+    const todos = getOpenTasks(path.join(__dirname, file));
+    if (todos.length === 0) {
+      console.log('Keine offenen Aufgaben gefunden.');
+      return;
+    }
+    todos.forEach(t => {
+      console.log(`- ${t.task} (${t.path})`);
+    });
+  });
+
+program
   .command('grep-conversations <keyword>')
   .option('-o, --output <dir>', 'Zielordner', '../../docs/sigils/conversations')
   .description('Filtert conversations.json nach Stichwort')


### PR DESCRIPTION
## Summary
- list open tasks from advancedToDo.yaml via new `list-open-tasks` command
- implement helper `OpenTaskLister` and tests
- document command in CLI tools README

## Testing
- `pnpm lint`
- `pnpm test`
- `pyright` *(fails: missing modules)*
- `poetry install --with test` *(fails: no pyproject)*
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_686a71caf52483229f4092c9f5874eff