### PR TITLE
Extract new advanced ToDos

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: set todo extraction step",
+  "lastCommit": "Merge pull request #549 from GenesisAeon/zxw6lz-codex/extrahiere-und-implementiere-todos-für-fraktal-prozess",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/packages/agents/ZIPMEMManagementAgent.test.ts
+++ b/packages/agents/ZIPMEMManagementAgent.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { test, expect } from 'vitest';
 import { ZIPMEMManagementAgent, Fragment } from './ZIPMEMManagementAgent';
 
 test('organize writes fragments', () => {


### PR DESCRIPTION
## Summary
- extract todo entries from new advanced conversations
- fix missing vitest import in ZIPMEMManagementAgent test

## Testing
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_686a7f91b75083228e3a7589ebfc70e4