### PR TITLE
Add tasks from fractal conversations

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4461,5 +4461,40 @@
     "task": "Implement WebXR immersive experience for Pyramid UI",
     "test": "packages/unifiedmandala-ui/pyramid/PyramidVRView.test.tsx",
     "status": "todo"
+  },
+  {
+    "commit": "Setup Proto-Deploy infrastructure",
+    "path": "infrastructure/protodeploy",
+    "task": "Docker Compose config for local Aeon system",
+    "test": "scripts/protodeploy.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Validate TheoryAgentConfig with AJV",
+    "path": "packages/agents/TheoryAgentConfig.ts",
+    "task": "Add AJV schema & config validation logic",
+    "test": "packages/agents/TheoryAgentConfig.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Add SigilAlert integration",
+    "path": "packages/unifiedmandala-ui/components/SigilAlert.tsx",
+    "task": "Integrate SigilAlert UI component into main layout",
+    "test": "packages/unifiedmandala-ui/__tests__/SigilAlert.test.tsx",
+    "status": "todo"
+  },
+  {
+    "commit": "Setup CI pipeline with OTel Collector",
+    "path": ".github/workflows/ci.yml",
+    "task": "Add Docker and OTel pipeline for CosmicTheoryAgent",
+    "test": "ci/ci-pipeline.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Add Cypress E2E tests for SigilAlert",
+    "path": "packages/unifiedmandala-ui/tests/e2e",
+    "task": "Cypress flow for SigilAlert UI",
+    "test": "packages/unifiedmandala-ui/tests/e2e/sigilAlert.spec.ts",
+    "status": "todo"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6205,3 +6205,28 @@
   task: Implement WebXR immersive experience for Pyramid UI
   test: packages/unifiedmandala-ui/pyramid/PyramidVRView.test.tsx
   status: todo
+- commit: Setup Proto-Deploy infrastructure
+  path: infrastructure/protodeploy
+  task: Docker Compose config for local Aeon system
+  test: scripts/protodeploy.test.ts
+  status: todo
+- commit: Validate TheoryAgentConfig with AJV
+  path: packages/agents/TheoryAgentConfig.ts
+  task: Add AJV schema & config validation logic
+  test: packages/agents/TheoryAgentConfig.test.ts
+  status: todo
+- commit: Add SigilAlert integration
+  path: packages/unifiedmandala-ui/components/SigilAlert.tsx
+  task: Integrate SigilAlert UI component into main layout
+  test: packages/unifiedmandala-ui/__tests__/SigilAlert.test.tsx
+  status: todo
+- commit: Setup CI pipeline with OTel Collector
+  path: .github/workflows/ci.yml
+  task: Add Docker and OTel pipeline for CosmicTheoryAgent
+  test: ci/ci-pipeline.test.ts
+  status: todo
+- commit: Add Cypress E2E tests for SigilAlert
+  path: packages/unifiedmandala-ui/tests/e2e
+  task: Cypress flow for SigilAlert UI
+  test: packages/unifiedmandala-ui/tests/e2e/sigilAlert.spec.ts
+  status: todo

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "Add CosmicTheoryAgent sigil and update fractal metadata",
-  "fractalStep": "todo-extracted",
+  "lastCommit": "Normalize progress file",
+  "fractalStep": "sync",
   "openBranches": [
     "work"
   ],


### PR DESCRIPTION
## Summary
- parse new conversation file for todo items
- update advancedToDo.yaml and advancedToDo.json with extracted tasks
- refresh fractal progress metadata

## Testing
- `pyright`
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686a85bab6f883228c316bd38aea53ca