### PR TITLE
Add offline compose docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,18 @@ festzulegen.
 Damit werden mehrere Node.js-Worker über Port 80 erreichbar und WebSocket-
 Verbindungen durchgereicht.
 
+## 📴 Offline Setup
+
+Eine kompakte Docker-Compose-Datei für Offline-Tests findest du unter `docs/offline/docker-compose.yml`. Damit lassen sich UI und Agent ohne Netzwerkzugriff starten.
+
+```bash
+cd docs/offline
+docker compose up
+```
+
+UI läuft danach auf http://localhost:3000, der Agent auf http://localhost:4000.
+
+
 ## 🌀 Mandala-Poesie und Automation
 
 Verwende `./scripts/aeon.sh <command>` für alle CLI-Aufrufe.

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4537,7 +4537,7 @@
     "path": "docs/offline/docker-compose.yml",
     "task": "Provide local stack for Aeon services",
     "test": "",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Draft AeonUniversal DSL grammar",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6259,7 +6259,7 @@
   path: docs/offline/docker-compose.yml
   task: Provide local stack for Aeon services
   test: ""
-  status: todo
+  status: done
 - commit: Draft AeonUniversal DSL grammar
   path: docs/AeonUniversalDSL.md
   task: Document DSL syntax and compiler hooks

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,9 +1,8 @@
 {
-  "lastCommit": "chore: extract tasks from conversations",
-  "fractalStep": "todo-update",
+  "lastCommit": "docs: add offline compose",
+  "fractalStep": "implementation",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": []
 }
-

--- a/docs/offline/docker-compose.yml
+++ b/docs/offline/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+services:
+  ui:
+    build:
+      context: ../../
+      dockerfile: Dockerfile.dev
+    command: pnpm dev
+    ports:
+      - "3000:3000"
+    volumes:
+      - ../../:/workspace/unified-mandala
+  agent:
+    build:
+      context: ../../
+      dockerfile: Dockerfile.dev
+    command: pnpm dev
+    environment:
+      - PORT=4000
+    ports:
+      - "4000:4000"
+    volumes:
+      - ../../:/workspace/unified-mandala


### PR DESCRIPTION
## Summary
- add offline docker compose config for local tests
- document offline setup in README
- mark offline compose todo as done
- record progress in advancedprogress

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686aa06c6ef083229caab4de7244da7f