### PR TITLE
Add fetchCosmicData utility to CosmicTheoryAgent

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@react-three/fiber": "^9.1.4",
     "ajv": "^8.0.0",
     "ajv-formats": "^3.0.1",
+    "axios": "^1.10.0",
     "chokidar": "^3.5.3",
     "commander": "^11.0.0",
     "d3": "^7.8.5",

--- a/packages/agents/CosmicTheoryAgent.ts
+++ b/packages/agents/CosmicTheoryAgent.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+export async function fetchCosmicData(url: string): Promise<any> {
+  try {
+    const response = await axios.get(url);
+    return response.data;
+  } catch (err) {
+    console.error('Failed to fetch cosmic data', err);
+    throw err;
+  }
+}
+

--- a/packages/agents/__tests__/CosmicTheoryAgent.spec.ts
+++ b/packages/agents/__tests__/CosmicTheoryAgent.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect, vi } from 'vitest';
+import axios from 'axios';
+import { fetchCosmicData } from '../CosmicTheoryAgent';
+
+vi.mock('axios');
+
+describe('fetchCosmicData', () => {
+  it('throws on network error', async () => {
+    (axios.get as any).mockRejectedValueOnce(new Error('Network Error'));
+    await expect(fetchCosmicData('http://example.com')).rejects.toThrow('Network Error');
+  });
+});
+

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -49,3 +49,4 @@ export * from "./AeonRustTranspilerAgent";
 export * from "./AeonJsTranspilerAgent";
 export * from './AeonAuraAgent';
 export * from './AeonMembraneAgent';
+export * from './CosmicTheoryAgent';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.17.1)
+      axios:
+        specifier: ^1.10.0
+        version: 1.10.0
       chokidar:
         specifier: ^3.5.3
         version: 3.6.0
@@ -1651,6 +1654,9 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
+  axios@1.10.0:
+    resolution: {integrity: sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==}
+
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
 
@@ -2547,6 +2553,15 @@ packages:
 
   focus-trap@6.9.4:
     resolution: {integrity: sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==}
+
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -6160,6 +6175,14 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
+  axios@1.10.0:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.3
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   b4a@1.6.7: {}
 
   babel-jest@29.7.0(@babel/core@7.27.4):
@@ -7128,6 +7151,8 @@ snapshots:
   focus-trap@6.9.4:
     dependencies:
       tabbable: 5.3.3
+
+  follow-redirects@1.15.9: {}
 
   foreground-child@3.3.1:
     dependencies:


### PR DESCRIPTION
## Summary
- add axios as dependency
- implement `fetchCosmicData` async API helper
- export `fetchCosmicData` from agents index
- include tests for network error handling

## Testing
- `pnpm test:agents`

------
https://chatgpt.com/codex/tasks/task_e_686ab85863488322942c72ace91254d2