### PR TITLE
Add cosmic theory extraction tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4678,5 +4678,40 @@
     "task": "Save mood and archetype info per memory entry",
     "test": "GenesisAeonAdvancedAi/test_memory_store.py",
     "status": "todo"
+  },
+  {
+    "commit": "Add CosmicDataLoader module",
+    "path": "packages/data/CosmicDataLoader.ts",
+    "task": "Provide functions to load CMB maps and neutrino flux data",
+    "test": "packages/data/CosmicDataLoader.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Add FractalAnalyzer utilities",
+    "path": "packages/analysis/FractalAnalyzer.ts",
+    "task": "Implement fractalDecompose and metric helpers",
+    "test": "packages/analysis/FractalAnalyzer.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Implement SymbolicRegression module",
+    "path": "packages/analysis/SymbolicRegression.ts",
+    "task": "Generate candidate formulas via symbolic regression",
+    "test": "packages/analysis/SymbolicRegression.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Add CosmicTheoryAgentEvents definitions",
+    "path": "packages/agents/CosmicTheoryAgentEvents.ts",
+    "task": "Define event types and tracing metadata for CosmicTheoryAgent",
+    "test": "packages/agents/CosmicTheoryAgentEvents.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Create CosmicTheoryPanel component",
+    "path": "packages/unifiedmandala-ui/components/CosmicTheoryPanel.tsx",
+    "task": "Display generated cosmic formulas in UI panel",
+    "test": "packages/unifiedmandala-ui/components/CosmicTheoryPanel.test.tsx",
+    "status": "todo"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6365,3 +6365,28 @@
   task: Save mood and archetype info per memory entry
   test: GenesisAeonAdvancedAi/test_memory_store.py
   status: todo
+- commit: Add CosmicDataLoader module
+  path: packages/data/CosmicDataLoader.ts
+  task: Provide functions to load CMB maps and neutrino flux data
+  test: packages/data/CosmicDataLoader.test.ts
+  status: todo
+- commit: Add FractalAnalyzer utilities
+  path: packages/analysis/FractalAnalyzer.ts
+  task: Implement fractalDecompose and metric helpers
+  test: packages/analysis/FractalAnalyzer.test.ts
+  status: todo
+- commit: Implement SymbolicRegression module
+  path: packages/analysis/SymbolicRegression.ts
+  task: Generate candidate formulas via symbolic regression
+  test: packages/analysis/SymbolicRegression.test.ts
+  status: todo
+- commit: Add CosmicTheoryAgentEvents definitions
+  path: packages/agents/CosmicTheoryAgentEvents.ts
+  task: Define event types and tracing metadata for CosmicTheoryAgent
+  test: packages/agents/CosmicTheoryAgentEvents.test.ts
+  status: todo
+- commit: Create CosmicTheoryPanel component
+  path: packages/unifiedmandala-ui/components/CosmicTheoryPanel.tsx
+  task: Display generated cosmic formulas in UI panel
+  test: packages/unifiedmandala-ui/components/CosmicTheoryPanel.test.tsx
+  status: todo

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: add analysis todos",
+  "lastCommit": "chore: add cosmic theory tasks",
   "fractalStep": "sync",
   "openBranches": [
     "work"


### PR DESCRIPTION
## Summary
- extract CosmicTheoryAgent ToDos from conversations
- append tasks for cosmic modules and UI panel
- update progress tracking

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686ae2e41a28832297516ad2493538ea