### PR TITLE
Implement symbolic regression and CREP circle

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-06, in der Zeit des Abend.
+Am 2025-07-07, in der Zeit des Morgen.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4740,14 +4740,14 @@
     "path": "packages/agents/CosmicTheoryAgent.ts",
     "task": "Add fractal decomposition and SymbolicRegression modules",
     "test": "packages/agents/__tests__/CosmicTheoryAgent.spec.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add MandalaCREPCircle component",
     "path": "packages/unifiedmandala-ui/components/MandalaCREPCircle.tsx",
     "task": "Visualize CREP values as circular arc chart",
     "test": "packages/unifiedmandala-ui/components/MandalaCREPCircle.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add MetricsDashboard component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6409,12 +6409,12 @@
   path: packages/agents/CosmicTheoryAgent.ts
   task: Add fractal decomposition and SymbolicRegression modules
   test: packages/agents/__tests__/CosmicTheoryAgent.spec.ts
-  status: todo
+  status: done
 - commit: Add MandalaCREPCircle component
   path: packages/unifiedmandala-ui/components/MandalaCREPCircle.tsx
   task: Visualize CREP values as circular arc chart
   test: packages/unifiedmandala-ui/components/MandalaCREPCircle.test.tsx
-  status: todo
+  status: done
 - commit: Add MetricsDashboard component
   path: packages/unifiedmandala-ui/components/MetricsDashboard.tsx
   task: Recharts dashboard showing CREP metrics

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "add zip analysis script",
-  "fractalStep": "implement",
+  "lastCommit": "chore: sync progress metadata",
+  "fractalStep": "sync",
   "openBranches": [
     "work"
   ],

--- a/packages/agents/CosmicTheoryAgent.ts
+++ b/packages/agents/CosmicTheoryAgent.ts
@@ -1,4 +1,6 @@
 import axios from 'axios';
+import { fractalDecompose, computeFractalMetric } from '../analysis/FractalAnalyzer';
+import { symbolicRegression } from '../analysis/SymbolicRegression';
 
 export async function fetchCosmicData(url: string): Promise<any> {
   try {
@@ -8,5 +10,11 @@ export async function fetchCosmicData(url: string): Promise<any> {
     console.error('Failed to fetch cosmic data', err);
     throw err;
   }
+}
+
+export function analyzeCosmicData(values: number[]): string {
+  const fragments = values.flatMap(v => fractalDecompose(v));
+  const metric = computeFractalMetric(fragments);
+  return symbolicRegression([metric]);
 }
 

--- a/packages/agents/CosmicTheoryAgentEvents.test.ts
+++ b/packages/agents/CosmicTheoryAgentEvents.test.ts
@@ -1,3 +1,4 @@
+import { test, expect } from 'vitest';
 import { CosmicTheoryEventHub } from './CosmicTheoryAgentEvents';
 
 test('emit and receive events', () => {

--- a/packages/agents/__tests__/CosmicTheoryAgent.spec.ts
+++ b/packages/agents/__tests__/CosmicTheoryAgent.spec.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, test } from 'vitest';
 import axios from 'axios';
-import { fetchCosmicData } from '../CosmicTheoryAgent';
+import { fetchCosmicData, analyzeCosmicData } from '../CosmicTheoryAgent';
 
 vi.mock('axios');
 
@@ -9,5 +9,10 @@ describe('fetchCosmicData', () => {
     (axios.get as any).mockRejectedValueOnce(new Error('Network Error'));
     await expect(fetchCosmicData('http://example.com')).rejects.toThrow('Network Error');
   });
+});
+
+test('analyzes cosmic values', () => {
+  const result = analyzeCosmicData([4]);
+  expect(result).toBe('y = 2.0');
 });
 

--- a/packages/unifiedmandala-ui/components/MandalaCREPCircle.test.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaCREPCircle.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MandalaCREPCircle from './MandalaCREPCircle';
+
+test('renders svg element', () => {
+  const { container } = render(<MandalaCREPCircle value={5} />);
+  expect(container.querySelector('svg')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/MandalaCREPCircle.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaCREPCircle.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { RadialBarChart, RadialBar } from 'recharts';
+
+interface MandalaCREPCircleProps {
+  value: number;
+  max?: number;
+}
+
+const MandalaCREPCircle: React.FC<MandalaCREPCircleProps> = ({ value, max = 10 }) => {
+  const data = [{ name: 'CREP', value }];
+  return (
+    <RadialBarChart width={200} height={200} innerRadius="80%" outerRadius="100%" data={data}>
+      <RadialBar dataKey="value" fill="#8884d8" cornerRadius={10} />
+    </RadialBarChart>
+  );
+};
+
+export default MandalaCREPCircle;

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -14,6 +14,7 @@ export { default as LogbuchPanel } from './components/LogbuchPanel';
 export { default as SigillinOverlay } from './components/SigillinOverlay';
 export * from './hooks/useCREPManager';
 export * from './hooks/useCREPHistory';
+export { default as MandalaCREPCircle } from './components/MandalaCREPCircle';
 export { SymbolzeitManager } from '../aeon-shell/SymbolzeitManager';
 export { runCommand as AeonShellBridge } from '../aeon-shell/AeonShellBridge';
 export * from './utils/PyramidUtils';


### PR DESCRIPTION
## Summary
- integrate symbolic regression logic into `CosmicTheoryAgent`
- add new `MandalaCREPCircle` chart component
- export new component via UI package index
- extend CosmicTheoryAgent tests and add CREPCircle tests
- mark corresponding tasks as done in advancedToDo files
- update CHRONOPOEM and progress metadata

## Testing
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_686bacf4470c8322a7f2feac0ee6f2d2