### PR TITLE
Implement conversationProgress tracker

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -3865,98 +3865,98 @@
     "path": "packages/shared-utils/todoSigilUpdater.ts",
     "task": "Update status in ToDo Sigil files",
     "test": "packages/shared-utils/todoSigilUpdater.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add todoCommentScanner tool",
     "path": "packages/shared-utils/todoCommentScanner.ts",
     "task": "Scan repository for TODO comments and produce summary",
     "test": "packages/shared-utils/todoCommentScanner.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add conversationProgress tracker",
     "path": "packages/agents/conversationProgress.ts",
     "task": "Mark processed conversation fragments to avoid duplication",
     "test": "packages/agents/__tests__/conversationProgress.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Extend selfAnalyzer module",
     "path": "packages/shared-utils/selfAnalyzer.ts",
     "task": "Provide repository statistics like file counts and test coverage",
     "test": "packages/shared-utils/selfAnalyzer.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Create GespraechsfallGenerator utility",
     "path": "packages/shared-utils/GespraechsfallGenerator.ts",
     "task": "Generate conversation protocols from transcripts",
     "test": "packages/shared-utils/GespraechsfallGenerator.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Implement loadSymbolphasen helper",
     "path": "config/loadSymbolphasen.ts",
     "task": "Read symbolphasen.yaml and expose phase data",
     "test": "config/loadSymbolphasen.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add simple RestClient module",
     "path": "packages/shared-utils/RestClient.ts",
     "task": "Provide minimal HTTP/HTTPS client for tests and scripts",
     "test": "packages/shared-utils/RestClient.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add todoSigilUpdater module",
     "path": "packages/shared-utils/todoSigilUpdater.ts",
     "task": "Update status in ToDo Sigil files",
     "test": "packages/shared-utils/todoSigilUpdater.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add todoCommentScanner tool",
     "path": "packages/shared-utils/todoCommentScanner.ts",
     "task": "Scan repository for TODO comments and produce summary",
     "test": "packages/shared-utils/todoCommentScanner.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add conversationProgress tracker",
     "path": "packages/agents/conversationProgress.ts",
     "task": "Mark processed conversation fragments to avoid duplication",
     "test": "packages/agents/__tests__/conversationProgress.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Extend selfAnalyzer module",
     "path": "packages/shared-utils/selfAnalyzer.ts",
     "task": "Provide repository statistics like file counts and test coverage",
     "test": "packages/shared-utils/selfAnalyzer.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Create GespraechsfallGenerator utility",
     "path": "packages/shared-utils/GespraechsfallGenerator.ts",
     "task": "Generate conversation protocols from transcripts",
     "test": "packages/shared-utils/GespraechsfallGenerator.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Implement loadSymbolphasen helper",
     "path": "config/loadSymbolphasen.ts",
     "task": "Read symbolphasen.yaml and expose phase data",
     "test": "config/loadSymbolphasen.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add simple RestClient module",
     "path": "packages/shared-utils/RestClient.ts",
     "task": "Provide minimal HTTP/HTTPS client for tests and scripts",
     "test": "packages/shared-utils/RestClient.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Implement MetaRunner script for fractal tasks",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -5860,27 +5860,27 @@
   path: packages/agents/conversationProgress.ts
   task: Mark processed conversation fragments to avoid duplication
   test: packages/agents/__tests__/conversationProgress.test.ts
-  status: todo
+  status: done
 - commit: Extend selfAnalyzer module
   path: packages/shared-utils/selfAnalyzer.ts
   task: Provide repository statistics like file counts and test coverage
   test: packages/shared-utils/selfAnalyzer.test.ts
-  status: todo
+  status: done
 - commit: Create GespraechsfallGenerator utility
   path: packages/shared-utils/GespraechsfallGenerator.ts
   task: Generate conversation protocols from transcripts
   test: packages/shared-utils/GespraechsfallGenerator.test.ts
-  status: todo
+  status: done
 - commit: Implement loadSymbolphasen helper
   path: config/loadSymbolphasen.ts
   task: Read symbolphasen.yaml and expose phase data
   test: config/loadSymbolphasen.test.ts
-  status: todo
+  status: done
 - commit: Add simple RestClient module
   path: packages/shared-utils/RestClient.ts
   task: Provide minimal HTTP/HTTPS client for tests and scripts
   test: packages/shared-utils/RestClient.test.ts
-  status: todo
+  status: done
 - commit: Implement MetaRunner script for fractal tasks
   path: scripts/metaRunner.ts
   task: Run tasks recursively using fractal anchor reference

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: sync progress metadata",
+  "lastCommit": "feat: implement conversationProgress and update ToDo statuses",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/packages/agents/__tests__/conversationProgress.test.ts
+++ b/packages/agents/__tests__/conversationProgress.test.ts
@@ -1,0 +1,18 @@
+import fs from 'fs';
+import path from 'path';
+import { markProcessed, isProcessed } from '../conversationProgress';
+import { describe, it, expect, afterEach } from 'vitest';
+
+const STORE = path.resolve('GenesisAeonZIPMEM/conversation_progress.json');
+
+afterEach(() => {
+  if (fs.existsSync(STORE)) fs.unlinkSync(STORE);
+});
+
+describe('conversationProgress', () => {
+  it('records and checks processed ids', () => {
+    markProcessed('frag1');
+    expect(isProcessed('frag1')).toBe(true);
+    expect(isProcessed('other')).toBe(false);
+  });
+});

--- a/packages/agents/conversationProgress.ts
+++ b/packages/agents/conversationProgress.ts
@@ -1,0 +1,28 @@
+import fs from 'fs';
+import path from 'path';
+
+const STORE_PATH = path.resolve('GenesisAeonZIPMEM/conversation_progress.json');
+
+export interface ProgressState {
+  processed: string[];
+}
+
+export function loadProgress(): ProgressState {
+  if (fs.existsSync(STORE_PATH)) {
+    return JSON.parse(fs.readFileSync(STORE_PATH, 'utf8')) as ProgressState;
+  }
+  return { processed: [] };
+}
+
+export function markProcessed(id: string): void {
+  const state = loadProgress();
+  if (!state.processed.includes(id)) {
+    state.processed.push(id);
+    fs.writeFileSync(STORE_PATH, JSON.stringify(state, null, 2), 'utf8');
+  }
+}
+
+export function isProcessed(id: string): boolean {
+  const state = loadProgress();
+  return state.processed.includes(id);
+}


### PR DESCRIPTION
## Summary
- add `conversationProgress` agent utility with persistence
- test the new progress tracker
- update statuses in `advancedToDo` files to reflect completed utilities
- record progress metadata

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686bb1a698f883229fdead38c272c76a