### PR TITLE
Add FourierLayer analysis module

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4762,5 +4762,26 @@
     "task": "Move completed ToDos to GenesisAeonZIPMEM",
     "test": "scripts/__tests__/autoArchiveTodos_test.py",
     "status": "todo"
+  },
+  {
+    "commit": "Add FourierLayer plugin",
+    "path": "packages/analysis/FourierLayer.ts",
+    "task": "Implement Fourier-based emergence analyzer",
+    "test": "packages/analysis/FourierLayer.test.ts",
+    "status": "done"
+  },
+  {
+    "commit": "Add FourierLayerConfig schema",
+    "path": "packages/analysis/fourier-layer-config.json",
+    "task": "JSON schema for FourierLayer configuration",
+    "test": "packages/analysis/FourierLayer.test.ts",
+    "status": "done"
+  },
+  {
+    "commit": "Add createFourierLayerTree utility",
+    "path": "packages/analysis/createFourierLayerTree.ts",
+    "task": "Build FourierLayer tree from inputs",
+    "test": "packages/analysis/createFourierLayerTree.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6425,3 +6425,18 @@
   task: Move completed ToDos to GenesisAeonZIPMEM
   test: scripts/__tests__/autoArchiveTodos_test.py
   status: todo
+- commit: Add FourierLayer plugin
+  path: packages/analysis/FourierLayer.ts
+  task: Implement Fourier-based emergence analyzer
+  test: packages/analysis/FourierLayer.test.ts
+  status: done
+- commit: Add FourierLayerConfig schema
+  path: packages/analysis/fourier-layer-config.json
+  task: JSON schema for FourierLayer configuration
+  test: packages/analysis/FourierLayer.test.ts
+  status: done
+- commit: Add createFourierLayerTree utility
+  path: packages/analysis/createFourierLayerTree.ts
+  task: Build FourierLayer tree from inputs
+  test: packages/analysis/createFourierLayerTree.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: implement conversationProgress and update ToDo statuses",
+  "lastCommit": "feat: add FourierLayer module",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/packages/analysis/FourierLayer.test.ts
+++ b/packages/analysis/FourierLayer.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { FourierLayer } from './FourierLayer';
+
+describe('FourierLayer', () => {
+  it('computes amplitude metrics', () => {
+    const layer = new FourierLayer('L1', 1, [1, 0, -1, 0], { depth: 1 });
+    const metrics = layer.analyze();
+    expect(metrics.maxAmplitude).toBeGreaterThan(0);
+    expect(metrics.avgAmplitude).toBeGreaterThan(0);
+  });
+});

--- a/packages/analysis/FourierLayer.ts
+++ b/packages/analysis/FourierLayer.ts
@@ -1,0 +1,49 @@
+export interface FourierLayerConfig {
+  depth: number;
+  threshold?: number;
+}
+
+export interface EmergenceMetrics {
+  maxAmplitude: number;
+  avgAmplitude: number;
+}
+
+export class FourierLayer {
+  id: string;
+  level: number;
+  weight: number;
+  private threshold: number;
+  private data: number[];
+
+  constructor(id: string, level: number, data: number[], config: FourierLayerConfig) {
+    this.id = id;
+    this.level = level;
+    this.threshold = config.threshold ?? 0.1;
+    this.weight = data.length / (config.depth || 1);
+    this.data = data;
+  }
+
+  private dft(): [number, number][] {
+    const N = this.data.length;
+    const result: [number, number][] = [];
+    for (let k = 0; k < N; k++) {
+      let real = 0;
+      let imag = 0;
+      for (let n = 0; n < N; n++) {
+        const angle = (2 * Math.PI * k * n) / N;
+        real += this.data[n] * Math.cos(angle);
+        imag -= this.data[n] * Math.sin(angle);
+      }
+      result.push([real, imag]);
+    }
+    return result;
+  }
+
+  analyze(): EmergenceMetrics {
+    const phasors = this.dft();
+    const amps = phasors.map(([re, im]) => Math.hypot(re, im));
+    const maxAmplitude = Math.max(...amps);
+    const avgAmplitude = amps.reduce((a, b) => a + b, 0) / amps.length;
+    return { maxAmplitude, avgAmplitude };
+  }
+}

--- a/packages/analysis/createFourierLayerTree.test.ts
+++ b/packages/analysis/createFourierLayerTree.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { createFourierLayerTree } from './createFourierLayerTree';
+
+describe('createFourierLayerTree', () => {
+  it('creates child layers', () => {
+    const tree = createFourierLayerTree([[1,2],[3,4]], { depth: 1 });
+    expect(tree.children.length).toBe(2);
+  });
+});

--- a/packages/analysis/createFourierLayerTree.ts
+++ b/packages/analysis/createFourierLayerTree.ts
@@ -1,0 +1,12 @@
+import { FourierLayer, FourierLayerConfig } from './FourierLayer';
+
+export interface LayerNode {
+  id: string;
+  children: FourierLayer[];
+}
+
+export function createFourierLayerTree(inputs: number[][], config: FourierLayerConfig): LayerNode {
+  const root: LayerNode = { id: 'root', children: [] };
+  root.children = inputs.map((arr, i) => new FourierLayer(`F-L${i}`, 1, arr, config));
+  return root;
+}

--- a/packages/analysis/fourier-layer-config.json
+++ b/packages/analysis/fourier-layer-config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "FourierLayerConfig",
+  "type": "object",
+  "properties": {
+    "depth": { "type": "integer", "minimum": 1 },
+    "threshold": { "type": "number", "minimum": 0 }
+  },
+  "required": ["depth"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- implement FourierLayer with DFT
- create createFourierLayerTree helper
- add JSON schema for FourierLayer config
- add unit tests
- record tasks in advancedToDo files
- update progress tracker

## Testing
- `pnpm install`
- `npm run test:agents`
- `pyright` *(fails: multiple missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686c1f7fdba08322bf321fa65045b1e4