### PR TITLE
feat: add MetricsDashboard component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4750,11 +4750,11 @@
     "status": "done"
   },
   {
-    "commit": "Add MetricsDashboard component",
-    "path": "packages/unifiedmandala-ui/components/MetricsDashboard.tsx",
-    "task": "Recharts dashboard showing CREP metrics",
-    "test": "packages/unifiedmandala-ui/components/MetricsDashboard.test.tsx",
-    "status": "todo"
+  "commit": "Add MetricsDashboard component",
+  "path": "packages/unifiedmandala-ui/components/MetricsDashboard.tsx",
+  "task": "Recharts dashboard showing CREP metrics",
+  "test": "packages/unifiedmandala-ui/components/MetricsDashboard.test.tsx",
+  "status": "done"
   },
   {
     "commit": "Add auto archive script",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6419,7 +6419,7 @@
   path: packages/unifiedmandala-ui/components/MetricsDashboard.tsx
   task: Recharts dashboard showing CREP metrics
   test: packages/unifiedmandala-ui/components/MetricsDashboard.test.tsx
-  status: todo
+  status: done
 - commit: Add auto archive script
   path: scripts/autoArchiveTodos.py
   task: Move completed ToDos to GenesisAeonZIPMEM

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add FourierLayer module",
+  "lastCommit": "feat: add MetricsDashboard component",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/packages/analysis/FourierLayer.test.ts
+++ b/packages/analysis/FourierLayer.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from 'vitest';
 import { FourierLayer } from './FourierLayer';
 
 describe('FourierLayer', () => {

--- a/packages/analysis/createFourierLayerTree.test.ts
+++ b/packages/analysis/createFourierLayerTree.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from 'vitest';
 import { createFourierLayerTree } from './createFourierLayerTree';
 
 describe('createFourierLayerTree', () => {

--- a/packages/unifiedmandala-ui/components/MetricsDashboard.test.tsx
+++ b/packages/unifiedmandala-ui/components/MetricsDashboard.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MetricsDashboard from './MetricsDashboard';
+
+jest.mock('../hooks/useMetaScores', () => ({
+  useMetaScores: () => [{ layer: 'alpha', score: 0.8 }]
+}));
+
+test('renders metrics line chart', () => {
+  render(<MetricsDashboard />);
+  expect(screen.getByText('alpha')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/MetricsDashboard.tsx
+++ b/packages/unifiedmandala-ui/components/MetricsDashboard.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
+import { useMetaScores } from '../hooks/useMetaScores';
+
+const MetricsDashboard: React.FC = () => {
+  const data = useMetaScores();
+  return (
+    <LineChart width={500} height={300} data={data}>
+      <CartesianGrid stroke="#ccc" />
+      <XAxis dataKey="layer" />
+      <YAxis domain={[0, 1]} />
+      <Tooltip />
+      <Line type="monotone" dataKey="score" stroke="#82ca9d" />
+    </LineChart>
+  );
+};
+
+export default MetricsDashboard;


### PR DESCRIPTION
## Summary
- implement new MetricsDashboard component and tests
- update FourierLayer tests for jest
- mark MetricsDashboard task as done and log progress

## Testing
- `pyright`
- `poetry install --with test` *(fails: pyproject missing)*
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686c2370bdfc83229146e961881d203a