### PR TITLE
feat: add RL weight adjustment to CosmicTheoryAgent

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4173,7 +4173,7 @@
     "path": "packages/agents/CosmicTheoryAgent.ts",
     "task": "Implement reinforcement learning policy update",
     "test": "packages/agents/CosmicTheoryAgent.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add mutation crossover for CosmicTheoryAgent",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6037,7 +6037,7 @@
   path: packages/agents/CosmicTheoryAgent.ts
   task: Implement reinforcement learning policy update
   test: packages/agents/CosmicTheoryAgent.test.ts
-  status: todo
+  status: done
 - commit: Add mutation crossover for CosmicTheoryAgent
   path: packages/agents/CosmicTheoryAgent.ts
   task: Evolve weighting formulas via mutation and crossover

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add MetricsDashboard component",
+  "lastCommit": "feat: add RL weight adjustment for CosmicTheoryAgent",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/packages/agents/CosmicTheoryAgent.test.ts
+++ b/packages/agents/CosmicTheoryAgent.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { adjustWeights, AgentWeights } from './CosmicTheoryAgent';
+
+describe('adjustWeights', () => {
+  it('increases weights with positive reward', () => {
+    const w: AgentWeights = { coherence: 0.5, resonance: 0.5, emergence: 0.5 };
+    const metrics: AgentWeights = { coherence: 0.8, resonance: 0.2, emergence: 0.4 };
+    const result = adjustWeights(w, metrics, 1, 0.1);
+    expect(result.coherence).toBeGreaterThan(w.coherence);
+  });
+
+  it('clamps weights between 0 and 1', () => {
+    const w: AgentWeights = { coherence: 0.95, resonance: 0.95, emergence: 0.95 };
+    const metrics: AgentWeights = { coherence: 1, resonance: 1, emergence: 1 };
+    const result = adjustWeights(w, metrics, 1, 1);
+    expect(result.coherence).toBeLessThanOrEqual(1);
+    expect(result.coherence).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/agents/CosmicTheoryAgent.ts
+++ b/packages/agents/CosmicTheoryAgent.ts
@@ -2,6 +2,30 @@ import axios from 'axios';
 import { fractalDecompose, computeFractalMetric } from '../analysis/FractalAnalyzer';
 import { symbolicRegression } from '../analysis/SymbolicRegression';
 
+export interface AgentWeights {
+  coherence: number;
+  resonance: number;
+  emergence: number;
+}
+
+export function adjustWeights(
+  weights: AgentWeights,
+  metrics: AgentWeights,
+  reward: number,
+  lr = 0.1
+): AgentWeights {
+  const updated: AgentWeights = {
+    coherence: clamp(weights.coherence + lr * reward * metrics.coherence, 0, 1),
+    resonance: clamp(weights.resonance + lr * reward * metrics.resonance, 0, 1),
+    emergence: clamp(weights.emergence + lr * reward * metrics.emergence, 0, 1)
+  };
+  return updated;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
 export async function fetchCosmicData(url: string): Promise<any> {
   try {
     const response = await axios.get(url);


### PR DESCRIPTION
## Summary
- implement adjustable RL weights for `CosmicTheoryAgent`
- provide `CosmicTheoryAgent` unit test using vitest
- mark RL weight adjustment task as done in advanced ToDo lists
- update progress tracking

## Testing
- `pnpm test` *(fails: jest not found)*
- `npx vitest run packages/agents/CosmicTheoryAgent.test.ts` *(fails: need to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_686c360152d88322bd274e9215144cf0