### PR TITLE
Implement mutation crossover for CosmicTheoryAgent

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-07, in der Zeit des Morgen.
+Am 2025-07-07, in der Zeit des Abend.
 
-Symbolphase: Initiation (Fokus: C)
+Symbolphase: Integration (Fokus: E)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4180,7 +4180,7 @@
     "path": "packages/agents/CosmicTheoryAgent.ts",
     "task": "Evolve weighting formulas via mutation and crossover",
     "test": "packages/agents/CosmicTheoryAgent.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add trace context events",
@@ -4750,18 +4750,18 @@
     "status": "done"
   },
   {
-  "commit": "Add MetricsDashboard component",
-  "path": "packages/unifiedmandala-ui/components/MetricsDashboard.tsx",
-  "task": "Recharts dashboard showing CREP metrics",
-  "test": "packages/unifiedmandala-ui/components/MetricsDashboard.test.tsx",
-  "status": "done"
+    "commit": "Add MetricsDashboard component",
+    "path": "packages/unifiedmandala-ui/components/MetricsDashboard.tsx",
+    "task": "Recharts dashboard showing CREP metrics",
+    "test": "packages/unifiedmandala-ui/components/MetricsDashboard.test.tsx",
+    "status": "done"
   },
   {
-  "commit": "Add auto archive script",
-  "path": "scripts/autoArchiveTodos.py",
-  "task": "Move completed ToDos to GenesisAeonZIPMEM",
-  "test": "scripts/__tests__/autoArchiveTodos_test.py",
-  "status": "done"
+    "commit": "Add auto archive script",
+    "path": "scripts/autoArchiveTodos.py",
+    "task": "Move completed ToDos to GenesisAeonZIPMEM",
+    "test": "scripts/__tests__/autoArchiveTodos_test.py",
+    "status": "done"
   },
   {
     "commit": "Add FourierLayer plugin",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6042,7 +6042,7 @@
   path: packages/agents/CosmicTheoryAgent.ts
   task: Evolve weighting formulas via mutation and crossover
   test: packages/agents/CosmicTheoryAgent.test.ts
-  status: todo
+  status: done
 - commit: Add trace context events
   path: packages/agents/CosmicTheoryAgentEvents.ts
   task: Define events with trace metadata for cosmic agent

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add RL weight adjustment for CosmicTheoryAgent",
+  "lastCommit": "chore: update progress",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/packages/agents/CosmicTheoryAgent.test.ts
+++ b/packages/agents/CosmicTheoryAgent.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { adjustWeights, AgentWeights } from './CosmicTheoryAgent';
+import { adjustWeights, mutateWeights, crossoverWeights, AgentWeights } from './CosmicTheoryAgent';
 
 describe('adjustWeights', () => {
   it('increases weights with positive reward', () => {
@@ -15,5 +15,23 @@ describe('adjustWeights', () => {
     const result = adjustWeights(w, metrics, 1, 1);
     expect(result.coherence).toBeLessThanOrEqual(1);
     expect(result.coherence).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('mutation and crossover', () => {
+  it('mutateWeights stays within range', () => {
+    const w: AgentWeights = { coherence: 0.5, resonance: 0.5, emergence: 0.5 };
+    const mutated = mutateWeights(w, 0.2);
+    expect(mutated.coherence).toBeGreaterThanOrEqual(0);
+    expect(mutated.coherence).toBeLessThanOrEqual(1);
+  });
+
+  it('crossoverWeights picks values from parents', () => {
+    const a: AgentWeights = { coherence: 0.1, resonance: 0.2, emergence: 0.3 };
+    const b: AgentWeights = { coherence: 0.9, resonance: 0.8, emergence: 0.7 };
+    const child = crossoverWeights(a, b);
+    expect([a.coherence, b.coherence]).toContain(child.coherence);
+    expect([a.resonance, b.resonance]).toContain(child.resonance);
+    expect([a.emergence, b.emergence]).toContain(child.emergence);
   });
 });

--- a/packages/agents/CosmicTheoryAgent.ts
+++ b/packages/agents/CosmicTheoryAgent.ts
@@ -22,6 +22,28 @@ export function adjustWeights(
   return updated;
 }
 
+export function mutateWeights(
+  weights: AgentWeights,
+  rate = 0.1
+): AgentWeights {
+  return {
+    coherence: clamp(weights.coherence + (Math.random() * 2 - 1) * rate, 0, 1),
+    resonance: clamp(weights.resonance + (Math.random() * 2 - 1) * rate, 0, 1),
+    emergence: clamp(weights.emergence + (Math.random() * 2 - 1) * rate, 0, 1)
+  };
+}
+
+export function crossoverWeights(
+  a: AgentWeights,
+  b: AgentWeights
+): AgentWeights {
+  return {
+    coherence: Math.random() < 0.5 ? a.coherence : b.coherence,
+    resonance: Math.random() < 0.5 ? a.resonance : b.resonance,
+    emergence: Math.random() < 0.5 ? a.emergence : b.emergence
+  };
+}
+
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }


### PR DESCRIPTION
## Summary
- implement mutation/crossover helpers for CosmicTheoryAgent
- test weight mutation and crossover
- mark mutation/crossover task done in advancedToDo files
- update progress

## Testing
- `pnpm install`
- `pnpm test:agents`
- `pyright packages/agents/CosmicTheoryAgent.ts` *(fails: import resolution errors)*
- `poetry install --with test` *(fails: no pyproject)*

------
https://chatgpt.com/codex/tasks/task_e_686c3b62e7b8832287974660e61ebdb2