### PR TITLE
Implement docs and sonification update

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -12,6 +12,9 @@ Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 Das Pendant zum Genesis ZIPMEM ist die Datei `advancedconversations.json`.
 Ergänzende Ausschnitte landen unter `GenesisAeonZIPMEM/<Chat>`.
 Pitch-Beispiele für Events sind unter `docs/pitch/` abgelegt.
+Weitere Hinweise aus dem „Sigil Übergang“:
+- Offline-Nutzung über [localhost-offline](localhost-offline)
+- Siehe Agenten-Mapping-Blueprint in [docs/architecture/AgentMappingBlueprint.md](docs/architecture/AgentMappingBlueprint.md)
 
 > **TL;DR**
 > - Installation: `./scripts/setup-unifiedmandala.sh`

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ narrative Interfaces und adaptive Bewusstseinsräume.
 Schau auch ins [Glossar](docs/glossar-genesis.md) für Begriffe.
 Einen Überblick über die Agenten bietet [docs/architecture/agent-system.md](docs/architecture/agent-system.md).
 Strategische Leitlinien stehen in [docs/agents/AgentStrategy.md](docs/agents/AgentStrategy.md).
+Weitere Hinweise aus dem „Sigil Übergang“:
+- Lokales Offline-Paket in [localhost-offline](localhost-offline)
+- Blueprint für UI/Agenten-Mapping siehe [AgentMappingBlueprint](docs/architecture/AgentMappingBlueprint.md)
 
 ## 🚀 Features
 

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: update progress",
+  "lastCommit": "chore: refresh progress",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/docs/architecture/AgentMappingBlueprint.md
+++ b/docs/architecture/AgentMappingBlueprint.md
@@ -1,1 +1,22 @@
 # Agent Mapping Blueprint
+
+Dieses Dokument fasst die Beziehung zwischen den wichtigsten UI-Modulen und den zugehörigen Agenten zusammen. Grundlage sind die Gespräche aus dem Sigil-Übergang.
+
+## UI Komponenten
+- **PyramidView** – visualisiert die CREP-Pyramide und spiegelt Symbolzeit.
+- **AgentHeatmap** – zeigt aktuelle Agenten-Aktivität.
+- **MetricsDashboard** – fasst CREP- und Sigillin-Metriken zusammen.
+
+## Agenten
+- **CodexNavigatorAgent** – steuert Pfadwechsel anhand der Sigillin-Konfiguration.
+- **QualityAssuranceAgent** – prüft Tests und Linting-Ergebnisse.
+- **PatternReactivator** – reaktiviert Muster bei niedrigem CREP.
+
+## Beziehungen
+| UI Modul | Agent | Zweck |
+|----------|-------|-------|
+| `PyramidView` | `GenesisAeonNavigator` | Phase-Wechsel über CREP-Werte |
+| `AgentHeatmap` | `AgentCoordinator` | Priorisierung laufender Agenten |
+| `MetricsDashboard` | `DepthBundleExporter` | Exportiert Sigillin- und CREP-Daten |
+
+Weitere Details finden sich in den Gesprächen "Aeon - Sigil Übergang und Kontext".

--- a/packages/visuals/Sonification.ts
+++ b/packages/visuals/Sonification.ts
@@ -8,6 +8,7 @@ export function playCREPTone(crep: number) {
     ctx = new AudioCtx();
   } catch (err) {
     console.warn('Audio context init failed, using fallback tone', err);
+    showErrorMarker();
     return fallbackTone(crep);
   }
   try {
@@ -18,6 +19,7 @@ export function playCREPTone(crep: number) {
     osc.stop(ctx.currentTime + 1);
   } catch (err) {
     console.error('Sonification error', err);
+    showErrorMarker();
     fallbackTone(crep);
   }
 }
@@ -25,5 +27,26 @@ export function playCREPTone(crep: number) {
 export function fallbackTone(crep: number) {
   if (typeof console !== 'undefined') {
     console.log('fallback tone', crep);
+  }
+}
+
+export function showErrorMarker() {
+  if (typeof document === 'undefined') return;
+  let el = document.getElementById('sonification-error');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'sonification-error';
+    el.style.position = 'fixed';
+    el.style.bottom = '10px';
+    el.style.right = '10px';
+    el.style.background = 'rgba(255,0,0,0.8)';
+    el.style.color = '#fff';
+    el.style.padding = '4px 8px';
+    el.style.zIndex = '1000';
+    el.textContent = 'Audio error';
+    document.body.appendChild(el);
+    setTimeout(() => {
+      el && el.remove();
+    }, 2000);
   }
 }

--- a/packages/visuals/__tests__/Sonification.test.ts
+++ b/packages/visuals/__tests__/Sonification.test.ts
@@ -1,4 +1,4 @@
-import { playCREPTone, fallbackTone } from '../Sonification';
+import { playCREPTone, fallbackTone, showErrorMarker } from '../Sonification';
 
 test('plays tone without throwing', () => {
   globalThis.AudioContext = function () {
@@ -21,4 +21,11 @@ test('uses fallback when AudioContext fails', () => {
   playCREPTone(0.5);
   expect(spy).toHaveBeenCalled();
   globalThis.AudioContext = orig;
+});
+
+test('showErrorMarker adds element', () => {
+  document.body.innerHTML = '';
+  showErrorMarker();
+  const el = document.getElementById('sonification-error');
+  expect(el).not.toBeNull();
 });


### PR DESCRIPTION
## Summary
- add error marker overlay in Sonification module and test
- document UI↔agent mapping blueprint
- apply transition feedback to README and Handbuch
- refresh advanced progress

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686c3e3380388322a3b41d5c69e47df2