### PR TITLE
Implement memory metadata and update progress

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-07, in der Zeit des Abend.
+Am 2025-07-07, in der Zeit des Nacht.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Reflexion (Fokus: P)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/GenesisAeonAdvancedAi/memory_store.py
+++ b/GenesisAeonAdvancedAi/memory_store.py
@@ -8,7 +8,10 @@ import statistics
 
 
 def store_result(result: Dict[str, Any], path: Path) -> None:
-    """Append result to a JSON list stored at path."""
+    """Append result to a JSON list stored at path.
+
+    Ensures ``mood`` and ``archetype`` metadata are present.
+    """
     if path.exists():
         try:
             data = json.loads(path.read_text())
@@ -19,6 +22,8 @@ def store_result(result: Dict[str, Any], path: Path) -> None:
 
     entry = dict(result)
     entry.setdefault("timestamp", time.time())
+    entry.setdefault("mood", "neutral")
+    entry.setdefault("archetype", "unknown")
     data.append(entry)
     path.write_text(json.dumps(data, indent=2))
 

--- a/GenesisAeonAdvancedAi/test_memory_store.py
+++ b/GenesisAeonAdvancedAi/test_memory_store.py
@@ -29,6 +29,26 @@ class TestMemoryStore(unittest.TestCase):
         self.assertEqual(len(data), 2)
         path.unlink()
 
+    def test_metadata_defaults(self):
+        path = pathlib.Path('temp_meta.json')
+        if path.exists():
+            path.unlink()
+        store_result({'x': 42}, path)
+        data = load_results(path)
+        self.assertEqual(data[0]['mood'], 'neutral')
+        self.assertEqual(data[0]['archetype'], 'unknown')
+        path.unlink()
+
+    def test_metadata_custom(self):
+        path = pathlib.Path('temp_meta.json')
+        if path.exists():
+            path.unlink()
+        store_result({'x': 1, 'mood': 'happy', 'archetype': 'hero'}, path)
+        data = load_results(path)
+        self.assertEqual(data[0]['mood'], 'happy')
+        self.assertEqual(data[0]['archetype'], 'hero')
+        path.unlink()
+
     def test_load_results(self):
         path = pathlib.Path('temp_mem.json')
         if path.exists():

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1398,13 +1398,15 @@
     "commit": "Create ResonanceAudioVisualizer",
     "path": "packages/visuals/ResonanceAudioVisualizer.ts",
     "task": "Map resonance data to audiovisual output",
-    "test": "packages/visuals/ResonanceAudioVisualizer.test.ts"
+    "test": "packages/visuals/ResonanceAudioVisualizer.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add RealTimeCREPSonification",
     "path": "packages/visuals/RealTimeCREPSonification.ts",
     "task": "Sonify CREP values in real time",
-    "test": "packages/visuals/RealTimeCREPSonification.test.ts"
+    "test": "packages/visuals/RealTimeCREPSonification.test.ts",
+    "status": "done"
   },
   {
     "commit": "Introduce CREPInsightDashboard",
@@ -3627,7 +3629,7 @@
     "path": "packages/visuals/Sonification.ts",
     "task": "Provide fallback synthesizer and visual markers on audio errors",
     "test": "packages/visuals/__tests__/Sonification.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "feat: add PyramidWeighting module",
@@ -4719,14 +4721,14 @@
     "path": "docs/architecture/AgentMappingBlueprint.md",
     "task": "Document UI and agent relationships from transition chat",
     "test": "",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Apply README and Handbuch feedback",
     "path": "README.md; Handbuch.md",
     "task": "Integrate structure and usability updates from Sigil Übergang chat",
     "test": "",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Create ZIP analysis script",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -5458,22 +5458,22 @@
   path: packages/visuals/Sonification.ts
   task: Provide playCREPTone function using Web Audio API
   test: packages/visuals/__tests__/Sonification.test.ts
-  status: todo
+  status: done
 - commit: Implement weighted node generation
   path: packages/unifiedmandala-ui/utils/PyramidUtils.ts
   task: Calculate node weights using phi, pi and e constants
   test: packages/unifiedmandala-ui/utils/PyramidUtils.test.ts
-  status: todo
+  status: done
 - commit: Add ARIA labels for PyramidView
   path: packages/unifiedmandala-ui/components/PyramidView.tsx
   task: Improve accessibility by adding ARIA labels and color contrast checks
   test: packages/unifiedmandala-ui/components/PyramidView.a11y.test.tsx
-  status: todo
+  status: done
 - commit: Add fallback audio and error markers
   path: packages/visuals/Sonification.ts
   task: Provide fallback synthesizer and visual markers on audio errors
   test: packages/visuals/__tests__/Sonification.test.ts
-  status: todo
+  status: done
 - commit: "feat: add PyramidWeighting module"
   path: packages/unifiedmandala-ui/pyramid/PyramidWeighting.ts
   task: compute layer weights using PHI, PI and E constants
@@ -6394,12 +6394,12 @@
   path: docs/architecture/AgentMappingBlueprint.md
   task: Document UI and agent relationships from transition chat
   test: ""
-  status: todo
+  status: done
 - commit: Apply README and Handbuch feedback
   path: README.md; Handbuch.md
   task: Integrate structure and usability updates from Sigil Übergang chat
   test: ""
-  status: todo
+  status: done
 - commit: Create ZIP analysis script
   path: scripts/analyze_zip.py
   task: Extract GenesisAeonAdvancedAi.zip and create summary


### PR DESCRIPTION
## Summary
- extend memory store with mood and archetype defaults
- add tests for new metadata
- update advanced todo statuses for completed UI and documentation tasks
- refresh chronopoem and progress tracker

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686c416a95c08322af196f80c0bd7bd9