### PR TITLE
Add JSONL logger for universe sim

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: refresh progress",
+  "lastCommit": "feat: add JSONL logger",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/simulations/universe-sim/pkg/logger/logger.go
+++ b/simulations/universe-sim/pkg/logger/logger.go
@@ -1,0 +1,31 @@
+package logger
+
+import (
+	"encoding/json"
+	"os"
+)
+
+type JSONLLogger struct {
+	file *os.File
+}
+
+func NewJSONLLogger(path string) (*JSONLLogger, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return nil, err
+	}
+	return &JSONLLogger{file: f}, nil
+}
+
+func (l *JSONLLogger) Close() error {
+	return l.file.Close()
+}
+
+func (l *JSONLLogger) Log(v interface{}) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	_, err = l.file.Write(append(b, '\n'))
+	return err
+}

--- a/simulations/universe-sim/pkg/logger/pipeline.go
+++ b/simulations/universe-sim/pkg/logger/pipeline.go
@@ -1,0 +1,24 @@
+package logger
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+)
+
+func ProcessJSONL(path string, cb func(map[string]interface{})) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		var v map[string]interface{}
+		if err := json.Unmarshal(line, &v); err == nil {
+			cb(v)
+		}
+	}
+	return scanner.Err()
+}

--- a/simulations/universe-sim/test/logger_test.go
+++ b/simulations/universe-sim/test/logger_test.go
@@ -1,0 +1,34 @@
+package test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/GenesisAeon/unified-mandala/universe-sim/pkg/logger"
+)
+
+func TestJSONLLogger(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	l, err := logger.NewJSONLLogger(path)
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+	if err := l.Log(map[string]string{"event": "start"}); err != nil {
+		t.Fatalf("log failed: %v", err)
+	}
+	l.Close()
+
+	var got []string
+	err = logger.ProcessJSONL(path, func(m map[string]interface{}) {
+		if e, ok := m["event"].(string); ok {
+			got = append(got, e)
+		}
+	})
+	if err != nil {
+		t.Fatalf("process failed: %v", err)
+	}
+	if len(got) != 1 || got[0] != "start" {
+		t.Fatalf("unexpected events %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- implement logger with JSONL output and processing pipeline for universe sim
- add tests for logger
- update progress record

## Testing
- `go test ./...`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c447323cc8322a1f32c1f89f90f44