### PR TITLE
Implement ProtoDeploy setup and documentation

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-07, in der Zeit des Abend.
+Am 2025-07-08, in der Zeit des Morgen.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -47,6 +47,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - `CREPBewertungsmodul` – Berechnet Score und Klassifizierung aus C,R,E,P
 - `TodoPriority` – Verknüpft Aufgaben mit CREP-Scores.
 - `CalendarSync` – Exportiert priorisierte ToDos als Kalenderereignisse.
+- `FourierLayer` – Bewertet Emergenz via Diskreter Fourier-Analyse.
 
 ### gpt-bridges
 - `GPTEventHub` – Zentrales Event-System zwischen GPT-Modulen.
@@ -332,6 +333,10 @@ npm install   # oder: yarn install
 npm run build # oder: yarn build
 npm run dev   # oder: yarn dev
 ```
+## 🐳 ProtoDeploy
+Nutze `scripts/protodeploy.sh up` für einen lokalen Docker-Start.
+Die Compose-Datei findet sich unter `infrastructure/protodeploy/docker-compose.yml`.
+
 
 ## QA-Workflow
 Führe `pnpm run qa` aus, um Linting und Tests zu starten. Das Skript `scripts/qa-test-runner.ts` erstellt im Projektstamm die Datei `qa-report.log`.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**MandalaNetworkView**](packages/unifiedmandala-ui/components/MandalaNetworkView.tsx) – Visualisierung aller Sigillin-Knoten und CREP-Felder
 - [**SigillinLoader**](packages/unifiedmandala-ui/components/SigillinLoader.tsx) – Import & Filter von Sigillin-Dateien
 - [**AutoDoc & Manifest-Generator**](packages/crep-engine/autoDocGeneration.ts) – Dokumentation auf Knopfdruck
+- [**FourierLayer Analyse**](packages/analysis/FourierLayer.ts) – Frequenzbasierte Emergenzbewertung
 - [**Plug-in-Architektur**](plugins/manifest.yaml) – GPT-Kommunikationsmodule, CLI-Tools
 - 🔗 [**GPTBridge (Go)**](go-bridge/pkg/gpt) – API- und Link-basierte GPT-Anbindung
 - [**Plugin-Registry & Dynamic Loader**](plugins/manifest.yaml) – `usePluginLoader` lädt jetzt YAML- und JSON-Manifeste
@@ -484,6 +485,10 @@ Nutze `node scripts/parse-advanced-conversations.js` um Gesprächs-TODOs aus dem
 - **Module**: unter `packages/` gegliedert in Agents, Core und mehr
 - **Utils**: zentrale Helfer liegen in `packages/shared-utils/`
 - **Scripts**: Automatisierungs- und CI-Skripte finden sich im `scripts/` Verzeichnis
+
+## 🐳 ProtoDeploy
+Nutze `scripts/protodeploy.sh` um eine lokale Docker-Umgebung zu starten.
+Der Compose-Stack liegt unter [infrastructure/protodeploy](infrastructure/protodeploy).
 
 \nDie komplette Ordnerstruktur samt Modulen, Utils und Skripten ist in [repositorypflege/repository_map.yaml](repositorypflege/repository_map.yaml) dokumentiert.
 Weitere Hinweise zum generellen Aufbau findest du zudem in [repositorypflege/repo-konzept.yaml](repositorypflege/repo-konzept.yaml).

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -3734,7 +3734,8 @@
     "dependencies": [
       "ProtoDeploy"
     ],
-    "self_check": true
+    "self_check": true,
+    "status": "done"
   },
   {
     "sprint": "ProtoDeploy",
@@ -3959,39 +3960,39 @@
     "status": "done"
   },
   {
-  "commit": "Implement MetaRunner script for fractal tasks",
-  "path": "scripts/metaRunner.ts",
-  "task": "Run tasks recursively using fractal anchor reference",
-  "test": "scripts/__tests__/metaRunner.test.ts",
-  "status": "done"
-},
-{
-  "commit": "Add MetaRunner blueprint YAML",
-  "path": "docs/sigils/metaRunnerBlueprint.yaml",
-  "task": "Outline structure for fractal task pipelines referenced by anchor",
-  "test": "",
-  "status": "done"
-},
-{
-  "commit": "Create ZIPMEM manifest structure",
-  "path": "GenesisAeonZIPMEM/ZIPMEM_manifest.yaml",
-  "task": "Define folder structure for conversation fragments and commit memory",
-  "test": "",
-  "status": "done"
-},
-{
-  "commit": "Implement ArchivAeon symbolic archive agent",
-  "path": "packages/agents/ArchivAeon.ts",
-  "task": "Organize conversation fragments and commit logs in GenesisAeonZIPMEM",
-  "test": "packages/agents/ArchivAeon.test.ts",
-  "status": "done"
-},
-{
-  "commit": "Add newadvancedconvo_splitter script",
-  "path": "scripts/newadvancedconvo_splitter.ts",
-  "task": "Split newadvancedconversations.json into YAML/JSON fragments in ZIPMEM",
-  "test": "scripts/__tests__/newadvancedconvo_splitter.test.ts",
-  "status": "done"
+    "commit": "Implement MetaRunner script for fractal tasks",
+    "path": "scripts/metaRunner.ts",
+    "task": "Run tasks recursively using fractal anchor reference",
+    "test": "scripts/__tests__/metaRunner.test.ts",
+    "status": "done"
+  },
+  {
+    "commit": "Add MetaRunner blueprint YAML",
+    "path": "docs/sigils/metaRunnerBlueprint.yaml",
+    "task": "Outline structure for fractal task pipelines referenced by anchor",
+    "test": "",
+    "status": "done"
+  },
+  {
+    "commit": "Create ZIPMEM manifest structure",
+    "path": "GenesisAeonZIPMEM/ZIPMEM_manifest.yaml",
+    "task": "Define folder structure for conversation fragments and commit memory",
+    "test": "",
+    "status": "done"
+  },
+  {
+    "commit": "Implement ArchivAeon symbolic archive agent",
+    "path": "packages/agents/ArchivAeon.ts",
+    "task": "Organize conversation fragments and commit logs in GenesisAeonZIPMEM",
+    "test": "packages/agents/ArchivAeon.test.ts",
+    "status": "done"
+  },
+  {
+    "commit": "Add newadvancedconvo_splitter script",
+    "path": "scripts/newadvancedconvo_splitter.ts",
+    "task": "Split newadvancedconversations.json into YAML/JSON fragments in ZIPMEM",
+    "test": "scripts/__tests__/newadvancedconvo_splitter.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add SealCore integration interface",
@@ -4467,7 +4468,7 @@
     "path": "infrastructure/protodeploy",
     "task": "Docker Compose config for local Aeon system",
     "test": "scripts/protodeploy.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Validate TheoryAgentConfig with AJV",
@@ -4715,19 +4716,19 @@
     "status": "done"
   },
   {
-  "commit": "Add AgentMapping blueprint",
-  "path": "docs/architecture/AgentMappingBlueprint.md",
-  "task": "Document UI and agent relationships from transition chat",
-  "test": "",
-  "status": "done"
-},
-{
-  "commit": "Apply README and Handbuch feedback",
-  "path": "README.md; Handbuch.md",
-  "task": "Integrate structure and usability updates from Sigil Übergang chat",
-  "test": "",
-  "status": "done"
-},
+    "commit": "Add AgentMapping blueprint",
+    "path": "docs/architecture/AgentMappingBlueprint.md",
+    "task": "Document UI and agent relationships from transition chat",
+    "test": "",
+    "status": "done"
+  },
+  {
+    "commit": "Apply README and Handbuch feedback",
+    "path": "README.md; Handbuch.md",
+    "task": "Integrate structure and usability updates from Sigil Übergang chat",
+    "test": "",
+    "status": "done"
+  },
   {
     "commit": "Create ZIP analysis script",
     "path": "scripts/analyze_zip.py",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -5488,6 +5488,7 @@
   responsible: Core Team
   dependencies: []
   self_check: true
+  status: done
 - sprint: Collaboration
   commit: "feat: add CollaborativeEditor and federation routes"
   path: packages/unifiedmandala-ui/components/; packages/core/routes/federation.ts
@@ -6209,7 +6210,7 @@
   path: infrastructure/protodeploy
   task: Docker Compose config for local Aeon system
   test: scripts/protodeploy.test.ts
-  status: todo
+  status: done
 - commit: Validate TheoryAgentConfig with AJV
   path: packages/agents/TheoryAgentConfig.ts
   task: Add AJV schema & config validation logic

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "feat: add metaRunner and archive scripts",
-  "fractalStep": "metaRunner",
+  "lastCommit": "chore: update progress files",
+  "fractalStep": "sync",
   "openBranches": [
     "work"
   ],

--- a/infrastructure/protodeploy/README.md
+++ b/infrastructure/protodeploy/README.md
@@ -1,0 +1,13 @@
+# ProtoDeploy
+
+Dieses Setup stellt eine minimale Docker-Compose-Umgebung bereit, um das Aeon-System lokal zu starten.
+
+```bash
+# Starten
+./scripts/protodeploy.sh up
+
+# Stoppen
+./scripts/protodeploy.sh down
+```
+
+Der Dienst `aeon-core` nutzt `Dockerfile.dev` und bindet den Repository-Ordner ein. So kann die Entwicklungsumgebung auch offline genutzt werden.

--- a/infrastructure/protodeploy/docker-compose.yml
+++ b/infrastructure/protodeploy/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  aeon-core:
+    build:
+      context: ../..
+      dockerfile: Dockerfile.dev
+    command: pnpm dev
+    volumes:
+      - ../..:/workspace/unified-mandala
+    ports:
+      - "4000:3000"

--- a/scripts/__tests__/protodeploy.test.ts
+++ b/scripts/__tests__/protodeploy.test.ts
@@ -1,0 +1,7 @@
+import fs from 'fs';
+import path from 'path';
+
+test('protodeploy docker-compose exists', () => {
+  const file = path.join(__dirname, '../../infrastructure/protodeploy/docker-compose.yml');
+  expect(fs.existsSync(file)).toBe(true);
+});

--- a/scripts/protodeploy.sh
+++ b/scripts/protodeploy.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+COMPOSE_FILE="$(dirname "$0")/../infrastructure/protodeploy/docker-compose.yml"
+
+docker-compose -f "$COMPOSE_FILE" "$@"


### PR DESCRIPTION
## Summary
- add ProtoDeploy Docker Compose environment
- provide script and basic test
- document usage in README and Handbuch
- note FourierLayer analysis in docs
- mark ProtoDeploy tasks as done

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686cc23625708322822914fc736b2e9f