### PR TITLE
Implement trace context events

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4188,7 +4188,7 @@
     "path": "packages/agents/CosmicTheoryAgentEvents.ts",
     "task": "Define events with trace metadata for cosmic agent",
     "test": "packages/agents/CosmicTheoryAgentEvents.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add live sigil alert bridge",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6048,7 +6048,7 @@
   path: packages/agents/CosmicTheoryAgentEvents.ts
   task: Define events with trace metadata for cosmic agent
   test: packages/agents/CosmicTheoryAgentEvents.test.ts
-  status: todo
+  status: done
 - commit: Add live sigil alert bridge
   path: packages/unifiedmandala-ui/api/cosmicBridge.ts
   task: Send live sigil alerts to UI via WebSocket

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: update progress files",
+  "lastCommit": "chore: update progress state",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.9.10",
+    "@opentelemetry/api": "^1.9.0",
     "@react-three/fiber": "^9.1.4",
     "ajv": "^8.0.0",
     "ajv-formats": "^3.0.1",

--- a/packages/agents/CosmicTheoryAgentEvents.test.ts
+++ b/packages/agents/CosmicTheoryAgentEvents.test.ts
@@ -1,11 +1,11 @@
 import { test, expect } from 'vitest';
-import { CosmicTheoryEventHub } from './CosmicTheoryAgentEvents';
+import { CosmicTheoryEventHub, logTrace } from './CosmicTheoryAgentEvents';
 
 test('emit and receive events', () => {
   const logs: string[] = [];
   CosmicTheoryEventHub.on('trace:log', (payload) => {
     logs.push(payload.message);
   });
-  CosmicTheoryEventHub.emit('trace:log', { message: 'hello', timestamp: Date.now() });
+  logTrace('hello');
   expect(logs).toContain('hello');
 });

--- a/packages/agents/CosmicTheoryAgentEvents.ts
+++ b/packages/agents/CosmicTheoryAgentEvents.ts
@@ -1,10 +1,28 @@
 import mitt, { Emitter } from 'mitt';
+import { context, trace } from '@opentelemetry/api';
+
+export interface TraceLogPayload {
+  message: string;
+  timestamp: number;
+  spanId?: string;
+  traceId?: string;
+}
 
 export type CosmicTheoryAgentEvents = {
   'sigil:generated': { sigilId: string; formula: string };
   'theory:updated': { formula: string; score: number };
-  'trace:log': { message: string; timestamp: number };
+  'trace:log': TraceLogPayload;
   [key: string]: any;
 };
 
 export const CosmicTheoryEventHub: Emitter<CosmicTheoryAgentEvents> = mitt<CosmicTheoryAgentEvents>();
+
+export function logTrace(message: string): void {
+  const span = trace.getSpan(context.active());
+  CosmicTheoryEventHub.emit('trace:log', {
+    message,
+    timestamp: Date.now(),
+    spanId: span?.spanContext().spanId,
+    traceId: span?.spanContext().traceId
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@grpc/grpc-js':
         specifier: ^1.9.10
         version: 1.13.4
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@react-three/fiber':
         specifier: ^9.1.4
         version: 9.1.4(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.161.0)
@@ -4062,10 +4065,12 @@ packages:
   superagent@10.2.1:
     resolution: {integrity: sha512-O+PCv11lgTNJUzy49teNAWLjBZfc+A1enOwTpLlH6/rsvKcTwcdTT8m9azGkVqM7HBl5jpyZ7KTPhHweokBcdg==}
     engines: {node: '>=14.18.0'}
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supertest@7.1.1:
     resolution: {integrity: sha512-aI59HBTlG9e2wTjxGJV+DygfNLgnWbGdZxiA/sgrnNNikIW8lbDvCtF6RnhZoJ82nU7qv7ZLjrvWqCEm52fAmw==}
     engines: {node: '>=14.18.0'}
+    deprecated: Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}


### PR DESCRIPTION
## Summary
- extend `CosmicTheoryAgentEvents` with trace context
- add `logTrace` helper
- update corresponding test
- mark "Add trace context events" as done in advancedToDo files
- track dependency for OpenTelemetry API

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686cc95192bc8322beed668f6f7850d8