### PR TITLE
Add dev env setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,62 @@ pip install pyright
 # Install dependencies
 poetry install --with test
 pnpm install
+## Entwicklungsumgebung
+Zur Einrichtung kann das Skript `scripts/setup-dev-env.sh` verwendet werden:
+
+```bash
+./scripts/setup-dev-env.sh
+```
+
+Der Inhalt des Skripts:
+
+```bash
+#!/bin/bash
+
+# Setup script for development environment
+# Detect package manager and install required tools.
+
+if command -v apt &> /dev/null; then
+  sudo apt update
+  sudo apt upgrade -y
+  sudo apt install -y git curl wget build-essential python3 python3-pip nodejs npm
+elif command -v brew &> /dev/null; then
+  brew update
+  brew upgrade
+  brew install git curl wget python node
+else
+  echo "Kein unterst\u00fctzter Paketmanager gefunden (apt oder brew)."
+  exit 1
+fi
+
+# Configure Git if not configured
+if ! git config --global user.name >/dev/null; then
+  git config --global user.name "your_name"
+fi
+if ! git config --global user.email >/dev/null; then
+  git config --global user.email "your_email@example.com"
+fi
+
+echo "\nSetting up Python virtual environment";
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+if [ -f requirements.txt ]; then
+  pip install -r requirements.txt
+fi
+
+echo "\nInstalling Node dependencies";
+pnpm install || npm install
+
+# Example VS Code configuration
+if command -v code &> /dev/null; then
+  code --install-extension ms-python.python >/dev/null 2>&1
+  code --install-extension esbenp.prettier-vscode >/dev/null 2>&1
+fi
+
+echo "Entwicklungsumgebung erfolgreich eingerichtet!"
+```
+
 # 📘 AEON-CODEX – AGENTS
 schema_version: "1.1"
 description: >

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Setup script for development environment
+# Detect package manager and install required tools.
+
+if command -v apt &> /dev/null; then
+  sudo apt update
+  sudo apt upgrade -y
+  sudo apt install -y git curl wget build-essential python3 python3-pip nodejs npm
+elif command -v brew &> /dev/null; then
+  brew update
+  brew upgrade
+  brew install git curl wget python node
+else
+  echo "Kein unterst\u00fctzter Paketmanager gefunden (apt oder brew)."
+  exit 1
+fi
+
+# Configure Git if not configured
+if ! git config --global user.name >/dev/null; then
+  git config --global user.name "your_name"
+fi
+if ! git config --global user.email >/dev/null; then
+  git config --global user.email "your_email@example.com"
+fi
+
+echo "\nSetting up Python virtual environment";
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+if [ -f requirements.txt ]; then
+  pip install -r requirements.txt
+fi
+
+echo "\nInstalling Node dependencies";
+pnpm install || npm install
+
+# Example VS Code configuration
+if command -v code &> /dev/null; then
+  code --install-extension ms-python.python >/dev/null 2>&1
+  code --install-extension esbenp.prettier-vscode >/dev/null 2>&1
+fi
+
+echo "Entwicklungsumgebung erfolgreich eingerichtet!"


### PR DESCRIPTION
## Summary
- add `scripts/setup-dev-env.sh` to bootstrap dependencies on apt or brew
- document the new setup in `AGENTS.md`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686cd5726e84832286c767b941f7ecab