### PR TITLE
Extend memory store metadata and symbol mapping

### DIFF
--- a/GenesisAeonAdvancedAi/aeon_processor.py
+++ b/GenesisAeonAdvancedAi/aeon_processor.py
@@ -38,21 +38,24 @@ def assign_symbol(values: Iterable[float]) -> str:
     """Assign a symbolic marker based on the average value.
 
     Mapping inspired by project guidelines:
-    - avg > 0.8 → sun symbol (☀️)
-    - avg > 0.5 → growth symbol (🌱)
-    - avg > 0.2 → fluid symbol (💧)
-    - otherwise → void symbol (⚫)
+    - avg > 0.8 -> sun symbol (☀)
+    - avg > 0.6 -> fire archetype (🔥)
+    - avg > 0.4 -> growth symbol (🌱)
+    - avg > 0.2 -> fluid symbol (💧)
+    - otherwise -> void symbol (⚫)
     """
     vals = list(values)
     avg = sum(vals) / len(vals) if vals else 0
     if avg > 0.8:
-        return "\u2600"  # ☀️
-    elif avg > 0.5:
-        return "\U0001F331"  # 🌱
+        return "\u2600"  # sun
+    elif avg > 0.6:
+        return "\U0001F525"  # fire
+    elif avg > 0.4:
+        return "\U0001F331"  # sprout
     elif avg > 0.2:
-        return "\U0001F4A7"  # 💧
+        return "\U0001F4A7"  # droplet
     else:
-        return "\u26AB"  # ⚫
+        return "\u26AB"  # void
 
 
 def translate_numeric_to_symbolic(tensor: Iterable[float]) -> Dict[str, Any]:

--- a/GenesisAeonAdvancedAi/memory_store.py
+++ b/GenesisAeonAdvancedAi/memory_store.py
@@ -7,8 +7,12 @@ from typing import Any, Dict, List, Iterable
 import statistics
 
 
-def store_result(result: Dict[str, Any], path: Path) -> None:
-    """Append result to a JSON list stored at path."""
+def store_result(result: Dict[str, Any], path: Path, *, mood: str | None = None, archetype: str | None = None) -> None:
+    """Append result to a JSON list stored at path.
+
+    Additional metadata ``mood`` and ``archetype`` can be provided and will be
+    stored with each entry.
+    """
     if path.exists():
         try:
             data = json.loads(path.read_text())
@@ -19,6 +23,10 @@ def store_result(result: Dict[str, Any], path: Path) -> None:
 
     entry = dict(result)
     entry.setdefault("timestamp", time.time())
+    if mood is not None:
+        entry["mood"] = mood
+    if archetype is not None:
+        entry["archetype"] = archetype
     data.append(entry)
     path.write_text(json.dumps(data, indent=2))
 

--- a/GenesisAeonAdvancedAi/test_memory_store.py
+++ b/GenesisAeonAdvancedAi/test_memory_store.py
@@ -24,9 +24,11 @@ class TestMemoryStore(unittest.TestCase):
         self.assertTrue(path.exists())
         data = json.loads(path.read_text())
         self.assertEqual(len(data), 1)
-        store_result({'b': 2}, path)
+        store_result({'b': 2}, path, mood='happy', archetype='sun')
         data = json.loads(path.read_text())
         self.assertEqual(len(data), 2)
+        self.assertEqual(data[1]['mood'], 'happy')
+        self.assertEqual(data[1]['archetype'], 'sun')
         path.unlink()
 
     def test_load_results(self):

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4282,18 +4282,18 @@
     "status": "todo"
   },
   {
-  "commit": "Add UI Agent mapping matrix",
-  "path": "docs/mapping/ui-agent-matrix.yaml",
-  "task": "Document feature mapping between UI and agents",
-  "test": "",
-  "status": "done"
-},
-{
-  "commit": "Add AeonNeuroNetz comparison docs",
-  "path": "docs/analysis/AeonNeuroNetzComparison.md",
-  "task": "Compare AeonNeuroNetz with state-of-the-art neural nets",
-  "test": "",
-  "status": "done"
+    "commit": "Add UI Agent mapping matrix",
+    "path": "docs/mapping/ui-agent-matrix.yaml",
+    "task": "Document feature mapping between UI and agents",
+    "test": "",
+    "status": "done"
+  },
+  {
+    "commit": "Add AeonNeuroNetz comparison docs",
+    "path": "docs/analysis/AeonNeuroNetzComparison.md",
+    "task": "Compare AeonNeuroNetz with state-of-the-art neural nets",
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "TODO from newadvancedconversations.json - AgentCoordinator",

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "feat: nested pyramid generator",
-  "fractalStep": "implement",
+  "lastCommit": "chore: update advanced todo metadata",
+  "fractalStep": "sync",
   "openBranches": [
     "work"
   ],


### PR DESCRIPTION
## Summary
- extend assign_symbol in aeon_processor to include a fire archetype step
- allow mood and archetype metadata in memory_store entries
- test new memory fields in memory_store
- update progress tracking

## Testing
- `pytest GenesisAeonAdvancedAi/test_memory_store.py`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686cf3a7e814832296100afcbf13a06b