### PR TITLE
feat: add remote analysis helper

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4332,10 +4332,10 @@
   },
   {
     "commit": "TODO from CosmicTheoryAgent conversation - implement gRPC call",
-    "path": "docs/sigils/newadvancedconversations.json",
+    "path": "packages/agents/CosmicTheoryAgent.ts",
     "task": "CosmicTheoryAgent TODO: Implement gRPC/REST-Aufruf",
     "test": "packages/agents/CosmicTheoryAgent.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from CosmicTheoryAgent conversation - Python service access",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6151,10 +6151,10 @@
   test: ""
   status: todo
 - commit: TODO from CosmicTheoryAgent conversation - implement gRPC call
-  path: docs/sigils/newadvancedconversations.json
+  path: packages/agents/CosmicTheoryAgent.ts
   task: "CosmicTheoryAgent TODO: Implement gRPC/REST-Aufruf"
   test: packages/agents/CosmicTheoryAgent.test.ts
-  status: todo
+  status: done
 - commit: TODO from CosmicTheoryAgent conversation - Python service access
   path: docs/sigils/newadvancedconversations.json
   task: "CosmicTheoryAgent TODO: Zugriff auf PySR-Service via Axios/gRPC"

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: update advanced todo metadata",
+  "lastCommit": "chore: update progress",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/packages/agents/CosmicTheoryAgent.test.ts
+++ b/packages/agents/CosmicTheoryAgent.test.ts
@@ -1,6 +1,18 @@
-import { describe, it, expect } from 'vitest';
-import { adjustWeights, mutateWeights, crossoverWeights, AgentWeights, loadSigil, sigilManager } from './CosmicTheoryAgent';
+import { describe, it, expect, vi } from 'vitest';
+import axios from 'axios';
+import { Client } from '@grpc/grpc-js';
+import {
+  adjustWeights,
+  mutateWeights,
+  crossoverWeights,
+  AgentWeights,
+  loadSigil,
+  sigilManager,
+  performRemoteAnalysis
+} from './CosmicTheoryAgent';
 import { CosmicTheoryEventHub } from './CosmicTheoryAgentEvents';
+
+vi.mock('axios');
 
 describe('adjustWeights', () => {
   it('increases weights with positive reward', () => {
@@ -44,5 +56,20 @@ describe('sigil integration', () => {
     loadSigil('alpha', '{"f":1}');
     expect(sigilManager.list()[0].id).toBe('alpha');
     expect(events[0].sigilId).toBe('alpha');
+  });
+});
+
+describe('performRemoteAnalysis', () => {
+  it('calls REST endpoint', async () => {
+    vi.spyOn(axios, 'post').mockResolvedValue({ data: { result: [1, 2, 3] } });
+    const res = await performRemoteAnalysis([1], 'http://localhost/analyze');
+    expect(res).toEqual([1, 2, 3]);
+  });
+
+  it('calls gRPC endpoint', async () => {
+    const makeUnaryRequest = vi.fn((path, ser, des, arg, cb) => cb(null, { result: [42] }));
+    vi.spyOn(Client.prototype, 'makeUnaryRequest').mockImplementation(makeUnaryRequest as any);
+    const res = await performRemoteAnalysis([1], 'localhost:50051', 'grpc');
+    expect(res).toEqual([42]);
   });
 });

--- a/packages/agents/CosmicTheoryAgent.ts
+++ b/packages/agents/CosmicTheoryAgent.ts
@@ -76,3 +76,29 @@ export function analyzeCosmicData(values: number[]): string {
   return symbolicRegression([metric]);
 }
 
+export async function performRemoteAnalysis(
+  data: number[],
+  endpoint: string,
+  protocol: 'rest' | 'grpc' = 'rest'
+): Promise<number[]> {
+  if (protocol === 'grpc') {
+    const { Client, credentials } = await import('@grpc/grpc-js');
+    const client = new Client(endpoint, credentials.createInsecure());
+    return new Promise((resolve, reject) => {
+      client.makeUnaryRequest(
+        '/AnalysisService/Analyze',
+        arg => Buffer.from(JSON.stringify(arg)),
+        buffer => JSON.parse(buffer.toString()),
+        { data },
+        (err, resp: any) => {
+          client.close();
+          if (err) return reject(err);
+          resolve(resp?.result ?? []);
+        }
+      );
+    });
+  }
+  const resp = await axios.post(endpoint, { data });
+  return resp.data.result;
+}
+


### PR DESCRIPTION
## Summary
- add `performRemoteAnalysis` helper to CosmicTheoryAgent
- test REST and gRPC paths
- mark related TODOs as done in advancedToDo files

## Testing
- `pnpm test:agents packages/agents/CosmicTheoryAgent.test.ts`
- `pyright packages/agents/CosmicTheoryAgent.ts` *(fails: module resolution issues)*
- `poetry install --with test` *(failed: no pyproject found)*

------
https://chatgpt.com/codex/tasks/task_e_686cf8b300ec8322bb6904f7f09d0c56