### PR TITLE
Implement TheoryAgentConfig validation

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4475,7 +4475,7 @@
     "path": "packages/agents/TheoryAgentConfig.ts",
     "task": "Add AJV schema & config validation logic",
     "test": "packages/agents/TheoryAgentConfig.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add SigilAlert integration",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6215,7 +6215,7 @@
   path: packages/agents/TheoryAgentConfig.ts
   task: Add AJV schema & config validation logic
   test: packages/agents/TheoryAgentConfig.test.ts
-  status: todo
+  status: done
 - commit: Add SigilAlert integration
   path: packages/unifiedmandala-ui/components/SigilAlert.tsx
   task: Integrate SigilAlert UI component into main layout

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "chore: update progress",
-  "fractalStep": "sync",
+  "lastCommit": "feat: add TheoryAgentConfig validation",
+  "fractalStep": "implementation",
   "openBranches": [
     "work"
   ],

--- a/packages/agents/TheoryAgentConfig.test.ts
+++ b/packages/agents/TheoryAgentConfig.test.ts
@@ -1,0 +1,19 @@
+import { loadTheoryAgentConfig } from './TheoryAgentConfig';
+import { describe, expect, test } from 'vitest';
+
+describe('loadTheoryAgentConfig', () => {
+  test('loads valid config', () => {
+    const cfg = loadTheoryAgentConfig({
+      name: 'agent',
+      version: '1.0',
+      description: 'test',
+      weights: { theory: 1, practice: 2 }
+    });
+    expect(cfg.name).toBe('agent');
+    expect(cfg.weights.theory).toBe(1);
+  });
+
+  test('throws on invalid config', () => {
+    expect(() => loadTheoryAgentConfig({})).toThrow();
+  });
+});

--- a/packages/agents/TheoryAgentConfig.ts
+++ b/packages/agents/TheoryAgentConfig.ts
@@ -1,0 +1,40 @@
+import Ajv from 'ajv';
+
+export interface TheoryAgentConfig {
+  name: string;
+  version: string;
+  description?: string;
+  weights: {
+    theory: number;
+    practice: number;
+  };
+}
+
+const schema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    version: { type: 'string' },
+    description: { type: 'string', nullable: true },
+    weights: {
+      type: 'object',
+      properties: {
+        theory: { type: 'number' },
+        practice: { type: 'number' }
+      },
+      required: ['theory', 'practice'],
+      additionalProperties: false
+    }
+  },
+  required: ['name', 'version', 'weights'],
+  additionalProperties: false
+};
+
+export function loadTheoryAgentConfig(raw: unknown): TheoryAgentConfig {
+  const ajv = new Ajv({ allErrors: true });
+  const validate = ajv.compile(schema);
+  if (!validate(raw)) {
+    throw new Error('Invalid TheoryAgentConfig: ' + ajv.errorsText(validate.errors));
+  }
+  return raw as TheoryAgentConfig;
+}


### PR DESCRIPTION
## Summary
- validate TheoryAgentConfig with AJV
- add tests for TheoryAgentConfig
- update advanced TODO lists and progress

## Testing
- `pnpm test`
- `pnpm test:agents`


------
https://chatgpt.com/codex/tasks/task_e_686cfc9ec5588322b1618c6d51193220