### PR TITLE
feat: add Streamlit demo interface

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4671,7 +4671,7 @@
     "path": "apps/aeon-demo/app.py",
     "task": "Showcase Aeon features in Streamlit web app",
     "test": "apps/aeon-demo/test_app.py",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Extend memory store with mood and archetype metadata",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6360,7 +6360,7 @@
   path: apps/aeon-demo/app.py
   task: Showcase Aeon features in Streamlit web app
   test: apps/aeon-demo/test_app.py
-  status: todo
+  status: done
 - commit: Extend memory store with mood and archetype metadata
   path: GenesisAeonAdvancedAi/memory_store.py
   task: Save mood and archetype info per memory entry

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add TheoryAgentConfig validation",
+  "lastCommit": "feat: add Streamlit demo interface",
   "fractalStep": "implementation",
   "openBranches": [
     "work"

--- a/apps/aeon-demo/app.py
+++ b/apps/aeon-demo/app.py
@@ -1,0 +1,18 @@
+import streamlit as st
+from GenesisAeonAdvancedAi.aeon_processor import symbolic_manifestation
+
+st.title("Aeon Demo")
+values = st.text_input("Values (comma separated)", "0.1,0.5,0.9")
+nums = []
+for part in values.split(','):
+    part = part.strip()
+    if part:
+        try:
+            nums.append(float(part))
+        except ValueError:
+            st.error(f"Invalid number: {part}")
+            nums = []
+            break
+if st.button("Process") and nums:
+    result = symbolic_manifestation(nums)
+    st.json(result)

--- a/apps/aeon-demo/test_app.py
+++ b/apps/aeon-demo/test_app.py
@@ -1,0 +1,20 @@
+import runpy
+import types
+import sys
+import os
+import unittest
+
+class TestDemoApp(unittest.TestCase):
+    def test_app_runs(self):
+        mod = types.ModuleType('streamlit')
+        mod.title = lambda *a, **k: None
+        mod.text_input = lambda *a, **k: "0.1"
+        mod.button = lambda *a, **k: False
+        mod.json = lambda *a, **k: None
+        mod.error = lambda *a, **k: None
+        sys.modules['streamlit'] = mod
+        sys.path.insert(0, os.path.abspath('.'))
+        runpy.run_path('apps/aeon-demo/app.py', run_name='__main__')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- provide simple Streamlit demo under `apps/aeon-demo`
- unit test ensures the demo app runs with a stubbed Streamlit
- mark Streamlit demo task as completed

## Testing
- `pip install pyright`
- `poetry install --with test` *(fails: Poetry could not find a pyproject.toml)*
- `pnpm install`
- `pyright`
- `pip install pyyaml numpy streamlit plotly scikit-learn flask`
- `python -m unittest discover`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686d01a2fc5483228c4e54d36f553366