### PR TITLE
Add FourierLayer tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4820,5 +4820,19 @@
     "task": "Add animated timeline for Mandala crystal emergence",
     "test": "packages/unifiedmandala-ui/components/CREPVisualizer.test.tsx",
     "status": "done"
+  },
+  {
+    "commit": "Add FourierLayer metrics API",
+    "path": "services/fourier-metrics/index.ts",
+    "task": "Provide WebSocket and REST endpoints for FourierLayer metrics",
+    "test": "services/fourier-metrics/index.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Split newadvancedconversations into fragments",
+    "path": "scripts/newadvancedconvo_splitter.ts",
+    "task": "Split newadvancedconversations.json into numbered YAML/JSON fragments",
+    "test": "scripts/__tests__/newadvancedconvo_splitter.test.ts",
+    "status": "todo"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6467,3 +6467,13 @@
   task: Add animated timeline for Mandala crystal emergence
   test: packages/unifiedmandala-ui/components/CREPVisualizer.test.tsx
   status: done
+- commit: Add FourierLayer metrics API
+  path: services/fourier-metrics/index.ts
+  task: Provide WebSocket and REST endpoints for FourierLayer metrics
+  test: services/fourier-metrics/index.test.ts
+  status: todo
+- commit: Split newadvancedconversations into fragments
+  path: scripts/newadvancedconvo_splitter.ts
+  task: Split newadvancedconversations.json into numbered YAML/JSON fragments
+  test: scripts/__tests__/newadvancedconvo_splitter.test.ts
+  status: todo


### PR DESCRIPTION
## Summary
- extract new tasks from conversations: FourierLayer metrics API and conversation splitter
- update advancedToDo.yaml and advancedToDo.json lists accordingly

## Testing
- `pyright`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686d2c4b595c832298a59dfa9978e141