### PR TITLE
Add CREPWaves component and mark task as done

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4574,7 +4574,7 @@
     "path": "packages/unifiedmandala-ui/components/CREPWaves.tsx",
     "task": "Visualisiert CREP-Historie als Wellenform",
     "test": "packages/unifiedmandala-ui/components/CREPWaves.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from CosmicTheoryAgent conversation - TaskDNA component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6286,7 +6286,7 @@
   path: packages/unifiedmandala-ui/components/CREPWaves.tsx
   task: Visualisiert CREP-Historie als Wellenform
   test: packages/unifiedmandala-ui/components/CREPWaves.test.tsx
-  status: todo
+  status: done
 - commit: TODO from CosmicTheoryAgent conversation - TaskDNA component
   path: packages/unifiedmandala-ui/components/TaskDNA.tsx
   task: Stellt Task-Cluster als DNA-ähnliche Struktur dar

--- a/packages/unifiedmandala-ui/components/CREPWaves.test.tsx
+++ b/packages/unifiedmandala-ui/components/CREPWaves.test.tsx
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react';
+import CREPWaves from './CREPWaves';
+
+describe('CREPWaves', () => {
+  it('renders wave svg', () => {
+    const { getByLabelText } = render(
+      <CREPWaves history={[{ timestamp: new Date(1), C: 1, R: 1, E: 1, P: 1 }]} />
+    );
+    const svg = getByLabelText('CREP Waves');
+    expect(svg.nodeName.toLowerCase()).toBe('svg');
+  });
+});

--- a/packages/unifiedmandala-ui/components/CREPWaves.tsx
+++ b/packages/unifiedmandala-ui/components/CREPWaves.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { CREPEntry } from '../../crep-engine/types';
+
+interface Props {
+  history: CREPEntry[];
+}
+
+const CREPWaves: React.FC<Props> = ({ history }) => {
+  const path = history
+    .map((e, idx) => {
+      const x = idx * 10;
+      const y = 50 - e.C * 5;
+      return `${idx === 0 ? 'M' : 'L'} ${x} ${y}`;
+    })
+    .join(' ');
+
+  return (
+    <svg width={history.length * 10} height={60} aria-label="CREP Waves">
+      <path d={path} stroke="#8884d8" fill="none" />
+    </svg>
+  );
+};
+
+export default CREPWaves;


### PR DESCRIPTION
## Summary
- implement `CREPWaves` component to visualize CREP history
- add corresponding unit test
- mark the CREPWaves task in advancedToDo lists as done

## Testing
- `pnpm run qa` *(fails: command exited with code 2)*

------
https://chatgpt.com/codex/tasks/task_e_686d342f5e748322a650992b9a947902