### PR TITLE
Implement real-time CREP sonification

### DIFF
--- a/packages/visuals/RealTimeCREPSonification.ts
+++ b/packages/visuals/RealTimeCREPSonification.ts
@@ -1,3 +1,29 @@
-export function sonifyCREP(crep: number): number {
-  return crep * 100;
+export interface SonifyOptions {
+  duration?: number;
+  ctx?: AudioContext;
+}
+
+export function sonifyCREP(
+  crep: number,
+  { duration = 0.5, ctx }: SonifyOptions = {}
+): OscillatorNode | undefined {
+  const AudioCtx =
+    (typeof window !== 'undefined' &&
+      ((window as any).AudioContext || (window as any).webkitAudioContext)) ||
+    AudioContext;
+  let audioCtx = ctx;
+  try {
+    if (!audioCtx) {
+      audioCtx = new AudioCtx();
+    }
+  } catch {
+    return undefined;
+  }
+  if (!audioCtx) return undefined;
+  const osc = audioCtx.createOscillator();
+  osc.frequency.value = 220 + crep * 220;
+  osc.connect(audioCtx.destination);
+  osc.start();
+  osc.stop(audioCtx.currentTime + duration);
+  return osc;
 }

--- a/packages/visuals/__tests__/RealTimeCREPSonification.test.ts
+++ b/packages/visuals/__tests__/RealTimeCREPSonification.test.ts
@@ -1,5 +1,23 @@
-import { sonifyCREP } from '../RealTimeCREPSonification';
-
-test('multiplies crep', () => {
-  expect(sonifyCREP(2)).toBe(200);
+test('creates oscillator with mapped frequency', () => {
+  const start = jest.fn();
+  const stop = jest.fn();
+  const connect = jest.fn();
+  const ctx = {
+    createOscillator: () => ({
+      frequency: { value: 0 },
+      connect,
+      start,
+      stop,
+    }),
+    destination: {},
+    currentTime: 0,
+  } as any;
+  (global as any).AudioContext = function () {
+    return ctx;
+  } as any;
+  const { sonifyCREP } = require('../RealTimeCREPSonification');
+  const osc = sonifyCREP(0.5, { duration: 1 });
+  expect(osc.frequency.value).toBeCloseTo(330);
+  expect(start).toHaveBeenCalled();
+  expect(stop).toHaveBeenCalledWith(1);
 });


### PR DESCRIPTION
## Summary
- implement `sonifyCREP` with Web Audio API fallback
- add unit test for real-time sonification

## Testing
- `pnpm test packages/visuals/__tests__/RealTimeCREPSonification.test.ts`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686d381d46308322848ca34ba5e40fe1