### PR TITLE
Implement resonance metrics update

### DIFF
--- a/GenesisAeonAdvancedAi/aeon_processor.py
+++ b/GenesisAeonAdvancedAi/aeon_processor.py
@@ -109,10 +109,14 @@ def advanced_crep_eval(
 
     resonance = 0.0
     if prev_states:
-        prev = [float(f) for f in prev_states[-1].get("klang", [])]
-        m = min(len(prev), len(klang))
-        if m:
-            resonance = pearson_corr(prev[:m], klang[:m])
+        correlations = []
+        for state in prev_states:
+            prev = [float(f) for f in state.get("klang", [])]
+            m = min(len(prev), len(klang))
+            if m:
+                correlations.append(pearson_corr(prev[:m], klang[:m]))
+        if correlations:
+            resonance = sum(correlations) / len(correlations)
 
     emergence = (
         mean(abs(klang[i] - klang[i - 1]) for i in range(1, len(klang)))

--- a/GenesisAeonAdvancedAi/test_advanced_crep.py
+++ b/GenesisAeonAdvancedAi/test_advanced_crep.py
@@ -32,6 +32,15 @@ class TestAdvancedCREP(unittest.TestCase):
         metrics = advanced_crep_eval(curr, [prev])
         self.assertAlmostEqual(round(metrics["resonanz"], 5), -1.0)
 
+    def test_resonance_multiple_states(self):
+        s1 = translate_numeric_to_symbolic([0.1, 0.2, 0.3])
+        s2 = translate_numeric_to_symbolic([0.1, 0.3, 0.5])
+        curr = translate_numeric_to_symbolic([0.1, 0.2, 0.3])
+        metrics = advanced_crep_eval(curr, [s1, s2])
+        # correlation with s1 is 1, with s2 is slightly lower
+        self.assertLess(metrics["resonanz"], 1.0)
+        self.assertGreater(metrics["resonanz"], 0.8)
+
     def test_emergence_cluster(self):
         sym = translate_numeric_to_symbolic([0.0, 1.0, 0.0, 1.0])
         metrics = advanced_crep_eval(sym)

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -17,6 +17,8 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - Siehe Agenten-Mapping-Blueprint in [docs/architecture/AgentMappingBlueprint.md](docs/architecture/AgentMappingBlueprint.md)
 - Lokaler Test-Stack unter `docs/offline/docker-compose.yml`
 - ToDo-Dateien vor größeren Commits mit `scripts/sync-todo-progress.js` abgleichen
+- Über `scripts/generate-next-sigil.js` wird nach jedem Zyklus ein neues Sigil
+  mit aktuellem `update_time` erzeugt.
 
 > **TL;DR**
 > - Installation: `./scripts/setup-unifiedmandala.sh`

--- a/README.md
+++ b/README.md
@@ -335,6 +335,14 @@ docker compose up
 
 UI läuft danach auf http://localhost:3000, der Agent auf http://localhost:4000.
 
+## 🔄 Sigil Transition Workflow
+
+Beim Wechsel zwischen Entwicklungszyklen werden Sigillin-Dateien und ToDos
+synchronisiert. Nutze `scripts/sync-todo-progress.js`, bevor du größere
+Commits erstellst. Über `scripts/generate-next-sigil.js` wird anschließend ein
+neues Sigil mit aktualisiertem Zeitstempel erzeugt. Die Offline-Compose-Datei
+ermöglicht Tests dieser Schritte ohne Internetverbindung.
+
 
 ## 🌀 Mandala-Poesie und Automation
 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4553,7 +4553,7 @@
     "path": "README.md",
     "task": "Add overview of Sigil transition and offline workflow",
     "test": "",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Extend advanced_crep_eval with resonance correlation",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6271,12 +6271,12 @@
   path: README.md
   task: Add overview of Sigil transition and offline workflow
   test: ""
-  status: todo
+  status: done
 - commit: Extend advanced_crep_eval with resonance correlation
   path: GenesisAeonAdvancedAi/aeon_processor.py
   task: Calculate resonance via pearson correlation of states
   test: GenesisAeonAdvancedAi/test_advanced_crep.py
-  status: todo
+  status: done
 - commit: Add AeonAgent example using advanced_crep_eval
   path: GenesisAeonAdvancedAi/advanced_agent.py
   task: Use fraktal_feedback_metrics and save haiku output


### PR DESCRIPTION
## Summary
- compute averaged resonance across previous states in `advanced_crep_eval`
- test resonance against multiple prior states
- document sigil transition workflow in README and Handbuch
- update todo statuses for completed tasks

## Testing
- `pyright`
- `pnpm test --silent`
- `pytest GenesisAeonAdvancedAi/test_advanced_crep.py`

------
https://chatgpt.com/codex/tasks/task_e_686d3ce43fe08322bad76241e1abfedf