### PR TITLE
Implement FractalSigilGenerator

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-08, in der Zeit des Morgen.
+Am 2025-07-08, in der Zeit des Tag.
 
-Symbolphase: Initiation (Fokus: C)
+Symbolphase: Aktivierung (Fokus: R)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4515,10 +4515,10 @@
   },
   {
     "commit": "Add FractalSigilGenerator",
-    "path": "src/sigil/FractalSigilGenerator.ts",
+    "path": "packages/genesis-sigillin-core/FractalSigilGenerator.ts",
     "task": "Convert theory formulas to fractal sigil SVG",
-    "test": "src/sigil/__tests__/FractalSigilGenerator.test.ts",
-    "status": "todo"
+    "test": "packages/genesis-sigillin-core/__tests__/FractalSigilGenerator.test.ts",
+    "status": "done"
   },
   {
     "commit": "Implement nested layer generator",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6243,10 +6243,10 @@
   test: packages/agents/CosmicTheoryAgent.test.ts
   status: done
 - commit: Add FractalSigilGenerator
-  path: src/sigil/FractalSigilGenerator.ts
+  path: packages/genesis-sigillin-core/FractalSigilGenerator.ts
   task: Convert theory formulas to fractal sigil SVG
-  test: src/sigil/__tests__/FractalSigilGenerator.test.ts
-  status: todo
+  test: packages/genesis-sigillin-core/__tests__/FractalSigilGenerator.test.ts
+  status: done
 - commit: Implement nested layer generator
   path: packages/unifiedmandala-ui/pyramid/generateNestedLayers.ts
   task: Generate layered pyramid structure with weights

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "add SealCore integration interface",
-  "fractalStep": "implementation",
+  "lastCommit": "feat: add FractalSigilGenerator",
+  "fractalStep": "sync",
   "openBranches": [
     "work"
   ],

--- a/packages/genesis-sigillin-core/FractalSigilGenerator.ts
+++ b/packages/genesis-sigillin-core/FractalSigilGenerator.ts
@@ -1,0 +1,10 @@
+export function generateFractalSigil(formula: string): string {
+  const points = formula.split('').map((c, i) => {
+    const angle = ((c.charCodeAt(0) * 137.5) % 360) * (Math.PI / 180);
+    const radius = 10 + i * 2;
+    const x = Number((radius * Math.cos(angle)).toFixed(2));
+    const y = Number((radius * Math.sin(angle)).toFixed(2));
+    return `${x},${y}`;
+  }).join(' ');
+  return `<svg viewBox="-50 -50 100 100" xmlns="http://www.w3.org/2000/svg"><polyline points="${points}" fill="none" stroke="currentColor"/></svg>`;
+}

--- a/packages/genesis-sigillin-core/__tests__/FractalSigilGenerator.test.ts
+++ b/packages/genesis-sigillin-core/__tests__/FractalSigilGenerator.test.ts
@@ -1,0 +1,7 @@
+import { generateFractalSigil } from '../FractalSigilGenerator';
+
+test('generates SVG polyline for formula', () => {
+  const svg = generateFractalSigil('abc');
+  expect(svg).toContain('<polyline');
+  expect(svg).toContain('svg');
+});

--- a/packages/genesis-sigillin-core/index.ts
+++ b/packages/genesis-sigillin-core/index.ts
@@ -4,3 +4,4 @@ export * from './SigillinActivationManager';
 export * from './SigillinSuggestionEngine';
 export * from './SigillinSyncManager';
 export * from './SigilFormulaEngine';
+export * from './FractalSigilGenerator';


### PR DESCRIPTION
## Summary
- implement `generateFractalSigil` generator and tests
- export generator via `genesis-sigillin-core` index
- update advancedToDo tracking
- update chronopoem and progress metadata

## Testing
- `pyright`
- `pnpm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d437b0adc83229042efae721afd37