### PR TITLE
Implement config schema validation

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4056,7 +4056,7 @@
     "path": "packages/unifiedmandala-core/configSchema.ts",
     "task": "Build JSON schema and integrate AJV validation",
     "test": "packages/unifiedmandala-core/configSchema.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Implement composite core framework",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -5952,7 +5952,7 @@
   path: packages/unifiedmandala-core/configSchema.ts
   task: Build JSON schema and integrate AJV validation
   test: packages/unifiedmandala-core/configSchema.test.ts
-  status: todo
+  status: done
 - commit: Implement composite core framework
   path: packages/unifiedmandala-core/composite.ts
   task: Create core layer using Composite Pattern

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "chore: update progress step",
-  "fractalStep": "implement",
+  "lastCommit": "feat(core): add config schema validation",
+  "fractalStep": "sync",
   "openBranches": [
     "work"
   ],

--- a/packages/unifiedmandala-core/configSchema.test.ts
+++ b/packages/unifiedmandala-core/configSchema.test.ts
@@ -1,0 +1,11 @@
+import { validateConfig } from './configSchema';
+
+test('accepts valid config', () => {
+  const cfg = validateConfig({ name: 'mandala', version: '1.0', layers: 3, enableAudio: true });
+  expect(cfg.layers).toBe(3);
+  expect(cfg.enableAudio).toBe(true);
+});
+
+test('throws on invalid config', () => {
+  expect(() => validateConfig({})).toThrow();
+});

--- a/packages/unifiedmandala-core/configSchema.ts
+++ b/packages/unifiedmandala-core/configSchema.ts
@@ -1,0 +1,29 @@
+import Ajv, { JSONSchemaType } from 'ajv';
+
+export interface UnifiedMandalaConfig {
+  name: string;
+  version: string;
+  layers?: number;
+  enableAudio?: boolean;
+}
+
+const schema: JSONSchemaType<UnifiedMandalaConfig> = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    version: { type: 'string' },
+    layers: { type: 'integer', nullable: true },
+    enableAudio: { type: 'boolean', nullable: true }
+  },
+  required: ['name', 'version'],
+  additionalProperties: false
+};
+
+export function validateConfig(raw: unknown): UnifiedMandalaConfig {
+  const ajv = new Ajv();
+  const validate = ajv.compile(schema);
+  if (!validate(raw)) {
+    throw new Error('Invalid config: ' + ajv.errorsText(validate.errors));
+  }
+  return raw as UnifiedMandalaConfig;
+}

--- a/packages/unifiedmandala-core/tsconfig.json
+++ b/packages/unifiedmandala-core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist"
+  },
+  "include": ["./**/*"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - 'packages/crep-engine'
   - 'packages/unifiedmandala-ui'
+  - 'packages/unifiedmandala-core'
   - 'packages/bio'
   - 'packages/genesis-sigillin-core'
   - 'packages/gpt-bridges'


### PR DESCRIPTION
## Summary
- add new `unifiedmandala-core` package
- implement `configSchema` using AJV
- provide unit tests
- track progress and mark TODO as done

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686d48dfa9d8832294aaeae1e55db9f4