### PR TITLE
Add ThreeFiberSkeleton component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4070,7 +4070,7 @@
     "path": "packages/unifiedmandala-ui/ThreeFiberSkeleton.tsx",
     "task": "Build base UI skeleton with React and Three-Fiber",
     "test": "packages/unifiedmandala-ui/ThreeFiberSkeleton.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Build audio engine with WebAudio",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -5962,7 +5962,7 @@
   path: packages/unifiedmandala-ui/ThreeFiberSkeleton.tsx
   task: Build base UI skeleton with React and Three-Fiber
   test: packages/unifiedmandala-ui/ThreeFiberSkeleton.test.tsx
-  status: todo
+  status: done
 - commit: Build audio engine with WebAudio
   path: packages/unifiedmandala-audio/engine.ts
   task: Implement PhiTone, useCREPTone and Mandala soundscape modules

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat(core): add config schema validation",
+  "lastCommit": "feat(ui): add ThreeFiberSkeleton component",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/packages/unifiedmandala-ui/ThreeFiberSkeleton.test.tsx
+++ b/packages/unifiedmandala-ui/ThreeFiberSkeleton.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import ThreeFiberSkeleton from './ThreeFiberSkeleton';
+
+jest.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }: any) => <div data-testid="canvas">{children}</div>,
+  ambientLight: 'ambientLight',
+  mesh: 'mesh',
+  boxGeometry: 'boxGeometry',
+  meshStandardMaterial: 'meshStandardMaterial'
+}));
+
+test('renders three-fiber skeleton', () => {
+  const { getByTestId } = render(<ThreeFiberSkeleton />);
+  expect(getByTestId('canvas')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/ThreeFiberSkeleton.tsx
+++ b/packages/unifiedmandala-ui/ThreeFiberSkeleton.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Canvas } from '@react-three/fiber';
+
+const ThreeFiberSkeleton: React.FC = () => (
+  <Canvas>
+    <ambientLight />
+    <mesh>
+      <boxGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial color="orange" />
+    </mesh>
+  </Canvas>
+);
+
+export default ThreeFiberSkeleton;


### PR DESCRIPTION
## Summary
- implement ThreeFiberSkeleton React component using @react-three/fiber
- add unit test for ThreeFiberSkeleton
- mark related task as done in advancedToDo lists
- update progress tracker

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686d52ddc04483229cf1b4b216c55f66