### PR TITLE
Implement MandalaAudioEngine

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4077,7 +4077,7 @@
     "path": "packages/unifiedmandala-audio/engine.ts",
     "task": "Implement PhiTone, useCREPTone and Mandala soundscape modules",
     "test": "packages/unifiedmandala-audio/engine.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Connect CosmicTheoryAgent UI bridge",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -5967,7 +5967,7 @@
   path: packages/unifiedmandala-audio/engine.ts
   task: Implement PhiTone, useCREPTone and Mandala soundscape modules
   test: packages/unifiedmandala-audio/engine.test.ts
-  status: todo
+  status: done
 - commit: Connect CosmicTheoryAgent UI bridge
   path: packages/unifiedmandala-ui/api/cosmicBridge.ts
   task: Create REST and WebSocket endpoints with hooks

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,8 +1,7 @@
 {
-  "lastCommit": "chore(progress): sync after commit",
+  "lastCommit": "feat(audio): add MandalaAudioEngine",
   "fractalStep": "sync",
   "openBranches": [
     "work"
   ],
-  "mergeConflicts": []
-}
+  "mergeConflicts": []}

--- a/packages/unifiedmandala-audio/engine.test.ts
+++ b/packages/unifiedmandala-audio/engine.test.ts
@@ -1,0 +1,17 @@
+import { MandalaAudioEngine, PHI, createMandalaSoundscape } from './engine';
+
+test('phi constant value', () => {
+  expect(Number(PHI.toFixed(5))).toBeCloseTo(1.61803, 5);
+});
+
+test('createMandalaSoundscape returns tones', () => {
+  const tones = createMandalaSoundscape([0, 0.5]);
+  expect(tones).toHaveLength(2);
+  expect(tones[0].frequency).toBeCloseTo(220);
+});
+
+test('MandalaAudioEngine computes phi tone frequency', () => {
+  const engine = new MandalaAudioEngine(440);
+  // context might not exist in test env; ensure method doesn't throw
+  engine.phiTone(0.1);
+});

--- a/packages/unifiedmandala-audio/engine.ts
+++ b/packages/unifiedmandala-audio/engine.ts
@@ -1,0 +1,39 @@
+export const PHI = (1 + Math.sqrt(5)) / 2;
+export interface ToneConfig {
+  frequency: number;
+  duration: number;
+}
+
+export class MandalaAudioEngine {
+  private ctx: AudioContext | null;
+
+  constructor(private baseFreq = 440) {
+    if (typeof AudioContext !== 'undefined') {
+      this.ctx = new AudioContext();
+    } else {
+      this.ctx = null;
+    }
+  }
+
+  private playTone({ frequency, duration }: ToneConfig) {
+    if (!this.ctx) return;
+    const osc = this.ctx.createOscillator();
+    osc.frequency.value = frequency;
+    osc.connect(this.ctx.destination);
+    osc.start();
+    osc.stop(this.ctx.currentTime + duration);
+  }
+
+  phiTone(duration = 0.5) {
+    this.playTone({ frequency: this.baseFreq * PHI, duration });
+  }
+
+  useCREPTone(crep: number, duration = 0.5) {
+    const freq = this.baseFreq * (1 + crep);
+    this.playTone({ frequency: freq, duration });
+  }
+}
+
+export function createMandalaSoundscape(crepValues: number[]): ToneConfig[] {
+  return crepValues.map((c, i) => ({ frequency: 220 + c * 100 + i * 10, duration: 0.3 }));
+}

--- a/packages/unifiedmandala-audio/index.ts
+++ b/packages/unifiedmandala-audio/index.ts
@@ -1,0 +1,1 @@
+export * from './engine';


### PR DESCRIPTION
## Summary
- add new package `unifiedmandala-audio` with a simple WebAudio engine
- mark audio engine task as done in advancedToDo files
- track progress for the new feature

## Testing
- `pnpm test packages/unifiedmandala-audio/engine.test.ts`
- `pnpm lint` *(fails: Conversion of type error)*

------
https://chatgpt.com/codex/tasks/task_e_686d65fb12b48322895dd7421bb9351d