### PR TITLE
Add MandalaCycle and CompassionAgent

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4834,5 +4834,19 @@
     "task": "Split newadvancedconversations.json into numbered YAML/JSON fragments",
     "test": "scripts/__tests__/newadvancedconvo_splitter.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Implement AeonCompassionAgent",
+    "path": "packages/agents/AeonCompassionAgent.ts",
+    "task": "Process empathic inputs and update MandalaCycle.log",
+    "test": "packages/agents/AeonCompassionAgent.test.ts",
+    "status": "done"
+  },
+  {
+    "commit": "Add MandalaCycle core module",
+    "path": "packages/aeon-shell/MandalaCycle.ts",
+    "task": "Integrate cosmic origin sigil and dynamic weight factors via combinedWeight",
+    "test": "packages/aeon-shell/MandalaCycle.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -5908,6 +5908,16 @@
   task: Split newadvancedconversations.json into YAML/JSON fragments in ZIPMEM
   test: scripts/__tests__/newadvancedconvo_splitter.test.ts
   status: done
+- commit: Implement AeonCompassionAgent
+  path: packages/agents/AeonCompassionAgent.ts
+  task: Process empathic inputs and update MandalaCycle.log
+  test: packages/agents/AeonCompassionAgent.test.ts
+  status: done
+- commit: Add MandalaCycle core module
+  path: packages/aeon-shell/MandalaCycle.ts
+  task: Integrate cosmic origin sigil and dynamic weight factors via combinedWeight
+  test: packages/aeon-shell/MandalaCycle.test.ts
+  status: done
 - commit: Add SealCore integration interface
   path: packages/seal-core/SealCore.ts
   task: Bridge SelflearnAI with GenesisAeon system via SealCore membrane

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "chore(progress): update last commit",
-  "fractalStep": "sync",
+  "lastCommit": "feat: add MandalaCycle and CompassionAgent",
+  "fractalStep": "implementation",
   "openBranches": [
     "work"
   ],  "mergeConflicts": []

--- a/packages/aeon-shell/MandalaCycle.test.ts
+++ b/packages/aeon-shell/MandalaCycle.test.ts
@@ -1,0 +1,10 @@
+import { MandalaCycle } from './MandalaCycle';
+
+describe('MandalaCycle', () => {
+  it('refresh updates weightFactor', () => {
+    const cycle = new MandalaCycle({ cosmicFactor: 2 });
+    cycle.weightFactor = 0 as any;
+    cycle.refresh(3);
+    expect(cycle.weightFactor).toBeGreaterThan(0);
+  });
+});

--- a/packages/aeon-shell/MandalaCycle.ts
+++ b/packages/aeon-shell/MandalaCycle.ts
@@ -1,0 +1,26 @@
+import EventEmitter from 'events';
+import { combinedWeight } from '../analysis/weights';
+import { AeonCompassionAgent } from '../agents/AeonCompassionAgent';
+
+export interface MandalaCycleOptions {
+  cosmicFactor: number;
+}
+
+export class MandalaCycle extends EventEmitter {
+  private compassion: AeonCompassionAgent;
+  weightFactor = 1;
+
+  constructor(private opts: MandalaCycleOptions, bus = new EventEmitter()) {
+    super();
+    this.compassion = new AeonCompassionAgent(bus);
+  }
+
+  refresh(level = 1) {
+    this.weightFactor = combinedWeight(level, this.opts.cosmicFactor);
+    this.emit('cycle', { weight: this.weightFactor });
+  }
+
+  processInput(input: { type: string; intensity: number }) {
+    this.compassion.process(input, { log: () => {} });
+  }
+}

--- a/packages/agents/AeonCompassionAgent.test.ts
+++ b/packages/agents/AeonCompassionAgent.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { EventEmitter } from 'events';
+import { AeonCompassionAgent } from './AeonCompassionAgent';
+
+describe('AeonCompassionAgent', () => {
+  it('emits sigil-status and logs entry', () => {
+    const bus = new EventEmitter();
+    let logMsg = '';
+    const root = { log: (m: string) => { logMsg = m; } };
+    const agent = new AeonCompassionAgent(bus);
+    let emitted = '';
+    bus.on('sigil-status', (s) => (emitted = s));
+    agent.process({ type: 'kindness', intensity: 2 }, root);
+    expect(emitted).toBe('kindness:2');
+    expect(logMsg).toBe('kindness:2');
+  });
+});

--- a/packages/agents/AeonCompassionAgent.ts
+++ b/packages/agents/AeonCompassionAgent.ts
@@ -1,0 +1,17 @@
+import { EventEmitter } from 'events';
+
+export interface CompassionInput {
+  type: string;
+  intensity: number;
+  message?: string;
+}
+
+export class AeonCompassionAgent {
+  constructor(private bus: EventEmitter) {}
+
+  process(input: CompassionInput, root: { log?: (msg: string) => void }) {
+    const status = `${input.type}:${input.intensity}`;
+    this.bus.emit('sigil-status', status);
+    root.log?.(status);
+  }
+}

--- a/packages/analysis/weights.test.ts
+++ b/packages/analysis/weights.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { combinedWeight } from './weights';
+
+describe('combinedWeight', () => {
+  it('multiplies level with factor', () => {
+    expect(combinedWeight(2, 3)).toBe(6);
+  });
+});

--- a/packages/analysis/weights.ts
+++ b/packages/analysis/weights.ts
@@ -1,0 +1,3 @@
+export function combinedWeight(level: number, factor: number): number {
+  return level * factor;
+}


### PR DESCRIPTION
## Summary
- implement `AeonCompassionAgent` to capture empathic inputs
- introduce `MandalaCycle` core module with weight factor refresh
- expose `combinedWeight` helper
- document tasks in advancedToDo files and log progress

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686d6c97f08c8322a193fe0a1f57973d