### PR TITLE
Implement prototype deployment script

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4237,7 +4237,7 @@
     "commit": "Setup ProtoTyp deployment environment",
     "path": "scripts/prototype-deploy.sh",
     "task": "Create prototype deployment script for Aeon services",
-    "test": "",
+    "test": "scripts/__tests__/prototype-deploy.test.ts",
     "status": "done"
   },
   {

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6093,8 +6093,8 @@
 - commit: Setup ProtoTyp deployment environment
   path: scripts/prototype-deploy.sh
   task: Create prototype deployment script for Aeon services
-  test: ""
-  status: todo
+  test: scripts/__tests__/prototype-deploy.test.ts
+  status: done
 - commit: Add fractal anchor metadata
   path: docs/sigils/fractal-anchor.yaml
   task: Include fractal-entry sigil details across docs

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,7 +1,7 @@
 {
-  "lastCommit": "feat: add MandalaCycle and CompassionAgent",
-  "fractalStep": "implementation",
+  "lastCommit": "chore: update progress",
+  "fractalStep": "sync",
   "openBranches": [
     "work"
-  ],  "mergeConflicts": []
-}
+  ],
+  "mergeConflicts": []}

--- a/packages/analysis/weights.test.ts
+++ b/packages/analysis/weights.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+// Jest provides describe and it globals in this environment
 import { combinedWeight } from './weights';
 
 describe('combinedWeight', () => {

--- a/scripts/__tests__/prototype-deploy.test.ts
+++ b/scripts/__tests__/prototype-deploy.test.ts
@@ -1,0 +1,7 @@
+import fs from 'fs';
+import path from 'path';
+
+test('prototype deploy script exists', () => {
+  const script = path.join(__dirname, '../prototype-deploy.sh');
+  expect(fs.existsSync(script)).toBe(true);
+});

--- a/scripts/prototype-deploy.sh
+++ b/scripts/prototype-deploy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Prototype deployment environment for Aeon services
+COMPOSE_FILE="$(dirname "$0")/../infrastructure/protodeploy/docker-compose.yml"
+
+docker-compose -f "$COMPOSE_FILE" "$@"


### PR DESCRIPTION
## Summary
- add new `prototype-deploy.sh` script to run prototype docker compose
- test presence of deploy script
- mark related tasks done in advancedToDo files
- fix `weights.test.ts` for Jest
- update progress tracking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d71b51fc48322869dad5258b970ec