### PR TITLE
feat(ui): add PyramidBlueprint component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4255,11 +4255,11 @@
     "status": "done"
   },
   {
-    "commit": "Implement AeonAI Pyramid UI blueprint",
-    "path": "packages/unifiedmandala-ui/components/PyramidBlueprint.tsx",
-    "task": "Render dual-layer pyramid with weight nodes",
-    "test": "packages/unifiedmandala-ui/components/PyramidBlueprint.test.tsx",
-    "status": "todo"
+  "commit": "Implement AeonAI Pyramid UI blueprint",
+  "path": "packages/unifiedmandala-ui/components/PyramidBlueprint.tsx",
+  "task": "Render dual-layer pyramid with weight nodes",
+  "test": "packages/unifiedmandala-ui/components/PyramidBlueprint.test.tsx",
+  "status": "done"
   },
   {
     "commit": "Create LocalhostOffline Docker setup",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6109,7 +6109,7 @@
   path: packages/unifiedmandala-ui/components/PyramidBlueprint.tsx
   task: Render dual-layer pyramid with weight nodes
   test: packages/unifiedmandala-ui/components/PyramidBlueprint.test.tsx
-  status: todo
+  status: done
 - commit: Create LocalhostOffline Docker setup
   path: localhost-offline/docker-compose.yml
   task: Provide offline Docker Compose environment

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,7 +1,7 @@
 {
-  "lastCommit": "chore: update progress",
+  "lastCommit": "feat: add PyramidBlueprint",
   "fractalStep": "sync",
   "openBranches": [
     "work"
-  ],
-  "mergeConflicts": []}
+  ],  "mergeConflicts": []
+}

--- a/packages/unifiedmandala-ui/components/PyramidBlueprint.test.tsx
+++ b/packages/unifiedmandala-ui/components/PyramidBlueprint.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PyramidBlueprint from './PyramidBlueprint';
+
+jest.mock('./NestedPyramid', () => ({ __esModule: true, default: ({ root }: any) => (
+  <div data-testid="nested-pyramid">{JSON.stringify(root)}</div>
+)}));
+
+test('renders nested pyramid with default levels', () => {
+  render(<PyramidBlueprint />);
+  const div = screen.getByTestId('nested-pyramid');
+  expect(div).toBeInTheDocument();
+  const root = JSON.parse(div.textContent || '{}');
+  expect(root.index).toBe(0);
+  expect(root.children).toBeDefined();
+});

--- a/packages/unifiedmandala-ui/components/PyramidBlueprint.tsx
+++ b/packages/unifiedmandala-ui/components/PyramidBlueprint.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import NestedPyramid from './NestedPyramid';
+import { generateNestedLayers } from '../pyramid/generateNestedLayers';
+
+export interface PyramidBlueprintProps {
+  levels?: number;
+}
+
+const PyramidBlueprint: React.FC<PyramidBlueprintProps> = ({ levels = 2 }) => {
+  const root = generateNestedLayers(levels);
+  return <NestedPyramid root={root} />;
+};
+
+export default PyramidBlueprint;


### PR DESCRIPTION
## Summary
- implement new `PyramidBlueprint` component rendering nested pyramid
- test for default rendering behavior
- mark `PyramidBlueprint` todo complete in advancedToDo lists
- update progress

## Testing
- `npx vitest run packages/unifiedmandala-ui/components/PyramidBlueprint.test.tsx` *(fails: cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_686d7ebed1a88322bafc4e16393f46aa