### PR TITLE
feat(ui): add ThreeDPyramid component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4609,7 +4609,7 @@
     "path": "packages/unifiedmandala-ui/components/ThreeDPyramid.tsx",
     "task": "React-Three-Fiber Pyramide mit animierten Layern",
     "test": "packages/unifiedmandala-ui/components/ThreeDPyramid.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from AeonAI Pyramid UI conversation - AudioEngine module",
@@ -4854,5 +4854,5 @@
     "path": "docs/PyramidSuiteBlueprint.md",
     "task": "Add Hardcode Blueprint section after Next Steps",
     "test": "",
-    "status": "done"
-  }]
+    "status": "done"  }
+]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6321,7 +6321,7 @@
   path: packages/unifiedmandala-ui/components/ThreeDPyramid.tsx
   task: React-Three-Fiber Pyramide mit animierten Layern
   test: packages/unifiedmandala-ui/components/ThreeDPyramid.test.tsx
-  status: todo
+  status: done
 - commit: TODO from AeonAI Pyramid UI conversation - AudioEngine module
   path: packages/unifiedmandala-ui/lib/AudioEngine.ts
   task: Tone.js Integration für Phi-Skala und Fehlerklänge

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,8 +1,7 @@
 {
-  "lastCommit": "chore: finalize progress",
+  "lastCommit": "feat(ui): add ThreeDPyramid component",
   "fractalStep": "sync",
   "openBranches": [
     "work"
   ],
-  "mergeConflicts": []
-}
+  "mergeConflicts": []}

--- a/packages/unifiedmandala-ui/components/ThreeDPyramid.test.tsx
+++ b/packages/unifiedmandala-ui/components/ThreeDPyramid.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import ThreeDPyramid from './ThreeDPyramid';
+
+jest.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }: any) => <div>{children}</div>,
+  useFrame: () => {},
+  coneGeometry: 'coneGeometry',
+  mesh: 'mesh',
+  meshStandardMaterial: 'meshStandardMaterial',
+  ambientLight: 'ambientLight',
+  pointLight: 'pointLight',
+}));
+
+test('renders pyramid layers', () => {
+  const { getByLabelText } = render(<ThreeDPyramid layers={2} />);
+  expect(getByLabelText('pyramid-layer-0')).toBeInTheDocument();
+  expect(getByLabelText('pyramid-layer-1')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/ThreeDPyramid.tsx
+++ b/packages/unifiedmandala-ui/components/ThreeDPyramid.tsx
@@ -1,0 +1,38 @@
+import React, { useRef } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import type { Mesh } from 'three';
+
+interface ThreeDPyramidProps {
+  layers: number;
+}
+
+const Layer: React.FC<{ index: number }> = ({ index }) => {
+  const ref = useRef<Mesh>(null!);
+  const height = 1;
+  const size = (index + 1) * 2;
+
+  useFrame(() => {
+    if (ref.current) {
+      ref.current.rotation.y += 0.01 * (index + 1);
+    }
+  });
+
+  return (
+    <mesh ref={ref} position={[0, index * height, 0]} aria-label={`pyramid-layer-${index}`}> 
+      <coneGeometry args={[size, height]} />
+      <meshStandardMaterial color="teal" />
+    </mesh>
+  );
+};
+
+const ThreeDPyramid: React.FC<ThreeDPyramidProps> = ({ layers }) => (
+  <Canvas>
+    <ambientLight intensity={0.5} />
+    <pointLight position={[10, 10, 10]} />
+    {Array.from({ length: layers }).map((_, i) => (
+      <Layer key={i} index={i} />
+    ))}
+  </Canvas>
+);
+
+export default ThreeDPyramid;

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -18,3 +18,4 @@ export { default as MandalaCREPCircle } from './components/MandalaCREPCircle';
 export { SymbolzeitManager } from '../aeon-shell/SymbolzeitManager';
 export { runCommand as AeonShellBridge } from '../aeon-shell/AeonShellBridge';
 export * from './utils/PyramidUtils';
+export { default as ThreeDPyramid } from './components/ThreeDPyramid';


### PR DESCRIPTION
## Summary
- add a ThreeDPyramid React component with basic animation
- test ThreeDPyramid rendering
- mark the task as done in advancedToDo files
- document progress

## Testing
- `pyright`
- `pnpm install`
- `npx jest packages/unifiedmandala-ui/components/ThreeDPyramid.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_686d893526788322a801d0c4f8e999f8