### PR TITLE
Add episodic memory module and visualization CLI

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -144,6 +144,7 @@ GPTEventHub.emit('orakel:says', { content: 'Hallo Welt' });
 ### cli-tools
 - `sigillin-cli.ts` – Konvertiert und validiert Sigillin-Dateien.
 - `dispatchCmd.ts` – Startet Tasks via REST/gRPC aus der CLI.
+- `visualize_state.py` – erzeugt Fraktal-State-Charts aus CREP-Historien.
 
 ### sharedream-interface
 - `MetaScoreChart` – Zeigt Bewertungsdaten aus `/api/meta-scores`.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**GenerativeOverlay**](packages/art/generativeOverlay.ts) – GAN-Überlagerung für Live-Daten
 - [**UniversePulseSimulator**](packages/universum-simulationen/UniversePulseSimulator.ts) – simuliert emergente Zustände
 - [**ToDoWeaver**](packages/cli-tools/ToDoWeaver.ts) – generiert YAML-Aufgaben aus CREP-Clustern
+- [**EpisodicMemory**](packages/crep-engine/EpisodicMemory.ts) – speichert CREP-Folgen mit Zeit- und Symbolmetadaten
+- [**visualize_state.py**](packages/cli-tools/visualize_state.py) – erzeugt Fraktal-State-Charts aus CREP-Historien
 
 - [**WeightedDispatcher**](packages/agents/WeightedDispatcher.ts) – verteilt Tasks nach Priorität
 - [**patternReactivator**](packages/agents/patternReactivator.ts) – reaktiviert schwache Muster

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4860,13 +4860,13 @@
     "path": "packages/crep-engine/EpisodicMemory.ts",
     "task": "Store sequences of CREP states with timestamp and symbol metadata",
     "test": "packages/crep-engine/EpisodicMemory.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add CLI state visualization",
     "path": "packages/cli-tools/visualize_state.py",
     "task": "Provide Matplotlib-based fractal state charts from CLI",
     "test": "packages/cli-tools/visualize_state.test.py",
-    "status": "todo"
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6497,9 +6497,9 @@
   path: packages/crep-engine/EpisodicMemory.ts
   task: Store sequences of CREP states with timestamp and symbol metadata
   test: packages/crep-engine/EpisodicMemory.test.ts
-  status: todo
+  status: done
 - commit: Add CLI state visualization
   path: packages/cli-tools/visualize_state.py
   task: Provide Matplotlib-based fractal state charts from CLI
   test: packages/cli-tools/visualize_state.test.py
-  status: todo
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "feat: add episodic memory and visualization todos",
-  "fractalStep": "sync",
+  "lastCommit": "feat: episodic memory module and visualization cli",
+  "fractalStep": "implementation",
   "openBranches": [
     "work"  ],
   "mergeConflicts": []

--- a/packages/cli-tools/visualize_state.py
+++ b/packages/cli-tools/visualize_state.py
@@ -1,0 +1,39 @@
+import argparse
+import json
+from datetime import datetime
+from typing import List, Dict, Any
+import matplotlib.pyplot as plt
+
+
+def load_data(path: str) -> List[Dict[str, Any]]:
+    with open(path, 'r') as f:
+        return json.load(f)
+
+
+def visualize(data: List[Dict[str, Any]], outfile: str = None):
+    timestamps = [datetime.fromisoformat(d['timestamp']) for d in data]
+    for key in ['C', 'R', 'E', 'P']:
+        plt.plot(timestamps, [d[key] for d in data], label=key)
+    plt.xlabel('Time')
+    plt.ylabel('Value')
+    plt.legend()
+    fig = plt.gcf()
+    if outfile:
+        plt.savefig(outfile)
+    return fig
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Visualize CREP state history')
+    parser.add_argument('file', help='JSON file with CREP history')
+    parser.add_argument('--out', help='Output image file')
+    args = parser.parse_args()
+    data = load_data(args.file)
+    fig = visualize(data, args.out)
+    if not args.out:
+        plt.show()
+    return fig
+
+
+if __name__ == '__main__':
+    main()

--- a/packages/cli-tools/visualize_state.test.py
+++ b/packages/cli-tools/visualize_state.test.py
@@ -1,0 +1,17 @@
+import unittest
+from visualize_state import visualize
+
+class TestVisualizeState(unittest.TestCase):
+    def test_visualize_returns_figure(self):
+        data = [{
+            'timestamp': '2024-01-01T00:00:00',
+            'C': 1,
+            'R': 1,
+            'E': 1,
+            'P': 1
+        }]
+        fig = visualize(data)
+        self.assertEqual(fig.axes[0].lines[0].get_label(), 'C')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/packages/crep-engine/EpisodicMemory.test.ts
+++ b/packages/crep-engine/EpisodicMemory.test.ts
@@ -1,0 +1,20 @@
+import { EpisodicMemory } from './EpisodicMemory';
+
+describe('EpisodicMemory', () => {
+  it('stores entries with timestamp and symbol', () => {
+    const mem = new EpisodicMemory();
+    mem.add({ C: 1, R: 1, E: 1, P: 1, symbol: 'alpha' });
+    const all = mem.getAll();
+    expect(all).toHaveLength(1);
+    expect(all[0].symbol).toBe('alpha');
+    expect(all[0].timestamp instanceof Date).toBe(true);
+  });
+
+  it('returns last n entries', () => {
+    const mem = new EpisodicMemory();
+    for (let i = 0; i < 5; i++) {
+      mem.add({ C: i, R: i, E: i, P: i });
+    }
+    expect(mem.getLast(2).length).toBe(2);
+  });
+});

--- a/packages/crep-engine/EpisodicMemory.ts
+++ b/packages/crep-engine/EpisodicMemory.ts
@@ -1,0 +1,31 @@
+export interface EpisodicEntry {
+  timestamp: Date;
+  C: number;
+  R: number;
+  E: number;
+  P: number;
+  symbol?: string;
+}
+
+export class EpisodicMemory {
+  private memory: EpisodicEntry[] = [];
+
+  add(entry: Omit<EpisodicEntry, 'timestamp'> & { timestamp?: Date }): void {
+    this.memory.push({
+      timestamp: entry.timestamp ?? new Date(),
+      C: entry.C,
+      R: entry.R,
+      E: entry.E,
+      P: entry.P,
+      symbol: entry.symbol,
+    });
+  }
+
+  getAll(): EpisodicEntry[] {
+    return this.memory;
+  }
+
+  getLast(n: number): EpisodicEntry[] {
+    return this.memory.slice(-n);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `EpisodicMemory` class for storing CREP state sequences
- add CLI `visualize_state.py` to plot CREP history via matplotlib
- document new modules in README and Handbuch
- mark corresponding tasks complete in advancedToDo lists

## Testing
- `pnpm install`
- `pnpm run qa`


------
https://chatgpt.com/codex/tasks/task_e_686e05438b348322bad57a945dfb252d