### PR TITLE
Implement SigilManager hooks in CosmicTheoryAgent

### DIFF
--- a/packages/agents/CosmicTheoryAgent.test.ts
+++ b/packages/agents/CosmicTheoryAgent.test.ts
@@ -58,6 +58,16 @@ describe('sigil integration', () => {
     expect(sigilManager.list()[0].id).toBe('alpha');
     expect(events[0].sigilId).toBe('alpha');
   });
+
+  it('records history via SigilManager hooks', () => {
+    const events: any[] = [];
+    CosmicTheoryEventHub.on('sigil:added', e => events.push(e));
+    sigilManager.add({ id: 'beta', data: {} });
+    sigilManager.update('beta', { x: 1 });
+    sigilManager.remove('beta');
+    expect(events[0].sigilId).toBe('beta');
+    expect(sigilHistory.map(s => s.id)).toContain('beta');
+  });
 });
 
 describe('performRemoteAnalysis', () => {

--- a/packages/agents/CosmicTheoryAgent.ts
+++ b/packages/agents/CosmicTheoryAgent.ts
@@ -1,10 +1,25 @@
 import axios from 'axios';
 import { fractalDecompose, computeFractalMetric } from '../analysis/FractalAnalyzer';
 import { symbolicRegression } from '../analysis/SymbolicRegression';
-import { SigilManager } from '../shared-utils/SigilManager';
+import { SigilManager, SigilEntry } from '../shared-utils/SigilManager';
 import { CosmicTheoryEventHub } from './CosmicTheoryAgentEvents';
 
 export const sigilManager = new SigilManager();
+
+export const sigilHistory: SigilEntry[] = [];
+
+sigilManager.on('sigil:added', (entry: SigilEntry) => {
+  sigilHistory.push(entry);
+  CosmicTheoryEventHub.emit('sigil:added', { sigilId: entry.id });
+});
+
+sigilManager.on('sigil:updated', (entry: SigilEntry) => {
+  CosmicTheoryEventHub.emit('sigil:updated', { sigilId: entry.id });
+});
+
+sigilManager.on('sigil:removed', (id: string) => {
+  CosmicTheoryEventHub.emit('sigil:removed', { sigilId: id });
+});
 
 export function loadSigil(id: string, text: string): void {
   const entry = sigilManager.loadFromString(id, text);

--- a/packages/shared-utils/SigilManager.test.ts
+++ b/packages/shared-utils/SigilManager.test.ts
@@ -16,3 +16,21 @@ test('parses YAML or JSON strings', () => {
   mgr.loadFromString('s3', 'y: 2');
   expect(mgr.list().map(s => s.id)).toEqual(['s2', 's3']);
 });
+
+test('emits events on changes', () => {
+  const mgr = new SigilManager();
+  const added: string[] = [];
+  mgr.on('sigil:added', e => added.push(e.id));
+  const updated: string[] = [];
+  mgr.on('sigil:updated', e => updated.push(e.id));
+  const removed: string[] = [];
+  mgr.on('sigil:removed', id => removed.push(id));
+
+  mgr.add({ id: 's4', data: {} });
+  mgr.update('s4', { x: 1 });
+  mgr.remove('s4');
+
+  expect(added).toEqual(['s4']);
+  expect(updated).toEqual(['s4']);
+  expect(removed).toEqual(['s4']);
+});

--- a/packages/shared-utils/SigilManager.ts
+++ b/packages/shared-utils/SigilManager.ts
@@ -1,12 +1,22 @@
 import YAML from 'yaml';
+import { EventEmitter } from 'events';
 
 export interface SigilEntry {
   id: string;
   data: any;
 }
 
-export class SigilManager {
+export type SigilManagerEvent =
+  | { type: 'sigil:added'; entry: SigilEntry }
+  | { type: 'sigil:updated'; entry: SigilEntry }
+  | { type: 'sigil:removed'; id: string };
+
+export class SigilManager extends EventEmitter {
   private sigils: SigilEntry[] = [];
+
+  constructor() {
+    super();
+  }
 
   list(): SigilEntry[] {
     return this.sigils;
@@ -14,15 +24,20 @@ export class SigilManager {
 
   add(entry: SigilEntry): void {
     this.sigils.push(entry);
+    this.emit('sigil:added', entry);
   }
 
   update(id: string, data: any): void {
     const s = this.sigils.find(e => e.id === id);
-    if (s) s.data = data;
+    if (s) {
+      s.data = data;
+      this.emit('sigil:updated', s);
+    }
   }
 
   remove(id: string): void {
     this.sigils = this.sigils.filter(e => e.id !== id);
+    this.emit('sigil:removed', id);
   }
 
   loadFromString(id: string, text: string): SigilEntry {


### PR DESCRIPTION
## Summary
- extend `SigilManager` with EventEmitter and emit events on changes
- track sigil history and forward events through `CosmicTheoryEventHub`
- add regression test for new hooks

## Testing
- `pnpm test`
- `npx -y pyright -p tsconfig.json` *(fails: Import errors in Python files)*

------
https://chatgpt.com/codex/tasks/task_e_686e0a2957f483228d11083909501655