### PR TITLE
feat: add Fourier API and FrequencyMandala

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4280,7 +4280,7 @@
     "path": "packages/agents/CosmicTheoryAgent.ts",
     "task": "Load and store sigil states via SigilManager hooks",
     "test": "packages/agents/CosmicTheoryAgent.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add UI Agent mapping matrix",
@@ -4875,14 +4875,14 @@
     "path": "services/fourier-metrics/api.ts",
     "task": "Provide /api/fourier/analyze endpoint returning frequency data",
     "test": "services/fourier-metrics/api.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from newadvancedconversations.json - FrequencyMandala component",
     "path": "packages/unifiedmandala-ui/components/FrequencyMandala.tsx",
     "task": "Render frequency flower visualization from Fourier results",
     "test": "packages/unifiedmandala-ui/components/FrequencyMandala.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from newadvancedconversations.json - FractalTaskRunner",
@@ -4910,14 +4910,14 @@
     "path": "services/fourier-metrics/api.ts",
     "task": "Provide /api/fourier/analyze endpoint returning frequency data",
     "test": "services/fourier-metrics/api.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from newadvancedconversations.json - FrequencyMandala component",
     "path": "packages/unifiedmandala-ui/components/FrequencyMandala.tsx",
     "task": "Render frequency flower visualization from Fourier results",
     "test": "packages/unifiedmandala-ui/components/FrequencyMandala.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from newadvancedconversations.json - FractalTaskRunner",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6507,12 +6507,12 @@
   path: services/fourier-metrics/api.ts
   task: Provide /api/fourier/analyze endpoint returning frequency data
   test: services/fourier-metrics/api.test.ts
-  status: todo
+  status: done
 - commit: TODO from newadvancedconversations.json - FrequencyMandala component
   path: packages/unifiedmandala-ui/components/FrequencyMandala.tsx
   task: Render frequency flower visualization from Fourier results
   test: packages/unifiedmandala-ui/components/FrequencyMandala.test.tsx
-  status: todo
+  status: done
 - commit: TODO from newadvancedconversations.json - FractalTaskRunner
   path: packages/task-runner/FractalTaskRunner.ts
   task: Execute Fourier, CREP and Sigil plugins from YAML tasks

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: add FourierLayer and Pyramid UI tasks",
+  "lastCommit": "feat: add Fourier API and FrequencyMandala",
   "fractalStep": "implementation",
   "openBranches": [
     "work"

--- a/packages/unifiedmandala-ui/components/FrequencyMandala.test.tsx
+++ b/packages/unifiedmandala-ui/components/FrequencyMandala.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import FrequencyMandala from './FrequencyMandala';
+
+test('renders svg element', () => {
+  const { container } = render(<FrequencyMandala freqs={[1,2,3,4]} />);
+  expect(container.querySelector('svg')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/FrequencyMandala.tsx
+++ b/packages/unifiedmandala-ui/components/FrequencyMandala.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface Props {
+  freqs: number[];
+}
+
+const FrequencyMandala: React.FC<Props> = ({ freqs }) => {
+  const center = 50;
+  const base = 20;
+  const points = freqs.map((f, i) => {
+    const angle = (i / freqs.length) * 2 * Math.PI;
+    const r = base + f * 5;
+    const x = center + r * Math.cos(angle);
+    const y = center + r * Math.sin(angle);
+    return `${i === 0 ? 'M' : 'L'}${x},${y}`;
+  });
+  const pathData = points.join(' ') + ' Z';
+  return (
+    <svg width={100} height={100} aria-label="Frequency Mandala">
+      <path d={pathData} fill="none" stroke="#4a90e2" />
+    </svg>
+  );
+};
+
+export default FrequencyMandala;

--- a/services/fourier-metrics/api.test.ts
+++ b/services/fourier-metrics/api.test.ts
@@ -1,0 +1,20 @@
+import { TextEncoder } from 'util';
+(global as any).TextEncoder = TextEncoder;
+import request from 'supertest';
+import { createApp } from './api';
+
+const app = createApp();
+
+describe('Fourier API', () => {
+  it('returns metrics for data', async () => {
+    const res = await request(app)
+      .post('/api/fourier/analyze')
+      .send({ data: [1, 0, 1, 0] });
+    expect(res.body.metrics.maxAmplitude).toBeGreaterThan(0);
+  });
+
+  it('validates payload', async () => {
+    const res = await request(app).post('/api/fourier/analyze').send({});
+    expect(res.status).toBe(400);
+  });
+});

--- a/services/fourier-metrics/api.ts
+++ b/services/fourier-metrics/api.ts
@@ -1,0 +1,27 @@
+import express from 'express';
+import { FourierLayer } from '../../packages/analysis/FourierLayer';
+
+export function createApp() {
+  const app = express();
+  app.use(express.json());
+
+  app.post('/api/fourier/analyze', (req, res) => {
+    const data: number[] = req.body.data;
+    if (!Array.isArray(data)) {
+      return res.status(400).json({ error: 'data must be array of numbers' });
+    }
+    const layer = new FourierLayer('api', 1, data, { depth: 1 });
+    const metrics = layer.analyze();
+    res.json({ metrics });
+  });
+
+  return app;
+}
+
+if (require.main === module) {
+  const app = createApp();
+  const port = process.env.PORT ? Number(process.env.PORT) : 4200;
+  app.listen(port, () => {
+    console.log(`Fourier API listening on ${port}`);
+  });
+}


### PR DESCRIPTION
## Summary
- add express API for Fourier analysis
- implement FrequencyMandala component
- update advanced progress and todo lists
- provide tests

## Testing
- `pnpm test services/fourier-metrics/api.test.ts`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686e138a6fb083228ce011ccedfd7c47