### PR TITLE
Add Fourier observability and task runner

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4301,14 +4301,14 @@
     "path": "docs/sigils/newadvancedconversations.json",
     "task": "AgentCoordinator implementieren, Steuerungslogik und Schnittstellen bereitstellen",
     "test": "",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from newadvancedconversations.json - EmergencePredictorAgent",
     "path": "docs/sigils/newadvancedconversations.json",
     "task": "EmergencePredictorAgent entwickeln, CREP-Vorhersage KI-Modell",
     "test": "",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from newadvancedconversations.json - GPTContextSummarizer",
@@ -4889,21 +4889,21 @@
     "path": "packages/task-runner/FractalTaskRunner.ts",
     "task": "Execute Fourier, CREP and Sigil plugins from YAML tasks",
     "test": "packages/task-runner/FractalTaskRunner.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from newadvancedconversations.json - YAMLTaskGenerator UI",
     "path": "packages/unifiedmandala-ui/components/YAMLTaskGenerator.tsx",
     "task": "Generate YAML task definitions from interactive workflow design",
     "test": "packages/unifiedmandala-ui/components/YAMLTaskGenerator.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from newadvancedconversations.json - Fourier observability setup",
     "path": "services/fourier-metrics/observability.ts",
     "task": "Add OpenTelemetry tracing and metrics for Fourier pipeline",
     "test": "services/fourier-metrics/observability.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from newadvancedconversations.json - Fourier analysis REST API",
@@ -4924,20 +4924,20 @@
     "path": "packages/task-runner/FractalTaskRunner.ts",
     "task": "Execute Fourier, CREP and Sigil plugins from YAML tasks",
     "test": "packages/task-runner/FractalTaskRunner.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from newadvancedconversations.json - YAMLTaskGenerator UI",
     "path": "packages/unifiedmandala-ui/components/YAMLTaskGenerator.tsx",
     "task": "Generate YAML task definitions from interactive workflow design",
     "test": "packages/unifiedmandala-ui/components/YAMLTaskGenerator.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from newadvancedconversations.json - Fourier observability setup",
     "path": "services/fourier-metrics/observability.ts",
     "task": "Add OpenTelemetry tracing and metrics for Fourier pipeline",
     "test": "services/fourier-metrics/observability.test.ts",
-    "status": "todo"
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6492,7 +6492,6 @@
   task: Add Hardcode Blueprint section after Next Steps
   test: ""
   status: done
-
 - commit: Add EpisodicMemory storage
   path: packages/crep-engine/EpisodicMemory.ts
   task: Store sequences of CREP states with timestamp and symbol metadata
@@ -6517,14 +6516,14 @@
   path: packages/task-runner/FractalTaskRunner.ts
   task: Execute Fourier, CREP and Sigil plugins from YAML tasks
   test: packages/task-runner/FractalTaskRunner.test.ts
-  status: todo
+  status: done
 - commit: TODO from newadvancedconversations.json - YAMLTaskGenerator UI
   path: packages/unifiedmandala-ui/components/YAMLTaskGenerator.tsx
   task: Generate YAML task definitions from interactive workflow design
   test: packages/unifiedmandala-ui/components/YAMLTaskGenerator.test.tsx
-  status: todo
+  status: done
 - commit: TODO from newadvancedconversations.json - Fourier observability setup
   path: services/fourier-metrics/observability.ts
   task: Add OpenTelemetry tracing and metrics for Fourier pipeline
   test: services/fourier-metrics/observability.test.ts
-  status: todo
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "feat: add Fourier API and FrequencyMandala",
-  "fractalStep": "implementation",
+  "lastCommit": "chore: update todo progress",
+  "fractalStep": "sync",
   "openBranches": [
     "work"
   ],

--- a/packages/task-runner/FractalTaskRunner.test.ts
+++ b/packages/task-runner/FractalTaskRunner.test.ts
@@ -1,0 +1,19 @@
+import { FractalTaskRunner } from './FractalTaskRunner';
+import path from 'path';
+import fs from 'fs';
+
+const tmp = path.join(__dirname, 'tmp.yaml');
+const plugin = path.join(__dirname, 'sample-plugin.js');
+
+afterEach(() => {
+  if (fs.existsSync(tmp)) fs.unlinkSync(tmp);
+  if (fs.existsSync(plugin)) fs.unlinkSync(plugin);
+});
+
+test('runs tasks via plugins', async () => {
+  fs.writeFileSync(tmp, '- plugin: "./sample-plugin.js"\n  input: 2');
+  fs.writeFileSync(plugin, 'module.exports = (n) => n * 2;');
+  const runner = new FractalTaskRunner();
+  const [res] = await runner.runFile(tmp);
+  expect(res).toBe(4);
+});

--- a/packages/task-runner/FractalTaskRunner.ts
+++ b/packages/task-runner/FractalTaskRunner.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import YAML from 'yaml';
+
+export interface FractalTask {
+  plugin: string;
+  input: any;
+}
+
+export class FractalTaskRunner {
+  runFile(file: string) {
+    const tasks = YAML.parse(fs.readFileSync(file, 'utf8')) as FractalTask[];
+    return Promise.all(tasks.map(t => this.runTask(t)));
+  }
+
+  async runTask(task: FractalTask) {
+    const mod = require(task.plugin);
+    const fn = mod.default || mod;
+    if (typeof fn === 'function') {
+      return fn(task.input);
+    }
+    throw new Error('invalid plugin');
+  }
+}

--- a/packages/unifiedmandala-ui/components/YAMLTaskGenerator.test.tsx
+++ b/packages/unifiedmandala-ui/components/YAMLTaskGenerator.test.tsx
@@ -1,0 +1,9 @@
+import { render, fireEvent } from '@testing-library/react';
+import YAMLTaskGenerator from './YAMLTaskGenerator';
+
+test('generates yaml', () => {
+  const { getByText, container } = render(<YAMLTaskGenerator />);
+  fireEvent.click(getByText('Add Task'));
+  const pre = container.querySelector('pre');
+  expect(pre?.textContent).toContain('plugin');
+});

--- a/packages/unifiedmandala-ui/components/YAMLTaskGenerator.tsx
+++ b/packages/unifiedmandala-ui/components/YAMLTaskGenerator.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import YAML from 'yaml';
+
+export interface TaskDef { plugin: string; input: any }
+
+export const YAMLTaskGenerator: React.FC = () => {
+  const [tasks, setTasks] = useState<TaskDef[]>([]);
+
+  const addTask = () => setTasks([...tasks, { plugin: '', input: '' }]);
+
+  const updateTask = (i: number, field: keyof TaskDef, value: string) => {
+    const copy = [...tasks];
+    (copy[i] as any)[field] = value;
+    setTasks(copy);
+  };
+
+  const yaml = YAML.stringify(tasks);
+
+  return (
+    <div>
+      {tasks.map((t, i) => (
+        <div key={i}>
+          <input placeholder="plugin" value={t.plugin} onChange={e => updateTask(i, 'plugin', e.target.value)} />
+          <input placeholder="input" value={t.input} onChange={e => updateTask(i, 'input', e.target.value)} />
+        </div>
+      ))}
+      <button onClick={addTask}>Add Task</button>
+      <pre>{yaml}</pre>
+    </div>
+  );
+};
+
+export default YAMLTaskGenerator;

--- a/services/fourier-metrics/observability.test.ts
+++ b/services/fourier-metrics/observability.test.ts
@@ -1,0 +1,7 @@
+import { startFourierObservability } from './observability';
+
+it('initializes OpenTelemetry SDK', async () => {
+  const sdk = startFourierObservability('test');
+  expect(sdk).toBeDefined();
+  await sdk.shutdown();
+});

--- a/services/fourier-metrics/observability.ts
+++ b/services/fourier-metrics/observability.ts
@@ -1,0 +1,11 @@
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+
+export function startFourierObservability(serviceName = 'fourier-metrics') {
+  const sdk = new NodeSDK({
+    serviceName,
+    instrumentations: [getNodeAutoInstrumentations()],
+  });
+  sdk.start();
+  return sdk;
+}


### PR DESCRIPTION
## Summary
- add OpenTelemetry setup for Fourier metrics service
- scaffold FractalTaskRunner with plugin execution
- add YAMLTaskGenerator UI component
- update advanced ToDo lists

## Testing
- `npm test`
- `npm run test:agents` *(fails: CosmicTheoryAgent tests require network)*

------
https://chatgpt.com/codex/tasks/task_e_686e18f219c08322bd2f27889fdeab3e