### PR TITLE
Add advanced CREP example

### DIFF
--- a/GenesisAeonAdvancedAi/advanced_agent.py
+++ b/GenesisAeonAdvancedAi/advanced_agent.py
@@ -5,7 +5,11 @@ from typing import Any, Dict, List, Optional
 import yaml
 
 from .memory_store import store_result
-from .aeon_processor import fraktal_feedback_metrics
+from .aeon_processor import (
+    fraktal_feedback_metrics,
+    advanced_crep_eval,
+    translate_numeric_to_symbolic,
+)
 
 
 def generate_basic_haiku(symbol: str) -> str:
@@ -92,6 +96,19 @@ class AdvancedAeonAgent:
         self.persist(data, decision)
         return decision
 
+    def act_with_advanced_metrics(self, values: List[float]) -> Dict[str, Any]:
+        """Process numeric list with advanced_crep_eval and emit haiku."""
+        symbolic_data = translate_numeric_to_symbolic(values)
+        metrics = advanced_crep_eval(symbolic_data)
+        haiku = generate_basic_haiku(symbolic_data.get("symbol", "\u0394"))
+        decision = {
+            "symbolic": symbolic_data,
+            "metrics": metrics,
+            "haiku": haiku,
+        }
+        self.persist(values, decision)
+        return decision
+
     def save_symbol_memory(self, path: Optional[str] = None) -> None:
         """Persist symbol memory to a YAML file."""
         file_path = path or self.symbol_memory_path
@@ -120,6 +137,10 @@ def main(argv: Optional[List[str]] = None) -> None:
         help="Pfad für JSON-Datei zum Persistieren aller Aktionen",
     )
     parser.add_argument("--haiku", action="store_true", help="Gibt ein Haiku zum Ergebnis aus")
+    parser.add_argument(
+        "--advanced-values",
+        help="Komma-separierte Zahlen für advanced CREP Analyse",
+    )
     args = parser.parse_args(argv)
 
     agent = AdvancedAeonAgent(
@@ -130,7 +151,11 @@ def main(argv: Optional[List[str]] = None) -> None:
         symbol_memory_path=args.symbol_memory_file,
         memory_path=args.memory_file,
     )
-    result = agent.act(args.input)
+    if args.advanced_values:
+        values = [float(v.strip()) for v in args.advanced_values.split(",") if v.strip()]
+        result = agent.act_with_advanced_metrics(values)
+    else:
+        result = agent.act(args.input)
     dump_yaml(agent)
     agent.save_symbol_memory(args.symbol_memory_file)
     if args.haiku:

--- a/GenesisAeonAdvancedAi/test_advanced_agent.py
+++ b/GenesisAeonAdvancedAi/test_advanced_agent.py
@@ -64,6 +64,12 @@ class TestAdvancedAeonAgent(unittest.TestCase):
         out = agent.act_with_metrics(0.5)
         self.assertIn("metrics", out)
 
+    def test_act_with_advanced_metrics(self):
+        agent = AdvancedAeonAgent("test", {})
+        out = agent.act_with_advanced_metrics([0.1, 0.2, 0.3])
+        self.assertIn("metrics", out)
+        self.assertIn("haiku", out)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**NumericToSymbolicAdapter**](GenesisAeonAdvancedAi/aeon_processor.py) – übersetzt Tensorwerte in Klang- und Farbcodes
 - [**fraktal_feedback_graph**](GenesisAeonAdvancedAi/aeon_processor.py) – erstellt einen einfachen Graphen der Fraktal-Feedback-Schritte
 - [**Aeon CLI**](GenesisAeonAdvancedAi/aeon_cli.py) – erzeugt symbolische Ergebnisse aus Zahlenfolgen, kann Leistungsdaten, CREP-Metriken, Fraktal-Graphen (`--graph`) und poetische Kommentare (`--poetry`) ausgeben. Fehlt PyYAML, gibt die CLI stattdessen JSON aus und weist per Warnung darauf hin.
+- [**AdvancedAeonAgent**](GenesisAeonAdvancedAi/advanced_agent.py) – Beispielagent für `advanced_crep_eval` über `--advanced-values`, optional mit Haiku-Ausgabe.
 
 ## 📦 Paketstruktur
 

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,8 +1,7 @@
 {
-  "lastCommit": "chore: update todo progress",
+  "lastCommit": "feat: add advanced CREP metrics example",
   "fractalStep": "sync",
   "openBranches": [
     "work"
   ],
-  "mergeConflicts": []
-}
+  "mergeConflicts": []}


### PR DESCRIPTION
## Summary
- extend `AdvancedAeonAgent` with advanced CREP metrics logic
- expose `--advanced-values` CLI option
- document new agent usage in README
- test advanced metrics output

## Testing
- `pnpm install`
- `pnpm test`
- `pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686e2344926c8322970e19580d10c261