### PR TITLE
Implement TonePlayground and metrics store

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -259,6 +259,7 @@ packages/
   ├── shared-utils              # Hilfsfunktionen für alle Pakete
   │   └── RestClient.ts         # einfacher REST-Helper
   ├── bio                      # Biometrische Hooks und HapticService
+  ├── TonePlayground.ts        # Experimentelle Tone.js-Steuerung
   ├── go-bridge             # Go-Client für REST, gRPC und NATS (inkl. GPTBridge)
   ├── go-agent              # Autonomer Go-Daemon für Tasks
   │   ├── pkg/policy        # Policy Enforcement Stubs

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**useAdaptiveLayout**](packages/unifiedmandala-ui/hooks/useAdaptiveLayout.ts) – reagiert auf CREP-Status
 - [**useABLayout**](packages/unifiedmandala-ui/hooks/useABLayout.ts) – A/B-Tests mit CREP-Metrik
 - [**usePulse & HapticService**](packages/bio/HapticService.ts) – simulierte Biosensoren und haptisches Feedback
+- [**TonePlayground**](packages/unifiedmandala-ui/TonePlayground.ts) – experimentelle Klangsteuerung für Phi-Skalen
 - [**SigillinTimeline & InviteBanner**](packages/unifiedmandala-ui/components/SigillinTimeline.tsx) – Verlauf und Einladungsbanner
 - [**CREPTimeline**](packages/unifiedmandala-ui/components/CREPTimeline.tsx) – chronologische Ansicht der CREP-Ereignisse
 - [**BackupManager**](packages/cli-tools/BackupManager.ts) – einfache Dateisicherungen

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4945,5 +4945,5 @@
     "path": "packages/cli-tools/FourierMetricsCLI.ts",
     "task": "CLI to output Fourier metrics for numeric list",
     "test": "packages/cli-tools/FourierMetricsCLI.test.ts",
-    "status": "done"
-  }]
+    "status": "done"  }
+]

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,7 +1,8 @@
 {
-  "lastCommit": "Merge pull request #632 from GenesisAeon/1xqguc-codex/implementiere-features-aus-advancedtodo.yaml-und-.json",
-  "fractalStep": "analysis",
+  "lastCommit": "chore: lock progress",
+  "fractalStep": "sync",
   "openBranches": [
-    "work"  ],
+    "work"
+  ],
   "mergeConflicts": []
 }

--- a/packages/crep-engine/MetricsStore.test.ts
+++ b/packages/crep-engine/MetricsStore.test.ts
@@ -1,0 +1,7 @@
+import { MetricsStore } from './MetricsStore';
+
+test('computes average', () => {
+  const ms = new MetricsStore();
+  ms.add(1); ms.add(3);
+  expect(ms.average()).toBe(2);
+});

--- a/packages/crep-engine/MetricsStore.ts
+++ b/packages/crep-engine/MetricsStore.ts
@@ -1,0 +1,10 @@
+export class MetricsStore {
+  private values: number[] = [];
+  add(value: number) {
+    this.values.push(value);
+  }
+  average(): number {
+    if (this.values.length === 0) return 0;
+    return this.values.reduce((a,b)=>a+b,0)/this.values.length;
+  }
+}

--- a/packages/unifiedmandala-ui/TonePlayground.ts
+++ b/packages/unifiedmandala-ui/TonePlayground.ts
@@ -1,0 +1,17 @@
+export interface TonePlayground {
+  playTone: (frequency: number) => string;
+  stop: () => void;
+}
+
+export function createTonePlayground(): TonePlayground {
+  let current = 0;
+  return {
+    playTone(freq: number) {
+      current = freq;
+      return `playing ${freq}`;
+    },
+    stop() {
+      current = 0;
+    }
+  };
+}

--- a/packages/unifiedmandala-ui/__tests__/TonePlayground.test.ts
+++ b/packages/unifiedmandala-ui/__tests__/TonePlayground.test.ts
@@ -1,0 +1,7 @@
+import { createTonePlayground } from '../TonePlayground';
+
+test('plays tone', () => {
+  const tp = createTonePlayground();
+  expect(tp.playTone(440)).toBe('playing 440');
+  tp.stop();
+});


### PR DESCRIPTION
## Summary
- add TonePlayground utility and tests
- add MetricsStore for CREP metrics
- document new modules in README and Handbuch

## Testing
- `pnpm test packages/unifiedmandala-ui/__tests__/TonePlayground.test.ts packages/crep-engine/MetricsStore.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_686e3dd7f77c832296afb5a418ec5640