### PR TITLE
Add CREPContext state manager

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4945,5 +4945,12 @@
     "path": "packages/cli-tools/FourierMetricsCLI.ts",
     "task": "CLI to output Fourier metrics for numeric list",
     "test": "packages/cli-tools/FourierMetricsCLI.test.ts",
+    "status": "done"  },
+  {
+    "commit": "Add CREPContext state manager",
+    "path": "packages/crep-engine/CREPContext.ts",
+    "task": "Centralized CREP state context with reducer pattern",
+    "test": "packages/crep-engine/CREPContext.test.ts",
     "status": "done"
-  }]
+  }
+]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6532,3 +6532,8 @@
   task: CLI to output Fourier metrics for numeric list
   test: packages/cli-tools/FourierMetricsCLI.test.ts
   status: done
+- commit: Add CREPContext state manager
+  path: packages/crep-engine/CREPContext.ts
+  task: Centralized CREP state context with reducer pattern
+  test: packages/crep-engine/CREPContext.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,8 +1,9 @@
 {
-  "lastCommit": "chore: normalize progress files",
-  "fractalStep": "todo-scan",
+  "lastCommit": "chore(progress): update advanced progress",
+  "fractalStep": "sync",
   "openBranches": [
     "work"
-  ],  "mergeConflicts": [],
+  ],
+  "mergeConflicts": [],
   "notes": "No open TODOs found in newadvancedconversations"
 }

--- a/packages/crep-engine/CREPContext.test.ts
+++ b/packages/crep-engine/CREPContext.test.ts
@@ -1,0 +1,21 @@
+import { CREPContext } from './CREPContext';
+import { CREPEntry } from './types';
+
+test('dispatch adds entry and emits update', () => {
+  const ctx = new CREPContext();
+  const entry: CREPEntry = { timestamp: new Date(), C: 1, R: 1, E: 1, P: 1 };
+  let called = false;
+  ctx.on('update', state => {
+    called = true;
+    expect(state.history[0]).toEqual(entry);
+  });
+  ctx.dispatch({ type: 'ADD', entry });
+  expect(called).toBe(true);
+  expect(ctx.getState().history).toHaveLength(1);
+});
+
+test('reset clears history', () => {
+  const ctx = new CREPContext({ history: [{ timestamp: new Date(), C: 1, R: 1, E: 1, P: 1 }] });
+  ctx.dispatch({ type: 'RESET' });
+  expect(ctx.getState().history).toHaveLength(0);
+});

--- a/packages/crep-engine/CREPContext.ts
+++ b/packages/crep-engine/CREPContext.ts
@@ -1,0 +1,39 @@
+import { EventEmitter } from 'events';
+import { CREPEntry } from './types';
+
+export interface CREPState {
+  history: CREPEntry[];
+}
+
+export type CREPAction =
+  | { type: 'ADD'; entry: CREPEntry }
+  | { type: 'RESET' };
+
+export class CREPContext extends EventEmitter {
+  private state: CREPState;
+
+  constructor(initial: CREPState = { history: [] }) {
+    super();
+    this.state = initial;
+  }
+
+  dispatch(action: CREPAction) {
+    switch (action.type) {
+      case 'ADD':
+        this.state.history.push(action.entry);
+        this.emit('update', this.state);
+        break;
+      case 'RESET':
+        this.state.history = [];
+        this.emit('update', this.state);
+        break;
+      default:
+        // ignore
+        break;
+    }
+  }
+
+  getState() {
+    return this.state;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `CREPContext` with reducer pattern
- document new task in `advancedToDo.yaml` and `advancedToDo.json`
- update progress metadata

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686e52647ae88322925d34d4f153a0bc