### PR TITLE
Fix advancedToDo control character

### DIFF
--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6194,7 +6194,7 @@
   status: todo
 - commit: TODO from AeonAI Pyramid-UI conversation - generate nested layers
   path: packages/unifiedmandala-ui
-  task: "generateNestedLayers Funktion gemÃ¤Ã Blueprint implementieren"
+  task: "generateNestedLayers Funktion gemäß Blueprint implementieren"
   test: packages/unifiedmandala-ui/__tests__/generateNestedLayers.test.ts
   status: done
 - commit: TODO from AeonAI Pyramid-UI conversation - NestedPyramid component


### PR DESCRIPTION
## Summary
- remove control character around byte 352k in `advancedToDo.yaml`
- ensure YAML parses correctly

## Testing
- `pyright`
- `poetry install --with test` *(fails: pyproject missing)*
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686ed393f02483228d57ea851d4bc039