### PR TITLE
Integrate code TODO scanner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           node-version: '18'
       - run: pnpm install
+      - run: pnpm run update:code-todos
       - run: pnpm audit --audit-level=moderate
       - run: pnpm --filter ./packages/crep-engine run lint test build
       - run: pnpm --filter ./packages/unifiedmandala-ui run lint test build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
+node scripts/update-code-todos.js
 node scripts/sync-todo-progress.js

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "analyze:conversations": "node scripts/analyze-conversations.js",
     "parse:newconversations": "node scripts/parse-newadvanced-conversations.js",
     "update:advanced-todo": "node scripts/update-advanced-todo.js",
+    "update:code-todos": "node scripts/update-code-todos.js",
     "update:newadvanced-todo": "node scripts/update-newadvanced-todo.js",
     "export:crep-docs": "node scripts/export-crep-docs.js",
     "symbolzeit:run": "node scripts/symbolzeit-runner.js",

--- a/scripts/update-code-todos.js
+++ b/scripts/update-code-todos.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const YAML = require('yaml');
+let scanTodoComments;
+try {
+  ({ scanTodoComments } = require('../dist/shared-utils/todoCommentScanner.js'));
+} catch {
+  ({ scanTodoComments } = require('../packages/shared-utils/todoCommentScanner'));
+}
+
+function appendTasks(entries, yamlFile, jsonFile) {
+  const loadYaml = f => (fs.existsSync(f) ? YAML.parse(fs.readFileSync(f, 'utf8')) : []);
+  const loadJson = f => (fs.existsSync(f) ? JSON.parse(fs.readFileSync(f, 'utf8')) : []);
+  const merge = (existing, add) => {
+    const known = new Set(existing.map(e => e.commit));
+    for (const e of add) {
+      if (!known.has(e.commit)) {
+        existing.push(e);
+        known.add(e.commit);
+      }
+    }
+    return existing;
+  };
+  const y = merge(loadYaml(yamlFile), entries);
+  const j = merge(loadJson(jsonFile), entries);
+  fs.writeFileSync(yamlFile, YAML.stringify(y, null, 2));
+  fs.writeFileSync(jsonFile, JSON.stringify(j, null, 2));
+}
+
+function run(dir = path.join(__dirname, '..')) {
+  const yamlFile = path.join(__dirname, '../advancedToDo.yaml');
+  const jsonFile = path.join(__dirname, '../advancedToDo.json');
+  const todos = scanTodoComments(dir);
+  const entries = todos.map(t => ({
+    commit: `TODO in ${t.file}:${t.line}`,
+    path: t.file,
+    task: t.text,
+    test: ''
+  }));
+  appendTasks(entries, yamlFile, jsonFile);
+  console.log(`added ${entries.length} code todos from ${dir}`);
+  return entries;
+}
+
+if (require.main === module) {
+  run();
+}
+
+module.exports = { run };


### PR DESCRIPTION
## Summary
- add `update-code-todos` script to scan source files for TODO comments
- hook the script into pre-commit and CI
- expose `pnpm run update:code-todos` in package.json

## Testing
- `npx --yes pyright` *(fails: missing imports)*
- `npx --yes tsc -p tsconfig.json` *(fails: cannot find type definitions)*
- `poetry install --with test` *(fails: no pyproject file)*
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686f8c930db48322ac768dc9844921a3