### PR TITLE
Update progress reporting with pending tasks

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,9 +1,103 @@
 {
-  "lastCommit": "chore(progress): update advanced progress",
+  "lastCommit": "Merge pull request #641 from GenesisAeon/codex/integrate-todo-scanner-and-ci-step",
   "fractalStep": "sync",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "No open TODOs found in newadvancedconversations"
+  "notes": "Pending tasks: 23",
+  "pendingTasks": [
+    {
+      "commit": "TODO from newadvancedconversations.json - AgentCoordinator",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from newadvancedconversations.json - EmergencePredictorAgent",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from newadvancedconversations.json - GPTContextSummarizer",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from newadvancedconversations.json - SigillinBlockchainIntegration",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from newadvancedconversations.json - PrivacyComplianceAgent",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from CosmicTheoryAgent conversation - Python service access",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from CosmicTheoryAgent conversation - React Starter setup",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from CosmicTheoryAgent conversation - 3D canvas sketch",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from CosmicTheoryAgent conversation - Tone.js playground",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from CosmicTheoryAgent conversation - MetricsStore interface",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid-UI conversation - Sigillin initialization",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid-UI conversation - CREP tuning",
+      "status": "todo"
+    },
+    {
+      "commit": "Setup CI pipeline with OTel Collector",
+      "status": "todo"
+    },
+    {
+      "commit": "Add Cypress E2E tests for SigilAlert",
+      "status": "todo"
+    },
+    {
+      "commit": "Draft AeonUniversal DSL grammar",
+      "status": "todo"
+    },
+    {
+      "commit": "Add AeonAgent example using advanced_crep_eval",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - CREPVisualizer component",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - NumericDashboard component",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - AudioEngine module",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - ResonanceOverlay component",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - ErrorEmergence component",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - VRPortal component",
+      "status": "todo"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - UIPyramidPrototype",
+      "status": "todo"
+    }
+  ]
 }

--- a/scripts/update-advancedprogress.js
+++ b/scripts/update-advancedprogress.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const { execSync } = require('child_process');
 const path = require('path');
+const YAML = require('yaml');
 
 function getLastCommitMessage() {
   return execSync('git log -1 --pretty=%s').toString().trim();
@@ -20,6 +21,22 @@ function getMergeConflicts() {
   }
 }
 
+function getPendingTasks() {
+  const todoFile = path.join(__dirname, '../advancedToDo.yaml');
+  if (!fs.existsSync(todoFile)) return [];
+  try {
+    const items = YAML.parse(fs.readFileSync(todoFile, 'utf8'));
+    if (Array.isArray(items)) {
+      return items
+        .filter((i) => i.status && i.status !== 'done')
+        .map((i) => ({ commit: i.commit, status: i.status }));
+    }
+  } catch (err) {
+    console.warn('Could not parse advancedToDo.yaml', err.message);
+  }
+  return [];
+}
+
 function updateProgress(step) {
   const progressFile = path.join(__dirname, '../advancedprogress.json');
   let data = {};
@@ -30,6 +47,7 @@ function updateProgress(step) {
   data.fractalStep = step || data.fractalStep || '';
   data.openBranches = getOpenBranches();
   data.mergeConflicts = getMergeConflicts();
+  data.pendingTasks = getPendingTasks();
   fs.writeFileSync(progressFile, JSON.stringify(data, null, 2));
   console.log('advancedprogress.json updated');
 }
@@ -39,4 +57,4 @@ if (require.main === module) {
   updateProgress(step);
 }
 
-module.exports = { updateProgress };
+module.exports = { updateProgress, getPendingTasks };


### PR DESCRIPTION
## Summary
- parse advancedToDo.yaml for tasks not marked as `done`
- include these pending tasks when updating `advancedprogress.json`
- record current pending count in the progress file

## Testing
- `npx -y pyright` *(fails: missing imports)*
- `npx -y tsc -p tsconfig.json` *(fails: TS2304 Cannot find name 'sigilHistory')*

------
https://chatgpt.com/codex/tasks/task_e_686f99f9ff60832287118d4a3ebe5f9f