### PR TITLE
Implement fractal haiku mode for advanced agent

### DIFF
--- a/GenesisAeonAdvancedAi/advanced_agent.py
+++ b/GenesisAeonAdvancedAi/advanced_agent.py
@@ -109,6 +109,19 @@ class AdvancedAeonAgent:
         self.persist(values, decision)
         return decision
 
+    def act_with_fraktal_haiku(self, values: List[float]) -> Dict[str, Any]:
+        """Run fraktal feedback metrics and store haiku in the decision."""
+        symbolic, score, metrics = fraktal_feedback_metrics(values)
+        haiku = generate_basic_haiku(symbolic.get("symbol", "\u0394"))
+        decision = {
+            "symbolic": symbolic,
+            "crep_score": score,
+            "metrics": metrics,
+            "haiku": haiku,
+        }
+        self.persist(values, decision)
+        return decision
+
     def save_symbol_memory(self, path: Optional[str] = None) -> None:
         """Persist symbol memory to a YAML file."""
         file_path = path or self.symbol_memory_path
@@ -141,6 +154,10 @@ def main(argv: Optional[List[str]] = None) -> None:
         "--advanced-values",
         help="Komma-separierte Zahlen für advanced CREP Analyse",
     )
+    parser.add_argument(
+        "--fraktal-values",
+        help="Komma-separierte Zahlen für fraktal Feedback Analyse",
+    )
     args = parser.parse_args(argv)
 
     agent = AdvancedAeonAgent(
@@ -151,7 +168,10 @@ def main(argv: Optional[List[str]] = None) -> None:
         symbol_memory_path=args.symbol_memory_file,
         memory_path=args.memory_file,
     )
-    if args.advanced_values:
+    if args.fraktal_values:
+        values = [float(v.strip()) for v in args.fraktal_values.split(",") if v.strip()]
+        result = agent.act_with_fraktal_haiku(values)
+    elif args.advanced_values:
         values = [float(v.strip()) for v in args.advanced_values.split(",") if v.strip()]
         result = agent.act_with_advanced_metrics(values)
     else:

--- a/GenesisAeonAdvancedAi/test_advanced_agent.py
+++ b/GenesisAeonAdvancedAi/test_advanced_agent.py
@@ -70,6 +70,13 @@ class TestAdvancedAeonAgent(unittest.TestCase):
         self.assertIn("metrics", out)
         self.assertIn("haiku", out)
 
+    def test_act_with_fraktal_haiku(self):
+        agent = AdvancedAeonAgent("test", {})
+        out = agent.act_with_fraktal_haiku([0.1, 0.2, 0.3])
+        self.assertIn("metrics", out)
+        self.assertIn("haiku", out)
+        self.assertIn("crep_score", out)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4567,7 +4567,7 @@
     "path": "GenesisAeonAdvancedAi/advanced_agent.py",
     "task": "Use fraktal_feedback_metrics and save haiku output",
     "test": "GenesisAeonAdvancedAi/test_advanced_agent.py",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from CosmicTheoryAgent conversation - CREPWaves component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6291,7 +6291,7 @@
   path: GenesisAeonAdvancedAi/advanced_agent.py
   task: Use fraktal_feedback_metrics and save haiku output
   test: GenesisAeonAdvancedAi/test_advanced_agent.py
-  status: todo
+  status: done
 - commit: TODO from CosmicTheoryAgent conversation - CREPWaves component
   path: packages/unifiedmandala-ui/components/CREPWaves.tsx
   task: Visualisiert CREP-Historie als Wellenform

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5,7 +5,7 @@
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Pending tasks: 23",
+  "notes": "Pending tasks: 22",
   "pendingTasks": [
     {
       "commit": "TODO from newadvancedconversations.json - AgentCoordinator",
@@ -69,7 +69,7 @@
     },
     {
       "commit": "Add AeonAgent example using advanced_crep_eval",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "TODO from AeonAI Pyramid UI conversation - CREPVisualizer component",


### PR DESCRIPTION
## Summary
- extend `AdvancedAeonAgent` with `act_with_fraktal_haiku`
- expose new CLI option `--fraktal-values`
- test new behaviour
- mark corresponding TODOs as done

## Testing
- `pytest GenesisAeonAdvancedAi/test_advanced_agent.py -q`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687125608fe4832293ad03e7ea884e40