### PR TITLE
Add NumericDashboard and update progress

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4595,14 +4595,14 @@
     "path": "packages/unifiedmandala-ui/components/CREPVisualizer.tsx",
     "task": "Graphische Darstellung der C,R,E,P Werte als Farben und Formen",
     "test": "packages/unifiedmandala-ui/components/CREPVisualizer.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from AeonAI Pyramid UI conversation - NumericDashboard component",
     "path": "packages/unifiedmandala-ui/components/NumericDashboard.tsx",
     "task": "Tabellen und Histogramme für CREP- und Sigil-Daten",
     "test": "packages/unifiedmandala-ui/components/NumericDashboard.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "TODO from AeonAI Pyramid UI conversation - ThreeDPyramid component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6311,12 +6311,12 @@
   path: packages/unifiedmandala-ui/components/CREPVisualizer.tsx
   task: Graphische Darstellung der C,R,E,P Werte als Farben und Formen
   test: packages/unifiedmandala-ui/components/CREPVisualizer.test.tsx
-  status: todo
+  status: done
 - commit: TODO from AeonAI Pyramid UI conversation - NumericDashboard component
   path: packages/unifiedmandala-ui/components/NumericDashboard.tsx
   task: Tabellen und Histogramme für CREP- und Sigil-Daten
   test: packages/unifiedmandala-ui/components/NumericDashboard.test.tsx
-  status: todo
+  status: done
 - commit: TODO from AeonAI Pyramid UI conversation - ThreeDPyramid component
   path: packages/unifiedmandala-ui/components/ThreeDPyramid.tsx
   task: React-Three-Fiber Pyramide mit animierten Layern

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5,7 +5,7 @@
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Pending tasks: 22",
+  "notes": "Pending tasks: 20",
   "pendingTasks": [
     {
       "commit": "TODO from newadvancedconversations.json - AgentCoordinator",
@@ -73,11 +73,11 @@
     },
     {
       "commit": "TODO from AeonAI Pyramid UI conversation - CREPVisualizer component",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "TODO from AeonAI Pyramid UI conversation - NumericDashboard component",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "TODO from AeonAI Pyramid UI conversation - AudioEngine module",

--- a/packages/unifiedmandala-ui/components/NumericDashboard.test.tsx
+++ b/packages/unifiedmandala-ui/components/NumericDashboard.test.tsx
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import NumericDashboard from './NumericDashboard';
+
+test('renders table and histogram', () => {
+  const data = [{ label: 'C', value: 2 }];
+  const { getByLabelText } = render(<NumericDashboard data={data} />);
+  expect(getByLabelText('Numeric Table')).toBeInTheDocument();
+  const svg = getByLabelText('Numeric Histogram');
+  expect(svg.nodeName.toLowerCase()).toBe('svg');
+});
+

--- a/packages/unifiedmandala-ui/components/NumericDashboard.tsx
+++ b/packages/unifiedmandala-ui/components/NumericDashboard.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export interface NumericData {
+  label: string;
+  value: number;
+}
+
+interface Props {
+  data: NumericData[];
+}
+
+const NumericDashboard: React.FC<Props> = ({ data }) => {
+  return (
+    <div>
+      <table aria-label="Numeric Table">
+        <tbody>
+          {data.map((d) => (
+            <tr key={d.label}>
+              <td>{d.label}</td>
+              <td>{d.value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <svg width={data.length * 20} height={100} aria-label="Numeric Histogram">
+        {data.map((d, i) => (
+          <rect
+            key={i}
+            x={i * 20}
+            y={100 - d.value * 10}
+            width={15}
+            height={d.value * 10}
+            fill="#8884d8"
+          />
+        ))}
+      </svg>
+    </div>
+  );
+};
+
+export default NumericDashboard;
+


### PR DESCRIPTION
## Summary
- implement `NumericDashboard` component with simple table and histogram
- add corresponding tests
- mark CREPVisualizer and NumericDashboard tasks complete in advanced todo lists
- update progress file pending task count

## Testing
- `npx pyright` *(fails: streamlit, matplotlib missing)*
- `npx tsc -p tsconfig.json` *(fails: missing type definitions)*
- `npx vitest run packages/unifiedmandala-ui/components/NumericDashboard.test.tsx` *(fails: vitest config not found)*

------
https://chatgpt.com/codex/tasks/task_e_68712f18082c83228b7d8854a451a1ce