### PR TITLE
Add AudioEngine module

### DIFF
--- a/packages/agents/CosmicTheoryAgent.test.ts
+++ b/packages/agents/CosmicTheoryAgent.test.ts
@@ -8,8 +8,9 @@ import {
   AgentWeights,
   loadSigil,
   sigilManager,
-  performRemoteAnalysis
-  ,callPySRService
+  sigilHistory,
+  performRemoteAnalysis,
+  callPySRService
 } from './CosmicTheoryAgent';
 import { CosmicTheoryEventHub } from './CosmicTheoryAgentEvents';
 

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -21,3 +21,4 @@ export * from './utils/PyramidUtils';
 export { default as ThreeDPyramid } from './components/ThreeDPyramid';
 export { default as TaskDNA } from './components/TaskDNA';
 export { default as PyramidVRView } from './pyramid/PyramidVRView';
+export { AudioEngine } from './lib/AudioEngine';

--- a/packages/unifiedmandala-ui/lib/AudioEngine.test.ts
+++ b/packages/unifiedmandala-ui/lib/AudioEngine.test.ts
@@ -1,0 +1,9 @@
+import { AudioEngine } from './AudioEngine';
+
+describe('AudioEngine', () => {
+  it('plays and stops frequency', () => {
+    const engine = new AudioEngine();
+    expect(engine.play(440)).toBe('play 440');
+    engine.stop();
+  });
+});

--- a/packages/unifiedmandala-ui/lib/AudioEngine.ts
+++ b/packages/unifiedmandala-ui/lib/AudioEngine.ts
@@ -1,0 +1,10 @@
+export class AudioEngine {
+  private current = 0;
+  play(freq: number): string {
+    this.current = freq;
+    return `play ${freq}`;
+  }
+  stop() {
+    this.current = 0;
+  }
+}


### PR DESCRIPTION
## Summary
- implement simple AudioEngine utility
- export AudioEngine in UI index
- fix CosmicTheoryAgent test to import sigilHistory
- add AudioEngine unit test

## Testing
- `pnpm install`
- `npx tsc -p tsconfig.json`
- `npx jest packages/unifiedmandala-ui/lib/AudioEngine.test.ts`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6871342a0980832283fd0c0cde8eab77