### PR TITLE
Implement CREP tuning hook

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4395,11 +4395,11 @@
     "status": "done"
   },
   {
-    "commit": "TODO from AeonAI Pyramid-UI conversation - CREP tuning",
-    "path": "packages/unifiedmandala-ui",
-    "task": "CREP-Scores zur Gewichtung von Farben und Soundeffekten nutzen",
-    "test": "packages/unifiedmandala-ui/__tests__/CREPTuning.test.ts",
-    "status": "todo"
+  "commit": "TODO from AeonAI Pyramid-UI conversation - CREP tuning",
+  "path": "packages/unifiedmandala-ui",
+  "task": "CREP-Scores zur Gewichtung von Farben und Soundeffekten nutzen",
+  "test": "packages/unifiedmandala-ui/__tests__/CREPTuning.test.ts",
+  "status": "done"
   },
   {
     "commit": "TODO from CosmicTheoryAgent conversation - React Starter setup",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6211,7 +6211,7 @@
   path: packages/unifiedmandala-ui
   task: CREP-Scores zur Gewichtung von Farben und Soundeffekten nutzen
   test: packages/unifiedmandala-ui/__tests__/CREPTuning.test.ts
-  status: todo
+  status: done
 - commit: Add Pyramid VR mode
   path: packages/unifiedmandala-ui/pyramid/PyramidVRView.tsx
   task: Implement WebXR immersive experience for Pyramid UI

--- a/packages/shared-utils/README.md
+++ b/packages/shared-utils/README.md
@@ -7,6 +7,8 @@ Gemeinsame Hilfsfunktionen für UnifiedMandala.
 - **splitJsonArrayFile** und **writeJsonChunks** – teilen große JSON-Arrays auf
 - **grepJsonArrayFile** – filtert JSON-Arrays per Regex und schreibt Treffer
 - **getCREPPhaseColor** – ordnet CREP-Werten Farbstufen zu
+- **getCREPFrequency** – leitet aus P-Werten eine Grundfrequenz ab
+- **getCREPTuning** – kombiniert Farbe und Frequenz für CREP-basierte Effekte
 - **analyzeRepo** – liefert Paket- und Dokument-Statistiken
 - **extractTodosFromFile** – liest Aufgabenlisten aus Dateien
 - **updateTodoSigilStatus** – markiert erledigte Aufgaben im todo-sigil.yaml

--- a/packages/shared-utils/crepHelpers.test.ts
+++ b/packages/shared-utils/crepHelpers.test.ts
@@ -1,4 +1,4 @@
-import { getCREPPhaseColor } from './crepHelpers';
+import { getCREPPhaseColor, getCREPFrequency, getCREPTuning } from './crepHelpers';
 
 describe('getCREPPhaseColor', () => {
   it('returns red for critical values', () => {
@@ -9,5 +9,16 @@ describe('getCREPPhaseColor', () => {
   });
   it('returns orange otherwise', () => {
     expect(getCREPPhaseColor({ C: 5, R: 5, E: 5 })).toBe('orange');
+  });
+});
+
+describe('crep tuning helpers', () => {
+  test('getCREPFrequency returns expected value', () => {
+    expect(getCREPFrequency({ P: 5 })).toBe(270);
+  });
+
+  test('getCREPTuning returns color and frequency', () => {
+    const result = getCREPTuning({ C: 8, R: 8, E: 8, P: 5 });
+    expect(result).toEqual({ color: 'green', frequency: 270 });
   });
 });

--- a/packages/shared-utils/crepHelpers.ts
+++ b/packages/shared-utils/crepHelpers.ts
@@ -13,3 +13,16 @@ export function getCREPPhaseColor({ C, R, E }: CREPValues): string {
   if (C >= 7 && R >= 7 && E >= 7) return 'green';
   return 'orange';
 }
+
+export function getCREPFrequency({ P }: { P: number }): number {
+  return 220 + P * 10;
+}
+
+export interface CREPTuning {
+  color: string;
+  frequency: number;
+}
+
+export function getCREPTuning(values: CREPValues & { P: number }): CREPTuning {
+  return { color: getCREPPhaseColor(values), frequency: getCREPFrequency(values) };
+}

--- a/packages/unifiedmandala-ui/__tests__/CREPTuning.test.ts
+++ b/packages/unifiedmandala-ui/__tests__/CREPTuning.test.ts
@@ -1,0 +1,16 @@
+import { renderHook } from '@testing-library/react';
+import { useCREPTuning } from '../hooks/useCREPTuning';
+import * as crepHook from '../hooks/useCREP';
+import { getCREPTuning } from '../../shared-utils/crepHelpers';
+
+jest.mock('../hooks/useCREP');
+jest.mock('../../shared-utils/crepHelpers', () => ({
+  getCREPTuning: jest.fn(),
+}));
+
+test('maps latest CREP values to tuning info', () => {
+  (crepHook.useCREP as jest.Mock).mockReturnValue({ history: [{ C: 8, R: 8, E: 8, P: 5 }] });
+  (getCREPTuning as jest.Mock).mockReturnValue({ color: 'green', frequency: 270 });
+  const { result } = renderHook(() => useCREPTuning());
+  expect(result.current).toEqual({ color: 'green', frequency: 270 });
+});

--- a/packages/unifiedmandala-ui/hooks/useCREPTuning.test.ts
+++ b/packages/unifiedmandala-ui/hooks/useCREPTuning.test.ts
@@ -1,0 +1,16 @@
+import { renderHook } from '@testing-library/react';
+import { useCREPTuning } from './useCREPTuning';
+import * as crepHook from './useCREP';
+import { getCREPTuning } from '../../shared-utils/crepHelpers';
+
+jest.mock('./useCREP');
+jest.mock('../../shared-utils/crepHelpers', () => ({
+  getCREPTuning: jest.fn(),
+}));
+
+test('returns tuning based on latest CREP history', () => {
+  (crepHook.useCREP as jest.Mock).mockReturnValue({ history: [{ C: 8, R: 8, E: 8, P: 5 }] });
+  (getCREPTuning as jest.Mock).mockReturnValue({ color: 'green', frequency: 270 });
+  const { result } = renderHook(() => useCREPTuning());
+  expect(result.current).toEqual({ color: 'green', frequency: 270 });
+});

--- a/packages/unifiedmandala-ui/hooks/useCREPTuning.ts
+++ b/packages/unifiedmandala-ui/hooks/useCREPTuning.ts
@@ -1,0 +1,11 @@
+import { useCREP } from './useCREP';
+import { getCREPTuning, CREPTuning } from '../../shared-utils/crepHelpers';
+import { useMemo } from 'react';
+
+export function useCREPTuning(): CREPTuning {
+  const { history } = useCREP();
+  return useMemo(() => {
+    const latest = history[history.length - 1];
+    return latest ? getCREPTuning(latest) : { color: 'gray', frequency: 0 };
+  }, [history]);
+}

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -24,3 +24,4 @@ export { default as PyramidVRView } from './pyramid/PyramidVRView';
 export { AudioEngine } from './lib/AudioEngine';
 export { SigilProvider, useSigilManager } from './contexts/SigilContext';
 export { default as ResonanceOverlay } from './components/ResonanceOverlay';
+export { useCREPTuning } from './hooks/useCREPTuning';


### PR DESCRIPTION
## Summary
- add helper functions `getCREPFrequency` and `getCREPTuning`
- document the new helpers in shared-utils README
- introduce `useCREPTuning` hook for UI components
- export the hook via unifiedmandala-ui index
- add tests for the new helpers and hook
- mark CREP tuning task done in advancedToDo lists

## Testing
- `npx -y pyright` *(fails: missing imports)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definitions)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873af48d5648322ae92c47d3c6c4c55