### PR TITLE
Add chat writer service

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -569,7 +569,8 @@
     "commit": "Add append only chat writer",
     "path": "services/chat-writer/writer.go",
     "task": "Store messages.json logs and optional eventHook",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Add schema validation hook script",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -397,6 +397,7 @@
   path: services/chat-writer/writer.go
   task: Store messages.json logs and optional eventHook
   test: ""
+  status: done
 - commit: Add schema validation hook script
   path: scripts/validate-schemas.sh
   status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -102,6 +102,10 @@
     {
       "commit": "Updated advancedToDo with new advanced conversation tasks",
       "status": "done"
+    },
+    {
+      "commit": "Add append only chat writer",
+      "status": "done"
     }
   ]
 }

--- a/services/chat-writer/README.md
+++ b/services/chat-writer/README.md
@@ -1,0 +1,5 @@
+# Chat Writer Service
+
+This service provides an append-only writer for conversation logs.
+Messages are appended to a JSON lines file. Optional event hooks allow
+integration with other systems.

--- a/services/chat-writer/go.mod
+++ b/services/chat-writer/go.mod
@@ -1,0 +1,6 @@
+module github.com/GenesisAeon/unified-mandala/chat-writer
+
+go 1.20
+
+require (
+)

--- a/services/chat-writer/writer.go
+++ b/services/chat-writer/writer.go
@@ -1,0 +1,33 @@
+package chatwriter
+
+import (
+	"encoding/json"
+	"os"
+)
+
+type Message struct {
+	ID      string `json:"id"`
+	Content string `json:"content"`
+	Author  string `json:"author"`
+	Time    string `json:"time"`
+}
+
+// AppendMessage appends a message to messages.json. If eventHook is non-nil,
+// the function calls it with the message after writing.
+func AppendMessage(filePath string, msg Message, eventHook func(Message)) error {
+	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	if err := enc.Encode(&msg); err != nil {
+		return err
+	}
+
+	if eventHook != nil {
+		eventHook(msg)
+	}
+	return nil
+}

--- a/services/chat-writer/writer_test.go
+++ b/services/chat-writer/writer_test.go
@@ -1,0 +1,29 @@
+package chatwriter
+
+import (
+	"os"
+	"testing"
+)
+
+func TestAppendMessage(t *testing.T) {
+	tmp := "test_messages.json"
+	defer os.Remove(tmp)
+
+	msg := Message{ID: "1", Content: "hello", Author: "tester", Time: "now"}
+	called := false
+	err := AppendMessage(tmp, msg, func(m Message) { called = true })
+	if err != nil {
+		t.Fatalf("append failed: %v", err)
+	}
+	if !called {
+		t.Fatalf("event hook not called")
+	}
+
+	data, err := os.ReadFile(tmp)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatalf("no data written")
+	}
+}


### PR DESCRIPTION
## Summary
- implement simple append-only chat writer Go service
- add unit test and module setup
- mark related advancedToDo items as done

## Testing
- `go test ./services/chat-writer -run TestAppendMessage -v`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6873e932b6588322abb3b78f642ed194