### PR TITLE
Implement OTel collector in CI pipeline

### DIFF
--- a/.github/otel-collector-config.yaml
+++ b/.github/otel-collector-config.yaml
@@ -1,0 +1,12 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+exporters:
+  logging:
+    loglevel: debug
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [logging]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Start OTel Collector
+        run: |
+          docker run -d --name otel-collector -p 4317:4317 \
+            -v ${{ github.workspace }}/.github/otel-collector-config.yaml:/etc/otelcol/config.yaml \
+            otel/opentelemetry-collector:0.92.0
       - uses: actions/setup-node@v2
         with:
           node-version: '18'
@@ -23,3 +28,8 @@ jobs:
       - run: pnpm test
       - run: sh ci/helm/helm.test.sh
       - run: pnpm run docs:build
+      - name: Stop OTel Collector
+        if: always()
+        run: |
+          docker stop otel-collector
+          docker rm otel-collector

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4491,7 +4491,7 @@
     "path": ".github/workflows/ci.yml",
     "task": "Add Docker and OTel pipeline for CosmicTheoryAgent",
     "test": "ci/ci-pipeline.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add Cypress E2E tests for SigilAlert",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6237,7 +6237,7 @@
   path: .github/workflows/ci.yml
   task: Add Docker and OTel pipeline for CosmicTheoryAgent
   test: ci/ci-pipeline.test.ts
-  status: todo
+  status: done
 - commit: Add Cypress E2E tests for SigilAlert
   path: packages/unifiedmandala-ui/tests/e2e
   task: Cypress flow for SigilAlert UI

--- a/ci/ci-pipeline.test.ts
+++ b/ci/ci-pipeline.test.ts
@@ -1,0 +1,8 @@
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+test('CI config includes OTel Collector step', () => {
+  const config = yaml.load(fs.readFileSync('.github/workflows/ci.yml', 'utf8')) as any;
+  const steps = config.jobs.build.steps.map((s: any) => s.name || s.run || '');
+  expect(steps).toContain('Start OTel Collector');
+});


### PR DESCRIPTION
## Summary
- add OpenTelemetry collector config
- run OTel collector in CI and stop after tests
- verify CI setup via `ci-pipeline.test.ts`
- mark OTel CI task as done in advanced ToDo files

## Testing
- `npx -y pyright` *(fails: missing imports)*
- `npx tsc -p tsconfig.json` *(fails: missing type definitions)*
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68740881e1f48322bcb7a33d1f7cd607