### PR TITLE
Implement MetricsStore telemetry

### DIFF
--- a/packages/crep-engine/MetricsStore.test.ts
+++ b/packages/crep-engine/MetricsStore.test.ts
@@ -1,7 +1,21 @@
 import { MetricsStore } from './MetricsStore';
+import { metrics } from '@opentelemetry/api';
+
+const recordMock = jest.fn();
+jest.mock('@opentelemetry/api', () => ({
+  metrics: {
+    getMeter: () => ({ createHistogram: () => ({ record: recordMock }) })
+  }
+}));
 
 test('computes average', () => {
   const ms = new MetricsStore();
   ms.add(1); ms.add(3);
   expect(ms.average()).toBe(2);
+});
+
+test('records values via OpenTelemetry', () => {
+  const ms = new MetricsStore();
+  ms.add(5);
+  expect(recordMock).toHaveBeenCalledWith(5);
 });

--- a/packages/crep-engine/MetricsStore.ts
+++ b/packages/crep-engine/MetricsStore.ts
@@ -1,10 +1,21 @@
+import { metrics } from '@opentelemetry/api';
+
+const meter = metrics.getMeter('crep-engine');
+const valueHistogram = meter.createHistogram('crep_value', {
+  description: 'CREP metric values'
+});
+
 export class MetricsStore {
   private values: number[] = [];
   add(value: number) {
     this.values.push(value);
+    valueHistogram.record(value);
   }
+
   average(): number {
     if (this.values.length === 0) return 0;
-    return this.values.reduce((a,b)=>a+b,0)/this.values.length;
+    return this.values.reduce((a, b) => a + b, 0) / this.values.length;
   }
 }
+
+export { valueHistogram };


### PR DESCRIPTION
## Summary
- wire MetricsStore to OpenTelemetry histogram
- verify telemetry calls in unit test

## Testing
- `npx pyright` *(fails: streamlit & matplotlib missing)*
- `npx tsc -p tsconfig.json` *(fails: missing type definitions)*
- `npx vitest run` *(interactive install prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6874158869fc8322889b581328ce1c29