### PR TITLE
feat: emit Fourier metrics svg

### DIFF
--- a/packages/analysis/FourierLayer.test.ts
+++ b/packages/analysis/FourierLayer.test.ts
@@ -11,9 +11,13 @@ describe('FourierLayer', () => {
   it('emits metrics event', () => {
     const events: any[] = [];
     FourierLayerEvents.on('metrics', e => events.push(e));
+    const svgEvents: any[] = [];
+    FourierLayerEvents.on('metrics-svg', e => svgEvents.push(e));
     const layer = new FourierLayer('L2', 1, [0, 1, 0, -1], { depth: 1 });
     layer.analyze();
     expect(events.length).toBe(1);
     expect(events[0].id).toBe('L2');
+    expect(svgEvents.length).toBe(1);
+    expect(svgEvents[0].id).toBe('L2');
   });
 });

--- a/packages/analysis/FourierLayer.ts
+++ b/packages/analysis/FourierLayer.ts
@@ -50,6 +50,8 @@ export class FourierLayer {
     const avgAmplitude = amps.reduce((a, b) => a + b, 0) / amps.length;
     const metrics = { maxAmplitude, avgAmplitude };
     FourierLayerEvents.emit('metrics', { id: this.id, metrics });
+    const svg = metricsToSVG(metrics);
+    FourierLayerEvents.emit('metrics-svg', { id: this.id, svg });
     return metrics;
   }
 }


### PR DESCRIPTION
## Summary
- add `metrics-svg` event in FourierLayer
- test new metrics SVG event

## Testing
- `npx -y pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68741d947ac88322b3d140463b0bfbe6