### PR TITLE
feat: export Fourier metrics to SVG

### DIFF
--- a/packages/analysis/FourierLayer.test.ts
+++ b/packages/analysis/FourierLayer.test.ts
@@ -20,4 +20,13 @@ describe('FourierLayer', () => {
     expect(svgEvents.length).toBe(1);
     expect(svgEvents[0].id).toBe('L2');
   });
+
+  it('writes SVG when exportPath provided', () => {
+    const tmp = 'test.svg';
+    const layer = new FourierLayer('L3', 1, [1,1,1,1], { depth: 1, exportPath: tmp });
+    layer.analyze();
+    const content = require('fs').readFileSync(tmp, 'utf8');
+    expect(content.startsWith('<svg')).toBe(true);
+    require('fs').unlinkSync(tmp);
+  });
 });

--- a/packages/analysis/FourierLayer.ts
+++ b/packages/analysis/FourierLayer.ts
@@ -1,6 +1,11 @@
 export interface FourierLayerConfig {
   depth: number;
   threshold?: number;
+  /**
+   * Optional path to export the generated SVG metrics. If provided,
+   * `analyze` will write the SVG output to this location.
+   */
+  exportPath?: string;
 }
 
 export interface EmergenceMetrics {
@@ -9,6 +14,7 @@ export interface EmergenceMetrics {
 }
 
 import { EventEmitter } from 'events';
+import { writeFileSync } from 'fs';
 
 export const FourierLayerEvents = new EventEmitter();
 
@@ -18,6 +24,7 @@ export class FourierLayer {
   weight: number;
   private threshold: number;
   private data: number[];
+  private config: FourierLayerConfig;
 
   constructor(id: string, level: number, data: number[], config: FourierLayerConfig) {
     this.id = id;
@@ -25,6 +32,7 @@ export class FourierLayer {
     this.threshold = config.threshold ?? 0.1;
     this.weight = data.length / (config.depth || 1);
     this.data = data;
+    this.config = config;
   }
 
   private dft(): [number, number][] {
@@ -52,6 +60,9 @@ export class FourierLayer {
     FourierLayerEvents.emit('metrics', { id: this.id, metrics });
     const svg = metricsToSVG(metrics);
     FourierLayerEvents.emit('metrics-svg', { id: this.id, svg });
+    if (this.config.exportPath) {
+      writeFileSync(this.config.exportPath, svg, 'utf8');
+    }
     return metrics;
   }
 }

--- a/packages/analysis/fourier-layer-config.json
+++ b/packages/analysis/fourier-layer-config.json
@@ -4,7 +4,8 @@
   "type": "object",
   "properties": {
     "depth": { "type": "integer", "minimum": 1 },
-    "threshold": { "type": "number", "minimum": 0 }
+    "threshold": { "type": "number", "minimum": 0 },
+    "exportPath": { "type": "string" }
   },
   "required": ["depth"],
   "additionalProperties": false

--- a/packages/crep-engine/MetricsStore.test.ts
+++ b/packages/crep-engine/MetricsStore.test.ts
@@ -1,12 +1,15 @@
-import { MetricsStore } from './MetricsStore';
-import { metrics } from '@opentelemetry/api';
-
 const recordMock = jest.fn();
-jest.mock('@opentelemetry/api', () => ({
+jest.doMock('@opentelemetry/api', () => ({
   metrics: {
     getMeter: () => ({ createHistogram: () => ({ record: recordMock }) })
   }
 }));
+const { metrics } = require('@opentelemetry/api');
+const { MetricsStore } = require('./MetricsStore');
+
+beforeEach(() => {
+  recordMock.mockClear();
+});
 
 test('computes average', () => {
   const ms = new MetricsStore();


### PR DESCRIPTION
## Summary
- extend `FourierLayerConfig` with optional `exportPath`
- write SVG output when `exportPath` is given
- update schema and tests
- fix MetricsStore test mocking

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687423ce42ec832289518f396c5d2dcf