### PR TITLE
Add simple analysis utilities

### DIFF
--- a/simulations/universe-sim/pkg/analysis/crep.go
+++ b/simulations/universe-sim/pkg/analysis/crep.go
@@ -1,0 +1,29 @@
+package analysis
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+)
+
+type Event struct {
+	Type string `json:"type"`
+}
+
+func CountEventTypes(path string) (map[string]int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	counts := make(map[string]int)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var e Event
+		if err := json.Unmarshal(scanner.Bytes(), &e); err == nil {
+			counts[e.Type]++
+		}
+	}
+	return counts, scanner.Err()
+}

--- a/simulations/universe-sim/pkg/sigil/generator.go
+++ b/simulations/universe-sim/pkg/sigil/generator.go
@@ -1,0 +1,12 @@
+package sigil
+
+import (
+	"crypto/sha1"
+	"fmt"
+)
+
+// Generate returns a simple hex hash as sigil identifier.
+func Generate(seed string) string {
+	h := sha1.Sum([]byte(seed))
+	return fmt.Sprintf("%x", h[:8])
+}

--- a/simulations/universe-sim/test/analysis_test.go
+++ b/simulations/universe-sim/test/analysis_test.go
@@ -1,0 +1,24 @@
+package test
+
+import (
+	"os"
+	"testing"
+
+	analysis "github.com/GenesisAeon/unified-mandala/universe-sim/pkg/analysis"
+)
+
+func TestCountEventTypes(t *testing.T) {
+	dir := t.TempDir()
+	file := dir + "/events.jsonl"
+	data := []byte("{\"type\":\"A\"}\n{\"type\":\"B\"}\n{\"type\":\"A\"}\n")
+	if err := os.WriteFile(file, data, 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	counts, err := analysis.CountEventTypes(file)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if counts["A"] != 2 || counts["B"] != 1 {
+		t.Fatalf("unexpected counts %v", counts)
+	}
+}

--- a/simulations/universe-sim/test/sigil_test.go
+++ b/simulations/universe-sim/test/sigil_test.go
@@ -1,0 +1,14 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/GenesisAeon/unified-mandala/universe-sim/pkg/sigil"
+)
+
+func TestGenerate(t *testing.T) {
+	s := sigil.Generate("run1")
+	if len(s) == 0 {
+		t.Fatal("empty sigil")
+	}
+}


### PR DESCRIPTION
## Summary
- add analysis metrics for universe-sim
- generate sigils per simulation run
- test analysis and sigil generator

## Testing
- `go test ./...`
- `npx tsc -p tsconfig.json` *(fails: Cannot find module type declarations)*
- `npx pyright` *(interactive npm prompt)*

------
https://chatgpt.com/codex/tasks/task_e_687433b5a3208322bd4b38b9a60ef216