### PR TITLE
Add fractal-runner utility

### DIFF
--- a/packages/agents/bin/fractal-runner.ts
+++ b/packages/agents/bin/fractal-runner.ts
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import path from 'path';
+import YAML from 'yaml';
+import { exec } from 'child_process';
+
+interface TaskEntry {
+  command: string;
+  sound?: boolean;
+}
+
+function playMandalaSoundscape(_metrics: any[]) {
+  // Placeholder for future sound integration
+  console.log('play soundscape');
+}
+
+export async function runTask(file: string) {
+  const content = fs.readFileSync(file, 'utf8');
+  const data = YAML.parse(content) as { tasks: TaskEntry[] };
+  for (const task of data.tasks) {
+    console.log('Executing', task.command);
+    await new Promise<void>((resolve, reject) => {
+      const child = exec(task.command, (err, stdout, stderr) => {
+        if (stdout) process.stdout.write(stdout);
+        if (stderr) process.stderr.write(stderr);
+        if (err) return reject(err);
+        resolve();
+      });
+      child.stdout?.pipe(process.stdout);
+      child.stderr?.pipe(process.stderr);
+    });
+    if (task.sound) {
+      playMandalaSoundscape([]);
+    }
+  }
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (!args[0]) {
+    console.error('Usage: fractal-runner <task-file.yaml>');
+    process.exit(1);
+  }
+  runTask(path.resolve(args[0])).catch((err) => {
+    console.error('Fractal-TaskRunner Error:', err);
+    process.exit(1);
+  });
+}

--- a/tasks/fractal-analysis.yaml
+++ b/tasks/fractal-analysis.yaml
@@ -1,0 +1,4 @@
+tasks:
+  - command: "echo Running tests"
+  - command: "npx pyright"
+  - command: "npx tsc -p tsconfig.json"


### PR DESCRIPTION
## Summary
- implement `fractal-runner` utility under `packages/agents/bin`
- add example task file `tasks/fractal-analysis.yaml`

## Testing
- `npx pyright` *(fails: needs package installation)*
- `npx tsc -p tsconfig.json` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_687436f0f544832296318d6c837cca3b