### PR TITLE
Implement TaskRunner sigillin logging

### DIFF
--- a/packages/agents/services/TaskRunner.test.ts
+++ b/packages/agents/services/TaskRunner.test.ts
@@ -1,0 +1,23 @@
+import { test, expect, afterEach } from "vitest";
+import fs from 'fs';
+import path from 'path';
+import { runFractalTask } from './TaskRunner';
+
+const tmpYaml = path.join(__dirname, 'task.yaml');
+const pluginJs = path.join(__dirname, 'plugin.js');
+const historyFile = path.resolve('sigillin_history.yaml');
+
+afterEach(() => {
+  if (fs.existsSync(tmpYaml)) fs.unlinkSync(tmpYaml);
+  if (fs.existsSync(pluginJs)) fs.unlinkSync(pluginJs);
+  if (fs.existsSync(historyFile)) fs.unlinkSync(historyFile);
+});
+
+test('writes sigillin history after run', async () => {
+  fs.writeFileSync(pluginJs, 'module.exports = class { constructor(){} analyze(){ return {foo:1}; }}');
+  fs.writeFileSync(tmpYaml, 'sigillin_id: test\ninput: []\nsteps:\n - plugin: "' + pluginJs.replace(/\\/g,'/') + '"\n   config: {}\ndoc: true');
+  await runFractalTask(tmpYaml);
+  expect(fs.existsSync(historyFile)).toBe(true);
+  const content = fs.readFileSync(historyFile, 'utf8');
+  expect(content).toContain('sigillin_id: test');
+});

--- a/packages/agents/services/TaskRunner.ts
+++ b/packages/agents/services/TaskRunner.ts
@@ -1,0 +1,18 @@
+import fs from 'fs';
+import YAML from 'yaml';
+import { emitSigillinCommit } from './sigillin';
+
+export async function runFractalTask(taskYaml: string) {
+  const task = YAML.parse(fs.readFileSync(taskYaml, 'utf8'));
+  let currentData = task.input;
+  const history: any[] = [];
+  for (const step of task.steps) {
+    const Plugin = require(step.plugin).default || require(step.plugin);
+    const layer = new Plugin(step.plugin, 0, currentData, step.config);
+    const metrics = layer.analyze();
+    history.push({ plugin: step.plugin, metrics });
+    currentData = metrics;
+  }
+  if (task.doc) await emitSigillinCommit(task, history);
+  return history;
+}

--- a/packages/agents/services/sigillin.ts
+++ b/packages/agents/services/sigillin.ts
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+import YAML from 'yaml';
+import { AeonSigillinVault } from '../../core/AeonSigillinVault';
+
+export async function emitSigillinCommit(task: any, history: any[]) {
+  const record = {
+    sigillin_id: task.sigillin_id || 'unknown',
+    steps: task.steps.map((s: any) => s.plugin),
+    metrics: history,
+    config: task,
+  };
+  const file = path.resolve('sigillin_history.yaml');
+  const yaml = YAML.stringify(record);
+  if (fs.existsSync(file)) {
+    fs.appendFileSync(file, '\n---\n' + yaml);
+  } else {
+    fs.writeFileSync(file, yaml);
+  }
+  AeonSigillinVault.record({
+    id: record.sigillin_id,
+    timestamp: new Date().toISOString(),
+    content: 'fractal run',
+  });
+}


### PR DESCRIPTION
## Summary
- add `TaskRunner` utility under `packages/agents/services`
- add `emitSigillinCommit` helper writing YAML history and logging to `AeonSigillinVault`
- test that `TaskRunner` records sigillin history

## Testing
- `pnpm install`
- `npx vitest run packages/agents/services/TaskRunner.test.ts`
- `npx tsc -p tsconfig.json`
- `npx pyright` *(fails: needs package installation)*

------
https://chatgpt.com/codex/tasks/task_e_68743bdb1e048322a19ad8cf0aa4b384