### PR TITLE
Fix FourierMetricsServer and tsconfig

### DIFF
--- a/packages/analysis/FourierMetricsServer.test.ts
+++ b/packages/analysis/FourierMetricsServer.test.ts
@@ -1,9 +1,9 @@
 import { startFourierMetricsServer } from './FourierMetricsServer';
-import { FourierLayer, FourierLayerEvents } from './FourierLayer';
+import { FourierLayer } from './FourierLayer';
 import WebSocket from 'ws';
 import { once } from 'events';
 
-describe('FourierMetricsServer', async () => {
+describe('FourierMetricsServer', () => {
   it('broadcasts metrics via websocket', async () => {
     const server = startFourierMetricsServer(4050);
     const ws = new WebSocket('ws://localhost:4050');

--- a/packages/analysis/FourierMetricsServer.ts
+++ b/packages/analysis/FourierMetricsServer.ts
@@ -1,8 +1,8 @@
 import { FourierLayerEvents } from './FourierLayer';
-import { Server } from 'ws';
+import { WebSocketServer } from 'ws';
 
 export function startFourierMetricsServer(port = 4010) {
-  const wss = new Server({ port });
+  const wss = new WebSocketServer({ port });
   wss.on('connection', ws => {
     const metricsListener = (data: any) => {
       ws.send(JSON.stringify({ type: 'fourier-metrics', data }));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "jsx": "react-jsx",
-    "types": []
+    "types": ["node"]
   },
   "include": [
     "packages/**/*",


### PR DESCRIPTION
## Summary
- fix websocket server setup
- declare Node typings for CLI tools

## Testing
- `npm test packages/cli-tools/FourierMetricsCLI.test.ts packages/analysis/FourierMetricsServer.test.ts` *(fails: No test files found)*


------
https://chatgpt.com/codex/tasks/task_e_6874b4c7f43c8322a81bddd67a27aba1