### PR TITLE
Add Fourier metrics viewer UI component

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -52,6 +52,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - `FourierLayer` – Bewertet Emergenz via Diskreter Fourier-Analyse.
 - `metricsToSVG` – Erstellt einfache SVG-Grafik aus Emergenz-Metriken.
 - `FourierMetricsServer` – sendet FourierLayer-Metriken per WebSocket.
+- `FourierMetricsViewer` – zeigt SVG-Metriken aus dem WebSocket in der UI.
 - `EventBridge` – leitet CosmicTheoryAgent-Events an die UI weiter.
 - `archiveSigil` – schreibt Sigil-Dateien in GenesisAeonZIPMEM.
 - `CREPVisualizer` – zeigt CREP-Verlauf als animierte Timeline.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**FourierLayer Analyse**](packages/analysis/FourierLayer.ts) – Frequenzbasierte Emergenzbewertung
 - [**FourierLayer Docs**](docs/fourier-layer.md) – usage examples and metrics
 - [**FourierMetricsServer**](packages/analysis/FourierMetricsServer.ts) – broadcast Fourier metrics via WebSocket
+- [**FourierMetricsViewer**](packages/unifiedmandala-ui/components/FourierMetricsViewer.tsx) – displays SVG metrics from the Fourier bridge
 - [**React Starter**](packages/unifiedmandala-ui/ReactStarter.tsx) – Tailwind/Vite skeleton setup
 - [**EventBridge**](packages/unifiedmandala-ui/events/EventBridge.ts) – verbindet CosmicTheoryAgent mit der Pyramid UI
 - [**PySR Service Client**](packages/agents/CosmicTheoryAgent.ts) – Regression via REST/gRPC

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4974,9 +4974,10 @@
   },
   {
     "commit": "SVG-Export oder WebSocket-Event für UI",
-    "path": "",
+    "path": "packages/unifiedmandala-ui/components/FourierMetricsViewer.tsx",
     "task": "SVG-Export oder WebSocket-Event für UI",
-    "test": ""
+    "test": "packages/unifiedmandala-ui/components/FourierMetricsViewer.test.tsx",
+    "status": "done"
   },
   {
     "commit": "Add FourierMetricsServer",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6552,9 +6552,10 @@
   task: "cs**:"
   test: ""
 - commit: SVG-Export oder WebSocket-Event für UI
-  path: ""
+  path: packages/unifiedmandala-ui/components/FourierMetricsViewer.tsx
   task: SVG-Export oder WebSocket-Event für UI
-  test: ""
+  test: packages/unifiedmandala-ui/components/FourierMetricsViewer.test.tsx
+  status: done
 - commit: Add FourierMetricsServer
   path: packages/analysis/FourierMetricsServer.ts
   task: Broadcast FourierLayer metrics via WebSocket

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -126,6 +126,10 @@
     {
       "commit": "Implement dispatcher backoff and retry logic",
       "status": "done"
+    },
+    {
+      "commit": "SVG-Export oder WebSocket-Event für UI",
+      "status": "done"
     }
   ]
 }

--- a/packages/unifiedmandala-ui/api/fourierBridge.test.ts
+++ b/packages/unifiedmandala-ui/api/fourierBridge.test.ts
@@ -1,0 +1,30 @@
+import fourierBridge, { connectFourierBridge } from './fourierBridge';
+
+global.WebSocket = class {
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  constructor(public url: string) {}
+  send(data: string) {
+    this.onmessage?.({ data });
+  }
+  close() {}
+} as any;
+
+test('connectFourierBridge emits metric events', () => {
+  let payload: any = null;
+  fourierBridge.on('fourier:metrics', data => {
+    payload = data;
+  });
+  const ws = connectFourierBridge('ws://test');
+  (ws as any).send(JSON.stringify({ type: 'fourier-metrics', data: { m: 1 } }));
+  expect(payload).toEqual({ m: 1 });
+});
+
+test('connectFourierBridge emits svg events', () => {
+  let svg: any = null;
+  fourierBridge.on('fourier:metrics-svg', data => {
+    svg = data;
+  });
+  const ws = connectFourierBridge('ws://test');
+  (ws as any).send(JSON.stringify({ type: 'fourier-metrics-svg', data: { id: 'x', svg: '<svg/>' } }));
+  expect(svg).toEqual({ id: 'x', svg: '<svg/>' });
+});

--- a/packages/unifiedmandala-ui/api/fourierBridge.ts
+++ b/packages/unifiedmandala-ui/api/fourierBridge.ts
@@ -1,0 +1,32 @@
+import mitt from 'mitt';
+
+export type FourierBridgeEvents = {
+  'fourier:metrics': any;
+  'fourier:metrics-svg': { id: string; svg: string };
+};
+
+const emitter = mitt<FourierBridgeEvents>();
+
+export function connectFourierBridge(url = 'ws://localhost:4010'): WebSocket {
+  const ws = new WebSocket(url);
+  ws.onmessage = ev => {
+    try {
+      const message = JSON.parse(ev.data);
+      if (message.type === 'fourier-metrics') {
+        emitter.emit('fourier:metrics', message.data);
+      } else if (message.type === 'fourier-metrics-svg') {
+        emitter.emit('fourier:metrics-svg', message.data);
+      }
+    } catch (e) {
+      console.error('Invalid fourier metrics message', e);
+    }
+  };
+  return ws;
+}
+
+export default {
+  on: emitter.on,
+  off: emitter.off,
+  emit: emitter.emit,
+  connect: connectFourierBridge,
+};

--- a/packages/unifiedmandala-ui/components/FourierMetricsViewer.test.tsx
+++ b/packages/unifiedmandala-ui/components/FourierMetricsViewer.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import FourierMetricsViewer from './FourierMetricsViewer';
+import fourierBridge from '../api/fourierBridge';
+
+global.WebSocket = class {
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  close() {}
+  constructor(public url: string) {}
+  send(data: string) {
+    this.onmessage?.({ data });
+  }
+} as any;
+
+import { act } from 'react-dom/test-utils';
+
+test('renders svg when event received', () => {
+  render(<FourierMetricsViewer />);
+  act(() => {
+    fourierBridge.emit('fourier:metrics-svg', { id: 't', svg: '<svg></svg>' });
+  });
+  expect(screen.getByLabelText('Fourier Metrics SVG')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/FourierMetricsViewer.tsx
+++ b/packages/unifiedmandala-ui/components/FourierMetricsViewer.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+import fourierBridge, { connectFourierBridge } from '../api/fourierBridge';
+
+const FourierMetricsViewer: React.FC = () => {
+  const [svg, setSvg] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handler = (data: { id: string; svg: string }) => setSvg(data.svg);
+    const ws = connectFourierBridge();
+    fourierBridge.on('fourier:metrics-svg', handler);
+    return () => {
+      fourierBridge.off('fourier:metrics-svg', handler);
+      (ws as any).close?.();
+    };
+  }, []);
+
+  if (!svg) return <div>No metrics</div>;
+
+  return (
+    <div
+      aria-label="Fourier Metrics SVG"
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+};
+
+export default FourierMetricsViewer;


### PR DESCRIPTION
## Summary
- add `fourierBridge` WebSocket helper and tests
- render metrics SVGs in new `FourierMetricsViewer` React component
- document Fourier metrics viewer in README and Handbuch
- mark SVG/WebSocket task done in advancedToDo files
- log progress in `advancedprogress.json`

## Testing
- `npx pyright` *(fails: missing imports)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*
- `pnpm test`
- `npx jest packages/unifiedmandala-ui/components/FourierMetricsViewer.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6874c6556d5c8322a72915f7a6783b72