### PR TITLE
Add theory events to CosmicTheoryAgent

### DIFF
--- a/packages/agents/CosmicTheoryAgent.test.ts
+++ b/packages/agents/CosmicTheoryAgent.test.ts
@@ -99,4 +99,16 @@ describe('callPySRService', () => {
     const eq = await callPySRService([1,2], 'localhost:6000', 'grpc');
     expect(eq).toBe('y=x^2');
   });
+
+  it('emits start and success events', async () => {
+    const starts: any[] = [];
+    const successes: any[] = [];
+    CosmicTheoryEventHub.on('theory:start', p => starts.push(p));
+    CosmicTheoryEventHub.on('theory:regression:success', p => successes.push(p));
+    vi.spyOn(axios, 'post').mockResolvedValue({ data: { equation: 'y=2x' } });
+    const eq = await callPySRService([3,4], 'http://localhost/pysr');
+    expect(eq).toBe('y=2x');
+    expect(starts[0].dataPoints).toEqual([3,4]);
+    expect(successes[0].equation).toBe('y=2x');
+  });
 });

--- a/packages/agents/CosmicTheoryAgent.ts
+++ b/packages/agents/CosmicTheoryAgent.ts
@@ -122,6 +122,7 @@ export async function callPySRService(
   endpoint: string,
   protocol: 'rest' | 'grpc' = 'rest'
 ): Promise<string> {
+  CosmicTheoryEventHub.emit('theory:start', { dataPoints: data });
   if (protocol === 'grpc') {
     const { Client, credentials } = await import('@grpc/grpc-js');
     const client = new Client(endpoint, credentials.createInsecure());
@@ -134,12 +135,15 @@ export async function callPySRService(
         (err, resp: any) => {
           client.close();
           if (err) return reject(err);
-          resolve(resp?.equation ?? '');
+          const eq = resp?.equation ?? '';
+          CosmicTheoryEventHub.emit('theory:regression:success', { equation: eq });
+          resolve(eq);
         }
       );
     });
   }
   const resp = await axios.post(endpoint, { data });
+  CosmicTheoryEventHub.emit('theory:regression:success', { equation: resp.data.equation });
   return resp.data.equation;
 }
 

--- a/packages/agents/CosmicTheoryAgentEvents.ts
+++ b/packages/agents/CosmicTheoryAgentEvents.ts
@@ -11,6 +11,8 @@ export interface TraceLogPayload {
 export type CosmicTheoryAgentEvents = {
   'sigil:generated': { sigilId: string; formula: string };
   'theory:updated': { formula: string; score: number };
+  'theory:start': { dataPoints: number[] };
+  'theory:regression:success': { equation: string };
   'trace:log': TraceLogPayload;
   [key: string]: any;
 };


### PR DESCRIPTION
## Summary
- emit `theory:start` and `theory:regression:success` via CosmicTheoryEventHub
- notify clients of lifecycle events when calling `callPySRService`
- verify event emission in CosmicTheoryAgent tests

## Testing
- `npx pyright` *(fails: module not found)*
- `npx tsc -p tsconfig.json`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874e58d9970832291031dc9a40f0649