### PR TITLE
Implement CREP stats card and parsing test

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -501,18 +501,18 @@
     "status": "done"
   },
   {
-  "commit": "Expose Prometheus metrics",
-  "path": "go-agent/pkg/metrics",
-  "task": "Export task duration and queue length metrics",
-  "test": "",
-  "status": "done"
+    "commit": "Expose Prometheus metrics",
+    "path": "go-agent/pkg/metrics",
+    "task": "Export task duration and queue length metrics",
+    "test": "",
+    "status": "done"
   },
   {
-  "commit": "Create Grafana dashboard template",
-  "path": "ci/monitoring/grafana",
-  "task": "Provide JSON template for task overview",
-  "test": "",
-  "status": "done"
+    "commit": "Create Grafana dashboard template",
+    "path": "ci/monitoring/grafana",
+    "task": "Provide JSON template for task overview",
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Implement dispatcher backoff and retry logic",
@@ -4997,5 +4997,26 @@
     "path": "",
     "task": "emit SVG or WebSocket event for UI visualization\\n    }\\n    if (task.sound) {\\n      playMandalaSoundscape([metrics]);\\n    }\\n  }\\n}\\n\\n// Entry\\nconst args = process.argv.slice(2);\\nif (!args[0]) {\\n  console.error('Usage: fractal-runner <task-file.yaml>');\\n  process.exit(1);\\n}\\nrunTask(args[0]).catch(err => {\\n  console.error('Fractal-TaskRunner Error:', err);\\n  process.exit(1);\\n});\\n```\\n\\n**Usage:**\\n```sh\\npnpm --filter agent ts-node packages/agent/src/bin/fractal-runner.ts tasks/fractal-analysis.yaml\\n```\\n\\nMit diesem Skript ist der **„Start!“**–Live-Run deines **Future Resonance Stack** vollständig automatisiert: Tests, Analysen, Visualisierung und Klang werden fraktal orchestriert! 🚀\"}]}",
     "test": ""
+  },
+  {
+    "commit": "Add parse-newadvanced-conversations test",
+    "path": "scripts/__tests__/parse-newadvanced-conversations.test.ts",
+    "task": "Test extraction utility for newadvancedconversations dataset",
+    "test": "scripts/__tests__/parse-newadvanced-conversations.test.ts",
+    "status": "done"
+  },
+  {
+    "commit": "Implement CREPStatsCard component",
+    "path": "packages/unifiedmandala-ui/components/CREPStatsCard.tsx",
+    "task": "Display average CREP resonance with mini chart",
+    "test": "packages/unifiedmandala-ui/components/CREPStatsCard.test.tsx",
+    "status": "planned"
+  },
+  {
+    "commit": "Add impulse CREP update route",
+    "path": "packages/agent/src/routes/impulse.ts",
+    "task": "Provide POST /impulse/:idx/crep to update metrics",
+    "test": "packages/agent/src/routes/impulse.test.ts",
+    "status": "planned"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6683,3 +6683,18 @@
     automatisiert: Tests, Analysen, Visualisierung und Klang werden fraktal
     orchestriert! 🚀\"}]}"
   test: ""
+- commit: Add parse-newadvanced-conversations test
+  path: scripts/__tests__/parse-newadvanced-conversations.test.ts
+  task: Test extraction utility for newadvancedconversations dataset
+  test: scripts/__tests__/parse-newadvanced-conversations.test.ts
+  status: done
+- commit: Implement CREPStatsCard component
+  path: packages/unifiedmandala-ui/components/CREPStatsCard.tsx
+  task: Display average CREP resonance with mini chart
+  test: packages/unifiedmandala-ui/components/CREPStatsCard.test.tsx
+  status: planned
+- commit: Add impulse CREP update route
+  path: packages/agent/src/routes/impulse.ts
+  task: Provide POST /impulse/:idx/crep to update metrics
+  test: packages/agent/src/routes/impulse.test.ts
+  status: planned

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -130,6 +130,18 @@
     {
       "commit": "SVG-Export oder WebSocket-Event für UI",
       "status": "done"
+    },
+    {
+      "commit": "Add parse-newadvanced-conversations test",
+      "status": "done"
+    },
+    {
+      "commit": "Implement CREPStatsCard component",
+      "status": "planned"
+    },
+    {
+      "commit": "Add impulse CREP update route",
+      "status": "planned"
     }
   ]
 }

--- a/packages/agent/src/routes/impulse.test.ts
+++ b/packages/agent/src/routes/impulse.test.ts
@@ -1,0 +1,10 @@
+import request from 'supertest';
+import express from 'express';
+import impulseRouter from './impulse';
+
+test('POST /impulse/:idx/crep returns ok', async () => {
+  const app = express();
+  app.use(impulseRouter);
+  const res = await request(app).post('/impulse/1/crep');
+  expect(res.body.ok).toBe(true);
+});

--- a/packages/agent/src/routes/impulse.ts
+++ b/packages/agent/src/routes/impulse.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+export const impulseRouter = Router();
+
+impulseRouter.post('/impulse/:idx/crep', (req, res) => {
+  // TODO implement update logic
+  res.json({ ok: true });
+});
+
+export default impulseRouter;

--- a/packages/unifiedmandala-ui/components/CREPStatsCard.test.tsx
+++ b/packages/unifiedmandala-ui/components/CREPStatsCard.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import CREPStatsCard from './CREPStatsCard';
+
+test('renders average resonance', () => {
+  render(<CREPStatsCard avgResonance={5} />);
+  expect(screen.getByText(/Avg Resonance/)).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/CREPStatsCard.tsx
+++ b/packages/unifiedmandala-ui/components/CREPStatsCard.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+interface CREPStatsCardProps { avgResonance: number }
+export default function CREPStatsCard({ avgResonance }: CREPStatsCardProps) {
+  return (
+    <div className="crep-stats-card">
+      <strong>Avg Resonance:</strong> {avgResonance}
+      {/* TODO: Mini-Chart hier einfügen */}
+    </div>
+  );
+}

--- a/scripts/__tests__/parse-newadvanced-conversations.test.ts
+++ b/scripts/__tests__/parse-newadvanced-conversations.test.ts
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+const { parseNewAdvancedConversations } = require('../parse-newadvanced-conversations');
+
+test('parseNewAdvancedConversations extracts TODO fragments', () => {
+  const tmpDir = fs.mkdtempSync(path.join(__dirname, 'tmp'));
+  const file = path.join(tmpDir, 'convos.json');
+  const dest = path.join(tmpDir, 'out');
+  const data = [
+    { msg: 'hello' },
+    { msg: 'TODO: add feature' }
+  ];
+  fs.writeFileSync(file, JSON.stringify(data));
+  const matches = parseNewAdvancedConversations(file, dest, 'TODO');
+  expect(matches.length).toBe(1);
+  const out = fs.readFileSync(path.join(dest, 'convos-grep.json'), 'utf8');
+  expect(out.includes('add feature')).toBe(true);
+  fs.rmSync(tmpDir, { recursive: true });
+});

--- a/scripts/parse-newadvanced-conversations.js
+++ b/scripts/parse-newadvanced-conversations.js
@@ -1,11 +1,17 @@
 const path = require('path');
 const { grepJsonArrayFile } = require('../packages/shared-utils/jsonFragmenter');
 
-const file = path.join(__dirname, '../docs/sigils/newadvancedconversations.json');
-const dest = path.join(__dirname, '../GenesisAeonZIPMEM/newadvancedconversations');
-const keyword = process.argv[2] || 'TODO';
-const regex = new RegExp(keyword, 'i');
+function parseNewAdvancedConversations(filePath, destDir, keyword = 'TODO') {
+  const regex = new RegExp(keyword, 'i');
+  return grepJsonArrayFile(filePath, destDir, regex);
+}
 
-const matches = grepJsonArrayFile(file, dest, regex);
-console.log(`Parsed ${matches.length} fragments containing '${keyword}'. Output: ${dest}`);
+if (require.main === module) {
+  const file = path.join(__dirname, '../docs/sigils/newadvancedconversations.json');
+  const dest = path.join(__dirname, '../GenesisAeonZIPMEM/newadvancedconversations');
+  const keyword = process.argv[2] || 'TODO';
+  const matches = parseNewAdvancedConversations(file, dest, keyword);
+  console.log(`Parsed ${matches.length} fragments containing '${keyword}'. Output: ${dest}`);
+}
 
+module.exports = { parseNewAdvancedConversations };


### PR DESCRIPTION
## Summary
- add parse-newadvanced-conversations utility export and test
- add basic CREPStatsCard component
- scaffold impulse CREP route
- track new tasks in advancedToDo and progress

## Testing
- `npx pyright` *(fails: Import could not be resolved)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68752512f3d48322bdcc065e6d121862