### PR TITLE
Add sigillin lint CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       - run: pnpm --filter ./packages/genesis-sigillin-core run lint test build
       - run: pnpm --filter ./packages/gpt-bridges run lint test
       - run: pnpm --filter ./packages/cli-tools run lint test
+      - run: pnpm run sigillin:lint
       - run: pnpm test
       - run: sh ci/helm/helm.test.sh
       - run: pnpm run docs:build

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -150,6 +150,7 @@ GPTEventHub.emit('orakel:says', { content: 'Hallo Welt' });
 - `sigillin-cli.ts` – Konvertiert und validiert Sigillin-Dateien.
 - `dispatchCmd.ts` – Startet Tasks via REST/gRPC aus der CLI.
 - `visualize_state.py` – erzeugt Fraktal-State-Charts aus CREP-Historien.
+- `sigillin-lint.js` – überprüft alle Sigil-Dateien in `docs/sigils`.
 
 ### sharedream-interface
 - `MetaScoreChart` – Zeigt Bewertungsdaten aus `/api/meta-scores`.

--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ Verwende `./scripts/aeon.sh <command>` für alle CLI-Aufrufe.
 | `node packages/cli-tools/export-doc.js` | CREP-Historie als Markdown |
 | `node packages/cli-tools/sigillin-archive.js` | Archiviert Sigillin-Dateien |
 | `node packages/cli-tools/SigillinValidator.ts <file>` | Validiert eine Sigillin-Datei |
+| `pnpm run sigillin:lint` | Prüft alle Sigil-Dateien unter `docs/sigils` |
 | `node packages/cli-tools/dispatchCmd.ts` | Dispatcher für diverse Befehle |
 | `go run scripts/mock-data.go` | Gibt Beispiel-Mockdaten mit eventHook und fractalHash aus |
 | `go run go-bridge/cmd/todo_parser.go` | Startet einfachen TODO-Parser-Server |

--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -37,7 +37,7 @@ todos:
     status: offen
   - id: todo-13
     beschreibung: "Sigillin-Lint in CI integrieren"
-    status: offen
+    status: erledigt
   - id: todo-14
     beschreibung: "Verarbeitung von conversations.json mit Fortschrittsdatei automatisieren"
     status: offen

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -501,18 +501,18 @@
     "status": "done"
   },
   {
-  "commit": "Expose Prometheus metrics",
-  "path": "go-agent/pkg/metrics",
-  "task": "Export task duration and queue length metrics",
-  "test": "",
-  "status": "done"
+    "commit": "Expose Prometheus metrics",
+    "path": "go-agent/pkg/metrics",
+    "task": "Export task duration and queue length metrics",
+    "test": "",
+    "status": "done"
   },
   {
-  "commit": "Create Grafana dashboard template",
-  "path": "ci/monitoring/grafana",
-  "task": "Provide JSON template for task overview",
-  "test": "",
-  "status": "done"
+    "commit": "Create Grafana dashboard template",
+    "path": "ci/monitoring/grafana",
+    "task": "Provide JSON template for task overview",
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Implement dispatcher backoff and retry logic",
@@ -4997,5 +4997,12 @@
     "path": "",
     "task": "emit SVG or WebSocket event for UI visualization\\n    }\\n    if (task.sound) {\\n      playMandalaSoundscape([metrics]);\\n    }\\n  }\\n}\\n\\n// Entry\\nconst args = process.argv.slice(2);\\nif (!args[0]) {\\n  console.error('Usage: fractal-runner <task-file.yaml>');\\n  process.exit(1);\\n}\\nrunTask(args[0]).catch(err => {\\n  console.error('Fractal-TaskRunner Error:', err);\\n  process.exit(1);\\n});\\n```\\n\\n**Usage:**\\n```sh\\npnpm --filter agent ts-node packages/agent/src/bin/fractal-runner.ts tasks/fractal-analysis.yaml\\n```\\n\\nMit diesem Skript ist der **„Start!“**–Live-Run deines **Future Resonance Stack** vollständig automatisiert: Tests, Analysen, Visualisierung und Klang werden fraktal orchestriert! 🚀\"}]}",
     "test": ""
+  },
+  {
+    "commit": "Integrate Sigillin lint in CI",
+    "path": ".github/workflows/ci.yml",
+    "task": "Run scripts/sigillin-lint.js during CI build",
+    "test": "scripts/sigillin-lint.js",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -204,6 +204,11 @@
   status: done
   task: CLI dispatch via AgentRegistry
   test: ""
+- commit: Integrate Sigillin lint in CI
+  path: .github/workflows/ci.yml
+  task: Run scripts/sigillin-lint.js during CI build
+  test: scripts/sigillin-lint.js
+  status: done
 - commit: Add AdaptiveThreshold module
   path: packages/core/AdaptiveThreshold.ts
   status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -130,6 +130,10 @@
     {
       "commit": "SVG-Export oder WebSocket-Event für UI",
       "status": "done"
+    },
+    {
+      "commit": "Sigillin lint added to CI",
+      "status": "done"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ghost-shell:cluster": "ts-node services/ghost-shell/cluster.ts",
     "ghost-shell:server": "ts-node services/ghost-shell/server.ts",
     "generate:ghostshell-nginx": "ts-node scripts/generate-ghostshell-nginx.ts",
+    "sigillin:lint": "node scripts/sigillin-lint.js",
     "store:commit-memory": "node GenesisAeonZIPMEM/commitMemory/commit-memory.js",
     "generate:changelog": "node scripts/generate-changelog.js",
     "compile:agents-manifest": "node scripts/compile_agents_manifest.js",

--- a/scripts/sigillin-lint.js
+++ b/scripts/sigillin-lint.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+const glob = require('glob');
+const path = require('path');
+let validate;
+try {
+  ({ validateSigillin: validate } = require('../dist/shared-utils/SigillinValidator'));
+} catch {
+  ({ validateSigillin: validate } = require('../packages/shared-utils/SigillinValidator'));
+}
+
+const files = glob.sync('docs/sigils/**/*.{yaml,yml,json}', { nodir: true });
+let allOk = true;
+files.forEach(file => {
+  const { valid, errors } = validate(path.resolve(file));
+  if (valid) {
+    console.log(`${file}: OK`);
+  } else {
+    console.error(`${file}: INVALID`, errors);
+    allOk = false;
+  }
+});
+process.exitCode = allOk ? 0 : 1;


### PR DESCRIPTION
## Summary
- add `sigillin-lint.js` script to validate sigils
- expose `sigillin:lint` npm script and run it in CI
- mark ToDo for CI sigillin lint as done and record progress
- document new command in README and Handbuch

## Testing
- `npx pyright` *(fails: Import errors)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definitions)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68752512f3d48322bdcc065e6d121862