### PR TITLE
Implement CREPStatsCard and impulse route

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -149,6 +149,7 @@ GPTEventHub.emit('orakel:says', { content: 'Hallo Welt' });
 ### cli-tools
 - `sigillin-cli.ts` – Konvertiert und validiert Sigillin-Dateien.
 - `dispatchCmd.ts` – Startet Tasks via REST/gRPC aus der CLI.
+- `/impulse/:idx/crep` – REST-Route zum Aktualisieren von CREP-Metriken.
 - `visualize_state.py` – erzeugt Fraktal-State-Charts aus CREP-Historien.
 
 ### sharedream-interface
@@ -162,6 +163,7 @@ GPTEventHub.emit('orakel:says', { content: 'Hallo Welt' });
 ### unifiedmandala-ui (Auswahl)
 - `MandalaNetworkView` – Visualisierung der Sigillin-Knoten als D3-Graph.
 - `CREPChart` – Linienchart für CREP-Werte.
+- `CREPStatsCard` – zeigt Durchschnitts-CREP mit kleinem Chart.
 - `CREPTimeline` – zeigt historische CREP-Einträge als Liste.
 - `CREPTriggerPanel` – Buttons zum Auslösen von CREP-Ereignissen.
 - `LiveCREPPanel` – Kombiniert Trigger und Chart für Live-Daten.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**SelfAnalyzerAgent**](packages/agents/self-analyzer) – generiert automatische ToDos
 - [**FeedbackButtons**](packages/unifiedmandala-ui/components/FeedbackButtons.tsx) – zeichnet Nutzerfeedback als Sigil-Ereignis auf
 - [**ChatPanel**](packages/unifiedmandala-ui/components/ChatPanel.tsx) – einfacher GPT-gestützter Chat mit CREP-Logging
+- [**CREPStatsCard**](packages/unifiedmandala-ui/components/CREPStatsCard.tsx) – zeigt Durchschnitts-CREP mit Mini-Chart
+- `/impulse/:idx/crep` – Route zum Aktualisieren der CREP-Metriken
 - [**ArchetypeDecoderAgent**](packages/agents/ArchetypeDecoderAgent.ts) – extrahiert Archetypen aus Beschreibungen
 - [**SigillinInterpreterAgent**](packages/agents/SigillinInterpreterAgent.ts) – erkennt Sigillin-Symbole
 - [**ChronoPoemGeneratorAgent**](packages/agents/ChronoPoemGeneratorAgent.ts) – generiert poetische Zeilen

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5010,13 +5010,13 @@
     "path": "packages/unifiedmandala-ui/components/CREPStatsCard.tsx",
     "task": "Display average CREP resonance with mini chart",
     "test": "packages/unifiedmandala-ui/components/CREPStatsCard.test.tsx",
-    "status": "planned"
+    "status": "done"
   },
   {
     "commit": "Add impulse CREP update route",
     "path": "packages/agent/src/routes/impulse.ts",
     "task": "Provide POST /impulse/:idx/crep to update metrics",
     "test": "packages/agent/src/routes/impulse.test.ts",
-    "status": "planned"
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6692,9 +6692,9 @@
   path: packages/unifiedmandala-ui/components/CREPStatsCard.tsx
   task: Display average CREP resonance with mini chart
   test: packages/unifiedmandala-ui/components/CREPStatsCard.test.tsx
-  status: planned
+  status: done
 - commit: Add impulse CREP update route
   path: packages/agent/src/routes/impulse.ts
   task: Provide POST /impulse/:idx/crep to update metrics
   test: packages/agent/src/routes/impulse.test.ts
-  status: planned
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #641 from GenesisAeon/codex/integrate-todo-scanner-and-ci-step",
+  "lastCommit": "implement CREPStatsCard and impulse route",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -137,11 +137,11 @@
     },
     {
       "commit": "Implement CREPStatsCard component",
-      "status": "planned"
+      "status": "done"
     },
     {
       "commit": "Add impulse CREP update route",
-      "status": "planned"
+      "status": "done"
     }
   ]
 }

--- a/packages/agent/src/routes/impulse.test.ts
+++ b/packages/agent/src/routes/impulse.test.ts
@@ -1,10 +1,17 @@
+import { TextEncoder, TextDecoder } from 'util';
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder;
 import request from 'supertest';
 import express from 'express';
-import impulseRouter from './impulse';
+import impulseRouter, { impulseMetrics } from './impulse';
 
-test('POST /impulse/:idx/crep returns ok', async () => {
+test('POST /impulse/:idx/crep returns ok and stores value', async () => {
   const app = express();
+  app.use(express.json());
   app.use(impulseRouter);
-  const res = await request(app).post('/impulse/1/crep');
+  const res = await request(app)
+    .post('/impulse/1/crep')
+    .send({ value: 0.7 });
   expect(res.body.ok).toBe(true);
+  expect(impulseMetrics['1']).toContain(0.7);
 });

--- a/packages/agent/src/routes/impulse.ts
+++ b/packages/agent/src/routes/impulse.ts
@@ -1,8 +1,18 @@
 import { Router } from 'express';
+
 export const impulseRouter = Router();
+export const impulseMetrics: Record<string, number[]> = {};
 
 impulseRouter.post('/impulse/:idx/crep', (req, res) => {
-  // TODO implement update logic
+  const { idx } = req.params;
+  const value = Number(req.body?.value);
+  if (!Number.isFinite(value)) {
+    return res.status(400).json({ error: 'invalid value' });
+  }
+  if (!impulseMetrics[idx]) {
+    impulseMetrics[idx] = [];
+  }
+  impulseMetrics[idx].push(value);
   res.json({ ok: true });
 });
 

--- a/packages/unifiedmandala-ui/components/CREPStatsCard.test.tsx
+++ b/packages/unifiedmandala-ui/components/CREPStatsCard.test.tsx
@@ -1,7 +1,16 @@
 import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import CREPStatsCard from './CREPStatsCard';
 
 test('renders average resonance', () => {
   render(<CREPStatsCard avgResonance={5} />);
   expect(screen.getByText(/Avg Resonance/)).toBeInTheDocument();
+});
+
+test('renders chart when history provided', () => {
+  const history = [1, 2, 3];
+  render(<CREPStatsCard avgResonance={2} history={history} />);
+  // chart uses SVG path element for line
+  const paths = document.querySelectorAll('path');
+  expect(paths.length).toBeGreaterThan(0);
 });

--- a/packages/unifiedmandala-ui/components/CREPStatsCard.tsx
+++ b/packages/unifiedmandala-ui/components/CREPStatsCard.tsx
@@ -1,10 +1,29 @@
 import React from 'react';
-interface CREPStatsCardProps { avgResonance: number }
-export default function CREPStatsCard({ avgResonance }: CREPStatsCardProps) {
+import { LineChart, Line } from 'recharts';
+
+export interface CREPStatsCardProps {
+  avgResonance: number;
+  history?: number[];
+}
+
+export default function CREPStatsCard({
+  avgResonance,
+  history = [],
+}: CREPStatsCardProps) {
+  const data = history.map((val, idx) => ({ idx, val }));
   return (
     <div className="crep-stats-card">
-      <strong>Avg Resonance:</strong> {avgResonance}
-      {/* TODO: Mini-Chart hier einfügen */}
+      <strong>Avg Resonance:</strong> {avgResonance.toFixed(2)}
+      {history.length > 0 && (
+        <LineChart
+          width={120}
+          height={80}
+          data={data}
+          margin={{ top: 5, right: 5, left: 5, bottom: 5 }}
+        >
+          <Line type="monotone" dataKey="val" stroke="#82ca9d" dot={false} />
+        </LineChart>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- complete CREPStatsCard with mini chart
- add impulse CREP update route and tests
- mark tasks as done in advancedToDo and progress files
- mention new component and route in docs

## Testing
- `npx -y pyright` *(fails: Import "streamlit" could not be resolved)*
- `poetry install --with test` *(fails: pyproject.toml not found)*
- `pnpm install`
- `npx -y tsc -p tsconfig.json`
- `pnpm test packages/unifiedmandala-ui/components/CREPStatsCard.test.tsx packages/agent/src/routes/impulse.test.ts`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6875643950f88322ba38635b5e4af95f