### PR TITLE
Implement meta-scores averaging

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5018,5 +5018,12 @@
     "task": "Provide POST /impulse/:idx/crep to update metrics",
     "test": "packages/agent/src/routes/impulse.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Return avg resonance via metaScores route",
+    "path": "packages/core/routes/metaScores.ts",
+    "task": "Compute average from impulseMetrics and expose via GET /api/meta-scores",
+    "test": "packages/core/routes/metaScores.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6698,3 +6698,8 @@
   task: Provide POST /impulse/:idx/crep to update metrics
   test: packages/agent/src/routes/impulse.test.ts
   status: done
+- commit: Return avg resonance via metaScores route
+  path: packages/core/routes/metaScores.ts
+  task: Compute average from impulseMetrics and expose via GET /api/meta-scores
+  test: packages/core/routes/metaScores.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -142,6 +142,10 @@
     {
       "commit": "Add impulse CREP update route",
       "status": "done"
+    },
+    {
+      "commit": "Return avg resonance via metaScores route",
+      "status": "done"
     }
   ]
 }

--- a/packages/core/routes/metaScores.test.ts
+++ b/packages/core/routes/metaScores.test.ts
@@ -4,14 +4,29 @@ global.TextEncoder = TextEncoder;
 import request from 'supertest';
 import express from 'express';
 import metaScores from './metaScores';
+import impulseRouter, { impulseMetrics } from '../../agent/src/routes/impulse';
 
 const app = express();
+app.use(express.json());
+app.use(impulseRouter);
 app.use(metaScores);
+
+beforeEach(() => {
+  for (const key in impulseMetrics) delete impulseMetrics[key];
+});
 
 describe('metaScores route', () => {
   it('returns empty scores', async () => {
     const res = await request(app).get('/api/meta-scores');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ scores: [] });
+  });
+
+  it('returns average resonance for impulses', async () => {
+    await request(app).post('/impulse/1/crep').send({ value: 0.5 });
+    await request(app).post('/impulse/1/crep').send({ value: 1.0 });
+    const res = await request(app).get('/api/meta-scores');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ scores: [{ idx: '1', avgResonance: 0.75 }] });
   });
 });

--- a/packages/core/routes/metaScores.ts
+++ b/packages/core/routes/metaScores.ts
@@ -1,8 +1,15 @@
 import express from 'express';
+import { impulseMetrics } from '../../agent/src/routes/impulse';
+
 const router = express.Router();
 
 router.get('/api/meta-scores', (_req: any, res: any) => {
-  res.json({ scores: [] });
+  const scores = Object.entries(impulseMetrics).map(([idx, values]) => {
+    const sum = values.reduce((a, b) => a + b, 0);
+    const avgResonance = values.length ? sum / values.length : 0;
+    return { idx, avgResonance };
+  });
+  res.json({ scores });
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- compute average resonance in `metaScores` route
- test that metaScores returns averages
- document new metaScores feature in advanced progress and todo files

## Testing
- `npx pyright` *(fails: streamlit & matplotlib missing)*
- `npx tsc -p tsconfig.json`
- `npx jest packages/core/routes/metaScores.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_687576168dec83228862a7dc056a2e69