### PR TITLE
Update FourierLayer API

### DIFF
--- a/packages/analysis/FourierLayer.test.ts
+++ b/packages/analysis/FourierLayer.test.ts
@@ -3,9 +3,10 @@ import { FourierLayer, FourierLayerEvents } from './FourierLayer';
 describe('FourierLayer', () => {
   it('computes amplitude metrics', () => {
     const layer = new FourierLayer('L1', 1, [1, 0, -1, 0], { depth: 1 });
-    const metrics = layer.analyze();
-    expect(metrics.maxAmplitude).toBeGreaterThan(0);
-    expect(metrics.avgAmplitude).toBeGreaterThan(0);
+    const res = layer.analyze();
+    expect(res.metrics.maxAmplitude).toBeGreaterThan(0);
+    expect(res.metrics.avgAmplitude).toBeGreaterThan(0);
+    expect(res.amplitudes.length).toBeGreaterThan(0);
   });
 
   it('emits metrics event', () => {

--- a/packages/analysis/FourierLayer.ts
+++ b/packages/analysis/FourierLayer.ts
@@ -13,6 +13,11 @@ export interface EmergenceMetrics {
   avgAmplitude: number;
 }
 
+export interface FourierResult {
+  metrics: EmergenceMetrics;
+  amplitudes: number[];
+}
+
 import { EventEmitter } from 'events';
 import { writeFileSync } from 'fs';
 
@@ -51,7 +56,7 @@ export class FourierLayer {
     return result;
   }
 
-  analyze(): EmergenceMetrics {
+  analyze(): FourierResult {
     const phasors = this.dft();
     const amps = phasors.map(([re, im]) => Math.hypot(re, im));
     const maxAmplitude = Math.max(...amps);
@@ -63,7 +68,7 @@ export class FourierLayer {
     if (this.config.exportPath) {
       writeFileSync(this.config.exportPath, svg, 'utf8');
     }
-    return metrics;
+    return { metrics, amplitudes: amps };
   }
 }
 

--- a/services/fourier-metrics/api.test.ts
+++ b/services/fourier-metrics/api.test.ts
@@ -11,6 +11,7 @@ describe('Fourier API', () => {
       .post('/api/fourier/analyze')
       .send({ data: [1, 0, 1, 0] });
     expect(res.body.metrics.maxAmplitude).toBeGreaterThan(0);
+    expect(Array.isArray(res.body.amplitudes)).toBe(true);
   });
 
   it('validates payload', async () => {

--- a/services/fourier-metrics/api.ts
+++ b/services/fourier-metrics/api.ts
@@ -11,8 +11,8 @@ export function createApp() {
       return res.status(400).json({ error: 'data must be array of numbers' });
     }
     const layer = new FourierLayer('api', 1, data, { depth: 1 });
-    const metrics = layer.analyze();
-    res.json({ metrics });
+    const { metrics, amplitudes } = layer.analyze();
+    res.json({ metrics, amplitudes });
   });
 
   return app;


### PR DESCRIPTION
## Summary
- return amplitudes from `FourierLayer.analyze`
- update Fourier analysis API and tests
- adjust unit tests for new result shape

## Testing
- `npx pyright` *(failed: environment issue)*
- `npx tsc -p tsconfig.json` *(failed: missing @types/node)*
- `pnpm test` *(failed: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875f9c2d4ac8322a26738d0fc71b610