### PR TITLE
Implement feedback logging and taxonomy

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5032,14 +5032,14 @@
     "path": "packages/analysis/feedback_log.ts",
     "task": "Log scores, profile, entropy, variance and S_I after each iteration to feedback_log.json",
     "test": "packages/analysis/feedback_log.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Implement SystemComponent classification taxonomy",
     "path": "packages/analysis/system_component_classification.ts",
     "task": "Define taxonomy categories (nat\u00fcrlich, synthetisch, mental, physikalisch) and apply classification",
     "test": "packages/analysis/system_component_classification.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add Nullmembran SI Heatmap",
@@ -5053,6 +5053,6 @@
     "path": "services/nukleon-scanner/openapi.yaml",
     "task": "Expose Nukleon Scanner metrics via OpenAPI/GraphQL for integration",
     "test": "services/nukleon-scanner/openapi.test.ts",
-    "status": "todo"
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6707,12 +6707,12 @@
   path: packages/analysis/feedback_log.ts
   task: Log scores, profile, entropy, variance and S_I after each iteration to feedback_log.json
   test: packages/analysis/feedback_log.test.ts
-  status: todo
+  status: done
 - commit: Implement SystemComponent classification taxonomy
   path: packages/analysis/system_component_classification.ts
   task: Define taxonomy categories (natürlich, synthetisch, mental, physikalisch) and apply classification
   test: packages/analysis/system_component_classification.test.ts
-  status: todo
+  status: done
 - commit: Add Nullmembran SI Heatmap
   path: packages/unifiedmandala-ui/components/NullmembranSIHeatmap.tsx
   task: Visualize S_I distribution around threshold (ΔS_I ± σ) using heatmap
@@ -6722,4 +6722,4 @@
   path: services/nukleon-scanner/openapi.yaml
   task: Expose Nukleon Scanner metrics via OpenAPI/GraphQL for integration
   test: services/nukleon-scanner/openapi.test.ts
-  status: todo
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -149,11 +149,11 @@
     },
     {
       "commit": "TODO from newadvancedconversations.json - feedback_log",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "TODO from newadvancedconversations.json - component classification",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "TODO from newadvancedconversations.json - Nullmembran SI Heatmap",
@@ -161,7 +161,7 @@
     },
     {
       "commit": "TODO from newadvancedconversations.json - Nukleon OpenAPI",
-      "status": "todo"
+      "status": "done"
     }
   ]
 }

--- a/packages/analysis/feedback_log.test.ts
+++ b/packages/analysis/feedback_log.test.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import { logFeedback } from './feedback_log';
+
+test('appends feedback entries to log file', () => {
+  const file = 'feedback_log_test.json';
+  if (fs.existsSync(file)) fs.unlinkSync(file);
+
+  let data = logFeedback({ score: 1, profile: 'p1', entropy: 0.5, variance: 0.1, SI: 0.2 }, file);
+  expect(data.length).toBe(1);
+  data = logFeedback({ score: 2, profile: 'p2', entropy: 0.3, variance: 0.2, SI: 0.4 }, file);
+  expect(data.length).toBe(2);
+  const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+  expect(parsed[0]).toHaveProperty('timestamp');
+  expect(parsed[1].score).toBe(2);
+
+  fs.unlinkSync(file);
+});

--- a/packages/analysis/feedback_log.ts
+++ b/packages/analysis/feedback_log.ts
@@ -1,0 +1,20 @@
+export interface FeedbackEntry {
+  score: number;
+  profile: string;
+  entropy: number;
+  variance: number;
+  SI: number;
+  timestamp: string;
+}
+
+import fs from 'fs';
+
+export function logFeedback(entry: Omit<FeedbackEntry, 'timestamp'>, file: string = 'feedback_log.json'): FeedbackEntry[] {
+  const data: FeedbackEntry[] = fs.existsSync(file)
+    ? JSON.parse(fs.readFileSync(file, 'utf8'))
+    : [];
+  const record: FeedbackEntry = { ...entry, timestamp: new Date().toISOString() };
+  data.push(record);
+  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+  return data;
+}

--- a/packages/analysis/system_component_classification.test.ts
+++ b/packages/analysis/system_component_classification.test.ts
@@ -1,0 +1,13 @@
+import { classifyComponent } from './system_component_classification';
+
+test('classifies mental component', () => {
+  expect(classifyComponent({ origin: 'bio', domain: 'mental process' })).toBe('mental');
+});
+
+test('classifies natural component', () => {
+  expect(classifyComponent({ origin: 'biological', domain: 'physical' })).toBe('natuerlich');
+});
+
+test('classifies synthetic component', () => {
+  expect(classifyComponent({ origin: 'artificial', domain: 'physical' })).toBe('synthetisch');
+});

--- a/packages/analysis/system_component_classification.ts
+++ b/packages/analysis/system_component_classification.ts
@@ -1,0 +1,16 @@
+export type ComponentCategory = 'natuerlich' | 'synthetisch' | 'mental' | 'physikalisch';
+
+export interface ComponentAttributes {
+  origin: string;
+  domain: string;
+}
+
+export function classifyComponent(attrs: ComponentAttributes): ComponentCategory {
+  const origin = attrs.origin.toLowerCase();
+  const domain = attrs.domain.toLowerCase();
+  if (domain.includes('mental')) return 'mental';
+  if (origin.includes('bio') || origin.includes('natur')) return 'natuerlich';
+  if (origin.includes('artificial') || origin.includes('synthetic')) return 'synthetisch';
+  if (domain.includes('phys')) return 'physikalisch';
+  return 'synthetisch';
+}

--- a/packages/cli-tools/FourierMetricsCLI.ts
+++ b/packages/cli-tools/FourierMetricsCLI.ts
@@ -13,8 +13,12 @@ function parseArgs(): number[] {
 function main() {
   const data = parseArgs();
   const layer = new FourierLayer('cli', 1, data, { depth: data.length });
-  const metrics = layer.analyze();
-  console.log(JSON.stringify(metrics, null, 2));
+  const result = layer.analyze();
+  const out = {
+    maxAmplitude: result.metrics.maxAmplitude,
+    avgAmplitude: result.metrics.avgAmplitude
+  };
+  console.log(JSON.stringify(out, null, 2));
 }
 
 main();

--- a/services/nukleon-scanner/openapi.test.ts
+++ b/services/nukleon-scanner/openapi.test.ts
@@ -1,0 +1,9 @@
+import fs from 'fs';
+import path from 'path';
+import YAML from 'yaml';
+
+test('openapi spec defines scan path', () => {
+  const file = path.join(__dirname, 'openapi.yaml');
+  const spec = YAML.parse(fs.readFileSync(file, 'utf8'));
+  expect(spec.paths['/nukleon/scan']).toBeDefined();
+});

--- a/services/nukleon-scanner/openapi.yaml
+++ b/services/nukleon-scanner/openapi.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Nukleon Scanner API
+  version: 1.0.0
+paths:
+  /nukleon/scan:
+    post:
+      summary: Scan text and return CREP signature
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+      responses:
+        '200':
+          description: Scan result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  coherence:
+                    type: number
+                  resonance:
+                    type: number
+                  emergence:
+                    type: number
+                  poetics:
+                    type: number
+


### PR DESCRIPTION
## Summary
- add feedback_log module with logging to JSON
- add system component classification taxonomy
- expose Nukleon scanner OpenAPI spec
- output metrics in FourierMetricsCLI
- update advanced progress and todo lists

## Testing
- `npx -y pyright`
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68760fb9abb88322b15d0670cfa13706