### PR TITLE
Add chronopoem commit helper

### DIFF
--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -82,7 +82,7 @@ todos:
     status: erledigt
   - id: todo-28
     beschreibung: "chronopoem-committer.ts für poetische Commits mit CREP-Annotation entwickeln"
-    status: offen
+    status: erledigt
   - id: todo-29
     beschreibung: "mandala-dashboard.tsx zur Visualisierung des Synchronstatus aller Module erstellen"
     status: offen

--- a/scripts/__tests__/chronopoem-committer.test.ts
+++ b/scripts/__tests__/chronopoem-committer.test.ts
@@ -1,0 +1,6 @@
+import { parseCREP } from '../chronopoem-committer';
+
+test('parseCREP extracts values from poem', () => {
+  const poem = 'CREP-Strahl: 0.1, 0.2, 0.3, 0.4 - test';
+  expect(parseCREP(poem)).toBe('0.1, 0.2, 0.3, 0.4');
+});

--- a/scripts/chronopoem-committer.ts
+++ b/scripts/chronopoem-committer.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env ts-node
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+export function parseCREP(poem: string): string {
+  const match = poem.match(/CREP-Strahl:\s*([0-9.,\s]+)/);
+  return match ? match[1].trim() : '';
+}
+
+export function run() {
+  const root = path.resolve(__dirname, '..');
+  execSync(`node ${path.join(__dirname, 'generate-chronopoem.js')}`, { stdio: 'inherit' });
+  const content = fs.readFileSync(path.join(root, 'CHRONOPOEM.md'), 'utf8');
+  const crep = parseCREP(content) || 'unknown';
+  execSync('git add CHRONOPOEM.md');
+  const msg = `chore(chronopoem): update CREP ${crep}`;
+  execSync(`git commit -m "${msg}"`);
+  console.log(msg);
+  return msg;
+}
+
+if (require.main === module) {
+  run();
+}


### PR DESCRIPTION
## Summary
- add `chronopoem-committer.ts` to automate CHRONOPOEM commits
- test `parseCREP` util
- mark chronopoem-committer todo as complete

## Testing
- `npx -y pyright`
- `npx tsc -p tsconfig.json`
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68761f219e008322a859065ce7233d7d