### PR TITLE
Add universe-sim CI workflow

### DIFF
--- a/.github/workflows/sim-universe-ci.yaml
+++ b/.github/workflows/sim-universe-ci.yaml
@@ -1,0 +1,20 @@
+name: universe-sim CI
+on:
+  push:
+    paths:
+      - 'simulations/universe-sim/**'
+      - '.github/workflows/sim-universe-ci.yaml'
+  pull_request:
+    paths:
+      - 'simulations/universe-sim/**'
+      - '.github/workflows/sim-universe-ci.yaml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      - run: go test ./simulations/universe-sim/...

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -429,7 +429,8 @@
     "commit": "Set up CI/CD and tests",
     "path": ".github/workflows/sim-universe-ci.yaml",
     "task": "Configure CI to run tests for universe-sim",
-    "test": "simulations/universe-sim/test/ci_test.go"
+    "test": "simulations/universe-sim/test/ci_test.go",
+    "status": "done"
   },
   {
     "commit": "Import country and region profiles",
@@ -5025,8 +5026,7 @@
     "task": "Compute average from impulseMetrics and expose via GET /api/meta-scores",
     "test": "packages/core/routes/metaScores.test.ts",
     "status": "done"
-  }
-  ,
+  },
   {
     "commit": "Add feedback_log for adaptive systems",
     "path": "packages/analysis/feedback_log.ts",
@@ -5037,14 +5037,14 @@
   {
     "commit": "Implement SystemComponent classification taxonomy",
     "path": "packages/analysis/system_component_classification.ts",
-    "task": "Define taxonomy categories (nat\u00fcrlich, synthetisch, mental, physikalisch) and apply classification",
+    "task": "Define taxonomy categories (natürlich, synthetisch, mental, physikalisch) and apply classification",
     "test": "packages/analysis/system_component_classification.test.ts",
     "status": "done"
   },
   {
     "commit": "Add Nullmembran SI Heatmap",
     "path": "packages/unifiedmandala-ui/components/NullmembranSIHeatmap.tsx",
-    "task": "Visualize S_I distribution around threshold (\u0394S_I \u00b1 \u03c3) using heatmap",
+    "task": "Visualize S_I distribution around threshold (ΔS_I ± σ) using heatmap",
     "test": "packages/unifiedmandala-ui/components/NullmembranSIHeatmap.test.tsx",
     "status": "done"
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -305,6 +305,7 @@
   path: .github/workflows/sim-universe-ci.yaml
   task: Configure CI to run tests for universe-sim
   test: simulations/universe-sim/test/ci_test.go
+  status: done
 - commit: Import country and region profiles
   path: packages/userfriendship/region-profile-service/models
   task: Provide country.yaml and region.yaml for 5 countries

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "add new FourierLayer tasks",
+  "lastCommit": "Set up universe-sim CI",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -161,6 +161,10 @@
     },
     {
       "commit": "TODO from newadvancedconversations.json - Nukleon OpenAPI",
+      "status": "done"
+    },
+    {
+      "commit": "Set up CI/CD and tests for universe-sim",
       "status": "done"
     }
   ]

--- a/simulations/universe-sim/test/ci_test.go
+++ b/simulations/universe-sim/test/ci_test.go
@@ -1,0 +1,7 @@
+package test
+
+import "testing"
+
+func TestCI(t *testing.T) {
+    t.Log("ci pipeline test")
+}


### PR DESCRIPTION
## Summary
- automate universe-sim tests via GitHub Actions
- mark CI workflow task complete in advancedToDo files
- record progress update
- add simple CI test

## Testing
- `npx pyright` *(fails: Import "streamlit" could not be resolved)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68761f219e008322a859065ce7233d7d