### PR TITLE
Implement bump-version CLI

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5054,5 +5054,12 @@
     "task": "Expose Nukleon Scanner metrics via OpenAPI/GraphQL for integration",
     "test": "services/nukleon-scanner/openapi.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add bump-version command to sigillin-cli",
+    "path": "packages/cli-tools/sigillin-cli.js",
+    "task": "Implement bump-version subcommand to increment sigillin version",
+    "test": "packages/cli-tools/sigillin-cli.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3304,8 +3304,8 @@
     Templates\" },\n  { id: 10, modul: \"SigillinViewer.tsx\", status:
     \"GEPLANT\", beschreibung: \"React-Komponente zum Anzeigen und Durchblättern
     von Sigillin\" },\n\n  // === CLI & Utilities ===\n  { id: 11, modul:
-    \"sigillin-cli.js\", status: \"GEPLANT\", beschreibung: \"Kommandozeilentool
-    für create, validate, list-relations, bump-version\" },\n\n  // === Tests &
+    \"sigillin-cli.js\", status: \"done\", beschreibung: \"Kommandozeilentool
+    für create, validate, list-relations und bump-version\" },\n\n  // === Tests &
     CI/CD ===\n  { id: 12, modul: \"CREPTestHarness.tsx\", status: \"GEPLANT\",
     beschreibung: \"UI-Komponente zum Durchspielen von CREP-Wertänderungen\"
     },\n  { id: 13, modul: \"GitHub Action + npm Script\", status: \"GEPLANT\",

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "add new FourierLayer tasks",
+  "lastCommit": "implement bump-version command",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -161,6 +161,10 @@
     },
     {
       "commit": "TODO from newadvancedconversations.json - Nukleon OpenAPI",
+      "status": "done"
+    },
+    {
+      "commit": "Add bump-version command to sigillin-cli",
       "status": "done"
     }
   ]

--- a/packages/cli-tools/sigillin-cli.js
+++ b/packages/cli-tools/sigillin-cli.js
@@ -165,6 +165,23 @@ program
   });
 
 program
+  .command('bump-version <file>')
+  .description('Erhöht die Versionsnummer eines Sigillin-Dokuments')
+  .action((file) => {
+    const path = require('path');
+    const YAML = require('yaml');
+    const fp = path.resolve(file);
+    const content = require('fs').readFileSync(fp, 'utf8');
+    const isYaml = fp.endsWith('.yaml') || fp.endsWith('.yml');
+    const data = isYaml ? YAML.parse(content) : JSON.parse(content);
+    const current = data.version || 0;
+    data.version = current + 1;
+    const out = isYaml ? YAML.stringify(data) : JSON.stringify(data, null, 2);
+    require('fs').writeFileSync(fp, out);
+    console.log(`Version auf ${data.version} erhöht.`);
+  });
+
+program
   .command('grep-conversations <keyword>')
   .option('-o, --output <dir>', 'Zielordner', '../../docs/sigils/conversations')
   .description('Filtert conversations.json nach Stichwort')

--- a/packages/cli-tools/sigillin-cli.test.ts
+++ b/packages/cli-tools/sigillin-cli.test.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+describe('sigillin-cli bump-version', () => {
+  const tmp = path.join(__dirname, 'tmp.sigil.json');
+  beforeEach(() => {
+    fs.writeFileSync(tmp, JSON.stringify({ id: 'tmp', version: 1 }));
+  });
+  afterEach(() => {
+    fs.unlinkSync(tmp);
+  });
+  it('increments version field', () => {
+    const cli = path.join(__dirname, 'sigillin-cli.js');
+    const result = spawnSync('node', [cli, 'bump-version', tmp]);
+    expect(result.status).toBe(0);
+    const updated = JSON.parse(fs.readFileSync(tmp, 'utf8'));
+    expect(updated.version).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- extend `sigillin-cli.js` with `bump-version` command
- add Jest test for version bump
- mark CLI task complete in advancedToDo
- document progress in advancedprogress

## Testing
- `npx -y pyright` *(fails: Import errors)*
- `npx -y tsc -p tsconfig.json` *(fails: cannot find 'node' type definitions)*
- `npx -y jest packages/cli-tools/sigillin-cli.test.ts` *(fails: missing jest environment)*

------
https://chatgpt.com/codex/tasks/task_e_68761f219e008322a859065ce7233d7d