### PR TITLE
Add stop function for Fourier metrics server

### DIFF
--- a/services/fourier-metrics/index.test.ts
+++ b/services/fourier-metrics/index.test.ts
@@ -9,10 +9,10 @@ import { FourierLayerEvents } from '../../packages/analysis/FourierLayer';
 const PORT = 4110;
 
 describe('fourier metrics server', () => {
-  const { server } = startServer(PORT);
+  const { server, stop } = startServer(PORT);
 
   afterAll(() => {
-    server.close();
+    stop();
   });
 
   it('serves latest metrics via REST', async () => {

--- a/services/fourier-metrics/index.ts
+++ b/services/fourier-metrics/index.ts
@@ -34,5 +34,10 @@ export function startServer(port = 4100) {
     console.log(`Fourier metrics listening on ${port}`);
   });
 
-  return { app, server, wss };
+  function stop() {
+    wss.close();
+    server.close();
+  }
+
+  return { app, server, wss, stop };
 }


### PR DESCRIPTION
## Summary
- allow FourierMetricsServer to stop cleanly
- update server test to use stop()

## Testing
- `npx -y pyright`
- `npx -y tsc -p tsconfig.json`
- `npx jest services/fourier-metrics/index.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_687629608bd483229291c66344955bb5