### PR TITLE
Implement sigillin-cli features

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5055,5 +5055,12 @@
     "task": "Expose Nukleon Scanner metrics via OpenAPI/GraphQL for integration",
     "test": "services/nukleon-scanner/openapi.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Implement sigillin-cli features",
+    "path": "packages/genesis-sigillin-core/sigillin-cli.js",
+    "task": "CLI create, validate, list-relations, bump-version",
+    "test": "packages/genesis-sigillin-core/sigillin-cli.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6725,3 +6725,8 @@
   task: Expose Nukleon Scanner metrics via OpenAPI/GraphQL for integration
   test: services/nukleon-scanner/openapi.test.ts
   status: done
+- commit: Implement sigillin-cli features
+  path: packages/genesis-sigillin-core/sigillin-cli.js
+  task: CLI create, validate, list-relations, bump-version
+  test: packages/genesis-sigillin-core/sigillin-cli.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Set up universe-sim CI",
+  "lastCommit": "Implement sigillin-cli features",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -165,6 +165,10 @@
     },
     {
       "commit": "Set up CI/CD and tests for universe-sim",
+      "status": "done"
+    },
+    {
+      "commit": "sigillin-cli features",
       "status": "done"
     }
   ]

--- a/packages/genesis-sigillin-core/README.md
+++ b/packages/genesis-sigillin-core/README.md
@@ -6,3 +6,14 @@ Kernlogik zur Erzeugung und Validierung von Sigillin-Dateien.
 - **SigillinSyncManager** – Sync-Logik für externe Dateien
 - **Schemas** – JSON- und YAML-Schemata für Sigillin-Definitionen
 
+## CLI
+
+```
+sigillin-cli create <file> <id> <type> <status> <creator>
+sigillin-cli validate <file>
+sigillin-cli list-relations <file>
+sigillin-cli bump-version <file>
+```
+
+Der CLI-Befehl erleichtert das Erzeugen und Pflegen von Sigillin-Dateien.
+

--- a/packages/genesis-sigillin-core/sigillin-cli.js
+++ b/packages/genesis-sigillin-core/sigillin-cli.js
@@ -1,14 +1,83 @@
 #!/usr/bin/env node
-const { validateSigillin } = require('./dist/sigillin-validator');
+const fs = require('fs');
+const path = require('path');
+function load(mod) {
+  const dist = path.join(__dirname, 'dist', mod + '.js');
+  if (fs.existsSync(dist)) return require(dist);
+  const src = path.join(__dirname, mod + '.ts');
+  if (fs.existsSync(src)) {
+    require('ts-node/register');
+    return require(src);
+  }
+  return require('./' + mod);
+}
+const { SigillinGenerator } = load('SigillinGenerator');
+const { validateSigillin } = load('sigillin-validator');
 
-const file = process.argv[2];
-if (!file) {
-  console.error('Usage: sigillin-cli <file>');
-  process.exit(1);
+function usage() {
+  console.log(`Usage: sigillin-cli <command> [options]
+Commands:
+  create <file> <id> <type> <status> <creator>
+  validate <file>
+  list-relations <file>
+  bump-version <file>
+`);
 }
 
-if (validateSigillin(file)) {
-  console.log('Valid sigillin');
-} else {
-  process.exit(1);
+const [, , command, ...args] = process.argv;
+
+switch (command) {
+  case 'create': {
+    const [file, id, type, status, creator] = args;
+    if (!file || !id || !type || !status || !creator) {
+      usage();
+      process.exit(1);
+    }
+    const sig = SigillinGenerator(id, type, status, creator);
+    fs.writeFileSync(file, JSON.stringify(sig, null, 2));
+    console.log(`Created ${file}`);
+    break;
+  }
+  case 'validate': {
+    const [file] = args;
+    if (!file) {
+      usage();
+      process.exit(1);
+    }
+    if (validateSigillin(file)) {
+      console.log('Valid sigillin');
+    } else {
+      process.exit(1);
+    }
+    break;
+  }
+  case 'list-relations': {
+    const [file] = args;
+    if (!file) {
+      usage();
+      process.exit(1);
+    }
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    (data.related_sigils || []).forEach(r => {
+      console.log(`${r.id} (${r.relation})`);
+    });
+    break;
+  }
+  case 'bump-version': {
+    const [file] = args;
+    if (!file) {
+      usage();
+      process.exit(1);
+    }
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const parts = data.schema_version.split('.').map(Number);
+    parts[2] = (parts[2] || 0) + 1;
+    data.schema_version = parts.join('.');
+    fs.writeFileSync(file, JSON.stringify(data, null, 2));
+    console.log(`Bumped version to ${data.schema_version}`);
+    break;
+  }
+  default:
+    usage();
+    process.exit(1);
 }

--- a/packages/genesis-sigillin-core/sigillin-cli.test.ts
+++ b/packages/genesis-sigillin-core/sigillin-cli.test.ts
@@ -1,0 +1,14 @@
+import { execSync } from 'child_process';
+import { existsSync, readFileSync, unlinkSync } from 'fs';
+import { validateSigillin } from './sigillin-validator';
+
+test('sigillin-cli create and bump-version', () => {
+  const file = 'test-sigil.json';
+  execSync(`node packages/genesis-sigillin-core/sigillin-cli.js create ${file} testid poetic-root draft Tester`);
+  expect(existsSync(file)).toBe(true);
+  expect(validateSigillin(file)).toBe(true);
+  execSync(`node packages/genesis-sigillin-core/sigillin-cli.js bump-version ${file}`);
+  const data = JSON.parse(readFileSync(file, 'utf8'));
+  expect(data.schema_version).toMatch(/^1\.0\.\d+$/);
+  unlinkSync(file);
+});


### PR DESCRIPTION
## Summary
- extend sigillin-cli with create/validate/list-relations/bump-version
- add CLI tests
- document CLI usage in README
- track progress and tasks

## Testing
- `npx jest packages/genesis-sigillin-core/sigillin-cli.test.ts`
- `pnpm install`
- `npx tsc -p tsconfig.json`
- `npx pyright` *(failed: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_687629608bd483229291c66344955bb5