### PR TITLE
Add schema utilities and update advanced todo status

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -492,7 +492,8 @@
     "commit": "Add liveness and readiness endpoints",
     "path": "go-agent/cmd/go-agent.go",
     "task": "Implement /healthz/live and /healthz/ready probes",
-    "test": "test/health_test.go"
+    "test": "test/health_test.go",
+    "status": "done"
   },
   {
     "commit": "Add self-healing and dead letter queue",
@@ -631,7 +632,8 @@
     "commit": "Update shared schema utilities",
     "path": "shared-utils/schema",
     "task": "Support new metadata and consent fields",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Extend CI pipeline for schema and vector tests",
@@ -1139,13 +1141,15 @@
     "commit": "Add GhostShell NGINX config",
     "path": "config/nginx/ghostshell.conf",
     "task": "Provide NGINX reverse proxy for clustered GhostShellAgent",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Implement GhostShell session store",
     "path": "services/ghost-shell/session-store.ts",
     "task": "Track WebSocket message history per client",
-    "test": "services/ghost-shell/session-store.test.ts"
+    "test": "services/ghost-shell/session-store.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add GhostShell cluster manager",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -346,6 +346,7 @@
   path: go-agent/cmd/go-agent.go
   task: Implement /healthz/live and /healthz/ready probes
   test: test/health_test.go
+  status: done
 - commit: Add self-healing and dead letter queue
   path: go-agent/pkg/dispatcher
   task: Move failed tasks to todo.failed and auto restart
@@ -443,6 +444,7 @@
   path: shared-utils/schema
   task: Support new metadata and consent fields
   test: ""
+  status: done
 - commit: Extend CI pipeline for schema and vector tests
   path: ci/agent.yml
   status: done
@@ -823,10 +825,12 @@
   path: config/nginx/ghostshell.conf
   task: Provide NGINX reverse proxy for clustered GhostShellAgent
   test: ""
+  status: done
 - commit: Implement GhostShell session store
   path: services/ghost-shell/session-store.ts
   task: Track WebSocket message history per client
   test: services/ghost-shell/session-store.test.ts
+  status: done
 - commit: Add GhostShell cluster manager
   path: services/ghost-shell/cluster.ts
   task: Start Node.js cluster of GhostShellAgent workers using `cluster` API

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Set up universe-sim CI",
+  "lastCommit": "Update schema utilities",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -165,6 +165,10 @@
     },
     {
       "commit": "Set up CI/CD and tests for universe-sim",
+      "status": "done"
+    },
+    {
+      "commit": "Update shared schema utilities",
       "status": "done"
     }
   ]

--- a/packages/shared-utils/schema/index.test.ts
+++ b/packages/shared-utils/schema/index.test.ts
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+import { validateFile } from './index';
+
+const schemaPath = path.join(__dirname, '../../genesis-sigillin-core/schemas/sigillin.schema.json');
+const tmp = path.join(__dirname, 'test.sigil.json');
+
+beforeAll(() => {
+  const obj = {
+    schema_version: '1.0',
+    id: 'schema:test',
+    type: 'fallback-anchor',
+    status: 'draft',
+    creator: 'tester',
+    created_at: '2024-01-01T00:00:00Z',
+    metadata: { foo: 'bar' },
+    consent: 'granted'
+  };
+  fs.writeFileSync(tmp, JSON.stringify(obj, null, 2));
+});
+
+afterAll(() => {
+  fs.unlinkSync(tmp);
+});
+
+test('validates file with metadata and consent', () => {
+  const res = validateFile(tmp, schemaPath);
+  expect(res.valid).toBe(true);
+});

--- a/packages/shared-utils/schema/index.ts
+++ b/packages/shared-utils/schema/index.ts
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import Ajv, { ErrorObject } from 'ajv';
+import addFormats from 'ajv-formats';
+import YAML from 'yaml';
+
+export interface ValidationResult {
+  valid: boolean;
+  errors?: ErrorObject[] | null;
+}
+
+export function loadSchema(schemaPath: string): any {
+  return JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+}
+
+export function extendSchemaWithMetadata(schema: any): any {
+  if (!schema.properties) schema.properties = {};
+  if (!schema.properties.metadata) {
+    schema.properties.metadata = { type: 'object', additionalProperties: true };
+  }
+  if (!schema.properties.consent) {
+    schema.properties.consent = { type: 'string' };
+  }
+  return schema;
+}
+
+export function validateWithSchema(data: any, schema: any): ValidationResult {
+  const ajv = new Ajv();
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const valid = validate(data) as boolean;
+  return { valid, errors: validate.errors };
+}
+
+export function validateFile(file: string, schemaPath: string): ValidationResult {
+  const schema = extendSchemaWithMetadata(loadSchema(schemaPath));
+  const content = fs.readFileSync(file, 'utf8');
+  const data = file.endsWith('.yaml') || file.endsWith('.yml') ? YAML.parse(content) : JSON.parse(content);
+  return validateWithSchema(data, schema);
+}


### PR DESCRIPTION
## Summary
- implement shared schema utilities with metadata/consent support
- add test for schema validator
- mark GhostShell tasks, health endpoints, and schema utilities as done
- update progress log

## Testing
- `pnpm exec jest packages/shared-utils/schema/index.test.ts`
- `npx -y pyright` *(fails: Missing dependencies and import errors)*
- `npx -y tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_687629608bd483229291c66344955bb5