### PR TITLE
Implement cached Fourier metrics broadcast

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5062,5 +5062,12 @@
     "task": "CLI create, validate, list-relations, bump-version",
     "test": "packages/genesis-sigillin-core/sigillin-cli.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Send cached Fourier metrics on connection",
+    "path": "services/fourier-metrics/index.ts",
+    "task": "Send cached FourierLayer metrics to new websocket clients",
+    "test": "services/fourier-metrics/index.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6730,3 +6730,8 @@
   task: CLI create, validate, list-relations, bump-version
   test: packages/genesis-sigillin-core/sigillin-cli.test.ts
   status: done
+- commit: Send cached Fourier metrics on connection
+  path: services/fourier-metrics/index.ts
+  task: Send cached FourierLayer metrics to new websocket clients
+  test: services/fourier-metrics/index.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Implement sigillin-cli features",
+  "lastCommit": "Send cached Fourier metrics on connection",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -169,6 +169,10 @@
     },
     {
       "commit": "sigillin-cli features",
+      "status": "done"
+    },
+    {
+      "commit": "Send cached Fourier metrics on connection",
       "status": "done"
     }
   ]

--- a/services/fourier-metrics/index.test.ts
+++ b/services/fourier-metrics/index.test.ts
@@ -1,7 +1,11 @@
 import { TextEncoder } from 'util';
 (global as any).TextEncoder = TextEncoder;
 
-jest.mock('ws', () => ({ Server: class { on() {} close() {} } }));
+const mockServer = {
+  on: jest.fn(),
+  close: jest.fn(),
+};
+jest.mock('ws', () => ({ Server: jest.fn(() => mockServer) }));
 import request from 'supertest';
 import { startServer } from './index';
 import { FourierLayerEvents } from '../../packages/analysis/FourierLayer';
@@ -19,5 +23,18 @@ describe('fourier metrics server', () => {
     FourierLayerEvents.emit('metrics', { id: 'L1', metrics: { maxAmplitude: 1, avgAmplitude: 0.5 } });
     const res = await request(`http://localhost:${PORT}`).get('/fourier/latest');
     expect(res.body.L1.maxAmplitude).toBe(1);
+  });
+
+  it('sends cached metrics on websocket connection', () => {
+    const messages: any[] = [];
+    FourierLayerEvents.emit('metrics', { id: 'L2', metrics: { maxAmplitude: 2, avgAmplitude: 1 } });
+
+    // capture connection handler and invoke
+    const handler = mockServer.on.mock.calls.find(c => c[0] === 'connection')?.[1];
+    expect(handler).toBeDefined();
+    const socket = { send: (msg: string) => messages.push(JSON.parse(msg)), on: jest.fn() } as any;
+    handler(socket);
+
+    expect(messages.some(m => m.id === 'L2')).toBe(true);
   });
 });

--- a/services/fourier-metrics/index.ts
+++ b/services/fourier-metrics/index.ts
@@ -19,6 +19,11 @@ export function startServer(port = 4100) {
   const wss = new Server({ server });
 
   wss.on('connection', (socket: any) => {
+    // send the most recent metrics to new clients immediately
+    Object.entries(latestMetrics).forEach(([id, metrics]) => {
+      socket.send(JSON.stringify({ type: 'fourier-metrics', id, metrics }));
+    });
+
     const handler = (payload: any) => {
       socket.send(JSON.stringify(payload));
     };


### PR DESCRIPTION
## Summary
- send stored FourierLayer metrics to new WebSocket clients
- test metric broadcast on connection
- update advanced ToDos and progress

## Testing
- `pnpm install`
- `npx pyright` *(fails: Cannot find module)*
- `npx tsc -p tsconfig.json`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687635f60d1c8322b85ce5e4ea533971