### PR TITLE
Implement caching & metrics for CosmicTheoryAgent

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5069,5 +5069,19 @@
     "task": "Send cached FourierLayer metrics to new websocket clients",
     "test": "services/fourier-metrics/index.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add circuit breaker and caching to PySR service",
+    "path": "packages/agents/CosmicTheoryAgent.ts",
+    "task": "Wrap remote call with withCircuit and cache results",
+    "test": "packages/agents/__tests__/CosmicTheoryAgent.spec.ts",
+    "status": "done"
+  },
+  {
+    "commit": "Add metrics instrumentation for PySR service",
+    "path": "packages/agents/CosmicTheoryAgent.ts",
+    "task": "Record call duration via OpenTelemetry meter",
+    "test": "packages/agents/__tests__/CosmicTheoryAgent.spec.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6735,3 +6735,13 @@
   task: Send cached FourierLayer metrics to new websocket clients
   test: services/fourier-metrics/index.test.ts
   status: done
+- commit: Add circuit breaker and caching to PySR service
+  path: packages/agents/CosmicTheoryAgent.ts
+  task: Wrap remote call with withCircuit and cache results
+  test: packages/agents/__tests__/CosmicTheoryAgent.spec.ts
+  status: done
+- commit: Add metrics instrumentation for PySR service
+  path: packages/agents/CosmicTheoryAgent.ts
+  task: Record call duration via OpenTelemetry meter
+  test: packages/agents/__tests__/CosmicTheoryAgent.spec.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Send cached Fourier metrics on connection",
+  "lastCommit": "Add metrics instrumentation for PySR service",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -173,6 +173,14 @@
     },
     {
       "commit": "Send cached Fourier metrics on connection",
+      "status": "done"
+    },
+    {
+      "commit": "Add circuit breaker and caching to PySR service",
+      "status": "done"
+    },
+    {
+      "commit": "Add metrics instrumentation for PySR service",
       "status": "done"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "socket.io-client": "^4.7.5",
     "three": "^0.161.0",
     "ws": "^8.17.0",
-    "yaml": "^2.8.0"
+    "yaml": "^2.8.0",
+    "opossum": "^9.0.0"
   },
   "devDependencies": {
     "@cypress/react": "^9.0.1",

--- a/packages/agents/CosmicTheoryAgent.ts
+++ b/packages/agents/CosmicTheoryAgent.ts
@@ -1,12 +1,21 @@
 import axios from 'axios';
+import { metrics } from '@opentelemetry/api';
 import { fractalDecompose, computeFractalMetric } from '../analysis/FractalAnalyzer';
 import { symbolicRegression } from '../analysis/SymbolicRegression';
 import { SigilManager, SigilEntry } from '../shared-utils/SigilManager';
 import { CosmicTheoryEventHub } from './CosmicTheoryAgentEvents';
+import { withCircuit } from '../core/withCircuit';
 
 export const sigilManager = new SigilManager();
 
 export const sigilHistory: SigilEntry[] = [];
+
+const meter = metrics.getMeter('cosmic-theory-agent');
+const regressionDuration = meter.createHistogram('pysr_call_duration_seconds', {
+  description: 'Duration of PySR service calls'
+});
+
+const regressionCache = new Map<string, string>();
 
 sigilManager.on('sigil:added', (entry: SigilEntry) => {
   sigilHistory.push(entry);
@@ -123,27 +132,41 @@ export async function callPySRService(
   protocol: 'rest' | 'grpc' = 'rest'
 ): Promise<string> {
   CosmicTheoryEventHub.emit('theory:start', { dataPoints: data });
-  if (protocol === 'grpc') {
-    const { Client, credentials } = await import('@grpc/grpc-js');
-    const client = new Client(endpoint, credentials.createInsecure());
-    return new Promise((resolve, reject) => {
-      client.makeUnaryRequest(
-        '/PySRService/Regress',
-        arg => Buffer.from(JSON.stringify(arg)),
-        buffer => JSON.parse(buffer.toString()),
-        { data },
-        (err, resp: any) => {
-          client.close();
-          if (err) return reject(err);
-          const eq = resp?.equation ?? '';
-          CosmicTheoryEventHub.emit('theory:regression:success', { equation: eq });
-          resolve(eq);
-        }
-      );
-    });
+  const cacheKey = `${endpoint}:${protocol}:${JSON.stringify(data)}`;
+  if (regressionCache.has(cacheKey)) {
+    return regressionCache.get(cacheKey)!;
   }
-  const resp = await axios.post(endpoint, { data });
-  CosmicTheoryEventHub.emit('theory:regression:success', { equation: resp.data.equation });
-  return resp.data.equation;
+
+  const run = async (): Promise<string> => {
+    if (protocol === 'grpc') {
+      const { Client, credentials } = await import('@grpc/grpc-js');
+      const client = new Client(endpoint, credentials.createInsecure());
+      return new Promise((resolve, reject) => {
+        client.makeUnaryRequest(
+          '/PySRService/Regress',
+          arg => Buffer.from(JSON.stringify(arg)),
+          buffer => JSON.parse(buffer.toString()),
+          { data },
+          (err, resp: any) => {
+            client.close();
+            if (err) return reject(err);
+            const eq = resp?.equation ?? '';
+            CosmicTheoryEventHub.emit('theory:regression:success', { equation: eq });
+            resolve(eq);
+          }
+        );
+      });
+    }
+    const resp = await axios.post(endpoint, { data });
+    CosmicTheoryEventHub.emit('theory:regression:success', { equation: resp.data.equation });
+    return resp.data.equation;
+  };
+
+  const wrapped = withCircuit(run, { timeout: 5000 });
+  const start = Date.now();
+  const equation = await wrapped();
+  regressionDuration.record((Date.now() - start) / 1000);
+  regressionCache.set(cacheKey, equation);
+  return equation;
 }
 

--- a/packages/agents/__tests__/CosmicTheoryAgent.spec.ts
+++ b/packages/agents/__tests__/CosmicTheoryAgent.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, test } from 'vitest';
 import axios from 'axios';
-import { fetchCosmicData, analyzeCosmicData } from '../CosmicTheoryAgent';
+import { fetchCosmicData, analyzeCosmicData, callPySRService } from '../CosmicTheoryAgent';
 
 vi.mock('axios');
 
@@ -14,5 +14,21 @@ describe('fetchCosmicData', () => {
 test('analyzes cosmic values', () => {
   const result = analyzeCosmicData([4]);
   expect(result).toBe('y = 2.0');
+});
+
+describe('callPySRService', () => {
+  it('caches results for identical inputs', async () => {
+    (axios.post as any).mockResolvedValueOnce({ data: { equation: 'x' } });
+    const eq1 = await callPySRService([1], 'http://pysr');
+    const eq2 = await callPySRService([1], 'http://pysr');
+    expect(eq1).toBe('x');
+    expect(eq2).toBe('x');
+    expect(axios.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when remote call fails', async () => {
+    (axios.post as any).mockRejectedValueOnce(new Error('fail'));
+    await expect(callPySRService([2], 'http://pysr')).rejects.toThrow('fail');
+  });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       node-fetch:
         specifier: '2'
         version: 2.7.0
+      opossum:
+        specifier: ^9.0.0
+        version: 9.0.0
       pino:
         specifier: ^9.7.0
         version: 9.7.0
@@ -4339,6 +4342,10 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  opossum@9.0.0:
+    resolution: {integrity: sha512-K76U0QkxOfUZamneQuzz+AP0fyfTJcCplZ2oZL93nxeupuJbN4s6uFNbmVCt4eWqqGqRnnowdFuBicJ1fLMVxw==}
+    engines: {node: ^24 || ^22 || ^20}
 
   ospath@1.2.2:
     resolution: {integrity: sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==}
@@ -10465,6 +10472,8 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  opossum@9.0.0: {}
 
   ospath@1.2.2: {}
 


### PR DESCRIPTION
## Summary
- add circuit breaker, caching and metrics to `CosmicTheoryAgent`
- update tests for new caching logic
- install `opossum` and adjust lockfile
- record new tasks in `advancedToDo.*`
- update progress log

## Testing
- `pnpm install`
- `npx pyright` *(failed: MODULE_NOT_FOUND)*
- `npx tsc -p tsconfig.json`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6876729213b08322872b7f94ab9380b3