### PR TITLE
Add Pyramid VR meeting room and Fourier bridge

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5088,18 +5088,21 @@
     "commit": "Implement FourierLayerBridge for Pyramid UI integration",
     "path": "packages/unifiedmandala-ui/events/FourierLayerBridge.ts",
     "task": "Bridge FourierLayer metrics to Pyramid UI via WebSocket",
-    "test": "packages/unifiedmandala-ui/events/FourierLayerBridge.test.ts"
+    "test": "packages/unifiedmandala-ui/events/FourierLayerBridge.test.ts",
+    "status": "done"
   },
   {
     "commit": "Extend CosmicTheoryAgent with VR hooks",
     "path": "packages/agents/CosmicTheoryAgent.ts",
     "task": "Add VR interaction events from Pyramid UI",
-    "test": "packages/agents/CosmicTheoryAgent.test.ts"
+    "test": "packages/agents/CosmicTheoryAgent.test.ts",
+    "status": "done"
   },
   {
     "commit": "Create PyramidVRMeetingRoom component",
     "path": "packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.tsx",
     "task": "Allow multi-avatar VR interactions in the Pyramid UI",
-    "test": "packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx"
+    "test": "packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6749,11 +6749,14 @@
   path: packages/unifiedmandala-ui/events/FourierLayerBridge.ts
   task: Bridge FourierLayer metrics to Pyramid UI via WebSocket
   test: packages/unifiedmandala-ui/events/FourierLayerBridge.test.ts
+  status: done
 - commit: Extend CosmicTheoryAgent with VR hooks
   path: packages/agents/CosmicTheoryAgent.ts
   task: Add VR interaction events from Pyramid UI
   test: packages/agents/CosmicTheoryAgent.test.ts
+  status: done
 - commit: Create PyramidVRMeetingRoom component
   path: packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.tsx
   task: Allow multi-avatar VR interactions in the Pyramid UI
   test: packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -183,5 +183,18 @@
       "commit": "Add metrics instrumentation for PySR service",
       "status": "done"
     }
+    ,
+    {
+      "commit": "Implement FourierLayerBridge for Pyramid UI integration",
+      "status": "done"
+    },
+    {
+      "commit": "Extend CosmicTheoryAgent with VR hooks",
+      "status": "done"
+    },
+    {
+      "commit": "Create PyramidVRMeetingRoom component",
+      "status": "done"
+    }
   ]
 }

--- a/packages/agents/CosmicTheoryAgent.ts
+++ b/packages/agents/CosmicTheoryAgent.ts
@@ -3,7 +3,7 @@ import { metrics } from '@opentelemetry/api';
 import { fractalDecompose, computeFractalMetric } from '../analysis/FractalAnalyzer';
 import { symbolicRegression } from '../analysis/SymbolicRegression';
 import { SigilManager, SigilEntry } from '../shared-utils/SigilManager';
-import { CosmicTheoryEventHub } from './CosmicTheoryAgentEvents';
+import { CosmicTheoryEventHub, enterVR, exitVR } from './CosmicTheoryAgentEvents';
 import { withCircuit } from '../core/withCircuit';
 
 export const sigilManager = new SigilManager();
@@ -169,4 +169,6 @@ export async function callPySRService(
   regressionCache.set(cacheKey, equation);
   return equation;
 }
+
+export { enterVR, exitVR };
 

--- a/packages/agents/CosmicTheoryAgentEvents.test.ts
+++ b/packages/agents/CosmicTheoryAgentEvents.test.ts
@@ -1,5 +1,10 @@
 import { test, expect } from 'vitest';
-import { CosmicTheoryEventHub, logTrace } from './CosmicTheoryAgentEvents';
+import {
+  CosmicTheoryEventHub,
+  logTrace,
+  enterVR,
+  exitVR
+} from './CosmicTheoryAgentEvents';
 
 test('emit and receive events', () => {
   const logs: string[] = [];
@@ -8,4 +13,13 @@ test('emit and receive events', () => {
   });
   logTrace('hello');
   expect(logs).toContain('hello');
+});
+
+test('emit vr enter and exit', () => {
+  const events: string[] = [];
+  CosmicTheoryEventHub.on('vr:enter', () => events.push('enter'));
+  CosmicTheoryEventHub.on('vr:exit', () => events.push('exit'));
+  enterVR();
+  exitVR();
+  expect(events).toEqual(['enter', 'exit']);
 });

--- a/packages/agents/CosmicTheoryAgentEvents.ts
+++ b/packages/agents/CosmicTheoryAgentEvents.ts
@@ -13,6 +13,8 @@ export type CosmicTheoryAgentEvents = {
   'theory:updated': { formula: string; score: number };
   'theory:start': { dataPoints: number[] };
   'theory:regression:success': { equation: string };
+  'vr:enter': { timestamp: number };
+  'vr:exit': { timestamp: number };
   'trace:log': TraceLogPayload;
   [key: string]: any;
 };
@@ -27,4 +29,12 @@ export function logTrace(message: string): void {
     spanId: span?.spanContext().spanId,
     traceId: span?.spanContext().traceId
   });
+}
+
+export function enterVR(): void {
+  CosmicTheoryEventHub.emit('vr:enter', { timestamp: Date.now() });
+}
+
+export function exitVR(): void {
+  CosmicTheoryEventHub.emit('vr:exit', { timestamp: Date.now() });
 }

--- a/packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx
+++ b/packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PyramidVRMeetingRoom from './PyramidVRMeetingRoom';
+
+jest.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }: any) => <div role="presentation">{children}</div>,
+  sphereGeometry: 'sphereGeometry',
+  mesh: 'mesh',
+  meshStandardMaterial: 'meshStandardMaterial',
+  ambientLight: 'ambientLight',
+}));
+
+test('renders avatars', () => {
+  const { getAllByLabelText } = render(<PyramidVRMeetingRoom />);
+  expect(getAllByLabelText('avatar').length).toBeGreaterThan(0);
+});

--- a/packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.tsx
+++ b/packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Canvas } from '@react-three/fiber';
+
+const Avatar: React.FC<{ position: [number, number, number]; color: string }> = ({ position, color }) => (
+  <mesh position={position} aria-label="avatar">
+    <sphereGeometry args={[0.3, 16, 16]} />
+    <meshStandardMaterial color={color} />
+  </mesh>
+);
+
+const PyramidVRMeetingRoom: React.FC = () => (
+  <Canvas onCreated={({ gl }) => { if ((gl as any).xr) { (gl as any).xr.enabled = true; } }}>
+    <ambientLight intensity={0.5} />
+    <Avatar position={[0, 0, -2]} color="hotpink" />
+    <Avatar position={[1, 0, -2]} color="cyan" />
+  </Canvas>
+);
+
+export default PyramidVRMeetingRoom;

--- a/packages/unifiedmandala-ui/events/FourierLayerBridge.test.ts
+++ b/packages/unifiedmandala-ui/events/FourierLayerBridge.test.ts
@@ -1,0 +1,26 @@
+import bridge, { connectFourierLayerBridge } from './FourierLayerBridge';
+
+global.WebSocket = class {
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  constructor(public url: string) {}
+  send(data: string) {
+    this.onmessage?.({ data });
+  }
+  close() {}
+} as any;
+
+test('connectFourierLayerBridge relays events', () => {
+  let metrics: any = null;
+  let svg: any = null;
+  bridge.on('fourier:metrics', d => (metrics = d));
+  bridge.on('fourier:metrics-svg', d => (svg = d));
+  const ws = connectFourierLayerBridge('ws://test');
+  (ws as any).send(
+    JSON.stringify({ type: 'fourier-metrics', data: { a: 1 } })
+  );
+  (ws as any).send(
+    JSON.stringify({ type: 'fourier-metrics-svg', data: { id: 't', svg: '<svg />' } })
+  );
+  expect(metrics).toEqual({ a: 1 });
+  expect(svg).toEqual({ id: 't', svg: '<svg />' });
+});

--- a/packages/unifiedmandala-ui/events/FourierLayerBridge.ts
+++ b/packages/unifiedmandala-ui/events/FourierLayerBridge.ts
@@ -1,0 +1,32 @@
+import mitt from 'mitt';
+
+export type FourierLayerBridgeEvents = {
+  'fourier:metrics': any;
+  'fourier:metrics-svg': { id: string; svg: string };
+};
+
+const emitter = mitt<FourierLayerBridgeEvents>();
+
+export function connectFourierLayerBridge(url = 'ws://localhost:4010'): WebSocket {
+  const ws = new WebSocket(url);
+  ws.onmessage = ev => {
+    try {
+      const message = JSON.parse(ev.data);
+      if (message.type === 'fourier-metrics') {
+        emitter.emit('fourier:metrics', message.data);
+      } else if (message.type === 'fourier-metrics-svg') {
+        emitter.emit('fourier:metrics-svg', message.data);
+      }
+    } catch (e) {
+      console.error('Invalid FourierLayer message', e);
+    }
+  };
+  return ws;
+}
+
+export default {
+  on: emitter.on,
+  off: emitter.off,
+  emit: emitter.emit,
+  connect: connectFourierLayerBridge,
+};

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -27,5 +27,6 @@ export { default as ResonanceOverlay } from './components/ResonanceOverlay';
 export { useCREPTuning } from './hooks/useCREPTuning';
 export { default as ErrorEmergence } from './components/ErrorEmergence';
 export { default as VRPortal } from './components/VRPortal';
+export { default as PyramidVRMeetingRoom } from './components/PyramidVRMeetingRoom';
 export { default as ReactStarter } from './ReactStarter';
 export { default as NestedCanvas } from './NestedCanvas';


### PR DESCRIPTION
## Summary
- add `FourierLayerBridge` with tests
- extend CosmicTheoryAgent events with VR hooks
- export new VR functions from agent
- add `PyramidVRMeetingRoom` component and tests
- mark related tasks done in advanced todo lists
- track progress in `advancedprogress.json`

## Testing
- `npx -y pyright` *(fails: Import could not be resolved)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*
- `npx -y jest` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6876bc665c3883228c0deb1ce210d63c