### PR TITLE
Add sigillin version bump command

### DIFF
--- a/packages/cli-tools/README.md
+++ b/packages/cli-tools/README.md
@@ -3,6 +3,7 @@
 Sammlung von Befehlen zur Arbeit mit Sigillin- und CREP-Daten.
 
 - **sigillin-cli.js** – Validierung, Initialisierung und Graph-Export
+- **sigillin-cli.js bump** – erh\xF6ht die Version eines Sigillins
 - **export-doc.js** – Exportiert CREP-Historie als Markdown
 - **sigillin-archive.js** – Erstellt poetisches Archiv aller Sigillin-Dateien
 - **sigillin-cli.js todo-sigil** – erzeugt `docs/sigils/todo-sigil.yaml` aus Aufgabenlisten

--- a/packages/cli-tools/sigillin-cli.bump.test.ts
+++ b/packages/cli-tools/sigillin-cli.bump.test.ts
@@ -1,0 +1,11 @@
+import fs from 'fs';
+const { bumpVersion } = require('./sigillin-cli');
+
+test('bump increases patch version', () => {
+  const file = 'test.sigil.json';
+  fs.writeFileSync(file, JSON.stringify({ id: 't', version: '1.0.0' }, null, 2));
+  bumpVersion(file);
+  const res = JSON.parse(fs.readFileSync(file, 'utf8'));
+  expect(res.version).toBe('1.0.1');
+  fs.unlinkSync(file);
+});

--- a/packages/cli-tools/sigillin-cli.js
+++ b/packages/cli-tools/sigillin-cli.js
@@ -143,6 +143,35 @@ program
     console.log('todo-sigil.yaml Status gepr\xFCft und aktualisiert.');
   });
 
+function bumpVersion(file, level = 'patch') {
+  const path = require('path');
+  const fs = require('fs');
+  const YAML = require('yaml');
+  const filepath = path.resolve(file);
+  const content = fs.readFileSync(filepath, 'utf8');
+  const isYaml = filepath.endsWith('.yaml') || filepath.endsWith('.yml');
+  const sigil = isYaml ? YAML.parse(content) : JSON.parse(content);
+  const [major, minor, patch] = (sigil.version || '0.0.0').split('.').map(Number);
+  let m = major, n = minor, p = patch;
+  if (level === 'major') { m += 1; n = 0; p = 0; }
+  else if (level === 'minor') { n += 1; p = 0; }
+  else { p += 1; }
+  sigil.version = [m, n, p].join('.');
+  const out = isYaml ? YAML.stringify(sigil) : JSON.stringify(sigil, null, 2);
+  fs.writeFileSync(filepath, out);
+  return sigil.version;
+}
+
+program
+  .command('bump <file> [level]')
+  .description('Erh\xF6ht die Versionsnummer eines Sigillins (patch, minor, major)')
+  .action((file, level = 'patch') => {
+    const version = bumpVersion(file, level);
+    console.log(`Version auf ${version} gesetzt.`);
+  });
+
+module.exports = { bumpVersion };
+
 program
   .command('list-open-tasks [file]')
   .description('Listet offene Tasks aus advancedToDo.yaml')
@@ -183,4 +212,6 @@ program
     console.log(`Filtered ${matches.length} items containing '${keyword}'. Output: ${dest}`);
   });
 
-program.parse(process.argv);
+if (require.main === module) {
+  program.parse(process.argv);
+}


### PR DESCRIPTION
## Summary
- extend `sigillin-cli.js` with a `bump` command and export helper
- document the new command
- test bump logic

## Testing
- `npx jest packages/cli-tools/sigillin-cli.bump.test.ts`
- `npx tsc -p tsconfig.json`
- `npx pyright` *(fails: Import errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876d01393008322b6cc399f1daa2c95