### PR TITLE
Implement task prioritization plugin

### DIFF
--- a/go-agent/pkg/plugin/prioritizer.go
+++ b/go-agent/pkg/plugin/prioritizer.go
@@ -1,0 +1,34 @@
+package plugin
+
+import (
+    "bytes"
+    "encoding/json"
+    "net/http"
+)
+
+// MLServiceURL is the endpoint of the ML prioritization service.
+var MLServiceURL = "http://localhost:9000"
+
+// TaskInput represents a task for prioritization.
+type TaskInput struct {
+    ID    string `json:"id"`
+    Score float64 `json:"score"`
+}
+
+// RankTasks returns tasks ordered by priority using the ML service.
+func RankTasks(tasks []TaskInput) ([]TaskInput, error) {
+    body, err := json.Marshal(tasks)
+    if err != nil {
+        return nil, err
+    }
+    resp, err := http.Post(MLServiceURL+"/rank", "application/json", bytes.NewReader(body))
+    if err != nil {
+        return nil, err
+    }
+    defer resp.Body.Close()
+    var out []TaskInput
+    if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+        return nil, err
+    }
+    return out, nil
+}

--- a/go-agent/test/plugin_test.go
+++ b/go-agent/test/plugin_test.go
@@ -1,0 +1,35 @@
+package test
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "encoding/json"
+    "sort"
+    "testing"
+
+    "github.com/unified-mandala/go-agent/pkg/plugin"
+)
+
+func TestRankTasks(t *testing.T) {
+    // mock ML service
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        var in []plugin.TaskInput
+        if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+            t.Fatal(err)
+        }
+        // simple sort by score descending
+        sort.Slice(in, func(i, j int) bool { return in[i].Score > in[j].Score })
+        json.NewEncoder(w).Encode(in)
+    }))
+    defer srv.Close()
+
+    plugin.MLServiceURL = srv.URL
+    tasks := []plugin.TaskInput{{ID: "a", Score: 1}, {ID: "b", Score: 2}}
+    ranked, err := plugin.RankTasks(tasks)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if ranked[0].ID != "b" {
+        t.Fatalf("expected b first, got %s", ranked[0].ID)
+    }
+}


### PR DESCRIPTION
## Summary
- add a basic ML-based task prioritization plugin for go-agent
- add tests for RankTasks

## Testing
- `go test ./...`
- `npx pyright` *(fails: Import errors)*
- `npx tsc -p tsconfig.json`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6876d01393008322b6cc399f1daa2c95