### PR TITLE
Add public todo API

### DIFF
--- a/services/ghost-shell/server.test.ts
+++ b/services/ghost-shell/server.test.ts
@@ -39,4 +39,11 @@ describe('ghost-shell server', () => {
     expect(res.status).toBe(200);
     expect(res.text).toContain('ghost_connections_total');
   });
+
+  it('returns open todo count', async () => {
+    const res = await request(`http://localhost:${PORT}`).get('/api/public/todos');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('open');
+    expect(typeof res.body.open).toBe('number');
+  });
 });

--- a/services/ghost-shell/server.ts
+++ b/services/ghost-shell/server.ts
@@ -9,6 +9,7 @@ import { listPlugins, getPlugin } from '../plugin-loader';
 import { verifyPluginManifest } from './blockchain-trust';
 import { metricsMiddleware, metricsEndpoint } from '../../packages/core/middleware/metrics';
 import path from 'path';
+import fs from 'fs';
 import { addSession, getSession, removeSession } from './session-store';
 import { recordConnection, recordLatency } from './metrics';
 import { joinRoom, sendRoomMessage, leaveAll, leaveRoom } from './rooms';
@@ -40,6 +41,17 @@ export function startServer(
   });
 
   app.get('/metrics', metricsEndpoint);
+
+  app.get('/api/public/todos', (_req, res) => {
+    try {
+      const todoPath = path.join(__dirname, '..', '..', 'advancedToDo.json');
+      const list = JSON.parse(fs.readFileSync(todoPath, 'utf8'));
+      const open = list.filter((t: any) => t.status !== 'done');
+      res.json({ open: open.length });
+    } catch (e: any) {
+      res.status(500).json({ error: e.message });
+    }
+  });
 
   app.get('/api/plugins', (_req, res) => {
     res.json(listPlugins());


### PR DESCRIPTION
## Summary
- add `/api/public/todos` endpoint to ghost-shell service to expose open task count
- test public todo API

## Testing
- `poetry install --with test` *(fails: pyproject.toml missing)*
- `pnpm install`
- `npx pyright` *(fails: module not found)*
- `npx tsc -p tsconfig.json`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687769987d348322850edd911c7974e4