### PR TITLE
Add TODO items from advanced conversations

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -19,6 +19,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - ToDo-Dateien vor größeren Commits mit `scripts/sync-todo-progress.js` abgleichen
 - Über `scripts/generate-next-sigil.js` wird nach jedem Zyklus ein neues Sigil
   mit aktuellem `update_time` erzeugt.
+Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js` und aktualisiere `advancedToDo.json` sowie `advancedprogress.json`.
 
 > **TL;DR**
 > - Installation: `./scripts/setup-unifiedmandala.sh`

--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ Teil 5 enthält Aufgaben zur Sigil-Historie.
 
 Teil 7 listet Aufgaben zu poetischen Sigill- und Mandala-Modulen.
 Nutze `node scripts/parse-advanced-conversations.js` um Gesprächs-TODOs aus dem Datensatz zu filtern.
+Neu erzeugte Einträge landen in `advancedToDo.json` und `advancedToDo.yaml` und werden in `advancedprogress.json` dokumentiert.
 
 - **Module**: unter `packages/` gegliedert in Agents, Core und mehr
 - **Utils**: zentrale Helfer liegen in `packages/shared-utils/`

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5106,3 +5106,75 @@
     "status": "done"
   }
 ]
+  ,
+  {
+    "commit": "Add scan-todo-comments script",
+    "path": "scripts/scan-todo-comments.js",
+    "task": "Extract TODO comments across repo",
+    "test": "scripts/__tests__/scan-todo-comments.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add sigillin-cli grep-conversations command",
+    "path": "packages/cli-tools/sigillin-cli.js",
+    "task": "Filter conversations for TODO entries",
+    "test": "packages/cli-tools/__tests__/sigillin-cli.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Implement go todo_parser server",
+    "path": "go-bridge/cmd/todo_parser.go",
+    "task": "Start TODO parser service for Go tasks",
+    "test": "go-bridge/cmd/todo_parser_test.go",
+    "status": "open"
+  },
+  {
+    "commit": "Implement parse-advanced-conversations script",
+    "path": "scripts/parse-advanced-conversations.js",
+    "task": "Generate advanced ToDos from conversation dataset",
+    "test": "scripts/__tests__/parse-advanced-conversations.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "CosmicTheoryAgent gRPC REST access",
+    "path": "packages/agent/src/agents/CosmicTheoryAgent.ts",
+    "task": "Access PySR service via gRPC or REST",
+    "test": "packages/agent/__tests__/CosmicTheoryAgent.integration.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add FourierLayer unit tests",
+    "path": "common/src/layers/__tests__/FourierLayer.test.ts",
+    "task": "Validate FourierLayer plugin operations",
+    "test": "common/src/layers/__tests__/FourierLayer.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add fourier analysis endpoint",
+    "path": "packages/agent/src/routes/fourier.ts",
+    "task": "Provide Fourier analysis endpoint",
+    "test": "packages/agent/src/routes/__tests__/fourier.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Create FourierVisual component",
+    "path": "packages/unifiedmandala-ui/src/components/FourierVisual.tsx",
+    "task": "Render Fourier spectrum results",
+    "test": "packages/unifiedmandala-ui/src/components/FourierVisual.test.tsx",
+    "status": "open"
+  },
+  {
+    "commit": "Fetch real avgResonance in CREPStatsCard",
+    "path": "packages/unifiedmandala-ui/src/components/CREPStatsCard.tsx",
+    "task": "Load avgResonance from API and show mini chart",
+    "test": "packages/unifiedmandala-ui/src/components/CREPStatsCard.test.tsx",
+    "status": "open"
+  },
+  {
+    "commit": "Add Mandala SVG export event",
+    "path": "packages/unifiedmandala-ui/src/components/BlackboxMandala.tsx",
+    "task": "Offer SVG export or WebSocket event",
+    "test": "packages/unifiedmandala-ui/src/components/BlackboxMandala.test.tsx",
+    "status": "open"
+  }
+]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6760,3 +6760,53 @@
   task: Allow multi-avatar VR interactions in the Pyramid UI
   test: packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx
   status: done
+- commit: Add scan-todo-comments script
+  path: scripts/scan-todo-comments.js
+  task: Extract TODO comments across repo
+  test: scripts/__tests__/scan-todo-comments.test.ts
+  status: open
+- commit: Add sigillin-cli grep-conversations command
+  path: packages/cli-tools/sigillin-cli.js
+  task: Filter conversations for TODO entries
+  test: packages/cli-tools/__tests__/sigillin-cli.test.ts
+  status: open
+- commit: Implement go todo_parser server
+  path: go-bridge/cmd/todo_parser.go
+  task: Start TODO parser service for Go tasks
+  test: go-bridge/cmd/todo_parser_test.go
+  status: open
+- commit: Implement parse-advanced-conversations script
+  path: scripts/parse-advanced-conversations.js
+  task: Generate advanced ToDos from conversation dataset
+  test: scripts/__tests__/parse-advanced-conversations.test.ts
+  status: open
+- commit: CosmicTheoryAgent gRPC REST access
+  path: packages/agent/src/agents/CosmicTheoryAgent.ts
+  task: Access PySR service via gRPC or REST
+  test: packages/agent/__tests__/CosmicTheoryAgent.integration.test.ts
+  status: open
+- commit: Add FourierLayer unit tests
+  path: common/src/layers/__tests__/FourierLayer.test.ts
+  task: Validate FourierLayer plugin operations
+  test: common/src/layers/__tests__/FourierLayer.test.ts
+  status: open
+- commit: Add fourier analysis endpoint
+  path: packages/agent/src/routes/fourier.ts
+  task: Provide Fourier analysis endpoint
+  test: packages/agent/src/routes/__tests__/fourier.test.ts
+  status: open
+- commit: Create FourierVisual component
+  path: packages/unifiedmandala-ui/src/components/FourierVisual.tsx
+  task: Render Fourier spectrum results
+  test: packages/unifiedmandala-ui/src/components/FourierVisual.test.tsx
+  status: open
+- commit: Fetch real avgResonance in CREPStatsCard
+  path: packages/unifiedmandala-ui/src/components/CREPStatsCard.tsx
+  task: Load avgResonance from API and show mini chart
+  test: packages/unifiedmandala-ui/src/components/CREPStatsCard.test.tsx
+  status: open
+- commit: Add Mandala SVG export event
+  path: packages/unifiedmandala-ui/src/components/BlackboxMandala.tsx
+  task: Offer SVG export or WebSocket event
+  test: packages/unifiedmandala-ui/src/components/BlackboxMandala.test.tsx
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -182,8 +182,7 @@
     {
       "commit": "Add metrics instrumentation for PySR service",
       "status": "done"
-    }
-    ,
+    },
     {
       "commit": "Implement FourierLayerBridge for Pyramid UI integration",
       "status": "done"
@@ -195,6 +194,46 @@
     {
       "commit": "Create PyramidVRMeetingRoom component",
       "status": "done"
+    },
+    {
+      "commit": "Add scan-todo-comments script",
+      "status": "open"
+    },
+    {
+      "commit": "Add sigillin-cli grep-conversations command",
+      "status": "open"
+    },
+    {
+      "commit": "Implement go todo_parser server",
+      "status": "open"
+    },
+    {
+      "commit": "Implement parse-advanced-conversations script",
+      "status": "open"
+    },
+    {
+      "commit": "CosmicTheoryAgent gRPC REST access",
+      "status": "open"
+    },
+    {
+      "commit": "Add FourierLayer unit tests",
+      "status": "open"
+    },
+    {
+      "commit": "Add fourier analysis endpoint",
+      "status": "open"
+    },
+    {
+      "commit": "Create FourierVisual component",
+      "status": "open"
+    },
+    {
+      "commit": "Fetch real avgResonance in CREPStatsCard",
+      "status": "open"
+    },
+    {
+      "commit": "Add Mandala SVG export event",
+      "status": "open"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- append new tasks extracted from latest conversations to `advancedToDo.json` and `advancedToDo.yaml`
- log pending tasks in `advancedprogress.json`
- mention generation of new entries in README and Handbuch

## Testing
- `npx -y pyright` *(fails: Import "streamlit" could not be resolved)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68776ed607348322812a9a72e6e82970