### PR TITLE
Add tasks for Pantheon and VR modules

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5104,8 +5104,7 @@
     "task": "Allow multi-avatar VR interactions in the Pyramid UI",
     "test": "packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx",
     "status": "done"
-  }
-  ,
+  },
   {
     "commit": "Add scan-todo-comments script",
     "path": "scripts/scan-todo-comments.js",
@@ -5175,8 +5174,7 @@
     "task": "Offer SVG export or WebSocket event",
     "test": "packages/unifiedmandala-ui/src/components/BlackboxMandala.test.tsx",
     "status": "open"
-  }
-  ,
+  },
   {
     "commit": "Add PhanteonIntegration service",
     "path": "packages/phanteon/PhanteonIntegrator.ts",
@@ -5357,6 +5355,55 @@
     "path": "packages/crep-plugin-api/src/index.ts",
     "task": "Skeleton for Plugin API microservice",
     "test": "packages/crep-plugin-api/src/index.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add UnifiedMandalaPantheon package",
+    "path": "packages/unifiedmandala-pantheon/index.ts",
+    "task": "Initialize Pantheon orchestrator and onboarding flow",
+    "test": "packages/unifiedmandala-pantheon/index.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Create BoundaryDiscoveryAgent",
+    "path": "packages/unifiedmandala-boundary/boundary_discovery_agent.ts",
+    "task": "Detect discontinuities and formalize boundary rules",
+    "test": "packages/unifiedmandala-boundary/boundary_discovery_agent.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Implement VRBegegnungsraum module",
+    "path": "packages/unifiedmandala-vr/VRBegegnungsraum.ts",
+    "task": "WebXR based meeting space with FourierLayer link",
+    "test": "packages/unifiedmandala-vr/VRBegegnungsraum.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Scaffold ResonanceModules",
+    "path": "packages/resonance-modules",
+    "task": "Provide 10 microservice modules for extended resonance",
+    "test": "packages/resonance-modules/resonance_modules.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "CosmicTheoryAgent PySR gRPC access",
+    "path": "packages/agents/CosmicTheoryAgent.ts",
+    "task": "Call external PySR service via gRPC/REST",
+    "test": "packages/agents/CosmicTheoryAgent.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "CosmicTheoryAgent 3D canvas and Tone.js",
+    "path": "packages/unifiedmandala-ui/components/CosmicPlayground.tsx",
+    "task": "Interactive 3D canvas with Tone.js integration",
+    "test": "packages/unifiedmandala-ui/components/CosmicPlayground.test.tsx",
+    "status": "open"
+  },
+  {
+    "commit": "CosmicTheoryAgent MetricsStore interface",
+    "path": "packages/agents/CosmicTheoryAgentMetrics.ts",
+    "task": "Store agent metrics and provide hooks for UI",
+    "test": "packages/agents/CosmicTheoryAgentMetrics.test.ts",
     "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6940,3 +6940,38 @@
   task: Skeleton for Plugin API microservice
   test: packages/crep-plugin-api/src/index.test.ts
   status: open
+- commit: Add UnifiedMandalaPantheon package
+  path: packages/unifiedmandala-pantheon/index.ts
+  task: Initialize Pantheon orchestrator and onboarding flow
+  test: packages/unifiedmandala-pantheon/index.test.ts
+  status: open
+- commit: Create BoundaryDiscoveryAgent
+  path: packages/unifiedmandala-boundary/boundary_discovery_agent.ts
+  task: Detect discontinuities and formalize boundary rules
+  test: packages/unifiedmandala-boundary/boundary_discovery_agent.test.ts
+  status: open
+- commit: Implement VRBegegnungsraum module
+  path: packages/unifiedmandala-vr/VRBegegnungsraum.ts
+  task: WebXR based meeting space with FourierLayer link
+  test: packages/unifiedmandala-vr/VRBegegnungsraum.test.ts
+  status: open
+- commit: Scaffold ResonanceModules
+  path: packages/resonance-modules
+  task: Provide 10 microservice modules for extended resonance
+  test: packages/resonance-modules/resonance_modules.test.ts
+  status: open
+- commit: CosmicTheoryAgent PySR gRPC access
+  path: packages/agents/CosmicTheoryAgent.ts
+  task: Call external PySR service via gRPC/REST
+  test: packages/agents/CosmicTheoryAgent.test.ts
+  status: open
+- commit: CosmicTheoryAgent 3D canvas and Tone.js
+  path: packages/unifiedmandala-ui/components/CosmicPlayground.tsx
+  task: Interactive 3D canvas with Tone.js integration
+  test: packages/unifiedmandala-ui/components/CosmicPlayground.test.tsx
+  status: open
+- commit: CosmicTheoryAgent MetricsStore interface
+  path: packages/agents/CosmicTheoryAgentMetrics.ts
+  task: Store agent metrics and provide hooks for UI
+  test: packages/agents/CosmicTheoryAgentMetrics.test.ts
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Added Pantheon orchestrator and VR module tasks",
+  "lastCommit": "Added Pantheon, Boundary, VR and CosmicTheory tasks",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -337,6 +337,34 @@
     },
     {
       "commit": "Add CREPPluginAPI package",
+      "status": "open"
+    },
+    {
+      "commit": "Add UnifiedMandalaPantheon package",
+      "status": "open"
+    },
+    {
+      "commit": "Create BoundaryDiscoveryAgent",
+      "status": "open"
+    },
+    {
+      "commit": "Implement VRBegegnungsraum module",
+      "status": "open"
+    },
+    {
+      "commit": "Scaffold ResonanceModules",
+      "status": "open"
+    },
+    {
+      "commit": "CosmicTheoryAgent PySR gRPC access",
+      "status": "open"
+    },
+    {
+      "commit": "CosmicTheoryAgent 3D canvas and Tone.js",
+      "status": "open"
+    },
+    {
+      "commit": "CosmicTheoryAgent MetricsStore interface",
       "status": "open"
     }
   ]


### PR DESCRIPTION
## Summary
- document new tasks for UnifiedMandala Pantheon, Boundary agent, VR meeting space
- note CosmicTheoryAgent PySR integration and UI features
- update progress log

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm install`
- `poetry install --with test` *(fails: no pyproject)*

------
https://chatgpt.com/codex/tasks/task_e_6877a9e23a0c8322900e6cada2185b39