### PR TITLE
Update tasks for pantheon knowledge graph

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5461,8 +5461,7 @@
     "task": "Dynamic registration and loading for extended resonance modules",
     "test": "packages/resonance-modules/ResonanceModuleRegistry.test.ts",
     "status": "open"
-  }
-,
+  },
   {
     "commit": "Export Pantheon manifest in multiple formats",
     "path": "docs/pantheon/unified_mandala_pantheon.yaml",
@@ -5517,6 +5516,20 @@
     "path": "packages/unifiedmandala-vr/VRBegegnungsraum.ts",
     "task": "Link VR space with MandalaCanvas for interactive view",
     "test": "packages/unifiedmandala-vr/VRBegegnungsraumCanvas.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add PantheonKnowledgeGraph service",
+    "path": "packages/pantheon/PantheonKnowledgeGraph.ts",
+    "task": "Store Pantheon relations in Neo4j and expose RuleExplorer API",
+    "test": "packages/pantheon/PantheonKnowledgeGraph.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add RuleExplorer UI",
+    "path": "packages/unifiedmandala-ui/components/RuleExplorer.tsx",
+    "task": "Interactive UI to browse Pantheon and Boundary rules",
+    "test": "packages/unifiedmandala-ui/components/RuleExplorer.test.tsx",
     "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7055,3 +7055,13 @@
   task: Link VR space with MandalaCanvas for interactive view
   test: packages/unifiedmandala-vr/VRBegegnungsraumCanvas.test.ts
   status: open
+- commit: Add PantheonKnowledgeGraph service
+  path: packages/pantheon/PantheonKnowledgeGraph.ts
+  task: Store Pantheon relations in Neo4j and expose RuleExplorer API
+  test: packages/pantheon/PantheonKnowledgeGraph.test.ts
+  status: open
+- commit: Add RuleExplorer UI
+  path: packages/unifiedmandala-ui/components/RuleExplorer.tsx
+  task: Interactive UI to browse Pantheon and Boundary rules
+  test: packages/unifiedmandala-ui/components/RuleExplorer.test.tsx
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -398,8 +398,7 @@
     {
       "commit": "Add ResonanceModuleRegistry",
       "status": "open"
-    }
-  ,
+    },
     {
       "commit": "Export Pantheon manifest in multiple formats",
       "status": "open"
@@ -430,6 +429,14 @@
     },
     {
       "commit": "Integrate VRBegegnungsraum with MandalaCanvas",
+      "status": "open"
+    },
+    {
+      "commit": "Add PantheonKnowledgeGraph service",
+      "status": "open"
+    },
+    {
+      "commit": "Add RuleExplorer UI",
       "status": "open"
     }
   ]


### PR DESCRIPTION
## Summary
- append Pantheon knowledge graph service and RuleExplorer UI tasks to advanced ToDos
- track new tasks in `advancedprogress.json`

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `poetry install --with test` *(fails: could not find pyproject)*
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_6877c25ed0c483228edb6c86a5850d5d