### PR TITLE
Add VR Fourier tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5671,5 +5671,26 @@
     "task": "Integrate VR audio loops and resonance feedback",
     "test": "packages/resonance/ExtendedResonanceVRModule.test.ts",
     "status": "open"
+  },
+  {
+    "commit": "Add FourierLayerVRConnector",
+    "path": "packages/unifiedmandala-vr/FourierLayerVRConnector.ts",
+    "task": "Connect VRBegegnungsraum to FourierLayer pipeline",
+    "test": "packages/unifiedmandala-vr/FourierLayerVRConnector.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add BoundaryMatrixVisualizer",
+    "path": "packages/boundary-engine/BoundaryMatrixVisualizer.tsx",
+    "task": "Visualize boundary laws via interactive matrix",
+    "test": "packages/boundary-engine/BoundaryMatrixVisualizer.test.tsx",
+    "status": "open"
+  },
+  {
+    "commit": "Extend ExtendedResonanceVRModule with Fourier",
+    "path": "packages/resonance/ExtendedResonanceVRModule.ts",
+    "task": "Add Fourier-based resonance modulation",
+    "test": "packages/resonance/ExtendedResonanceVRModule.test.ts",
+    "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7167,3 +7167,19 @@
   task: Integrate VR audio loops and resonance feedback
   test: packages/resonance/ExtendedResonanceVRModule.test.ts
   status: open
+
+- commit: Add FourierLayerVRConnector
+  path: packages/unifiedmandala-vr/FourierLayerVRConnector.ts
+  task: Connect VRBegegnungsraum to FourierLayer pipeline
+  test: packages/unifiedmandala-vr/FourierLayerVRConnector.test.ts
+  status: open
+- commit: Add BoundaryMatrixVisualizer
+  path: packages/boundary-engine/BoundaryMatrixVisualizer.tsx
+  task: Visualize boundary laws via interactive matrix
+  test: packages/boundary-engine/BoundaryMatrixVisualizer.test.tsx
+  status: open
+- commit: Extend ExtendedResonanceVRModule with Fourier
+  path: packages/resonance/ExtendedResonanceVRModule.ts
+  task: Add Fourier-based resonance modulation
+  test: packages/resonance/ExtendedResonanceVRModule.test.ts
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -518,6 +518,18 @@
     {
       "commit": "Add ExtendedResonanceVRModule",
       "status": "open"
+    },
+    {
+      "commit": "Add FourierLayerVRConnector",
+      "status": "open"
+    },
+    {
+      "commit": "Add BoundaryMatrixVisualizer",
+      "status": "open"
+    },
+    {
+      "commit": "Extend ExtendedResonanceVRModule with Fourier",
+      "status": "open"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add VR Fourier connector and boundary visualizer tasks in advanced TODO lists
- log these new tasks in `advancedprogress.json`

## Testing
- `pnpm install`
- `yes | npx pyright` *(fails: missing imports)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6877e028b5a88322bacec22e020633c5