### PR TITLE
Add tasks for Pantheon and VR modules

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5692,5 +5692,40 @@
     "task": "Add Fourier-based resonance modulation",
     "test": "packages/resonance/ExtendedResonanceVRModule.test.ts",
     "status": "open"
+  },
+  {
+    "commit": "Implement PantheonFeedbackRound",
+    "path": "packages/pantheon/PantheonFeedbackService.ts",
+    "task": "Coordinate GPT feedback round with Pantheon agents",
+    "test": "packages/pantheon/PantheonFeedbackService.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add PoetryErrorBoundary component",
+    "path": "packages/unifiedmandala-ui/components/PoetryErrorBoundary.tsx",
+    "task": "Show ChronoPoem on errors when poetry mode active",
+    "test": "packages/unifiedmandala-ui/components/PoetryErrorBoundary.test.tsx",
+    "status": "open"
+  },
+  {
+    "commit": "Create VRBegegnungsraumLobby",
+    "path": "packages/unifiedmandala-vr/VRBegegnungsraumLobby.ts",
+    "task": "Prototype VR meeting space with WebXR and breath sync",
+    "test": "packages/unifiedmandala-vr/VRBegegnungsraumLobby.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Develop AeonResonanceModules",
+    "path": "packages/resonance/AeonResonanceModules.ts",
+    "task": "Implement AeonMythOS and AeonSigilNet modules for advanced resonance",
+    "test": "packages/resonance/AeonResonanceModules.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Implement Dispatcher Error-Boundary",
+    "path": "packages/core/GreekMathAeonDispatcher.ts",
+    "task": "Emit dispatcher:error event via try/catch wrapper",
+    "test": "packages/core/GreekMathAeonDispatcher.test.ts",
+    "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7183,3 +7183,28 @@
   task: Add Fourier-based resonance modulation
   test: packages/resonance/ExtendedResonanceVRModule.test.ts
   status: open
+- commit: Implement PantheonFeedbackRound
+  path: packages/pantheon/PantheonFeedbackService.ts
+  task: Coordinate GPT feedback round with Pantheon agents
+  test: packages/pantheon/PantheonFeedbackService.test.ts
+  status: open
+- commit: Add PoetryErrorBoundary component
+  path: packages/unifiedmandala-ui/components/PoetryErrorBoundary.tsx
+  task: Show ChronoPoem on errors when poetry mode active
+  test: packages/unifiedmandala-ui/components/PoetryErrorBoundary.test.tsx
+  status: open
+- commit: Create VRBegegnungsraumLobby
+  path: packages/unifiedmandala-vr/VRBegegnungsraumLobby.ts
+  task: Prototype VR meeting space with WebXR and breath sync
+  test: packages/unifiedmandala-vr/VRBegegnungsraumLobby.test.ts
+  status: open
+- commit: Develop AeonResonanceModules
+  path: packages/resonance/AeonResonanceModules.ts
+  task: Implement AeonMythOS and AeonSigilNet modules for advanced resonance
+  test: packages/resonance/AeonResonanceModules.test.ts
+  status: open
+- commit: Implement Dispatcher Error-Boundary
+  path: packages/core/GreekMathAeonDispatcher.ts
+  task: Emit dispatcher:error event via try/catch wrapper
+  test: packages/core/GreekMathAeonDispatcher.test.ts
+  status: open

--- a/advancedToDo_parts/advancedToDo.part10.json
+++ b/advancedToDo_parts/advancedToDo.part10.json
@@ -1,0 +1,37 @@
+[
+  {
+    "commit": "Implement PantheonFeedbackRound",
+    "path": "packages/pantheon/PantheonFeedbackService.ts",
+    "task": "Coordinate GPT feedback round with Pantheon agents",
+    "test": "packages/pantheon/PantheonFeedbackService.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add PoetryErrorBoundary component",
+    "path": "packages/unifiedmandala-ui/components/PoetryErrorBoundary.tsx",
+    "task": "Show ChronoPoem on errors when poetry mode active",
+    "test": "packages/unifiedmandala-ui/components/PoetryErrorBoundary.test.tsx",
+    "status": "open"
+  },
+  {
+    "commit": "Create VRBegegnungsraumLobby",
+    "path": "packages/unifiedmandala-vr/VRBegegnungsraumLobby.ts",
+    "task": "Prototype VR meeting space with WebXR and breath sync",
+    "test": "packages/unifiedmandala-vr/VRBegegnungsraumLobby.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Develop AeonResonanceModules",
+    "path": "packages/resonance/AeonResonanceModules.ts",
+    "task": "Implement AeonMythOS and AeonSigilNet modules for advanced resonance",
+    "test": "packages/resonance/AeonResonanceModules.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Implement Dispatcher Error-Boundary",
+    "path": "packages/core/GreekMathAeonDispatcher.ts",
+    "task": "Emit dispatcher:error event via try/catch wrapper",
+    "test": "packages/core/GreekMathAeonDispatcher.test.ts",
+    "status": "open"
+  }
+]

--- a/advancedToDo_parts/advancedToDo.part10.yaml
+++ b/advancedToDo_parts/advancedToDo.part10.yaml
@@ -1,0 +1,25 @@
+- commit: Implement PantheonFeedbackRound
+  path: packages/pantheon/PantheonFeedbackService.ts
+  task: Coordinate GPT feedback round with Pantheon agents
+  test: packages/pantheon/PantheonFeedbackService.test.ts
+  status: open
+- commit: Add PoetryErrorBoundary component
+  path: packages/unifiedmandala-ui/components/PoetryErrorBoundary.tsx
+  task: Show ChronoPoem on errors when poetry mode active
+  test: packages/unifiedmandala-ui/components/PoetryErrorBoundary.test.tsx
+  status: open
+- commit: Create VRBegegnungsraumLobby
+  path: packages/unifiedmandala-vr/VRBegegnungsraumLobby.ts
+  task: Prototype VR meeting space with WebXR and breath sync
+  test: packages/unifiedmandala-vr/VRBegegnungsraumLobby.test.ts
+  status: open
+- commit: Develop AeonResonanceModules
+  path: packages/resonance/AeonResonanceModules.ts
+  task: Implement AeonMythOS and AeonSigilNet modules for advanced resonance
+  test: packages/resonance/AeonResonanceModules.test.ts
+  status: open
+- commit: Implement Dispatcher Error-Boundary
+  path: packages/core/GreekMathAeonDispatcher.ts
+  task: Emit dispatcher:error event via try/catch wrapper
+  test: packages/core/GreekMathAeonDispatcher.test.ts
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -530,6 +530,26 @@
     {
       "commit": "Extend ExtendedResonanceVRModule with Fourier",
       "status": "open"
+    },
+    {
+      "commit": "Implement PantheonFeedbackRound",
+      "status": "open"
+    },
+    {
+      "commit": "Add PoetryErrorBoundary component",
+      "status": "open"
+    },
+    {
+      "commit": "Create VRBegegnungsraumLobby",
+      "status": "open"
+    },
+    {
+      "commit": "Develop AeonResonanceModules",
+      "status": "open"
+    },
+    {
+      "commit": "Implement Dispatcher Error-Boundary",
+      "status": "open"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- extract new ToDos from `newadvancedconversations.json`
- list Pantheon feedback, Poetry error boundary, VR lobby and resonance module tasks
- sync progress entries

## Testing
- `npx pyright` *(fails: missing modules)*
- `npx tsc -p tsconfig.json` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6877e5bccc9c8322aef61b4d2b202390