### PR TITLE
Add Pantheon and Boundary tasks

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-16, in der Zeit des Tag.
+Am 2025-07-16, in der Zeit des Abend.
 
-Symbolphase: Aktivierung (Fokus: R)
+Symbolphase: Integration (Fokus: E)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5727,5 +5727,40 @@
     "task": "Emit dispatcher:error event via try/catch wrapper",
     "test": "packages/core/GreekMathAeonDispatcher.test.ts",
     "status": "open"
+  },
+  {
+    "commit": "Add PantheonLobbyService",
+    "path": "packages/pantheon/PantheonLobbyService.ts",
+    "task": "Manage session handshakes and presence for Pantheon modules",
+    "test": "packages/pantheon/PantheonLobbyService.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add PantheonLobbyUI",
+    "path": "packages/unifiedmandala-ui/components/PantheonLobbyUI.tsx",
+    "task": "Lobby screen to select Pantheon modules before entering VR",
+    "test": "packages/unifiedmandala-ui/components/PantheonLobbyUI.test.tsx",
+    "status": "open"
+  },
+  {
+    "commit": "Add BoundaryPolicyManager",
+    "path": "packages/boundary-engine/BoundaryPolicyManager.ts",
+    "task": "Define governance policies for boundaries",
+    "test": "packages/boundary-engine/BoundaryPolicyManager.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Extend ResonanceModuleOrchestrator VR integration",
+    "path": "packages/resonance-modules/ResonanceModuleOrchestrator.ts",
+    "task": "Connect modules with VR audio and haptic feedback",
+    "test": "packages/resonance-modules/ResonanceModuleOrchestrator.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "CosmicTheoryAgent FourierLayer gRPC bridge",
+    "path": "packages/agents/CosmicTheoryAgent.ts",
+    "task": "Stream FourierLayer metrics via gRPC to Pyramid UI",
+    "test": "packages/agents/CosmicTheoryAgent.test.ts",
+    "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7208,3 +7208,28 @@
   task: Emit dispatcher:error event via try/catch wrapper
   test: packages/core/GreekMathAeonDispatcher.test.ts
   status: open
+- commit: Add PantheonLobbyService
+  path: packages/pantheon/PantheonLobbyService.ts
+  task: Manage session handshakes and presence for Pantheon modules
+  test: packages/pantheon/PantheonLobbyService.test.ts
+  status: open
+- commit: Add PantheonLobbyUI
+  path: packages/unifiedmandala-ui/components/PantheonLobbyUI.tsx
+  task: Lobby screen to select Pantheon modules before entering VR
+  test: packages/unifiedmandala-ui/components/PantheonLobbyUI.test.tsx
+  status: open
+- commit: Add BoundaryPolicyManager
+  path: packages/boundary-engine/BoundaryPolicyManager.ts
+  task: Define governance policies for boundaries
+  test: packages/boundary-engine/BoundaryPolicyManager.test.ts
+  status: open
+- commit: Extend ResonanceModuleOrchestrator VR integration
+  path: packages/resonance-modules/ResonanceModuleOrchestrator.ts
+  task: Connect modules with VR audio and haptic feedback
+  test: packages/resonance-modules/ResonanceModuleOrchestrator.test.ts
+  status: open
+- commit: CosmicTheoryAgent FourierLayer gRPC bridge
+  path: packages/agents/CosmicTheoryAgent.ts
+  task: Stream FourierLayer metrics via gRPC to Pyramid UI
+  test: packages/agents/CosmicTheoryAgent.test.ts
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5,7 +5,7 @@
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added future resonance anchor",
+  "notes": "Added future resonance anchor; extracted Pantheon, Boundary and VR tasks",
   "pendingTasks": [
     {
       "commit": "TODO from newadvancedconversations.json - AgentCoordinator",
@@ -549,6 +549,26 @@
     },
     {
       "commit": "Implement Dispatcher Error-Boundary",
+      "status": "open"
+    },
+    {
+      "commit": "Add PantheonLobbyService",
+      "status": "open"
+    },
+    {
+      "commit": "Add PantheonLobbyUI",
+      "status": "open"
+    },
+    {
+      "commit": "Add BoundaryPolicyManager",
+      "status": "open"
+    },
+    {
+      "commit": "Extend ResonanceModuleOrchestrator VR integration",
+      "status": "open"
+    },
+    {
+      "commit": "CosmicTheoryAgent FourierLayer gRPC bridge",
       "status": "open"
     }
   ]


### PR DESCRIPTION
## Summary
- add PantheonLobbyService and UI tasks
- add BoundaryPolicyManager and ResonanceModule VR tasks
- log new tasks in advancedprogress
- update chrono poem

## Testing
- `npx pyright` *(fails: missing imports)*
- `npx tsc -p tsconfig.json` *(fails: missing type definitions)*
- `poetry install --with test` *(fails: no pyproject file)*
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_6877e9d469a08322ba954d5bf5323b54