### PR TITLE
Update ToDo lists with tasks from conversations

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5797,5 +5797,33 @@
     "task": "Introspective logging of FourierLayer metrics",
     "test": "packages/agents/CosmicTheoryAgent.test.ts",
     "status": "open"
+  },
+  {
+    "commit": "PantheonOnboardingBlueprint",
+    "path": "docs/pantheon/PantheonOnboardingBlueprint.md",
+    "task": "Outline onboarding and expansion plan for Pantheon modules",
+    "test": "docs/pantheon/PantheonOnboardingBlueprint.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "BoundaryPrototypeScaffold",
+    "path": "packages/boundary/BoundaryPrototype.ts",
+    "task": "Build initial Boundary framework based on new blueprint",
+    "test": "packages/boundary/__tests__/BoundaryPrototype.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "VRBegegnungsraumProjectPlan",
+    "path": "docs/vr/VRBegegnungsraumProjektplan.md",
+    "task": "Document architecture and guidelines for VR meeting space",
+    "test": "docs/vr/VRBegegnungsraumProjektplan.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "ResonanceModuleScaffold",
+    "path": "packages/resonance/ResonanceModulesScaffold.ts",
+    "task": "Setup scaffold for ten advanced resonance modules",
+    "test": "packages/resonance/ResonanceModulesScaffold.test.ts",
+    "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7258,3 +7258,23 @@
   task: Introspective logging of FourierLayer metrics
   test: packages/agents/CosmicTheoryAgent.test.ts
   status: open
+- commit: PantheonOnboardingBlueprint
+  path: docs/pantheon/PantheonOnboardingBlueprint.md
+  task: Outline onboarding and expansion plan for Pantheon modules
+  test: docs/pantheon/PantheonOnboardingBlueprint.test.ts
+  status: open
+- commit: BoundaryPrototypeScaffold
+  path: packages/boundary/BoundaryPrototype.ts
+  task: Build initial Boundary framework based on new blueprint
+  test: packages/boundary/__tests__/BoundaryPrototype.test.ts
+  status: open
+- commit: VRBegegnungsraumProjectPlan
+  path: docs/vr/VRBegegnungsraumProjektplan.md
+  task: Document architecture and guidelines for VR meeting space
+  test: docs/vr/VRBegegnungsraumProjektplan.test.ts
+  status: open
+- commit: ResonanceModuleScaffold
+  path: packages/resonance/ResonanceModulesScaffold.ts
+  task: Setup scaffold for ten advanced resonance modules
+  test: packages/resonance/ResonanceModulesScaffold.test.ts
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Added AeonKernel and MandalaInterface tasks",
+  "lastCommit": "Extracted Pantheon, Boundary, VR and Resonance tasks",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -589,6 +589,22 @@
     },
     {
       "commit": "Add CosmicTheoryAgent introspection logs",
+      "status": "open"
+    },
+    {
+      "commit": "PantheonOnboardingBlueprint",
+      "status": "open"
+    },
+    {
+      "commit": "BoundaryPrototypeScaffold",
+      "status": "open"
+    },
+    {
+      "commit": "VRBegegnungsraumProjectPlan",
+      "status": "open"
+    },
+    {
+      "commit": "ResonanceModuleScaffold",
       "status": "open"
     }
   ]


### PR DESCRIPTION
## Summary
- parse TODOs from conversations and add new tasks for Pantheon, Boundary, VR-Begegnungsraum and Resonance modules
- keep progress log updated

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6877f8ee678483229e0e89a0000f0d63