### PR TITLE
Implement Pantheon, Boundary, VR and resonance scaffolds

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-16, in der Zeit des Abend.
+Am 2025-07-17, in der Zeit des Morgen.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5803,27 +5803,27 @@
     "path": "docs/pantheon/PantheonOnboardingBlueprint.md",
     "task": "Outline onboarding and expansion plan for Pantheon modules",
     "test": "docs/pantheon/PantheonOnboardingBlueprint.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "BoundaryPrototypeScaffold",
     "path": "packages/boundary/BoundaryPrototype.ts",
     "task": "Build initial Boundary framework based on new blueprint",
     "test": "packages/boundary/__tests__/BoundaryPrototype.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "VRBegegnungsraumProjectPlan",
     "path": "docs/vr/VRBegegnungsraumProjektplan.md",
     "task": "Document architecture and guidelines for VR meeting space",
     "test": "docs/vr/VRBegegnungsraumProjektplan.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "ResonanceModuleScaffold",
     "path": "packages/resonance/ResonanceModulesScaffold.ts",
     "task": "Setup scaffold for ten advanced resonance modules",
     "test": "packages/resonance/ResonanceModulesScaffold.test.ts",
-    "status": "open"
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7262,19 +7262,19 @@
   path: docs/pantheon/PantheonOnboardingBlueprint.md
   task: Outline onboarding and expansion plan for Pantheon modules
   test: docs/pantheon/PantheonOnboardingBlueprint.test.ts
-  status: open
+  status: done
 - commit: BoundaryPrototypeScaffold
   path: packages/boundary/BoundaryPrototype.ts
   task: Build initial Boundary framework based on new blueprint
   test: packages/boundary/__tests__/BoundaryPrototype.test.ts
-  status: open
+  status: done
 - commit: VRBegegnungsraumProjectPlan
   path: docs/vr/VRBegegnungsraumProjektplan.md
   task: Document architecture and guidelines for VR meeting space
   test: docs/vr/VRBegegnungsraumProjektplan.test.ts
-  status: open
+  status: done
 - commit: ResonanceModuleScaffold
   path: packages/resonance/ResonanceModulesScaffold.ts
   task: Setup scaffold for ten advanced resonance modules
   test: packages/resonance/ResonanceModulesScaffold.test.ts
-  status: open
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Extracted Pantheon, Boundary, VR and Resonance tasks",
+  "lastCommit": "Initialized Pantheon, Boundary, VR and Resonance scaffolds",
   "fractalStep": "sync",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added future resonance anchor; extracted Pantheon, Boundary and VR tasks",
+  "notes": "Implemented initial blueprints and scaffolds for Pantheon, Boundary, VR space and resonance modules",
   "pendingTasks": [
     {
       "commit": "TODO from newadvancedconversations.json - AgentCoordinator",
@@ -593,19 +593,19 @@
     },
     {
       "commit": "PantheonOnboardingBlueprint",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "BoundaryPrototypeScaffold",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "VRBegegnungsraumProjectPlan",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "ResonanceModuleScaffold",
-      "status": "open"
+      "status": "done"
     }
   ]
 }

--- a/docs/pantheon/PantheonOnboardingBlueprint.md
+++ b/docs/pantheon/PantheonOnboardingBlueprint.md
@@ -1,0 +1,8 @@
+# Pantheon Onboarding Blueprint
+
+Dieses Dokument skizziert den geplanten Ablauf zur Einbindung neuer Pantheon-Module. Die wichtigsten Punkte:
+
+- Rollen und Verantwortlichkeiten definieren
+- Module registrieren und initialisieren
+- Feedback-Runden und CREP-Validierung
+- Übergabe an das Mandala-Orchestrator-System

--- a/docs/pantheon/PantheonOnboardingBlueprint.test.ts
+++ b/docs/pantheon/PantheonOnboardingBlueprint.test.ts
@@ -1,0 +1,9 @@
+import { readFileSync } from 'fs';
+import { describe, it, expect } from 'vitest';
+
+describe('PantheonOnboardingBlueprint', () => {
+  it('contains onboarding heading', () => {
+    const content = readFileSync('docs/pantheon/PantheonOnboardingBlueprint.md', 'utf-8');
+    expect(content).toMatch(/Pantheon Onboarding Blueprint/);
+  });
+});

--- a/docs/vr/VRBegegnungsraumProjektplan.md
+++ b/docs/vr/VRBegegnungsraumProjektplan.md
@@ -1,0 +1,7 @@
+# VR-Begegnungsraum Projektplan
+
+Dieser Plan beschreibt die Architektur des virtuellen Begegnungsraums:
+
+- WebXR-Grundgerüst und Avatar-Management
+- Anbindung an FourierLayer für Audiofeedback
+- Synchronisation mit Mandala-UI und Pantheon-Modulen

--- a/docs/vr/VRBegegnungsraumProjektplan.test.ts
+++ b/docs/vr/VRBegegnungsraumProjektplan.test.ts
@@ -1,0 +1,9 @@
+import { readFileSync } from 'fs';
+import { describe, it, expect } from 'vitest';
+
+describe('VRBegegnungsraumProjektplan', () => {
+  it('describes VR plan', () => {
+    const content = readFileSync('docs/vr/VRBegegnungsraumProjektplan.md', 'utf-8');
+    expect(content).toMatch(/VR-Begegnungsraum Projektplan/);
+  });
+});

--- a/packages/boundary/BoundaryPrototype.ts
+++ b/packages/boundary/BoundaryPrototype.ts
@@ -1,0 +1,16 @@
+export interface BoundaryRule {
+  id: string;
+  description: string;
+}
+
+export class BoundaryPrototype {
+  private rules: BoundaryRule[] = [];
+
+  addRule(rule: BoundaryRule) {
+    this.rules.push(rule);
+  }
+
+  listRules(): BoundaryRule[] {
+    return this.rules;
+  }
+}

--- a/packages/boundary/__tests__/BoundaryPrototype.test.ts
+++ b/packages/boundary/__tests__/BoundaryPrototype.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { BoundaryPrototype } from '../BoundaryPrototype';
+
+describe('BoundaryPrototype', () => {
+  it('stores added rules', () => {
+    const proto = new BoundaryPrototype();
+    proto.addRule({ id: '1', description: 'test rule' });
+    expect(proto.listRules()).toHaveLength(1);
+  });
+});

--- a/packages/resonance/ResonanceModulesScaffold.test.ts
+++ b/packages/resonance/ResonanceModulesScaffold.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { ResonanceModulesScaffold } from './ResonanceModulesScaffold';
+
+describe('ResonanceModulesScaffold', () => {
+  it('registers modules', () => {
+    const scaffold = new ResonanceModulesScaffold();
+    scaffold.register({ id: 'mod1', activate() {} });
+    expect(scaffold.getModules()).toHaveLength(1);
+  });
+});

--- a/packages/resonance/ResonanceModulesScaffold.ts
+++ b/packages/resonance/ResonanceModulesScaffold.ts
@@ -1,0 +1,16 @@
+export interface ResonanceModule {
+  id: string;
+  activate(): void;
+}
+
+export class ResonanceModulesScaffold {
+  private modules: ResonanceModule[] = [];
+
+  register(module: ResonanceModule) {
+    this.modules.push(module);
+  }
+
+  getModules(): ResonanceModule[] {
+    return this.modules;
+  }
+}


### PR DESCRIPTION
## Summary
- add onboarding blueprint for Pantheon modules
- document VR Begegnungsraum plan
- create BoundaryPrototype and resonance module scaffolds
- update ToDo trackers and progress

## Testing
- `pnpm install`
- `npx vitest run`
- `npx tsc -p tsconfig.json`
- `npx -y pyright` *(fails: Import errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878abaf3a6c832294b2c32abda04aa9