### PR TITLE
Update advanced ToDos with new VR and Pantheon tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5825,5 +5825,33 @@
     "task": "Setup scaffold for ten advanced resonance modules",
     "test": "packages/resonance/ResonanceModulesScaffold.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "PantheonArchiveExporter",
+    "path": "packages/pantheon/PantheonArchiveExporter.ts",
+    "task": "Export Pantheon data sets as YAML, JSON and graph",
+    "test": "packages/pantheon/PantheonArchiveExporter.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "BoundaryLawAnalyticsDashboard",
+    "path": "packages/boundary-ui/BoundaryLawAnalyticsDashboard.tsx",
+    "task": "Display analytics for boundary law discovery engine",
+    "test": "packages/boundary-ui/BoundaryLawAnalyticsDashboard.test.tsx",
+    "status": "open"
+  },
+  {
+    "commit": "VRAvatarCustomization",
+    "path": "packages/unifiedmandala-vr/VRAvatarCustomization.ts",
+    "task": "Support custom avatars in VR Begegnungsraum",
+    "test": "packages/unifiedmandala-vr/VRAvatarCustomization.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "ResonanceFeedbackModule",
+    "path": "packages/resonance/ResonanceFeedbackModule.ts",
+    "task": "Collect user feedback and convert to resonance metrics",
+    "test": "packages/resonance/ResonanceFeedbackModule.test.ts",
+    "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7278,3 +7278,23 @@
   task: Setup scaffold for ten advanced resonance modules
   test: packages/resonance/ResonanceModulesScaffold.test.ts
   status: done
+- commit: PantheonArchiveExporter
+  path: packages/pantheon/PantheonArchiveExporter.ts
+  task: Export Pantheon data sets as YAML, JSON and graph
+  test: packages/pantheon/PantheonArchiveExporter.test.ts
+  status: open
+- commit: BoundaryLawAnalyticsDashboard
+  path: packages/boundary-ui/BoundaryLawAnalyticsDashboard.tsx
+  task: Display analytics for boundary law discovery engine
+  test: packages/boundary-ui/BoundaryLawAnalyticsDashboard.test.tsx
+  status: open
+- commit: VRAvatarCustomization
+  path: packages/unifiedmandala-vr/VRAvatarCustomization.ts
+  task: Support custom avatars in VR Begegnungsraum
+  test: packages/unifiedmandala-vr/VRAvatarCustomization.test.ts
+  status: open
+- commit: ResonanceFeedbackModule
+  path: packages/resonance/ResonanceFeedbackModule.ts
+  task: Collect user feedback and convert to resonance metrics
+  test: packages/resonance/ResonanceFeedbackModule.test.ts
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -606,6 +606,22 @@
     {
       "commit": "ResonanceModuleScaffold",
       "status": "done"
+    },
+    {
+      "commit": "PantheonArchiveExporter",
+      "status": "open"
+    },
+    {
+      "commit": "BoundaryLawAnalyticsDashboard",
+      "status": "open"
+    },
+    {
+      "commit": "VRAvatarCustomization",
+      "status": "open"
+    },
+    {
+      "commit": "ResonanceFeedbackModule",
+      "status": "open"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add new advanced tasks for Pantheon, Boundary, VR and resonance modules
- track new tasks in `advancedprogress.json`

## Testing
- `npx -y pyright` *(fails: missing imports)*
- `npx -y tsc -p tsconfig.json` *(fails: missing node typings)*

------
https://chatgpt.com/codex/tasks/task_e_6878c4acf8c88322820e1ee93995231e