### PR TITLE
Add tasks for Pantheon, Boundary, VR and resonance modules

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5917,4 +5917,33 @@
     "test": "packages/resonance-modules/__tests__/ResonanceModuleOrchestrator.test.ts",
     "status": "open"
   }
+
+  ,{
+    "commit": "Add VRMeetingHall3D",
+    "path": "packages/unifiedmandala-vr/components/VRMeetingHall3D.tsx",
+    "task": "Collaborative VR meeting hall environment",
+    "test": "packages/unifiedmandala-vr/components/__tests__/VRMeetingHall3D.test.tsx",
+    "status": "open"
+  }
+  ,{
+    "commit": "Add BoundaryLawSimulator",
+    "path": "packages/boundary-engine/BoundaryLawSimulator.ts",
+    "task": "Simulate boundary rule interactions",
+    "test": "packages/boundary-engine/__tests__/BoundaryLawSimulator.test.ts",
+    "status": "open"
+  }
+  ,{
+    "commit": "Add PantheonMemorySync",
+    "path": "packages/pantheon/PantheonMemorySync.ts",
+    "task": "Synchronize Pantheon agent memory across sessions",
+    "test": "packages/pantheon/PantheonMemorySync.test.ts",
+    "status": "open"
+  }
+  ,{
+    "commit": "Add ResonanceModuleDiagnostics",
+    "path": "packages/resonance-modules/ResonanceModuleDiagnostics.ts",
+    "task": "Monitor resonance modules and report health metrics",
+    "test": "packages/resonance-modules/__tests__/ResonanceModuleDiagnostics.test.ts",
+    "status": "open"
+  }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7343,3 +7343,23 @@
   task: Coordinate extended resonance modules
   test: packages/resonance-modules/__tests__/ResonanceModuleOrchestrator.test.ts
   status: open
+- commit: Add VRMeetingHall3D
+  path: packages/unifiedmandala-vr/components/VRMeetingHall3D.tsx
+  task: Collaborative VR meeting hall environment
+  test: packages/unifiedmandala-vr/components/__tests__/VRMeetingHall3D.test.tsx
+  status: open
+- commit: Add BoundaryLawSimulator
+  path: packages/boundary-engine/BoundaryLawSimulator.ts
+  task: Simulate boundary rule interactions
+  test: packages/boundary-engine/__tests__/BoundaryLawSimulator.test.ts
+  status: open
+- commit: Add PantheonMemorySync
+  path: packages/pantheon/PantheonMemorySync.ts
+  task: Synchronize Pantheon agent memory across sessions
+  test: packages/pantheon/PantheonMemorySync.test.ts
+  status: open
+- commit: Add ResonanceModuleDiagnostics
+  path: packages/resonance-modules/ResonanceModuleDiagnostics.ts
+  task: Monitor resonance modules and report health metrics
+  test: packages/resonance-modules/__tests__/ResonanceModuleDiagnostics.test.ts
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -639,10 +639,30 @@
       "commit": "Add ResonanceTuningKit",
       "status": "done"
     }
+    ,{
+      "commit": "Add VRMeetingHall3D",
+      "status": "open"
+    }
+    ,{
+      "commit": "Add BoundaryLawSimulator",
+      "status": "open"
+    }
+    ,{
+      "commit": "Add PantheonMemorySync",
+      "status": "open"
+    }
+    ,{
+      "commit": "Add ResonanceModuleDiagnostics",
+      "status": "open"
+    }
   ],
   "progress": [
     {
       "commit": "Implement boundary manager modules",
+      "status": "done"
+    }
+    ,{
+      "commit": "Extracted new Pantheon/Boundary/VR/Resonance tasks",
       "status": "done"
     }
   ]


### PR DESCRIPTION
## Summary
- add new tasks extracted from latest conversations to advancedToDo.yaml and advancedToDo.json
- update progress with new pending tasks

## Testing
- `npx pyright` *(fails: Import errors)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6879460a5fec83229fd60fbff5bd1c81