### PR TITLE
Add new tasks for Pantheon and resonance modules

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5946,4 +5946,39 @@
     "test": "packages/resonance-modules/__tests__/ResonanceModuleDiagnostics.test.ts",
     "status": "open"
   }
+  ,{
+    "commit": "Add PantheonBoundaryResolver service",
+    "path": "packages/pantheon/PantheonBoundaryResolver.ts",
+    "task": "Bridge Pantheon modules with boundary engine",
+    "test": "packages/pantheon/PantheonBoundaryResolver.test.ts",
+    "status": "open"
+  }
+  ,{
+    "commit": "Create VRPulseSynchronizer module",
+    "path": "packages/unifiedmandala-vr/VRPulseSynchronizer.ts",
+    "task": "Sync user pulses with audio resonance",
+    "test": "packages/unifiedmandala-vr/VRPulseSynchronizer.test.ts",
+    "status": "open"
+  }
+  ,{
+    "commit": "Add ResonanceAutoTuner",
+    "path": "packages/resonance/ResonanceAutoTuner.ts",
+    "task": "Auto tune resonance modules via Fourier analysis",
+    "test": "packages/resonance/ResonanceAutoTuner.test.ts",
+    "status": "open"
+  }
+  ,{
+    "commit": "Create BoundaryLawPatternGenerator",
+    "path": "packages/boundary-engine/BoundaryLawPatternGenerator.ts",
+    "task": "Generate boundary patterns from datasets",
+    "test": "packages/boundary-engine/__tests__/BoundaryLawPatternGenerator.test.ts",
+    "status": "open"
+  }
+  ,{
+    "commit": "Add PantheonPortalAnalytics",
+    "path": "packages/pantheon/PantheonPortalAnalytics.ts",
+    "task": "Collect analytics for Pantheon portal usage",
+    "test": "packages/pantheon/PantheonPortalAnalytics.test.ts",
+    "status": "open"
+  }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7363,3 +7363,28 @@
   task: Monitor resonance modules and report health metrics
   test: packages/resonance-modules/__tests__/ResonanceModuleDiagnostics.test.ts
   status: open
+- commit: Add PantheonBoundaryResolver service
+  path: packages/pantheon/PantheonBoundaryResolver.ts
+  task: Bridge Pantheon modules with boundary engine
+  test: packages/pantheon/PantheonBoundaryResolver.test.ts
+  status: open
+- commit: Create VRPulseSynchronizer module
+  path: packages/unifiedmandala-vr/VRPulseSynchronizer.ts
+  task: Sync user pulses with audio resonance
+  test: packages/unifiedmandala-vr/VRPulseSynchronizer.test.ts
+  status: open
+- commit: Add ResonanceAutoTuner
+  path: packages/resonance/ResonanceAutoTuner.ts
+  task: Auto tune resonance modules via Fourier analysis
+  test: packages/resonance/ResonanceAutoTuner.test.ts
+  status: open
+- commit: Create BoundaryLawPatternGenerator
+  path: packages/boundary-engine/BoundaryLawPatternGenerator.ts
+  task: Generate boundary patterns from datasets
+  test: packages/boundary-engine/__tests__/BoundaryLawPatternGenerator.test.ts
+  status: open
+- commit: Add PantheonPortalAnalytics
+  path: packages/pantheon/PantheonPortalAnalytics.ts
+  task: Collect analytics for Pantheon portal usage
+  test: packages/pantheon/PantheonPortalAnalytics.test.ts
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Implemented session manager and VR modules",
+  "lastCommit": "Added new Pantheon/Boundary/VR/Resonance tasks",
   "fractalStep": "implementation",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added FrequencyMandala3D, FourierAPI and new Pantheon/Boundary tasks",
+  "notes": "Added new tasks for PantheonBoundaryResolver, VRPulseSynchronizer and ResonanceAutoTuner",
   "pendingTasks": [
     {
       "commit": "TODO from newadvancedconversations.json - AgentCoordinator",
@@ -655,6 +655,26 @@
       "commit": "Add ResonanceModuleDiagnostics",
       "status": "open"
     }
+    ,{
+      "commit": "TODO from newadvancedconversations.json - PantheonBoundaryResolver",
+      "status": "open"
+    }
+    ,{
+      "commit": "TODO from newadvancedconversations.json - VRPulseSynchronizer",
+      "status": "open"
+    }
+    ,{
+      "commit": "TODO from newadvancedconversations.json - ResonanceAutoTuner",
+      "status": "open"
+    }
+    ,{
+      "commit": "TODO from newadvancedconversations.json - BoundaryLawPatternGenerator",
+      "status": "open"
+    }
+    ,{
+      "commit": "TODO from newadvancedconversations.json - PantheonPortalAnalytics",
+      "status": "open"
+    }
   ],
   "progress": [
     {
@@ -663,6 +683,10 @@
     }
     ,{
       "commit": "Extracted new Pantheon/Boundary/VR/Resonance tasks",
+      "status": "done"
+    }
+    ,{
+      "commit": "Added additional Pantheon/Boundary/VR/Resonance tasks",
       "status": "done"
     }
   ]


### PR DESCRIPTION
## Summary
- include PantheonBoundaryResolver, VRPulseSynchronizer, ResonanceAutoTuner and
  related tasks in `advancedToDo` lists
- track new pending tasks in `advancedprogress.json`

## Testing
- `poetry install --with test` *(failed: pyproject not found)*
- `pnpm install`
- `npx pyright` *(failed: npm canceled)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6879676b9b748322a738a846571fe3e6