### PR TITLE
Add resonance and VR tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6009,4 +6009,32 @@
     "test": "packages/pantheon/PantheonPortalAnalytics.test.ts",
     "status": "open"
   }
+,{
+  "commit": "Integrate FourierLayer with PyramidUI",
+  "path": "packages/unifiedmandala-ui/pyramid/FourierLayerIntegration.ts",
+  "task": "Connect Fourier-layer analysis to interactive Pyramid UI",
+  "test": "packages/unifiedmandala-ui/pyramid/FourierLayerIntegration.test.ts",
+  "status": "open"
+},
+{
+  "commit": "Add VRMandalaRoom WebXR",
+  "path": "packages/unifiedmandala-vr/VRMandalaRoom.tsx",
+  "task": "Build VR Mandala room with WebXR and Fourier support",
+  "test": "packages/unifiedmandala-vr/VRMandalaRoom.test.tsx",
+  "status": "open"
+},
+{
+  "commit": "Scaffold ResonanceModule microservices",
+  "path": "packages/resonance-modules",
+  "task": "Setup 10 advanced resonance modules as microservices",
+  "test": "packages/resonance-modules/__tests__/modules.test.ts",
+  "status": "open"
+},
+{
+  "commit": "Document MandalaBoundaryAgentFramework",
+  "path": "docs/boundary/MandalaBoundaryAgentFramework.md",
+  "task": "Blueprint for boundary law templates and agent setup",
+  "test": "",
+  "status": "open"
+}
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7408,3 +7408,23 @@
   task: Link resonance modules across network using quantum sync
   test: packages/resonance-modules/__tests__/ResonanceModuleQuantumLink.test.ts
   status: done
+- commit: Integrate FourierLayer with PyramidUI
+  path: packages/unifiedmandala-ui/pyramid/FourierLayerIntegration.ts
+  task: Connect Fourier-layer analysis to interactive Pyramid UI
+  test: packages/unifiedmandala-ui/pyramid/FourierLayerIntegration.test.ts
+  status: open
+- commit: Add VRMandalaRoom WebXR
+  path: packages/unifiedmandala-vr/VRMandalaRoom.tsx
+  task: Build VR Mandala room with WebXR and Fourier support
+  test: packages/unifiedmandala-vr/VRMandalaRoom.test.tsx
+  status: open
+- commit: Scaffold ResonanceModule microservices
+  path: packages/resonance-modules
+  task: Setup 10 advanced resonance modules as microservices
+  test: packages/resonance-modules/__tests__/modules.test.ts
+  status: open
+- commit: Document MandalaBoundaryAgentFramework
+  path: docs/boundary/MandalaBoundaryAgentFramework.md
+  task: Blueprint for boundary law templates and agent setup
+  test: ""
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -701,5 +701,9 @@
       "commit": "Implemented Gateway and Resonance modules",
       "status": "done"
     }
+  ,{
+    "commit": "Added FourierLayer integration and VR room tasks",
+    "status": "open"
+  }
   ]
 }


### PR DESCRIPTION
## Summary
- add new advanced tasks for FourierLayer integration, VR Mandala room and Resonance Modules
- document MandalaBoundaryAgentFramework
- log progress for new features

## Testing
- `pnpm install`
- `poetry install --with test` *(fails: no pyproject)*
- `npx -y pyright` *(fails: 40 errors)*
- `npx -y tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_687b8e9669848322b82b27d4e58f038b