### PR TITLE
Sync Pantheon/Boundary/VR tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5733,7 +5733,7 @@
     "path": "packages/pantheon/PantheonLobbyService.ts",
     "task": "Manage session handshakes and presence for Pantheon modules",
     "test": "packages/pantheon/PantheonLobbyService.test.ts",
-    "status": "done"
+    "status": "open"
   },
   {
     "commit": "Add PantheonLobbyUI",

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Add PantheonSonicGateway and related tasks",
+  "lastCommit": "Synced PantheonBoundaryVR todos",
   "fractalStep": "implementation",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Appended tasks for PantheonSonicGateway, BoundaryHarmonicResolver, VRHapticFeedbackSystem and ResonanceModuleQuantumLink",
+  "notes": "Updated Pantheon, Boundary, VR and Resonance tasks from conversations",
   "pendingTasks": [
     {
       "commit": "TODO from newadvancedconversations.json - AgentCoordinator",


### PR DESCRIPTION
## Summary
- update `advancedprogress.json` notes and lastCommit
- mark Pantheon lobby service task as open in `advancedToDo.json`

## Testing
- `npx pyright` *(fails: missing imports)*
- `npx tsc -p tsconfig.json` *(fails: missing node types)*

------
https://chatgpt.com/codex/tasks/task_e_687bf78cc9d483228fab5858b5671ccf