### PR TITLE
Add keyword todo extractor and FourierLayer test

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6035,5 +6035,12 @@
     "task": "Blueprint for boundary law templates and agent setup",
     "test": "",
     "status": "done"
+  },
+  {
+    "commit": "Extract keyword todos from new conversations",
+    "path": "scripts/extract-keyword-todos.js",
+    "task": "Parse newadvancedconversations.json for Pantheon, Boundary, VR and Resonanzmodule tasks",
+    "test": "scripts/__tests__/extract-keyword-todos.test.ts",
+    "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7428,3 +7428,9 @@
   task: Blueprint for boundary law templates and agent setup
   test: ""
   status: done
+- commit: Extract keyword todos from new conversations
+  path: scripts/extract-keyword-todos.js
+  task: Parse newadvancedconversations.json for Pantheon, Boundary, VR and
+    Resonanzmodule tasks
+  test: scripts/__tests__/extract-keyword-todos.test.ts
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Add boundary framework docs and integrate Fourier layer",
+  "lastCommit": "Update todo lists and progress",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -421,6 +421,10 @@
     },
     {
       "commit": "Add PantheonPortalAnalytics",
+      "status": "open"
+    },
+    {
+      "commit": "Extract keyword todos from new conversations",
       "status": "open"
     }
   ],

--- a/packages/common/src/layers/FourierLayer.ts
+++ b/packages/common/src/layers/FourierLayer.ts
@@ -1,0 +1,1 @@
+export * from '../../../analysis/FourierLayer';

--- a/packages/common/src/layers/__tests__/FourierLayer.test.ts
+++ b/packages/common/src/layers/__tests__/FourierLayer.test.ts
@@ -1,0 +1,11 @@
+import { FourierLayer } from '../FourierLayer';
+
+describe('FourierLayer (common)', () => {
+  it('honors threshold parameter', () => {
+    const layer = new FourierLayer('T', 1, [1, 0, -1, 0], { depth: 2, threshold: 0.2 });
+    const result = layer.analyze();
+    expect(result.metrics.maxAmplitude).toBeGreaterThan(0);
+    // threshold does not affect weight but ensures property is set
+    expect((layer as any).threshold).toBe(0.2);
+  });
+});

--- a/scripts/__tests__/extract-keyword-todos.test.ts
+++ b/scripts/__tests__/extract-keyword-todos.test.ts
@@ -1,0 +1,11 @@
+import { extractKeywordTodos } from '../extract-keyword-todos';
+import fs from 'fs';
+import path from 'path';
+
+test('extractKeywordTodos finds keywords', () => {
+  const file = path.join(__dirname, 'sample.json');
+  fs.writeFileSync(file, JSON.stringify([{mapping:{a:{message:{content:{parts:['Pantheon test']}}}}}]));
+  const res = extractKeywordTodos(file, ['Pantheon']);
+  expect(res[0]).toContain('Pantheon');
+  fs.unlinkSync(file);
+});

--- a/scripts/extract-keyword-todos.js
+++ b/scripts/extract-keyword-todos.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+
+function extractKeywordTodos(file, keywords) {
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const todos = [];
+  for (const conv of data) {
+    for (const node of Object.values(conv.mapping)) {
+      const parts = node.message?.content?.parts || [];
+      for (const part of parts) {
+        if (typeof part !== 'string') continue;
+        for (const kw of keywords) {
+          if (part.includes(kw)) {
+            todos.push(part.trim());
+            break;
+          }
+        }
+      }
+    }
+  }
+  return todos;
+}
+
+if (require.main === module) {
+  const file = process.argv[2] || path.join(__dirname, '../docs/sigils/newadvancedconversations.json');
+  const keywords = ['Pantheon', 'Boundary', 'VR', 'Resonanzmodule'];
+  const results = extractKeywordTodos(file, keywords);
+  console.log(JSON.stringify(results, null, 2));
+}
+
+module.exports = { extractKeywordTodos };


### PR DESCRIPTION
## Summary
- add reusable keyword-based todo extraction script with test
- expose FourierLayer through new `common` package and test threshold logic
- update advanced todo lists and progress

## Testing
- `npx pyright` *(fails: missing streamlit, matplotlib)*
- `npx tsc -p tsconfig.json` *(fails: missing node type defs)*
- `npx -y jest --runInBand` *(fails: missing jest-environment-jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_687ca08b33f48322a17d0c2d667756a2