### PR TITLE
Implement docs generator and todo archiver

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6041,13 +6041,13 @@
     "path": "scripts/doc-comments-generator.ts",
     "task": "Generate Markdown docs from code comments",
     "test": "scripts/__tests__/doc-comments-generator.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add archive-old-todos script",
     "path": "scripts/archive-old-todos.ts",
     "task": "Archive completed ToDos to GenesisAeonZIPMEM",
     "test": "scripts/__tests__/archive-old-todos.test.ts",
-    "status": "open"
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7432,9 +7432,9 @@
   path: scripts/doc-comments-generator.ts
   task: Generate Markdown docs from code comments
   test: scripts/__tests__/doc-comments-generator.test.ts
-  status: open
+  status: done
 - commit: Add archive-old-todos script
   path: scripts/archive-old-todos.ts
   task: Archive completed ToDos to GenesisAeonZIPMEM
   test: scripts/__tests__/archive-old-todos.test.ts
-  status: open
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Implement Poetry boundary and resonance modules",
+  "lastCommit": "Implement doc generation and todo archiver",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -459,6 +459,10 @@
     },
     {
       "commit": "PoetryErrorBoundary and AeonResonanceModules implemented",
+      "status": "done"
+    },
+    {
+      "commit": "Implemented doc generation and todo archiver",
       "status": "done"
     }
   ]

--- a/scripts/archive-old-todos.ts
+++ b/scripts/archive-old-todos.ts
@@ -1,3 +1,26 @@
-export function archiveTodos() {
+import fs from 'fs';
+import path from 'path';
+
+export function archiveTodos(src = 'advancedToDo.json', archiveDir = 'GenesisAeonZIPMEM') {
+  if (!fs.existsSync(src)) return 'archived';
+  const data = JSON.parse(fs.readFileSync(src, 'utf-8')) as any[];
+  const remaining = [] as any[];
+  const archived = [] as any[];
+  for (const item of data) {
+    if (item.status === 'done') {
+      archived.push(item);
+    } else {
+      remaining.push(item);
+    }
+  }
+  fs.mkdirSync(archiveDir, { recursive: true });
+  const archivePath = path.join(archiveDir, 'archived_todos.json');
+  const prev = fs.existsSync(archivePath) ? JSON.parse(fs.readFileSync(archivePath, 'utf-8')) : [];
+  fs.writeFileSync(archivePath, JSON.stringify([...prev, ...archived], null, 2));
+  fs.writeFileSync(src, JSON.stringify(remaining, null, 2));
   return 'archived';
+}
+
+if (require.main === module) {
+  console.log(archiveTodos());
 }

--- a/scripts/doc-comments-generator.ts
+++ b/scripts/doc-comments-generator.ts
@@ -1,3 +1,26 @@
-export function generateDocs() {
+import fs from 'fs';
+import path from 'path';
+import { extractComments } from './autodoc-comments';
+
+export function generateDocs(files: string[] = [], outDir = 'docs/generated'): string {
+  if (!files.length) return 'docs generated';
+  fs.mkdirSync(outDir, { recursive: true });
+  for (const file of files) {
+    const comments = extractComments(file).join('\n\n');
+    if (comments) {
+      const base = path.basename(file, path.extname(file));
+      const outPath = path.join(outDir, `${base}.md`);
+      fs.writeFileSync(outPath, comments);
+    }
+  }
   return 'docs generated';
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (!args.length) {
+    console.error('Usage: ts-node doc-comments-generator.ts <files...>');
+    process.exit(1);
+  }
+  console.log(generateDocs(args));
 }


### PR DESCRIPTION
## Summary
- flesh out `doc-comments-generator.ts` to generate Markdown docs
- implement `archive-old-todos.ts` to store completed tasks in ZIPMEM
- mark the two tasks as done in advancedToDo files
- update progress log

## Testing
- `npx -y pyright` *(fails: Import could not be resolved)*
- `npx -y tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cae07a4c083228f673987c8b6e8c1