### PR TITLE
Implement Pantheon Gateway and update ToDo tracking

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,7 +1,7 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-17, in der Zeit des Morgen.
+Am 2025-07-21, in der Zeit des Morgen.
 
 Symbolphase: Initiation (Fokus: C)
 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5768,7 +5768,7 @@
     "path": "packages/unifiedmandala-pantheon/PantheonGateway.ts",
     "task": "Central routing layer for pantheon modules",
     "test": "packages/unifiedmandala-pantheon/PantheonGateway.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add BoundaryVisualDebugger",
@@ -6077,5 +6077,33 @@
     "task": "Generate pantheon manifest YAML/JSON from modules",
     "test": "docs/pantheon/__tests__/generate_pantheon_manifest.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add PantheonHologramProjector",
+    "path": "packages/unifiedmandala-vr/PantheonHologramProjector.ts",
+    "task": "Render holographic avatars in VR",
+    "test": "packages/unifiedmandala-vr/PantheonHologramProjector.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add BoundaryResonanceMapper",
+    "path": "packages/boundary-engine/BoundaryResonanceMapper.ts",
+    "task": "Map boundary rules to resonance modules",
+    "test": "packages/boundary-engine/BoundaryResonanceMapper.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add VRResonanceAvatar",
+    "path": "packages/unifiedmandala-vr/VRResonanceAvatar.ts",
+    "task": "Avatar responds to resonance levels",
+    "test": "packages/unifiedmandala-vr/VRResonanceAvatar.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add ResonanceModulePortal",
+    "path": "packages/resonance-modules/ResonanceModulePortal.ts",
+    "task": "Portal to chain resonance modules",
+    "test": "packages/resonance-modules/ResonanceModulePortal.test.ts",
+    "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7237,7 +7237,7 @@
   path: packages/unifiedmandala-pantheon/PantheonGateway.ts
   task: Central routing layer for pantheon modules
   test: packages/unifiedmandala-pantheon/PantheonGateway.test.ts
-  status: open
+  status: done
 - commit: Add BoundaryVisualDebugger
   path: packages/boundary-engine/BoundaryVisualDebugger.ts
   task: Visualize active boundaries and collisions
@@ -7458,3 +7458,23 @@
   task: Generate pantheon manifest YAML/JSON from modules
   test: docs/pantheon/__tests__/generate_pantheon_manifest.test.ts
   status: done
+- commit: Add PantheonHologramProjector
+  path: packages/unifiedmandala-vr/PantheonHologramProjector.ts
+  task: Render holographic avatars in VR
+  test: packages/unifiedmandala-vr/PantheonHologramProjector.test.ts
+  status: open
+- commit: Add BoundaryResonanceMapper
+  path: packages/boundary-engine/BoundaryResonanceMapper.ts
+  task: Map boundary rules to resonance modules
+  test: packages/boundary-engine/BoundaryResonanceMapper.test.ts
+  status: open
+- commit: Add VRResonanceAvatar
+  path: packages/unifiedmandala-vr/VRResonanceAvatar.ts
+  task: Avatar responds to resonance levels
+  test: packages/unifiedmandala-vr/VRResonanceAvatar.test.ts
+  status: open
+- commit: Add ResonanceModulePortal
+  path: packages/resonance-modules/ResonanceModulePortal.ts
+  task: Portal to chain resonance modules
+  test: packages/resonance-modules/ResonanceModulePortal.test.ts
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: update progress metadata",
+  "lastCommit": "chore: update progress and chronopoem",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -296,10 +296,6 @@
       "status": "open"
     },
     {
-      "commit": "Add PantheonGateway service",
-      "status": "open"
-    },
-    {
       "commit": "Add BoundaryVisualDebugger",
       "status": "open"
     },
@@ -376,19 +372,19 @@
       "status": "open"
     },
     {
-      "commit": "Create MandalaCollectiveActivator service",
+      "commit": "Add PantheonHologramProjector",
       "status": "open"
     },
     {
-      "commit": "Add AvatarraumEncounterOrchestrator",
+      "commit": "Add BoundaryResonanceMapper",
       "status": "open"
     },
     {
-      "commit": "Create MandalaOrchestratorControl",
+      "commit": "Add VRResonanceAvatar",
       "status": "open"
     },
     {
-      "commit": "PantheonManifestGenerator",
+      "commit": "Add ResonanceModulePortal",
       "status": "open"
     }
   ],
@@ -439,6 +435,10 @@
     },
     {
       "commit": "skeleton modules for pantheon boundary vr",
+      "status": "done"
+    },
+    {
+      "commit": "Implemented PantheonGateway service",
       "status": "done"
     }
   ]

--- a/packages/boundary-engine/BoundaryResonanceMapper.test.ts
+++ b/packages/boundary-engine/BoundaryResonanceMapper.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { mapBoundaryToResonance } from './BoundaryResonanceMapper';
+
+describe('BoundaryResonanceMapper', () => {
+  it('maps rule to resonance', () => {
+    expect(mapBoundaryToResonance('r')).toBe('mapped:r');
+  });
+});

--- a/packages/boundary-engine/BoundaryResonanceMapper.ts
+++ b/packages/boundary-engine/BoundaryResonanceMapper.ts
@@ -1,0 +1,3 @@
+export function mapBoundaryToResonance(rule: string): string {
+  return `mapped:${rule}`;
+}

--- a/packages/resonance-modules/ResonanceModulePortal.test.ts
+++ b/packages/resonance-modules/ResonanceModulePortal.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { ResonanceModulePortal } from './ResonanceModulePortal';
+
+describe('ResonanceModulePortal', () => {
+  it('connects modules', () => {
+    const p = new ResonanceModulePortal();
+    expect(p.connect('a','b')).toBe('a->b');
+  });
+});

--- a/packages/resonance-modules/ResonanceModulePortal.ts
+++ b/packages/resonance-modules/ResonanceModulePortal.ts
@@ -1,0 +1,5 @@
+export class ResonanceModulePortal {
+  connect(modA: string, modB: string): string {
+    return `${modA}->${modB}`;
+  }
+}

--- a/packages/unifiedmandala-pantheon/PantheonGateway.test.ts
+++ b/packages/unifiedmandala-pantheon/PantheonGateway.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { PantheonGateway } from './PantheonGateway';
+
+describe('PantheonGateway', () => {
+  it('registers and retrieves routes', () => {
+    const g = new PantheonGateway();
+    g.register('mod', 'http://localhost');
+    expect(g.getRoute('mod')).toBe('http://localhost');
+    expect(g.list()).toEqual({ mod: 'http://localhost' });
+  });
+});

--- a/packages/unifiedmandala-pantheon/PantheonGateway.ts
+++ b/packages/unifiedmandala-pantheon/PantheonGateway.ts
@@ -1,0 +1,15 @@
+export class PantheonGateway {
+  private routes: Map<string, string> = new Map();
+
+  register(name: string, url: string): void {
+    this.routes.set(name, url);
+  }
+
+  getRoute(name: string): string | undefined {
+    return this.routes.get(name);
+  }
+
+  list(): Record<string, string> {
+    return Object.fromEntries(this.routes.entries());
+  }
+}

--- a/packages/unifiedmandala-vr/PantheonHologramProjector.test.ts
+++ b/packages/unifiedmandala-vr/PantheonHologramProjector.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { PantheonHologramProjector } from './PantheonHologramProjector';
+
+describe('PantheonHologramProjector', () => {
+  it('projects hologram messages', () => {
+    const p = new PantheonHologramProjector();
+    expect(p.project('hello')).toBe('hologram:hello');
+  });
+});

--- a/packages/unifiedmandala-vr/PantheonHologramProjector.ts
+++ b/packages/unifiedmandala-vr/PantheonHologramProjector.ts
@@ -1,0 +1,5 @@
+export class PantheonHologramProjector {
+  project(message: string): string {
+    return `hologram:${message}`;
+  }
+}

--- a/packages/unifiedmandala-vr/VRResonanceAvatar.test.ts
+++ b/packages/unifiedmandala-vr/VRResonanceAvatar.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { VRResonanceAvatar } from './VRResonanceAvatar';
+
+describe('VRResonanceAvatar', () => {
+  it('updates level', () => {
+    const av = new VRResonanceAvatar();
+    av.update(5);
+    expect(av.getLevel()).toBe(5);
+  });
+});

--- a/packages/unifiedmandala-vr/VRResonanceAvatar.ts
+++ b/packages/unifiedmandala-vr/VRResonanceAvatar.ts
@@ -1,0 +1,9 @@
+export class VRResonanceAvatar {
+  private level = 0;
+  update(level: number) {
+    this.level = level;
+  }
+  getLevel() {
+    return this.level;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `PantheonGateway` service and tests
- add placeholder modules for hologram and resonance tasks
- append new Pantheon and resonance todos
- update progress metadata and chronopoem

## Testing
- `npx tsc -p tsconfig.json`
- `npx vitest run`
- `npx pyright` *(failed: package missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e192407548322b90d9756f322f80e