### PR TITLE
Add Fourier visuals and CREP hook

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5127,11 +5127,11 @@
     "status": "open"
   },
   {
-    "commit": "Implement parse-advanced-conversations script",
-    "path": "scripts/parse-advanced-conversations.js",
-    "task": "Generate advanced ToDos from conversation dataset",
-    "test": "scripts/__tests__/parse-advanced-conversations.test.ts",
-    "status": "open"
+  "commit": "Implement parse-advanced-conversations script",
+  "path": "scripts/parse-advanced-conversations.js",
+  "task": "Generate advanced ToDos from conversation dataset",
+  "test": "scripts/__tests__/parse-advanced-conversations.test.ts",
+  "status": "done"
   },
   {
     "commit": "CosmicTheoryAgent gRPC REST access",
@@ -5155,18 +5155,18 @@
     "status": "done"
   },
   {
-    "commit": "Create FourierVisual component",
-    "path": "packages/unifiedmandala-ui/src/components/FourierVisual.tsx",
-    "task": "Render Fourier spectrum results",
-    "test": "packages/unifiedmandala-ui/src/components/FourierVisual.test.tsx",
-    "status": "open"
+  "commit": "Create FourierVisual component",
+  "path": "packages/unifiedmandala-ui/components/FourierVisual.tsx",
+  "task": "Render Fourier spectrum results",
+  "test": "packages/unifiedmandala-ui/components/FourierVisual.test.tsx",
+  "status": "done"
   },
   {
-    "commit": "Fetch real avgResonance in CREPStatsCard",
-    "path": "packages/unifiedmandala-ui/src/components/CREPStatsCard.tsx",
-    "task": "Load avgResonance from API and show mini chart",
-    "test": "packages/unifiedmandala-ui/src/components/CREPStatsCard.test.tsx",
-    "status": "open"
+  "commit": "Fetch real avgResonance in CREPStatsCard",
+  "path": "packages/unifiedmandala-ui/components/CREPStatsCard.tsx",
+  "task": "Load avgResonance from API and show mini chart",
+  "test": "packages/unifiedmandala-ui/components/CREPStatsCard.test.tsx",
+  "status": "done"
   },
   {
     "commit": "Add Mandala SVG export event",
@@ -6132,6 +6132,29 @@
     "path": "docs/resonance/ExtendedResonanceModules.md",
     "task": "Outline microservice modules for resonance expansion",
     "test": "",
+    "status": "open"
+  }
+]
+,
+  {
+    "commit": "Create HeatmapWidget component",
+    "path": "packages/unifiedmandala-ui/components/HeatmapWidget.tsx",
+    "task": "Display CREP heatmap across sessions",
+    "test": "packages/unifiedmandala-ui/components/HeatmapWidget.test.tsx",
+    "status": "open"
+  },
+  {
+    "commit": "Create OnboardingModal component",
+    "path": "packages/unifiedmandala-ui/components/OnboardingModal.tsx",
+    "task": "Show onboarding steps for new users",
+    "test": "packages/unifiedmandala-ui/components/OnboardingModal.test.tsx",
+    "status": "open"
+  },
+  {
+    "commit": "Create HaikuOverlay component",
+    "path": "packages/unifiedmandala-ui/components/HaikuOverlay.tsx",
+    "task": "Overlay UI with random haikus",
+    "test": "packages/unifiedmandala-ui/components/HaikuOverlay.test.tsx",
     "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6766,7 +6766,7 @@
   path: scripts/scan-todo-comments.js
   task: Extract TODO comments across repo
   test: scripts/__tests__/scan-todo-comments.test.ts
-  status: open
+  status: done
 - commit: Add sigillin-cli grep-conversations command
   path: packages/cli-tools/sigillin-cli.js
   task: Filter conversations for TODO entries
@@ -6781,7 +6781,7 @@
   path: scripts/parse-advanced-conversations.js
   task: Generate advanced ToDos from conversation dataset
   test: scripts/__tests__/parse-advanced-conversations.test.ts
-  status: open
+  status: done
 - commit: CosmicTheoryAgent gRPC REST access
   path: packages/agent/src/agents/CosmicTheoryAgent.ts
   task: Access PySR service via gRPC or REST
@@ -6798,15 +6798,15 @@
   test: packages/agent/src/routes/fourier.test.ts
   status: done
 - commit: Create FourierVisual component
-  path: packages/unifiedmandala-ui/src/components/FourierVisual.tsx
+  path: packages/unifiedmandala-ui/components/FourierVisual.tsx
   task: Render Fourier spectrum results
-  test: packages/unifiedmandala-ui/src/components/FourierVisual.test.tsx
-  status: open
+  test: packages/unifiedmandala-ui/components/FourierVisual.test.tsx
+  status: done
 - commit: Fetch real avgResonance in CREPStatsCard
-  path: packages/unifiedmandala-ui/src/components/CREPStatsCard.tsx
+  path: packages/unifiedmandala-ui/components/CREPStatsCard.tsx
   task: Load avgResonance from API and show mini chart
-  test: packages/unifiedmandala-ui/src/components/CREPStatsCard.test.tsx
-  status: open
+  test: packages/unifiedmandala-ui/components/CREPStatsCard.test.tsx
+  status: done
 - commit: Add Mandala SVG export event
   path: packages/unifiedmandala-ui/src/components/BlackboxMandala.tsx
   task: Offer SVG export or WebSocket event
@@ -7498,3 +7498,18 @@
   task: Portal to chain resonance modules
   test: packages/resonance-modules/ResonanceModulePortal.test.ts
   status: done
+- commit: Create HeatmapWidget component
+  path: packages/unifiedmandala-ui/components/HeatmapWidget.tsx
+  task: Display CREP heatmap across sessions
+  test: packages/unifiedmandala-ui/components/HeatmapWidget.test.tsx
+  status: open
+- commit: Create OnboardingModal component
+  path: packages/unifiedmandala-ui/components/OnboardingModal.tsx
+  task: Show onboarding steps for new users
+  test: packages/unifiedmandala-ui/components/OnboardingModal.test.tsx
+  status: open
+- commit: Create HaikuOverlay component
+  path: packages/unifiedmandala-ui/components/HaikuOverlay.tsx
+  task: Overlay UI with random haikus
+  test: packages/unifiedmandala-ui/components/HaikuOverlay.test.tsx
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -9,7 +9,7 @@
   "pendingTasks": [
     {
       "commit": "Add scan-todo-comments script",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add sigillin-cli grep-conversations command",
@@ -21,7 +21,7 @@
     },
     {
       "commit": "Implement parse-advanced-conversations script",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "CosmicTheoryAgent gRPC REST access",
@@ -29,11 +29,11 @@
     },
     {
       "commit": "Create FourierVisual component",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Fetch real avgResonance in CREPStatsCard",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add Mandala SVG export event",
@@ -439,6 +439,10 @@
     },
     {
       "commit": "Add ResonanceModuleDiagnostics",
+      "status": "done"
+    },
+    {
+      "commit": "Implement FourierVisual and CREPStatsCard hooks",
       "status": "done"
     }
   ]

--- a/packages/unifiedmandala-ui/components/CREPStatsCard.test.tsx
+++ b/packages/unifiedmandala-ui/components/CREPStatsCard.test.tsx
@@ -14,3 +14,11 @@ test('renders chart when history provided', () => {
   const paths = document.querySelectorAll('path');
   expect(paths.length).toBeGreaterThan(0);
 });
+
+test('fetches resonance when no value provided', async () => {
+  (global as any).fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve({ scores: [{ idx: '1', avgResonance: 0.4 }] }) })
+  );
+  render(<CREPStatsCard />);
+  await screen.findByText(/0\.40/);
+});

--- a/packages/unifiedmandala-ui/components/CREPStatsCard.tsx
+++ b/packages/unifiedmandala-ui/components/CREPStatsCard.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
+import { useAvgResonance } from '../hooks/useAvgResonance';
 import { LineChart, Line } from 'recharts';
 
 export interface CREPStatsCardProps {
-  avgResonance: number;
+  avgResonance?: number;
   history?: number[];
+  id?: string;
 }
 
 export default function CREPStatsCard({
   avgResonance,
   history = [],
+  id = '1',
 }: CREPStatsCardProps) {
+  const fetched = useAvgResonance(id);
+  const value = avgResonance ?? fetched;
   const data = history.map((val, idx) => ({ idx, val }));
   return (
     <div className="crep-stats-card">
-      <strong>Avg Resonance:</strong> {avgResonance.toFixed(2)}
+      <strong>Avg Resonance:</strong> {value.toFixed(2)}
       {history.length > 0 && (
         <LineChart
           width={120}

--- a/packages/unifiedmandala-ui/components/FourierVisual.test.tsx
+++ b/packages/unifiedmandala-ui/components/FourierVisual.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { act } from 'react-dom/test-utils';
+import FourierVisual from './FourierVisual';
+import fourierBridge from '../api/fourierBridge';
+
+(global as any).WebSocket = class {
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  close() {}
+  constructor(public url: string) {}
+};
+
+test('renders chart when metrics received', () => {
+  render(<FourierVisual />);
+  act(() => {
+    fourierBridge.emit('fourier:metrics', {
+      id: 't',
+      metrics: { maxAmplitude: 1, avgAmplitude: 0.5 },
+    });
+  });
+  expect(screen.getByLabelText('Fourier Visual')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/FourierVisual.tsx
+++ b/packages/unifiedmandala-ui/components/FourierVisual.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { BarChart, Bar, XAxis, YAxis } from 'recharts';
+import fourierBridge, { connectFourierBridge } from '../api/fourierBridge';
+
+interface MetricsData {
+  id: string;
+  metrics: { maxAmplitude: number; avgAmplitude: number };
+}
+
+export default function FourierVisual() {
+  const [data, setData] = useState<{ name: string; value: number }[]>([]);
+
+  useEffect(() => {
+    const handler = (payload: MetricsData) => {
+      setData([
+        { name: 'max', value: payload.metrics.maxAmplitude },
+        { name: 'avg', value: payload.metrics.avgAmplitude },
+      ]);
+    };
+    const ws = connectFourierBridge();
+    fourierBridge.on('fourier:metrics', handler);
+    return () => {
+      fourierBridge.off('fourier:metrics', handler);
+      (ws as any).close?.();
+    };
+  }, []);
+
+  if (!data.length) return <div>No data</div>;
+  return (
+    <BarChart width={200} height={100} data={data} aria-label="Fourier Visual">
+      <XAxis dataKey="name" />
+      <YAxis />
+      <Bar dataKey="value" fill="#8884d8" />
+    </BarChart>
+  );
+}

--- a/packages/unifiedmandala-ui/hooks/useAvgResonance.test.ts
+++ b/packages/unifiedmandala-ui/hooks/useAvgResonance.test.ts
@@ -1,0 +1,13 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useAvgResonance } from './useAvgResonance';
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({ json: () => Promise.resolve({ scores: [{ idx: '1', avgResonance: 0.8 }] }) })
+) as any;
+
+test('fetches avg resonance', async () => {
+  const { result } = renderHook(() => useAvgResonance('1', '/api/meta-scores'));
+  await waitFor(() => expect(result.current).toBeGreaterThan(0));
+  expect(result.current).toBe(0.8);
+});

--- a/packages/unifiedmandala-ui/hooks/useAvgResonance.ts
+++ b/packages/unifiedmandala-ui/hooks/useAvgResonance.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+export function useAvgResonance(idx = '1', endpoint = '/api/meta-scores') {
+  const [avg, setAvg] = useState(0);
+  useEffect(() => {
+    fetch(endpoint)
+      .then(r => r.json())
+      .then(data => {
+        const entry = data.scores.find((s: any) => s.idx === idx);
+        if (entry) setAvg(entry.avgResonance);
+      })
+      .catch(() => {});
+  }, [idx, endpoint]);
+  return avg;
+}

--- a/scripts/__tests__/parse-advanced-conversations.test.ts
+++ b/scripts/__tests__/parse-advanced-conversations.test.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+const { parseAdvancedConversations } = require('../parse-advanced-conversations');
+
+test('parseAdvancedConversations extracts TODO fragments', () => {
+  const tmpDir = fs.mkdtempSync(path.join(__dirname, 'tmp'));
+  const file = path.join(tmpDir, 'convos.json');
+  const dest = path.join(tmpDir, 'out');
+  const data = [{ msg: 'hello' }, { msg: 'TODO: test' }];
+  fs.writeFileSync(file, JSON.stringify(data));
+  const matches = parseAdvancedConversations(file, dest, 'TODO');
+  expect(matches.length).toBe(1);
+  const out = fs.readFileSync(path.join(dest, 'convos-grep.json'), 'utf8');
+  expect(out.includes('test')).toBe(true);
+  fs.rmSync(tmpDir, { recursive: true });
+});

--- a/scripts/__tests__/scan-todo-comments.test.ts
+++ b/scripts/__tests__/scan-todo-comments.test.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+
+jest.mock('../../packages/shared-utils/todoCommentScanner', () => ({
+  scanTodoComments: () => [{ text: 'todo', file: 'a.ts', line: 1 }],
+}));
+
+jest.mock('../../packages/shared-utils/todoSigilGenerator', () => ({
+  createTodoSigil: () => 'yaml',
+}));
+
+const { run } = require('../scan-todo-comments');
+
+test('writes sigil file', () => {
+  const sigil = path.join(__dirname, '../../docs/sigils/todo-sigil.yaml');
+  const spy = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+  run();
+  expect(spy).toHaveBeenCalledWith(sigil, 'yaml');
+  spy.mockRestore();
+});

--- a/scripts/parse-advanced-conversations.js
+++ b/scripts/parse-advanced-conversations.js
@@ -1,11 +1,20 @@
 const path = require('path');
 const { grepJsonArrayFile } = require('../packages/shared-utils/jsonFragmenter');
 
-const file = path.join(__dirname, '../docs/sigils/advancedconversations.json');
-const dest = path.join(__dirname, '../docs/sigils/advancedconversations');
-const keyword = process.argv[2] || 'TODO';
-const regex = new RegExp(keyword, 'i');
+function parseAdvancedConversations(filePath, destDir, keyword = 'TODO') {
+  const regex = new RegExp(keyword, 'i');
+  return grepJsonArrayFile(filePath, destDir, regex);
+}
 
-const matches = grepJsonArrayFile(file, dest, regex);
-console.log(`Parsed ${matches.length} fragments containing '${keyword}'. Output: ${dest}`);
+if (require.main === module) {
+  const file = path.join(__dirname, '../docs/sigils/advancedconversations.json');
+  const dest = path.join(__dirname, '../docs/sigils/advancedconversations');
+  const keyword = process.argv[2] || 'TODO';
+  const matches = parseAdvancedConversations(file, dest, keyword);
+  console.log(
+    `Parsed ${matches.length} fragments containing '${keyword}'. Output: ${dest}`
+  );
+}
+
+module.exports = { parseAdvancedConversations };
 


### PR DESCRIPTION
## Summary
- implement FourierVisual component with tests
- add useAvgResonance hook and integrate into CREPStatsCard
- parse advanced conversations script now exportable and tested
- scan-todo-comments script tested
- track progress and update todo lists

## Testing
- `npx pyright` *(fails: Import errors)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e9e6775548322b5cbf1cb12d0f45a