### PR TITLE
Add OnboardingModal component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6133,5 +6133,19 @@
     "task": "Outline microservice modules for resonance expansion",
     "test": "",
     "status": "done"
+  },
+  {
+    "commit": "Create OnboardingModal component",
+    "path": "packages/unifiedmandala-ui/components/OnboardingModal.tsx",
+    "task": "Show onboarding steps for new users",
+    "test": "packages/unifiedmandala-ui/components/OnboardingModal.test.tsx",
+    "status": "done"
+  },
+  {
+    "commit": "Create HaikuOverlay component",
+    "path": "packages/unifiedmandala-ui/components/HaikuOverlay.tsx",
+    "task": "Overlay UI with random haikus",
+    "test": "packages/unifiedmandala-ui/components/HaikuOverlay.test.tsx",
+    "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7507,7 +7507,7 @@
   path: packages/unifiedmandala-ui/components/OnboardingModal.tsx
   task: Show onboarding steps for new users
   test: packages/unifiedmandala-ui/components/OnboardingModal.test.tsx
-  status: open
+  status: done
 - commit: Create HaikuOverlay component
   path: packages/unifiedmandala-ui/components/HaikuOverlay.tsx
   task: Overlay UI with random haikus

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: enhance BoundaryConditionManager",
+  "lastCommit": "feat: add OnboardingModal component",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -447,6 +447,10 @@
     },
     {
       "commit": "Added Pantheon and boundary docs",
+      "status": "done"
+    },
+    {
+      "commit": "Create OnboardingModal component",
       "status": "done"
     }
   ]

--- a/packages/unifiedmandala-ui/components/OnboardingModal.test.tsx
+++ b/packages/unifiedmandala-ui/components/OnboardingModal.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import OnboardingModal from './OnboardingModal';
+
+test('walks through steps and calls onComplete', () => {
+  const onComplete = jest.fn();
+  render(<OnboardingModal open={true} steps={["Step1","Step2"]} onComplete={onComplete} />);
+  expect(screen.getByText('Step1')).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button'));
+  expect(screen.getByText('Step2')).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button'));
+  expect(onComplete).toHaveBeenCalled();
+});

--- a/packages/unifiedmandala-ui/components/OnboardingModal.tsx
+++ b/packages/unifiedmandala-ui/components/OnboardingModal.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+
+interface OnboardingModalProps {
+  open: boolean;
+  steps: string[];
+  onComplete: () => void;
+}
+
+const OnboardingModal: React.FC<OnboardingModalProps> = ({ open, steps, onComplete }) => {
+  const [index, setIndex] = useState(0);
+  if (!open) return null;
+  const next = () => {
+    if (index < steps.length - 1) {
+      setIndex(index + 1);
+    } else {
+      onComplete();
+    }
+  };
+  return (
+    <div role="dialog" aria-modal="true" className="onboarding-modal">
+      <p>{steps[index]}</p>
+      <button onClick={next}>{index < steps.length - 1 ? 'Weiter' : 'Fertig'}</button>
+    </div>
+  );
+};
+
+export default OnboardingModal;


### PR DESCRIPTION
## Summary
- create `OnboardingModal` React component with basic step flow
- add matching test
- mark OnboardingModal task done in `advancedToDo.yaml` and add entries in `advancedToDo.json`
- update `advancedprogress.json` with latest commit info

## Testing
- `pnpm install`
- `npx --yes pyright` *(fails: missing modules)*
- `npx --yes tsc -p tsconfig.json`
- `pnpm test packages/unifiedmandala-ui/components/OnboardingModal.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_687f87c2550883228c631b2b0f92cd93