### PR TITLE
Add grep-todos CLI and update advanced docs

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-22, in der Zeit des Tag.
+Am 2025-07-22, in der Zeit des Abend.
 
-Symbolphase: Aktivierung (Fokus: R)
+Symbolphase: Integration (Fokus: E)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6182,5 +6182,33 @@
     "task": "Provide shared types and utility functions",
     "test": "packages/common/index.test.ts",
     "status": "open"
+  },
+  {
+    "commit": "CosmicTheoryAgent blueprint documentation",
+    "path": "docs/cosmic/CosmicTheoryAgent-Blueprint.md",
+    "task": "Summarize code extension ideas from conversations",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Sigillin Mandala Fraktal design doc",
+    "path": "docs/mandala/Sigillin-Fractal-Design.md",
+    "task": "Outline fractal sigil architecture from chat logs",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "AeonAI Pyramid-UI specification",
+    "path": "docs/pyramid/AeonAI-Pyramid-UI-Spec.md",
+    "task": "Document UI blueprint from planning discussion",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Extended Resonanzmodule integration guide",
+    "path": "docs/resonance/ExtendedResonanzmodule-Overview.md",
+    "task": "Detail integration of advanced resonance modules",
+    "test": "",
+    "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6771,7 +6771,7 @@
   path: packages/cli-tools/sigillin-cli.js
   task: Filter conversations for TODO entries
   test: packages/cli-tools/__tests__/sigillin-cli.test.ts
-  status: open
+  status: done
 - commit: Implement go todo_parser server
   path: go-bridge/cmd/todo_parser.go
   task: Start TODO parser service for Go tasks
@@ -7537,4 +7537,24 @@
   path: packages/common/index.ts
   task: Provide shared types and utility functions
   test: packages/common/index.test.ts
+  status: open
+- commit: CosmicTheoryAgent blueprint documentation
+  path: docs/cosmic/CosmicTheoryAgent-Blueprint.md
+  task: Summarize code extension ideas from conversations
+  test: ""
+  status: open
+- commit: Sigillin Mandala Fraktal design doc
+  path: docs/mandala/Sigillin-Fractal-Design.md
+  task: Outline fractal sigil architecture from chat logs
+  test: ""
+  status: open
+- commit: AeonAI Pyramid-UI specification
+  path: docs/pyramid/AeonAI-Pyramid-UI-Spec.md
+  task: Document UI blueprint from planning discussion
+  test: ""
+  status: open
+- commit: Extended Resonanzmodule integration guide
+  path: docs/resonance/ExtendedResonanzmodule-Overview.md
+  task: Detail integration of advanced resonance modules
+  test: ""
   status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: update progress and todo",
+  "lastCommit": "chore: update progress",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -7,10 +7,6 @@
   "mergeConflicts": [],
   "notes": "Improved rule detection with regex support",
   "pendingTasks": [
-    {
-      "commit": "Add sigillin-cli grep-conversations command",
-      "status": "open"
-    },
     {
       "commit": "Implement go todo_parser server",
       "status": "open"
@@ -289,6 +285,22 @@
     },
     {
       "commit": "Add common utilities package",
+      "status": "open"
+    },
+    {
+      "commit": "CosmicTheoryAgent blueprint documentation",
+      "status": "open"
+    },
+    {
+      "commit": "Sigillin Mandala Fraktal design doc",
+      "status": "open"
+    },
+    {
+      "commit": "AeonAI Pyramid-UI specification",
+      "status": "open"
+    },
+    {
+      "commit": "Extended Resonanzmodule integration guide",
       "status": "open"
     }
   ],

--- a/docs/cosmic/CosmicTheoryAgent-Blueprint.md
+++ b/docs/cosmic/CosmicTheoryAgent-Blueprint.md
@@ -1,0 +1,3 @@
+# CosmicTheoryAgent Blueprint
+
+Placeholder for extracted code extension plans.

--- a/docs/mandala/Sigillin-Fractal-Design.md
+++ b/docs/mandala/Sigillin-Fractal-Design.md
@@ -1,0 +1,3 @@
+# Sigillin Mandala Fractal Design
+
+Placeholder for fractal sigil architecture.

--- a/docs/pyramid/AeonAI-Pyramid-UI-Spec.md
+++ b/docs/pyramid/AeonAI-Pyramid-UI-Spec.md
@@ -1,0 +1,3 @@
+# AeonAI Pyramid UI Specification
+
+Placeholder for UI blueprint from planning discussions.

--- a/docs/resonance/ExtendedResonanzmodule-Overview.md
+++ b/docs/resonance/ExtendedResonanzmodule-Overview.md
@@ -1,0 +1,3 @@
+# Extended Resonanzmodule Overview
+
+Placeholder for advanced resonance module integration details.

--- a/packages/cli-tools/__tests__/sigillin-cli.test.ts
+++ b/packages/cli-tools/__tests__/sigillin-cli.test.ts
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+describe('grep-todos command', () => {
+  const tmpDir = path.join(__dirname, '__tmp__');
+  const sample = path.join(tmpDir, 'conv.json');
+
+  beforeAll(() => {
+    if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
+    fs.writeFileSync(sample, JSON.stringify([{text:'hi'},{text:'TODO: do'}]));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('extracts TODO items', () => {
+    const cli = path.resolve(__dirname, '..', 'sigillin-cli.js');
+    execSync(`npx ts-node ${cli} grep-todos -i ${sample} -o ${tmpDir}`);
+    const out = JSON.parse(fs.readFileSync(path.join(tmpDir, 'conv-grep.json'), 'utf8'));
+    expect(out.length).toBe(1);
+    expect(out[0].text).toContain('TODO');
+  });
+});

--- a/packages/cli-tools/sigillin-cli.js
+++ b/packages/cli-tools/sigillin-cli.js
@@ -212,6 +212,25 @@ program
     console.log(`Filtered ${matches.length} items containing '${keyword}'. Output: ${dest}`);
   });
 
+program
+  .command('grep-todos')
+  .option('-i, --input <file>', 'Eingabedatei', '../../docs/sigils/newadvancedconversations.json')
+  .option('-o, --output <dir>', 'Zielordner', '../../docs/sigils/todo_conversations')
+  .description('Extrahiert alle Gespr\xE4chseintr\xE4ge mit TODO-Vermerken')
+  .action((opts) => {
+    const path = require('path');
+    let grepJsonArrayFile;
+    try {
+      ({ grepJsonArrayFile } = require('../../dist/shared-utils/jsonFragmenter.js'));
+    } catch {
+      ({ grepJsonArrayFile } = require('../shared-utils/jsonFragmenter'));
+    }
+    const file = path.isAbsolute(opts.input) ? opts.input : path.join(__dirname, opts.input);
+    const dest = path.isAbsolute(opts.output) ? opts.output : path.join(__dirname, '../../', opts.output);
+    const matches = grepJsonArrayFile(file, dest, /TODO/i);
+    console.log(`Filtered ${matches.length} TODO items. Output: ${dest}`);
+  });
+
 if (require.main === module) {
   program.parse(process.argv);
 }


### PR DESCRIPTION
## Summary
- implement `grep-todos` command in `sigillin-cli`
- add tests for the new command
- document blueprint placeholders for CosmicTheoryAgent, Sigillin Fractal, Pyramid UI and Resonanzmodule
- update advanced todo lists and progress tracking

## Testing
- `npx -y pyright` *(fails: 40 errors)*
- `npx -y tsc -p tsconfig.json` *(fails: missing node types)*
- `pnpm install --frozen-lockfile`
- `pnpm test packages/cli-tools/__tests__/sigillin-cli.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_687fd69b22e08322851fe3f24a7254e0