### PR TITLE
Add VR Pantheon concept and resonance docs

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -278,7 +278,7 @@ packages/
   ├── art                 # Sonification & AI-Art
   ├── shared-utils              # Hilfsfunktionen für alle Pakete
   │   └── RestClient.ts         # einfacher REST-Helper
-  ├── bio                      # Biometrische Hooks und HapticService
+  ├── common                # Gemeinsame Hilfsfunktionen (clamp, shuffle)
   ├── TonePlayground.ts        # Experimentelle Tone.js-Steuerung
   ├── go-bridge             # Go-Client für REST, gRPC und NATS (inkl. GPTBridge)
   ├── go-agent              # Autonomer Go-Daemon für Tasks
@@ -332,6 +332,7 @@ scripts/
 
 Jeder Unterordner kann eine eigene README enthalten – siehe die Links in den jeweiligen Verzeichnissen.
 Utilities liegen in `packages/shared-utils/`, weitere Module findest du ebenfalls unter `packages/`.
+Zusätzliche Utilities bietet `packages/common`.
 -### 🟦 Go-Bridge (go-bridge/)
 - Polyglottes Interface zu UnifiedMandala für Go (REST, NATS, gRPC, CLI)
 - Enthält **GPTBridge**-Module (`pkg/gpt`) und die Beispiel-CLIs `mandala-gpt.go`

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**EventBridge**](packages/unifiedmandala-ui/events/EventBridge.ts) – verbindet CosmicTheoryAgent mit der Pyramid UI
 - [**PyramidVRMeetingRoom**](packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.tsx) – enables multi-avatar VR sessions
 - CosmicTheoryAgent now exposes **VR hooks** for immersive interactions
+- [**VR Pantheon Konzept**](docs/pantheon/VR-Begegnungsraum-Concept.md) – Konzept für kollaborative Treffen
 - [**PySR Service Client**](packages/agents/CosmicTheoryAgent.ts) – Regression via REST/gRPC
 - [**Sigil Archive Service**](services/sigil-archive/index.ts) – speichert Sigille und CREP-Fragmente
 - [**CREPVisualizer**](packages/unifiedmandala-ui/components/CREPVisualizer.tsx) – animierte Timeline der Mandala-Kristalle
@@ -65,6 +66,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**Plugin-Registry & Dynamic Loader**](plugins/manifest.yaml) – `usePluginLoader` lädt jetzt YAML- und JSON-Manifeste
 - [**Objective2UI**](packages/unifiedmandala-ui/components/ObjectiveLayoutSuggester.tsx) – generiert Layout-Vorschläge via GPT
 - [**Ethik-Governance & Heimkehr-Deklaration**](docs/sigils/sigillin_heimkehr.md) – Offene, poetische Ethik als Systembasis
+- [**Advanced Resonanzmodule Plan**](docs/resonance/AdvancedResonanzModulePlan.md) – Fahrplan für kommende Erweiterungen
 - [**Poesie & Automation**](aeon.sh) – Bash-Interface, automatisches Chronopoem, symbolisches Onboarding
 - [**DocCommentsGenerator**](scripts/doc-comments-generator.ts) – erzeugt Markdown-Doku
 - [**ArchiveOldTodos**](scripts/archive-old-todos.ts) – verschiebt erledigte ToDos ins ZIPMEM
@@ -270,6 +272,7 @@ scripts/
 
 Jeder Unterordner kann eine eigene README enthalten – siehe die Links in den jeweiligen Verzeichnissen.
 Utilities liegen in `packages/shared-utils/`, weitere Module findest du ebenfalls unter `packages/`.
+Zusätzliche gemeinsame Funktionen befinden sich im Paket `packages/common`.
 Kurze Beschreibungen findest du nun direkt in den READMEs der Pakete
 `bio`, `codex-navigator`, `collab-editor`, `core`, `crep-automation`,
 `event-bus`, `nukleon-scanner`, `nukleon-sonifier`, `sharedream-interface`,

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6167,48 +6167,48 @@
     "path": "docs/pantheon/VR-Begegnungsraum-Concept.md",
     "task": "Extract VR meeting space design ideas from conversations",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Extended Resonanzmodule roadmap",
     "path": "docs/resonance/AdvancedResonanzModulePlan.md",
     "task": "Plan advanced resonance modules and integration points",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add common utilities package",
     "path": "packages/common/index.ts",
     "task": "Provide shared types and utility functions",
     "test": "packages/common/index.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "CosmicTheoryAgent blueprint documentation",
     "path": "docs/cosmic/CosmicTheoryAgent-Blueprint.md",
     "task": "Summarize code extension ideas from conversations",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Sigillin Mandala Fraktal design doc",
     "path": "docs/mandala/Sigillin-Fractal-Design.md",
     "task": "Outline fractal sigil architecture from chat logs",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "AeonAI Pyramid-UI specification",
     "path": "docs/pyramid/AeonAI-Pyramid-UI-Spec.md",
     "task": "Document UI blueprint from planning discussion",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Extended Resonanzmodule integration guide",
     "path": "docs/resonance/ExtendedResonanzmodule-Overview.md",
     "task": "Detail integration of advanced resonance modules",
     "test": "",
-    "status": "open"
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7527,34 +7527,34 @@
   path: docs/pantheon/VR-Begegnungsraum-Concept.md
   task: Extract VR meeting space design ideas from conversations
   test: ""
-  status: open
+  status: done
 - commit: Extended Resonanzmodule roadmap
   path: docs/resonance/AdvancedResonanzModulePlan.md
   task: Plan advanced resonance modules and integration points
   test: ""
-  status: open
+  status: done
 - commit: Add common utilities package
   path: packages/common/index.ts
   task: Provide shared types and utility functions
   test: packages/common/index.test.ts
-  status: open
+  status: done
 - commit: CosmicTheoryAgent blueprint documentation
   path: docs/cosmic/CosmicTheoryAgent-Blueprint.md
   task: Summarize code extension ideas from conversations
   test: ""
-  status: open
+  status: done
 - commit: Sigillin Mandala Fraktal design doc
   path: docs/mandala/Sigillin-Fractal-Design.md
   task: Outline fractal sigil architecture from chat logs
   test: ""
-  status: open
+  status: done
 - commit: AeonAI Pyramid-UI specification
   path: docs/pyramid/AeonAI-Pyramid-UI-Spec.md
   task: Document UI blueprint from planning discussion
   test: ""
-  status: open
+  status: done
 - commit: Extended Resonanzmodule integration guide
   path: docs/resonance/ExtendedResonanzmodule-Overview.md
   task: Detail integration of advanced resonance modules
   test: ""
-  status: open
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -274,34 +274,6 @@
     {
       "commit": "Create BoundaryLawPatternGenerator",
       "status": "open"
-    },
-    {
-      "commit": "Document VR Pantheon Begegnungsraum Concept",
-      "status": "open"
-    },
-    {
-      "commit": "Extended Resonanzmodule roadmap",
-      "status": "open"
-    },
-    {
-      "commit": "Add common utilities package",
-      "status": "open"
-    },
-    {
-      "commit": "CosmicTheoryAgent blueprint documentation",
-      "status": "open"
-    },
-    {
-      "commit": "Sigillin Mandala Fraktal design doc",
-      "status": "open"
-    },
-    {
-      "commit": "AeonAI Pyramid-UI specification",
-      "status": "open"
-    },
-    {
-      "commit": "Extended Resonanzmodule integration guide",
-      "status": "open"
     }
   ],
   "progress": [

--- a/docs/cosmic/CosmicTheoryAgent-Blueprint.md
+++ b/docs/cosmic/CosmicTheoryAgent-Blueprint.md
@@ -1,3 +1,9 @@
 # CosmicTheoryAgent Blueprint
 
-Placeholder for extracted code extension plans.
+Die Gespräche im Abschnitt "CosmicTheoryAgent Code Erweiterung" skizzieren eine modulare Erweiterung des Agents. Wichtige Punkte:
+
+- **HypothesisGPT** dient als Systemdenker und liefert alternative Ansätze.
+- **Interface-Forschung** verknüpft Pantheon- und Boundary-Module über einen gRPC Layer.
+- **Fehlerfreundlicher Workflow**: Jede Anomalie wird als Impuls für neue Features betrachtet.
+- **Resonanzanalyse**: FourierLayer und CREP-Scanner liefern Daten an den Agenten, der daraus ToDos generiert.
+- **Zukunftsaussicht**: Integration in die VR-Begegnungsräume und Verwendung des common-Utility-Pakets.

--- a/docs/mandala/Sigillin-Fractal-Design.md
+++ b/docs/mandala/Sigillin-Fractal-Design.md
@@ -1,3 +1,9 @@
 # Sigillin Mandala Fractal Design
 
-Placeholder for fractal sigil architecture.
+Dieses Dokument fasst die Ideen aus "Sigillin Mandala Fraktal" zusammen.
+
+- Sigillin werden in verschachtelten Ebenen gespeichert und können rekursiv erzeugt werden.
+- Jede Ebene enthält Meta-Informationen (CREP-Wert, Ursprungssigil, Update-Zeit).
+- Ein Parser generiert aus ZIP-Memory-Dateien neue Fraktal-Sigel.
+- Die Struktur ermöglicht MetaCommits: Jeder Commit enthält Verweise auf vorherige Ebenen.
+- Ziel ist ein leichtgewichtiges, aber erweiterbares Format für kollektive Sigillin.

--- a/docs/pantheon/VR-Begegnungsraum-Concept.md
+++ b/docs/pantheon/VR-Begegnungsraum-Concept.md
@@ -1,0 +1,13 @@
+# VR Pantheon Begegnungsraum Concept
+
+Dieses Dokument fasst die Ideen aus den Gesprächen „CosmicTheoryAgent Code Erweiterung“ und „AeonAI Pyramid-UI Konzept“ zusammen. Ziel ist ein virtueller Raum, in dem Avatare gemeinsam an Sigillin und Resonanzmodulen arbeiten können.
+
+## Kernpunkte
+
+- **Fraktales Meeting**: Der Raum ist als kreisförmiges Mandala aufgebaut. Jedes Segment repräsentiert ein Modul (Pantheon, Boundary, CREP-Analyse).
+- **Gemeinsame Interaktion**: Avatare können Sigillin platzieren, Kommentare hinterlassen und via Voice-Chat interagieren.
+- **Resonanz-Feedback**: Eine Heatmap zeigt die aktuelle CREP-Intensität an. Höhere Werte lassen die Umgebung pulsieren.
+- **Grenzregeln**: Boundary-Regeln verhindern missbräuchliche Aktionen. EthicsGuard prüft Inhalte in Echtzeit.
+- **Export**: Sitzungen können als Sigil-Bundles exportiert und im Repository versioniert werden.
+
+Dieses Konzept bildet die Grundlage für weitere Implementierungen im Paket `unifiedmandala-vr`.

--- a/docs/pyramid/AeonAI-Pyramid-UI-Spec.md
+++ b/docs/pyramid/AeonAI-Pyramid-UI-Spec.md
@@ -1,3 +1,11 @@
 # AeonAI Pyramid UI Specification
 
-Placeholder for UI blueprint from planning discussions.
+Die Pyramid-UI vereint zwei Ebenen:
+
+1. **Obere Hälfte**: Visualisiert CREP-Werte und Sigillin in einer dynamischen Ansicht.
+2. **Untere Hälfte**: Stellt Benutzeraktionen dar und verbindet sie mit Resonanzmodulen.
+
+Weitere Merkmale:
+- Responsive Layout für VR und Web.
+- Schnittstelle zum CosmicTheoryAgent über gRPC.
+- Nutzung der Utilities aus `packages/common` für Datenformatierung.

--- a/docs/resonance/AdvancedResonanzModulePlan.md
+++ b/docs/resonance/AdvancedResonanzModulePlan.md
@@ -1,0 +1,17 @@
+# Advanced Resonanzmodule Roadmap
+
+Basierend auf den Diskussionen in `newadvancedconversations.json` sollen die Resonanzmodule in mehreren Phasen erweitert werden.
+
+## Phase 1
+- Konsolidierung der bestehenden Module aus `ExtendedResonanceModules.md`.
+- Aufbau gemeinsamer Utilities über `packages/common`.
+
+## Phase 2
+- Einbindung von BioSensorGateway und CreativeDreamer in die VR-Begegnungsräume.
+- Synchronisierung der CREP-Daten via EventBus.
+
+## Phase 3
+- Ein modulares Plugin-System erlaubt das Nachladen neuer Resonanz-Algorithmen.
+- Dokumentation der Schnittstellen im `ExtendedResonanzmodule-Overview.md`.
+
+Diese Roadmap dient als Orientierung für kommende Implementierungen.

--- a/docs/resonance/ExtendedResonanzmodule-Overview.md
+++ b/docs/resonance/ExtendedResonanzmodule-Overview.md
@@ -1,3 +1,17 @@
 # Extended Resonanzmodule Overview
 
-Placeholder for advanced resonance module integration details.
+Dieses Dokument beschreibt die Integration der erweiterten Resonanzmodule in das UnifiedMandala.
+
+## Module
+1. **CoherenceAgent** – Bewertet Konsistenz und Struktur.
+2. **ArchetypeAnalyzer** – Erkennt archetypische Muster.
+3. **EthicGuardian** – Überprüft Inhalte auf Ethikverstöße.
+4. **CreativeDreamer** – Generiert kreative Impulse.
+5. **MemeChronicle** – Analysiert Memetik und Narrative.
+6. **SelfReflection** – Reflektiert Nutzerinteraktionen.
+7. **Synchronizer** – Synchronisiert Datenströme.
+8. **BioSensorGateway** – Bindet biometrische Daten ein.
+9. **FractalAuditTrail** – Zeichnet Ereignisse fraktal auf.
+10. **CREPPluginAPI** – Ermöglicht externe Erweiterungen.
+
+Die Module kommunizieren über REST oder gRPC. Gemeinsame Typen befinden sich im Paket `packages/common`.

--- a/packages/common/index.test.ts
+++ b/packages/common/index.test.ts
@@ -1,8 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { sum } from './index';
+import { sum, clamp, unique, shuffle } from './index';
 
 describe('common utils', () => {
   it('sums numbers', () => {
-    expect(sum(1,2)).toBe(3);
+    expect(sum(1, 2)).toBe(3);
+  });
+
+  it('clamps values', () => {
+    expect(clamp(5, 0, 3)).toBe(3);
+  });
+
+  it('returns unique items', () => {
+    expect(unique([1, 1, 2]).length).toBe(2);
+  });
+
+  it('shuffles array', () => {
+    const arr = [1, 2, 3];
+    const shuffled = shuffle(arr);
+    expect(shuffled).toHaveLength(3);
   });
 });

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -1,3 +1,15 @@
-export function sum(a: number, b: number) {
+export function sum(a: number, b: number): number {
   return a + b;
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function unique<T>(arr: T[]): T[] {
+  return Array.from(new Set(arr));
+}
+
+export function shuffle<T>(arr: T[]): T[] {
+  return arr.slice().sort(() => Math.random() - 0.5);
 }


### PR DESCRIPTION
## Summary
- document VR Pantheon Begegnungsraum concept and resonance roadmap
- expand CosmicTheoryAgent, Sigillin fractal design and Pyramid UI specs
- add common utilities with clamp, unique and shuffle helpers
- update ToDo status and progress log
- mention new docs and package in README and Handbuch

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687fdee2a1b8832283d4dfb5938f71ec