### PR TITLE
Add BlackboxMandala export event

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5173,7 +5173,7 @@
     "path": "packages/unifiedmandala-ui/src/components/BlackboxMandala.tsx",
     "task": "Offer SVG export or WebSocket event",
     "test": "packages/unifiedmandala-ui/src/components/BlackboxMandala.test.tsx",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add PhanteonIntegration service",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6811,7 +6811,7 @@
   path: packages/unifiedmandala-ui/src/components/BlackboxMandala.tsx
   task: Offer SVG export or WebSocket event
   test: packages/unifiedmandala-ui/src/components/BlackboxMandala.test.tsx
-  status: open
+  status: done
 - commit: Add PhanteonIntegration service
   path: packages/phanteon/PhanteonIntegrator.ts
   task: Integrate Pantheon modules into system

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -17,7 +17,7 @@
     },
     {
       "commit": "Add Mandala SVG export event",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add PhanteonIntegration service",
@@ -367,6 +367,10 @@
     },
     {
       "commit": "Extended Resonance VR module with Fourier",
+      "status": "done"
+    },
+    {
+      "commit": "Add Mandala SVG export event",
       "status": "done"
     }
   ]

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -35,3 +35,4 @@ export { default as PantheonLobbyUI } from './components/PantheonLobbyUI';
 export { default as RuleExplorer } from './components/RuleExplorer';
 export { default as HeatmapWidget } from './components/HeatmapWidget';
 export { default as HaikuOverlay } from './components/HaikuOverlay';
+export { default as BlackboxMandala } from './src/components/BlackboxMandala';

--- a/packages/unifiedmandala-ui/src/components/BlackboxMandala.test.tsx
+++ b/packages/unifiedmandala-ui/src/components/BlackboxMandala.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import BlackboxMandala from './BlackboxMandala';
+
+test('dispatches export event', () => {
+  const handler = jest.fn();
+  window.addEventListener('mandala:export', handler);
+  render(<BlackboxMandala />);
+  fireEvent.click(screen.getByText('Export'));
+  expect(handler).toHaveBeenCalled();
+  window.removeEventListener('mandala:export', handler);
+});

--- a/packages/unifiedmandala-ui/src/components/BlackboxMandala.tsx
+++ b/packages/unifiedmandala-ui/src/components/BlackboxMandala.tsx
@@ -1,0 +1,21 @@
+import React, { useRef } from 'react';
+
+export default function BlackboxMandala() {
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const handleExport = () => {
+    if (!svgRef.current) return;
+    const svgString = new XMLSerializer().serializeToString(svgRef.current);
+    const event = new CustomEvent('mandala:export', { detail: svgString });
+    window.dispatchEvent(event);
+  };
+
+  return (
+    <div>
+      <svg ref={svgRef} width={200} height={200} aria-label="Blackbox Mandala">
+        <circle cx="100" cy="100" r="80" fill="#111" stroke="#0ff" />
+      </svg>
+      <button onClick={handleExport}>Export</button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement BlackboxMandala component to emit SVG export event
- add corresponding tests
- export component in unifiedmandala-ui index
- mark task as done in advancedToDo files and progress tracker

## Testing
- `npx -y pyright`
- `npx -y tsc -p tsconfig.json`
- `pnpm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687fede7342883229880987d6e9f60d2