### PR TITLE
Implement Mandala SVG export event

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5173,7 +5173,7 @@
     "path": "packages/unifiedmandala-ui/src/components/BlackboxMandala.tsx",
     "task": "Offer SVG export or WebSocket event",
     "test": "packages/unifiedmandala-ui/src/components/BlackboxMandala.test.tsx",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add PhanteonIntegration service",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6811,7 +6811,7 @@
   path: packages/unifiedmandala-ui/src/components/BlackboxMandala.tsx
   task: Offer SVG export or WebSocket event
   test: packages/unifiedmandala-ui/src/components/BlackboxMandala.test.tsx
-  status: open
+  status: done
 - commit: Add PhanteonIntegration service
   path: packages/phanteon/PhanteonIntegrator.ts
   task: Integrate Pantheon modules into system

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -17,7 +17,7 @@
     },
     {
       "commit": "Add Mandala SVG export event",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add PhanteonIntegration service",

--- a/packages/unifiedmandala-ui/components/BlackboxMandala.test.tsx
+++ b/packages/unifiedmandala-ui/components/BlackboxMandala.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import BlackboxMandala from './BlackboxMandala';
+import MandalaEventBridge from '../events/MandalaEventBridge';
+
+beforeAll(() => {
+  // jsdom doesn't implement createObjectURL
+  (global as any).URL.createObjectURL = jest.fn();
+  (global as any).URL.revokeObjectURL = jest.fn();
+});
+
+test('emits svg export event', () => {
+  const handler = jest.fn();
+  MandalaEventBridge.on('mandala:export-svg', handler);
+  const { getByText } = render(<BlackboxMandala />);
+  fireEvent.click(getByText('Export SVG'));
+  expect(handler).toHaveBeenCalled();
+  MandalaEventBridge.off('mandala:export-svg', handler);
+});

--- a/packages/unifiedmandala-ui/components/BlackboxMandala.tsx
+++ b/packages/unifiedmandala-ui/components/BlackboxMandala.tsx
@@ -1,0 +1,40 @@
+import React, { useRef } from 'react';
+import MandalaEventBridge from '../events/MandalaEventBridge';
+
+const BlackboxMandala: React.FC = () => {
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const handleExportSVG = () => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const serializer = new XMLSerializer();
+    const source = serializer.serializeToString(svg);
+    const blob = new Blob([source], { type: 'image/svg+xml' });
+    MandalaEventBridge.emit('mandala:export-svg', { svg: source });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'blackbox-mandala.svg';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="flex flex-col items-center">
+      <svg
+        ref={svgRef}
+        width={200}
+        height={200}
+        viewBox="0 0 100 100"
+        aria-label="Blackbox Mandala"
+      >
+        <circle cx="50" cy="50" r="40" stroke="#000" fill="none" />
+      </svg>
+      <button onClick={handleExportSVG} className="mt-2 p-2 bg-gray-700 text-white">
+        Export SVG
+      </button>
+    </div>
+  );
+};
+
+export default BlackboxMandala;

--- a/packages/unifiedmandala-ui/events/MandalaEventBridge.ts
+++ b/packages/unifiedmandala-ui/events/MandalaEventBridge.ts
@@ -1,0 +1,13 @@
+import mitt from 'mitt';
+
+export type MandalaEventMap = {
+  'mandala:export-svg': { svg: string };
+};
+
+const emitter = mitt<MandalaEventMap>();
+
+export default {
+  on: emitter.on,
+  off: emitter.off,
+  emit: emitter.emit,
+};

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -35,3 +35,4 @@ export { default as PantheonLobbyUI } from './components/PantheonLobbyUI';
 export { default as RuleExplorer } from './components/RuleExplorer';
 export { default as HeatmapWidget } from './components/HeatmapWidget';
 export { default as HaikuOverlay } from './components/HaikuOverlay';
+export { default as BlackboxMandala } from './components/BlackboxMandala';


### PR DESCRIPTION
## Summary
- add `MandalaEventBridge` emitter
- create `BlackboxMandala` component with SVG export and event emission
- test BlackboxMandala component
- export new component in UI package
- mark related advanced ToDo entries as done

## Testing
- `npx -y pyright` *(fails: Import errors)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*
- `poetry install --with test` *(fails: no pyproject found)*
- `pnpm install`
- `pnpm test packages/unifiedmandala-ui/components/BlackboxMandala.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68808587068c8322a1e96d02e89a1722