### PR TITLE
Implement agent skeleton generator script

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,7 +1,7 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-22, in der Zeit des Abend.
+Am 2025-07-23, in der Zeit des Abend.
 
 Symbolphase: Integration (Fokus: E)
 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5481,7 +5481,7 @@
     "path": "scripts/init-agent-service.ts",
     "task": "Generate service skeleton for Pantheon agents",
     "test": "scripts/__tests__/init-agent-service.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create RuleRegistryService",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7051,7 +7051,7 @@
   path: scripts/init-agent-service.ts
   task: Generate service skeleton for Pantheon agents
   test: scripts/__tests__/init-agent-service.test.ts
-  status: open
+  status: done
 - commit: Create RuleRegistryService
   path: packages/boundary-engine/rule_registry_service/registry_api.ts
   task: REST API to persist boundary rules

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #771 from GenesisAeon/zrvdcv-codex/implement-features-from-advancedtodo.yaml-and-json",
+  "lastCommit": "chore: update progress",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -24,22 +24,6 @@
       "status": "open"
     },
     {
-      "commit": "Create AvatarManager module",
-      "status": "done"
-    },
-    {
-      "commit": "Create EthicsGuard module",
-      "status": "done"
-    },
-    {
-      "commit": "Create FourierLayerBridge",
-      "status": "done"
-    },
-    {
-      "commit": "Create CREPIntegration module",
-      "status": "done"
-    },
-    {
       "commit": "Create MandalaScene component",
       "status": "open"
     },
@@ -50,14 +34,6 @@
     {
       "commit": "Create UIControls component",
       "status": "open"
-    },
-    {
-      "commit": "Add safety utilities",
-      "status": "done"
-    },
-    {
-      "commit": "Create VR package scaffold",
-      "status": "done"
     },
     {
       "commit": "Create BoundaryDiscoveryAgent",
@@ -93,10 +69,6 @@
     },
     {
       "commit": "Pantheon EventBus migration",
-      "status": "open"
-    },
-    {
-      "commit": "Agent skeleton generator script",
       "status": "open"
     },
     {

--- a/scripts/__tests__/init-agent-service.test.ts
+++ b/scripts/__tests__/init-agent-service.test.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import { createAgentService } from '../init-agent-service';
+
+const TMP_DIR = 'tmp-test-agent';
+
+afterEach(() => {
+  fs.rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+describe('createAgentService', () => {
+  it('creates agent service skeleton', () => {
+    const file = createAgentService('TestAgent', TMP_DIR);
+    expect(fs.existsSync(file)).toBe(true);
+    const content = fs.readFileSync(file, 'utf8');
+    expect(content).toMatch('class TestAgent');
+  });
+});

--- a/scripts/init-agent-service.ts
+++ b/scripts/init-agent-service.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+
+export function createAgentService(name: string, baseDir = 'packages/pantheon/agents'): string {
+  const className = name.replace(/[^a-zA-Z0-9]/g, '')
+    .replace(/^[a-z]/, c => c.toUpperCase());
+  const dir = path.join(baseDir, name);
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, 'index.ts');
+  const content = `export class ${className} {\n  constructor() {}\n  init() {\n    // TODO: implement agent logic\n  }\n}\n`;
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
+
+if (require.main === module) {
+  const [name] = process.argv.slice(2);
+  if (!name) {
+    console.error('Usage: ts-node init-agent-service.ts <AgentName>');
+    process.exit(1);
+  }
+  const created = createAgentService(name);
+  console.log(`Created ${created}`);
+}


### PR DESCRIPTION
## Summary
- add `init-agent-service.ts` to scaffold Pantheon agent services
- test agent skeleton creation
- mark todo as done in advancedToDo files

## Testing
- `npx pyright -p tsconfig.json` *(fails: 35 errors)*
- `npx tsc -p tsconfig.json`
- `pnpm test scripts/__tests__/init-agent-service.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6881397edf7883228d0df61c47490fa9