### PR TITLE
Implement resonance modules

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6378,7 +6378,7 @@
     "commit": "Add ResonanceAutoTuner",
     "path": "packages/resonance-modules/ResonanceAutoTuner.ts",
     "task": "Auto adjust resonance parameters based on feedback",
-    "status": "open",
+    "status": "done",
     "test": "packages/resonance-modules/ResonanceAutoTuner.test.ts"
   },
   {
@@ -6386,7 +6386,7 @@
     "commit": "ResonanceFeedbackModule",
     "path": "packages/resonance-modules/ResonanceFeedbackModule.ts",
     "task": "Collect user resonance feedback for analysis",
-    "status": "open",
+    "status": "done",
     "test": "packages/resonance-modules/ResonanceFeedbackModule.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7685,11 +7685,11 @@
   commit: Add ResonanceAutoTuner
   path: packages/resonance-modules/ResonanceAutoTuner.ts
   task: Auto adjust resonance parameters based on feedback
-  status: open
+  status: done
   test: packages/resonance-modules/ResonanceAutoTuner.test.ts
 - category: Erweiterte Resonanzmodule
   commit: ResonanceFeedbackModule
   path: packages/resonance-modules/ResonanceFeedbackModule.ts
   task: Collect user resonance feedback for analysis
-  status: open
+  status: done
   test: packages/resonance-modules/ResonanceFeedbackModule.test.ts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -229,7 +229,7 @@
     },
     {
       "commit": "ResonanceFeedbackModule",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add FrequencyMandala3D component",
@@ -261,7 +261,7 @@
     },
     {
       "commit": "Add ResonanceAutoTuner",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Create BoundaryLawPatternGenerator",
@@ -387,6 +387,10 @@
     },
     {
       "commit": "Implement go todo_parser server",
+      "status": "done"
+    },
+    {
+      "commit": "Implemented ResonanceAutoTuner and FeedbackModule",
       "status": "done"
     }
   ]

--- a/packages/resonance-modules/ResonanceAutoTuner.ts
+++ b/packages/resonance-modules/ResonanceAutoTuner.ts
@@ -1,0 +1,15 @@
+export interface ResonanceParameters {
+  frequency: number;
+  intensity: number;
+}
+
+export class ResonanceAutoTuner {
+  tune(params: ResonanceParameters, feedback: number[]): ResonanceParameters {
+    if (feedback.length === 0) return params;
+    const avg = feedback.reduce((a, b) => a + b, 0) / feedback.length;
+    return {
+      frequency: params.frequency * (1 + avg),
+      intensity: params.intensity * (1 + avg / 2)
+    };
+  }
+}

--- a/packages/resonance-modules/ResonanceFeedbackModule.ts
+++ b/packages/resonance-modules/ResonanceFeedbackModule.ts
@@ -1,0 +1,12 @@
+export class ResonanceFeedbackModule {
+  private feedback: number[] = [];
+
+  record(value: number) {
+    this.feedback.push(value);
+  }
+
+  average(): number {
+    if (this.feedback.length === 0) return 0;
+    return this.feedback.reduce((a, b) => a + b, 0) / this.feedback.length;
+  }
+}

--- a/packages/resonance-modules/__tests__/ResonanceAutoTuner.test.ts
+++ b/packages/resonance-modules/__tests__/ResonanceAutoTuner.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { ResonanceAutoTuner, ResonanceParameters } from '../ResonanceAutoTuner';
+
+describe('ResonanceAutoTuner', () => {
+  it('tunes parameters based on average feedback', () => {
+    const tuner = new ResonanceAutoTuner();
+    const params: ResonanceParameters = { frequency: 100, intensity: 1 };
+    const result = tuner.tune(params, [0.1, 0.1]);
+    expect(result.frequency).toBeCloseTo(110);
+    expect(result.intensity).toBeCloseTo(1.05);
+  });
+});

--- a/packages/resonance-modules/__tests__/ResonanceFeedbackModule.test.ts
+++ b/packages/resonance-modules/__tests__/ResonanceFeedbackModule.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { ResonanceFeedbackModule } from '../ResonanceFeedbackModule';
+
+describe('ResonanceFeedbackModule', () => {
+  it('records and averages feedback', () => {
+    const mod = new ResonanceFeedbackModule();
+    mod.record(1);
+    mod.record(2);
+    expect(mod.average()).toBe(1.5);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `ResonanceAutoTuner` and `ResonanceFeedbackModule`
- add unit tests
- mark related tasks as done in advancedToDo and progress files

## Testing
- `npx pyright` *(fails: Import "streamlit" could not be resolved)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*
- `npx vitest run packages/resonance-modules/__tests__/ResonanceAutoTuner.test.ts packages/resonance-modules/__tests__/ResonanceFeedbackModule.test.ts` *(failed to load config: cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_68815740b2fc83229b4de4a1b5e0cc26