### PR TITLE
Add Pantheon portal component and tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6388,5 +6388,37 @@
     "task": "Collect user resonance feedback for analysis",
     "status": "open",
     "test": "packages/resonance-modules/ResonanceFeedbackModule.test.ts"
+  },
+  {
+    "category": "Pantheon",
+    "commit": "Add PantheonRitualOrchestrator",
+    "path": "packages/pantheon/PantheonRitualOrchestrator.ts",
+    "task": "Schedule and coordinate Pantheon ritual events",
+    "status": "open",
+    "test": "packages/pantheon/PantheonRitualOrchestrator.test.ts"
+  },
+  {
+    "category": "Boundary",
+    "commit": "Add BoundaryResearchPlanner",
+    "path": "packages/boundary-engine/BoundaryResearchPlanner.ts",
+    "task": "Manage research phases for boundary exploration",
+    "status": "open",
+    "test": "packages/boundary-engine/BoundaryResearchPlanner.test.ts"
+  },
+  {
+    "category": "VR-Begegnungsraum",
+    "commit": "Implement FourierVRMeetingHall",
+    "path": "packages/unifiedmandala-vr/FourierVRMeetingHall.ts",
+    "task": "VR meeting hall with Fourier-based soundscapes",
+    "status": "open",
+    "test": "packages/unifiedmandala-vr/FourierVRMeetingHall.test.ts"
+  },
+  {
+    "category": "Erweiterte Resonanzmodule",
+    "commit": "Add ResonanceMicroserviceSkeleton",
+    "path": "packages/resonance-modules/ResonanceMicroserviceSkeleton.ts",
+    "task": "Basic microservice template for new resonance modules",
+    "status": "open",
+    "test": "packages/resonance-modules/ResonanceMicroserviceSkeleton.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7693,3 +7693,27 @@
   task: Collect user resonance feedback for analysis
   status: open
   test: packages/resonance-modules/ResonanceFeedbackModule.test.ts
+- category: Pantheon
+  commit: Add PantheonRitualOrchestrator
+  path: packages/pantheon/PantheonRitualOrchestrator.ts
+  task: Schedule and coordinate Pantheon ritual events
+  status: open
+  test: packages/pantheon/PantheonRitualOrchestrator.test.ts
+- category: Boundary
+  commit: Add BoundaryResearchPlanner
+  path: packages/boundary-engine/BoundaryResearchPlanner.ts
+  task: Manage research phases for boundary exploration
+  status: open
+  test: packages/boundary-engine/BoundaryResearchPlanner.test.ts
+- category: VR-Begegnungsraum
+  commit: Implement FourierVRMeetingHall
+  path: packages/unifiedmandala-vr/FourierVRMeetingHall.ts
+  task: VR meeting hall with Fourier-based soundscapes
+  status: open
+  test: packages/unifiedmandala-vr/FourierVRMeetingHall.test.ts
+- category: Erweiterte Resonanzmodule
+  commit: Add ResonanceMicroserviceSkeleton
+  path: packages/resonance-modules/ResonanceMicroserviceSkeleton.ts
+  task: Basic microservice template for new resonance modules
+  status: open
+  test: packages/resonance-modules/ResonanceMicroserviceSkeleton.test.ts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Implement RuleRegistryService and GraphDB persistence",
+  "lastCommit": "Add PantheonPortal3D component and update ToDo lists",
   "fractalStep": "sync",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Improved rule detection with regex support | UnifiedMandalaPantheon initial module implemented",
+  "notes": "Added portal component and new tasks from conversations",
   "pendingTasks": [
     {
       "commit": "Implement go todo_parser server",
@@ -387,6 +387,10 @@
     },
     {
       "commit": "Implement go todo_parser server",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonPortal3D component",
       "status": "done"
     }
   ]

--- a/packages/unifiedmandala-ui/components/PantheonPortal3D.test.tsx
+++ b/packages/unifiedmandala-ui/components/PantheonPortal3D.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PantheonPortal3D from './PantheonPortal3D';
+
+jest.mock('@react-three/fiber', () => ({
+  Canvas: ({ children, ...props }: any) => <div aria-label={props['aria-label']}>{children}</div>,
+  ambientLight: 'ambientLight',
+  mesh: 'mesh',
+  boxGeometry: 'boxGeometry',
+  meshStandardMaterial: 'meshStandardMaterial'
+}));
+
+test('renders 3D portal canvas', () => {
+  const { getByLabelText } = render(<PantheonPortal3D />);
+  expect(getByLabelText('pantheon-portal-3d')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/PantheonPortal3D.tsx
+++ b/packages/unifiedmandala-ui/components/PantheonPortal3D.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Canvas } from '@react-three/fiber';
+
+export default function PantheonPortal3D() {
+  return (
+    <Canvas aria-label="pantheon-portal-3d">
+      <ambientLight intensity={0.4} />
+      <mesh>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial color="orange" />
+      </mesh>
+    </Canvas>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `PantheonPortal3D` React component with basic three.js setup
- add corresponding unit test
- append Pantheon, Boundary, VR and Resonance tasks from conversation to advanced todo files
- record progress for new component in `advancedprogress.json`

## Testing
- `pnpm exec vitest run packages/unifiedmandala-ui/components/PantheonPortal3D.test.tsx --passWithNoTests`
- `npx -y pyright` *(fails: missing modules)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68815740b2fc83229b4de4a1b5e0cc26