### PR TITLE
Implement agent init script and boundary policy manager

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5481,7 +5481,7 @@
     "path": "scripts/init-agent-service.ts",
     "task": "Generate service skeleton for Pantheon agents",
     "test": "scripts/__tests__/init-agent-service.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create RuleRegistryService",
@@ -5747,7 +5747,7 @@
     "path": "packages/boundary-engine/BoundaryPolicyManager.ts",
     "task": "Define governance policies for boundaries",
     "test": "packages/boundary-engine/BoundaryPolicyManager.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Extend ResonanceModuleOrchestrator VR integration",
@@ -6330,7 +6330,7 @@
     "commit": "Add BoundaryPolicyManager",
     "path": "packages/boundary-engine/BoundaryPolicyManager.ts",
     "task": "Manage policy definitions for boundary modules",
-    "status": "open",
+    "status": "done",
     "test": "packages/boundary-engine/BoundaryPolicyManager.test.ts"
   },
   {

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7051,7 +7051,7 @@
   path: scripts/init-agent-service.ts
   task: Generate service skeleton for Pantheon agents
   test: scripts/__tests__/init-agent-service.test.ts
-  status: open
+  status: done
 - commit: Create RuleRegistryService
   path: packages/boundary-engine/rule_registry_service/registry_api.ts
   task: REST API to persist boundary rules
@@ -7242,7 +7242,7 @@
   path: packages/boundary-engine/BoundaryPolicyManager.ts
   task: Define governance policies for boundaries
   test: packages/boundary-engine/BoundaryPolicyManager.test.ts
-  status: open
+  status: done
 - commit: Extend ResonanceModuleOrchestrator VR integration
   path: packages/resonance-modules/ResonanceModuleOrchestrator.ts
   task: Connect modules with VR audio and haptic feedback
@@ -7647,7 +7647,7 @@
   commit: Add BoundaryPolicyManager
   path: packages/boundary-engine/BoundaryPolicyManager.ts
   task: Manage policy definitions for boundary modules
-  status: open
+  status: done
   test: packages/boundary-engine/BoundaryPolicyManager.test.ts
 - category: Boundary
   commit: BoundaryLawAnalyticsDashboard

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -37,7 +37,7 @@
     },
     {
       "commit": "Agent skeleton generator script",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Create MandalaCanvas UI",
@@ -113,7 +113,7 @@
     },
     {
       "commit": "Add BoundaryPolicyManager",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Extend ResonanceModuleOrchestrator VR integration",
@@ -193,7 +193,7 @@
     },
     {
       "commit": "Add BoundaryPolicyManager",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "BoundaryLawAnalyticsDashboard",

--- a/packages/boundary-engine/BoundaryPolicyManager.test.ts
+++ b/packages/boundary-engine/BoundaryPolicyManager.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { BoundaryPolicyManager } from './BoundaryPolicyManager';
+
+describe('BoundaryPolicyManager', () => {
+  it('adds and removes policies', () => {
+    const mgr = new BoundaryPolicyManager();
+    mgr.add({ id: 'p1', rules: ['r1'] });
+    expect(mgr.get('p1')?.rules).toEqual(['r1']);
+    mgr.remove('p1');
+    expect(mgr.get('p1')).toBeUndefined();
+  });
+});

--- a/packages/boundary-engine/BoundaryPolicyManager.ts
+++ b/packages/boundary-engine/BoundaryPolicyManager.ts
@@ -1,0 +1,24 @@
+export interface Policy {
+  id: string;
+  rules: string[];
+}
+
+export class BoundaryPolicyManager {
+  private policies = new Map<string, Policy>();
+
+  add(policy: Policy): void {
+    this.policies.set(policy.id, policy);
+  }
+
+  remove(id: string): void {
+    this.policies.delete(id);
+  }
+
+  get(id: string): Policy | undefined {
+    return this.policies.get(id);
+  }
+
+  list(): Policy[] {
+    return Array.from(this.policies.values());
+  }
+}

--- a/scripts/__tests__/init-agent-service.test.ts
+++ b/scripts/__tests__/init-agent-service.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { initAgentService } from '../init-agent-service';
+
+describe('initAgentService', () => {
+  it('creates service folder and index.ts', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-'));
+    const dir = initAgentService('demo-agent', tmp);
+    const file = path.join(dir, 'index.ts');
+    expect(fs.existsSync(file)).toBe(true);
+  });
+});

--- a/scripts/init-agent-service.ts
+++ b/scripts/init-agent-service.ts
@@ -1,0 +1,28 @@
+import fs from 'fs';
+import path from 'path';
+
+export function camelCase(name: string): string {
+  return name
+    .replace(/[-_]+(.)/g, (_, c) => c.toUpperCase())
+    .replace(/^(.)/, m => m.toLowerCase());
+}
+
+export function initAgentService(name: string, baseDir = 'packages'): string {
+  const dir = path.join(baseDir, name);
+  fs.mkdirSync(dir, { recursive: true });
+  const indexPath = path.join(dir, 'index.ts');
+  if (!fs.existsSync(indexPath)) {
+    const id = camelCase(name);
+    fs.writeFileSync(indexPath, `export const ${id} = () => 'initialized';\n`);
+  }
+  return dir;
+}
+
+if (require.main === module) {
+  const [name, base] = process.argv.slice(2);
+  if (!name) {
+    console.error('Usage: ts-node init-agent-service.ts <name> [baseDir]');
+    process.exit(1);
+  }
+  console.log(initAgentService(name, base));
+}


### PR DESCRIPTION
## Summary
- add script to generate Pantheon agent scaffolds
- introduce `BoundaryPolicyManager` with simple policy registry
- update advanced ToDos and progress for these items

## Testing
- `npx tsc -p tsconfig.json`
- `npx -y pyright` *(fails: Import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68821da56cec8322ab0c9485051c5eea