### PR TITLE
Improve Pantheon navigator and resonance orchestrator

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-22, in der Zeit des Abend.
+Am 2025-07-24, in der Zeit des Tag.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Aktivierung (Fokus: R)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5425,7 +5425,7 @@
     "path": "packages/resonance-modules/ResonanceModuleOrchestrator.ts",
     "task": "Coordinate extended resonance modules via message bus",
     "test": "packages/resonance-modules/ResonanceModuleOrchestrator.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add PantheonK8sDeployment configs",
@@ -5915,7 +5915,7 @@
     "path": "packages/resonance-modules/ResonanceModuleOrchestrator.ts",
     "task": "Coordinate extended resonance modules",
     "test": "packages/resonance-modules/__tests__/ResonanceModuleOrchestrator.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add PantheonSonicGateway",
@@ -6370,7 +6370,7 @@
     "commit": "Implement ResonanceModuleOrchestrator",
     "path": "packages/resonance-modules/ResonanceModuleOrchestrator.ts",
     "task": "Coordinate extended resonance modules via message bus",
-    "status": "open",
+    "status": "done",
     "test": "packages/resonance-modules/ResonanceModuleOrchestrator.test.ts"
   },
   {
@@ -6394,6 +6394,6 @@
     "path": "packages/pantheon/PantheonSymbolzeitNavigator.ts",
     "task": "Navigate Pantheon modules based on Symbolzeit",
     "test": "packages/pantheon/PantheonSymbolzeitNavigator.test.ts",
-    "status": "open"
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6971,7 +6971,7 @@
   path: packages/agents/CosmicTheoryAgent.ts
   task: Call external PySR service via gRPC/REST
   test: packages/agents/CosmicTheoryAgent.test.ts
-  status: open
+  status: done
 - commit: CosmicTheoryAgent 3D canvas and Tone.js
   path: packages/unifiedmandala-ui/components/CosmicPlayground.tsx
   task: Interactive 3D canvas with Tone.js integration
@@ -6996,7 +6996,7 @@
   path: packages/resonance-modules/ResonanceModuleOrchestrator.ts
   task: Coordinate extended resonance modules via message bus
   test: packages/resonance-modules/ResonanceModuleOrchestrator.test.ts
-  status: open
+  status: done
 - commit: Scaffold Extended Resonance Modules docs
   path: docs/resonance/ExtendedResonanceModules.md
   task: Outline microservice modules for resonance expansion
@@ -7362,7 +7362,7 @@
   path: packages/resonance-modules/ResonanceModuleOrchestrator.ts
   task: Coordinate extended resonance modules
   test: packages/resonance-modules/__tests__/ResonanceModuleOrchestrator.test.ts
-  status: open
+  status: done
 - commit: Add VRMeetingHall3D
   path: packages/unifiedmandala-vr/components/VRMeetingHall3D.tsx
   task: Collaborative VR meeting hall environment
@@ -7677,7 +7677,7 @@
   commit: Implement ResonanceModuleOrchestrator
   path: packages/resonance-modules/ResonanceModuleOrchestrator.ts
   task: Coordinate extended resonance modules via message bus
-  status: open
+  status: done
   test: packages/resonance-modules/ResonanceModuleOrchestrator.test.ts
 - category: Erweiterte Resonanzmodule
   commit: Add ResonanceAutoTuner
@@ -7695,4 +7695,4 @@
   path: packages/pantheon/PantheonSymbolzeitNavigator.ts
   task: Navigate Pantheon modules based on Symbolzeit
   test: packages/pantheon/PantheonSymbolzeitNavigator.test.ts
-  status: open
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge branch 'main' of https://github.com/GenesisAeon/unified-mandala",
+  "lastCommit": "chore: normalize progress file",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -7,10 +7,6 @@
   "mergeConflicts": [],
   "notes": "Improved rule detection with regex support | UnifiedMandalaPantheon initial module implemented",
   "pendingTasks": [
-    {
-      "commit": "CosmicTheoryAgent PySR gRPC access",
-      "status": "open"
-    },
     {
       "commit": "CosmicTheoryAgent 3D canvas and Tone.js",
       "status": "open"
@@ -21,10 +17,6 @@
     },
     {
       "commit": "Create PantheonAvatarraum component",
-      "status": "open"
-    },
-    {
-      "commit": "Implement ResonanceModuleOrchestrator",
       "status": "open"
     },
     {
@@ -164,10 +156,6 @@
       "status": "open"
     },
     {
-      "commit": "Implement ResonanceModuleOrchestrator",
-      "status": "open"
-    },
-    {
       "commit": "Add BoundaryLawSimulator",
       "status": "open"
     },
@@ -205,10 +193,6 @@
     },
     {
       "commit": "Add SoundResonanceVR module",
-      "status": "open"
-    },
-    {
-      "commit": "Implement ResonanceModuleOrchestrator",
       "status": "open"
     },
     {
@@ -365,6 +349,14 @@
     },
     {
       "commit": "CosmicTheoryAgent gRPC REST access",
+      "status": "done"
+    },
+    {
+      "commit": "PantheonSymbolzeitNavigator enhanced",
+      "status": "done"
+    },
+    {
+      "commit": "ResonanceModuleOrchestrator bus support",
       "status": "done"
     }
   ]

--- a/packages/pantheon/PantheonSymbolzeitNavigator.test.ts
+++ b/packages/pantheon/PantheonSymbolzeitNavigator.test.ts
@@ -7,4 +7,11 @@ describe('PantheonSymbolzeitNavigator', () => {
     expect(nav.next()).toBe('b');
     expect(nav.next()).toBe('a');
   });
+
+  it('returns entry by symbolzeit', () => {
+    const nav = new PantheonSymbolzeitNavigator(['alpha', 'beta', 'gamma']);
+    expect(nav.forSymbolzeit(0)).toBe('alpha');
+    expect(nav.forSymbolzeit(2)).toBe('gamma');
+    expect(nav.forSymbolzeit(3)).toBe('alpha');
+  });
 });

--- a/packages/pantheon/PantheonSymbolzeitNavigator.ts
+++ b/packages/pantheon/PantheonSymbolzeitNavigator.ts
@@ -1,8 +1,23 @@
 export class PantheonSymbolzeitNavigator {
   private currentIndex = 0;
+
   constructor(private entries: string[]) {}
+
+  /**
+   * Get the next module in a simple cycle.
+   */
   next(): string {
     this.currentIndex = (this.currentIndex + 1) % this.entries.length;
     return this.entries[this.currentIndex];
+  }
+
+  /**
+   * Retrieve a module based on the provided Symbolzeit value.
+   * The Symbolzeit number is mapped cyclically to the module list.
+   */
+  forSymbolzeit(symbolzeit: number): string {
+    const index = Math.floor(symbolzeit) % this.entries.length;
+    this.currentIndex = index;
+    return this.entries[index];
   }
 }

--- a/packages/resonance-modules/ResonanceModuleOrchestrator.ts
+++ b/packages/resonance-modules/ResonanceModuleOrchestrator.ts
@@ -3,9 +3,12 @@ export interface ResonanceModule {
   process(input: unknown): unknown;
 }
 
+import { EventEmitter } from 'events';
+
 export class ResonanceModuleOrchestrator {
   private modules: ResonanceModule[] = [];
   private plugins: Array<(result: unknown) => void> = [];
+  readonly bus = new EventEmitter();
 
   register(module: ResonanceModule) {
     this.modules.push(module);
@@ -19,6 +22,7 @@ export class ResonanceModuleOrchestrator {
     const results = this.modules.map(m => m.process(input));
     for (const r of results) {
       for (const p of this.plugins) p(r);
+      this.bus.emit('result', r);
     }
     return results;
   }

--- a/packages/resonance-modules/__tests__/ResonanceModuleOrchestrator.test.ts
+++ b/packages/resonance-modules/__tests__/ResonanceModuleOrchestrator.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from 'vitest';
 import { ResonanceModuleOrchestrator } from '../ResonanceModuleOrchestrator';
 
 class DummyModule {
@@ -21,5 +20,14 @@ describe('ResonanceModuleOrchestrator', () => {
     orch.addPlugin(() => called++);
     orch.runAll('y');
     expect(called).toBe(1);
+  });
+
+  it('emits results on the bus', () => {
+    const orch = new ResonanceModuleOrchestrator();
+    orch.register(new DummyModule());
+    const received: unknown[] = [];
+    orch.bus.on('result', r => received.push(r));
+    orch.runAll('z');
+    expect(received).toEqual(['z']);
   });
 });


### PR DESCRIPTION
## Summary
- extend `PantheonSymbolzeitNavigator` with Symbolzeit lookup
- add event bus to `ResonanceModuleOrchestrator`
- update accompanying tests
- mark related tasks as completed in `advancedToDo`
- log progress in `advancedprogress.json`

## Testing
- `pnpm test`
- `npx tsc -p tsconfig.json`
- `yes | npx pyright` *(fails: multiple missing imports)*

------
https://chatgpt.com/codex/tasks/task_e_68821da56cec8322ab0c9485051c5eea