### PR TITLE
Add CosmicPlayground and orchestrator events

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -61,6 +61,7 @@ Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js`
 - `FourierMetricsCLI` – Kommandozeilenwerkzeug für Fourier-Berechnungen.
 - `FractalTaskRunner` – führt YAML-basierte Plugin-Workflows aus.
 - `EventBridge` – leitet CosmicTheoryAgent-Events an die UI weiter.
+- `CosmicPlayground` – 3D canvas mit Tone.js-Sound-Sphere.
 - `PyramidVRMeetingRoom` – VR-Raum für mehrere Avatare.
 - CosmicTheoryAgent liefert VR-Hooks für immersive Steuerung.
 - `AeonOrchestrator` – zentrale Steuerinstanz des Pantheon, verteilt Boundary-Regeln.
@@ -128,6 +129,7 @@ console.log(sigil.id); // hello
 - `KIBewusstseinResonanzMonitor` – Überwacht Bewusstseins- und Resonanzmetriken.
 - `StrategicAgentCoordinator` – synchronisiert die Agentenliste und schreibt `strategy-overview.json` ([docs/agents/StrategicAgentCoordinator.md](docs/agents/StrategicAgentCoordinator.md))
 - `VisionContextIntegrator` – verteilt die Vision aus `AgentStrategy.md` an alle Agenten ([docs/agents/VisionContextIntegrator.md](docs/agents/VisionContextIntegrator.md))
+- `ResonanceModuleOrchestrator` – orchestriert Module über EventEmitter.
 - `QualityAssuranceAgent` – führt Lint- und Test-Suites aus ([docs/agents/QualityAssuranceAgent.md](docs/agents/QualityAssuranceAgent.md))
 ### collab-editor
 - `CollaborativeEditor` – Federated Texteditor mit Remote-Sync.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**VR Pantheon Konzept**](docs/pantheon/VR-Begegnungsraum-Concept.md) – Konzept für kollaborative Treffen
 - [**PySR Service Client**](packages/agents/CosmicTheoryAgent.ts) – Regression via REST/gRPC
 - [**Sigil Archive Service**](services/sigil-archive/index.ts) – speichert Sigille und CREP-Fragmente
+- [**CosmicPlayground**](packages/unifiedmandala-ui/components/CosmicPlayground.tsx) – 3D canvas with Tone.js sound
 - [**CREPVisualizer**](packages/unifiedmandala-ui/components/CREPVisualizer.tsx) – animierte Timeline der Mandala-Kristalle
 - [**Plug-in-Architektur**](plugins/manifest.yaml) – GPT-Kommunikationsmodule, CLI-Tools
 - 🔗 [**GPTBridge (Go)**](go-bridge/pkg/gpt) – API- und Link-basierte GPT-Anbindung
@@ -84,6 +85,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**AeonStoryMode & Onboarding-Flow**](packages/unifiedmandala-ui/README.md) – Präsentations- und Einstiegskomponenten
 - [**MandalaThemeManager**](packages/unifiedmandala-ui/README.md) – hell/dunkel umschalten
 - [**SigillinActivationManager & MetaSignatur**](packages/genesis-sigillin-core) – Aktivierung & Signatur von Sigillin
+- [**ResonanceModuleOrchestrator**](packages/resonance-modules/ResonanceModuleOrchestrator.ts) – message bus for resonance modules
 - [**ThemeProvider & useResponsiveTheme**](packages/unifiedmandala-ui/hooks/useResponsiveTheme.ts) – CREP-basierte Farbwahl
 - [**useAdaptiveLayout**](packages/unifiedmandala-ui/hooks/useAdaptiveLayout.ts) – reagiert auf CREP-Status
 - [**useABLayout**](packages/unifiedmandala-ui/hooks/useABLayout.ts) – A/B-Tests mit CREP-Metrik

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5397,7 +5397,7 @@
     "path": "packages/unifiedmandala-ui/components/CosmicPlayground.tsx",
     "task": "Interactive 3D canvas with Tone.js integration",
     "test": "packages/unifiedmandala-ui/components/CosmicPlayground.test.tsx",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "CosmicTheoryAgent MetricsStore interface",
@@ -5425,7 +5425,7 @@
     "path": "packages/resonance-modules/ResonanceModuleOrchestrator.ts",
     "task": "Coordinate extended resonance modules via message bus",
     "test": "packages/resonance-modules/ResonanceModuleOrchestrator.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add PantheonK8sDeployment configs",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -6976,7 +6976,7 @@
   path: packages/unifiedmandala-ui/components/CosmicPlayground.tsx
   task: Interactive 3D canvas with Tone.js integration
   test: packages/unifiedmandala-ui/components/CosmicPlayground.test.tsx
-  status: open
+  status: done
 - commit: CosmicTheoryAgent MetricsStore interface
   path: packages/agents/CosmicTheoryAgentMetrics.ts
   task: Store agent metrics and provide hooks for UI
@@ -6996,7 +6996,7 @@
   path: packages/resonance-modules/ResonanceModuleOrchestrator.ts
   task: Coordinate extended resonance modules via message bus
   test: packages/resonance-modules/ResonanceModuleOrchestrator.test.ts
-  status: open
+  status: done
 - commit: Scaffold Extended Resonance Modules docs
   path: docs/resonance/ExtendedResonanceModules.md
   task: Outline microservice modules for resonance expansion

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5,7 +5,7 @@
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Improved rule detection with regex support | UnifiedMandalaPantheon initial module implemented",
+  "notes": "Added CosmicPlayground and message bus in ResonanceModuleOrchestrator",
   "pendingTasks": [
     {
       "commit": "CosmicTheoryAgent PySR gRPC access",
@@ -13,7 +13,7 @@
     },
     {
       "commit": "CosmicTheoryAgent 3D canvas and Tone.js",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add BoundaryLawDiscoveryEngine",
@@ -25,7 +25,7 @@
     },
     {
       "commit": "Implement ResonanceModuleOrchestrator",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add PantheonK8sDeployment configs",
@@ -165,7 +165,7 @@
     },
     {
       "commit": "Implement ResonanceModuleOrchestrator",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add BoundaryLawSimulator",
@@ -209,7 +209,7 @@
     },
     {
       "commit": "Implement ResonanceModuleOrchestrator",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add PantheonSymbolzeitNavigator",

--- a/packages/resonance-modules/ResonanceModuleOrchestrator.ts
+++ b/packages/resonance-modules/ResonanceModuleOrchestrator.ts
@@ -3,7 +3,9 @@ export interface ResonanceModule {
   process(input: unknown): unknown;
 }
 
-export class ResonanceModuleOrchestrator {
+import { EventEmitter } from 'events';
+
+export class ResonanceModuleOrchestrator extends EventEmitter {
   private modules: ResonanceModule[] = [];
   private plugins: Array<(result: unknown) => void> = [];
 
@@ -18,6 +20,7 @@ export class ResonanceModuleOrchestrator {
   runAll(input: unknown) {
     const results = this.modules.map(m => m.process(input));
     for (const r of results) {
+      this.emit('result', r);
       for (const p of this.plugins) p(r);
     }
     return results;

--- a/packages/resonance-modules/__tests__/ResonanceModuleOrchestrator.test.ts
+++ b/packages/resonance-modules/__tests__/ResonanceModuleOrchestrator.test.ts
@@ -22,4 +22,13 @@ describe('ResonanceModuleOrchestrator', () => {
     orch.runAll('y');
     expect(called).toBe(1);
   });
+
+  it('emits result events', () => {
+    const orch = new ResonanceModuleOrchestrator();
+    orch.register(new DummyModule());
+    let eventData: unknown;
+    orch.on('result', d => (eventData = d));
+    orch.runAll('z');
+    expect(eventData).toBe('z');
+  });
 });

--- a/packages/unifiedmandala-ui/components/CosmicPlayground.test.tsx
+++ b/packages/unifiedmandala-ui/components/CosmicPlayground.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CosmicPlayground from './CosmicPlayground';
+
+jest.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }: any) => <div role="presentation">{children}</div>,
+  sphereGeometry: 'sphereGeometry',
+  mesh: 'mesh',
+  meshStandardMaterial: 'meshStandardMaterial',
+  ambientLight: 'ambientLight',
+  pointLight: 'pointLight'
+}));
+
+jest.mock('tone', () => ({
+  Oscillator: jest.fn().mockImplementation(() => ({
+    start: jest.fn(),
+    stop: jest.fn(),
+    dispose: jest.fn(),
+    toDestination: jest.fn().mockReturnThis()
+  }))
+}));
+
+test('renders oscillator sphere', () => {
+  const { getByRole } = render(<CosmicPlayground />);
+  expect(getByRole('presentation')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/CosmicPlayground.tsx
+++ b/packages/unifiedmandala-ui/components/CosmicPlayground.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect } from 'react';
+import { Canvas } from '@react-three/fiber';
+import * as Tone from 'tone';
+
+const OscSphere: React.FC = () => {
+  useEffect(() => {
+    const osc = new Tone.Oscillator().toDestination();
+    osc.start();
+    return () => {
+      osc.stop();
+      osc.dispose();
+    };
+  }, []);
+
+  return (
+    <mesh>
+      <sphereGeometry args={[0.5, 16, 16]} />
+      <meshStandardMaterial color="orange" />
+    </mesh>
+  );
+};
+
+const CosmicPlayground: React.FC = () => (
+  <Canvas>
+    <ambientLight intensity={0.4} />
+    <pointLight position={[2, 2, 2]} />
+    <OscSphere />
+  </Canvas>
+);
+
+export default CosmicPlayground;


### PR DESCRIPTION
## Summary
- implement new `CosmicPlayground` UI component with Tone.js
- emit `result` events from `ResonanceModuleOrchestrator`
- update related tests
- mark tasks as completed in advancedToDo and progress files
- mention new component and orchestrator in docs

## Testing
- `npx tsc -p tsconfig.json`
- `pnpm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68821da56cec8322ab0c9485051c5eea