### PR TITLE
Add script to update advanced ToDo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ Teil 5 enthält Aufgaben zur Sigil-Historie.
 Teil 7 listet Aufgaben zu poetischen Sigill- und Mandala-Modulen.
 Nutze `node scripts/parse-advanced-conversations.js` um Gesprächs-TODOs aus dem Datensatz zu filtern.
 Neu erzeugte Einträge landen in `advancedToDo.json` und `advancedToDo.yaml` und werden in `advancedprogress.json` dokumentiert.
+Nutze `node scripts/update-advanced-from-newconvos.js` um die ToDo-Dateien aus `newadvancedconversations.json` zu aktualisieren.
 
 - **Module**: unter `packages/` gegliedert in Agents, Core und mehr
 - **Utils**: zentrale Helfer liegen in `packages/shared-utils/`

--- a/scripts/update-advanced-from-newconvos.js
+++ b/scripts/update-advanced-from-newconvos.js
@@ -1,0 +1,15 @@
+const path = require('path');
+const { updateAdvancedTodo } = require('../packages/shared-utils/advancedTodoUpdater');
+
+function updateFromNewConvos(convPath = path.join(__dirname, '../docs/sigils/newadvancedconversations.json'),
+                             yamlPath = path.join(__dirname, '../advancedToDo.yaml'),
+                             jsonPath = path.join(__dirname, '../advancedToDo.json')) {
+  updateAdvancedTodo(convPath, yamlPath, jsonPath);
+  console.log(`Updated advancedToDo files from ${path.basename(convPath)}`);
+}
+
+if (require.main === module) {
+  updateFromNewConvos();
+}
+
+module.exports = { updateFromNewConvos };


### PR DESCRIPTION
## Summary
- add `update-advanced-from-newconvos.js` to parse `newadvancedconversations.json`
- document script usage in README

## Testing
- `npx pyright` *(fails: various missing imports)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6882729be6b48322b02aca3addd1df61