### PR TITLE
meta: implement open-ethik-dashboard

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6521,5 +6521,12 @@
   },
   {
     "feature": "Visuelle Ausgabe mit Hinweisen"
+  },
+  {
+    "commit": "Add OpenEthikDashboard component",
+    "path": "packages/unifiedmandala-ui/components/OpenEthikDashboard.tsx",
+    "task": "Dashboard for community ethics metrics",
+    "test": "packages/unifiedmandala-ui/components/OpenEthikDashboard.test.tsx",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7812,3 +7812,8 @@
 - feature: Clustergrößenanalyse zur Stabilität
 - feature: Semantische Validierung vor Ausführung
 - feature: Visuelle Ausgabe mit Hinweisen
+- commit: Add OpenEthikDashboard component
+  path: packages/unifiedmandala-ui/components/OpenEthikDashboard.tsx
+  task: Dashboard for community ethics metrics
+  test: packages/unifiedmandala-ui/components/OpenEthikDashboard.test.tsx
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "meta:update-progress – sync lastCommit",
+  "lastCommit": "meta:update-progress – normalize",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -22,10 +22,6 @@
     {
       "commit": "Pantheon EventBus migration",
       "status": "open"
-    },
-    {
-      "commit": "Create MandalaCanvas UI",
-      "status": "done"
     },
     {
       "commit": "Integrate VRBegegnungsraum with MandalaCanvas",
@@ -348,6 +344,10 @@
     {
       "commit": "Add BoundaryLawDiscoveryEngine",
       "status": "done"
+    },
+    {
+      "commit": "Add OpenEthikDashboard component",
+      "status": "done"
     }
   ],
   "completed": [
@@ -371,8 +371,8 @@
   "featureLog": [
     {
       "featureId": "open-ethik-dashboard",
-      "commit": "meta:extract-features – open-ethik-dashboard",
-      "status": "todo"
+      "commit": "meta:implement-features – open-ethik-dashboard",
+      "status": "done"
     },
     {
       "featureId": "implicit-todos",

--- a/packages/unifiedmandala-ui/components/OpenEthikDashboard.test.tsx
+++ b/packages/unifiedmandala-ui/components/OpenEthikDashboard.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import OpenEthikDashboard from './OpenEthikDashboard';
+
+test('renders dashboard title', () => {
+  render(<OpenEthikDashboard />);
+  expect(screen.getByText(/Open Ethik Dashboard/)).toBeInTheDocument();
+});
+
+test('renders provided metrics', () => {
+  const metrics = [{ label: 'Transparency', value: 80 }];
+  render(<OpenEthikDashboard metrics={metrics} />);
+  expect(screen.getByText(/Transparency/)).toHaveTextContent('Transparency: 80');
+});

--- a/packages/unifiedmandala-ui/components/OpenEthikDashboard.tsx
+++ b/packages/unifiedmandala-ui/components/OpenEthikDashboard.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface Props {
+  metrics?: { label: string; value: number }[];
+}
+
+const OpenEthikDashboard: React.FC<Props> = ({ metrics }) => {
+  return (
+    <div className="p-4 border rounded">
+      <h2 className="text-lg font-bold mb-2">Open Ethik Dashboard</h2>
+      <ul>
+        {metrics?.map((m) => (
+          <li key={m.label}>{m.label}: {m.value}</li>
+        )) || <li>No data available</li>}
+      </ul>
+    </div>
+  );
+};
+
+export default OpenEthikDashboard;


### PR DESCRIPTION
## Summary
- add simple OpenEthikDashboard component and tests
- log dashboard feature progress
- update advanced todo lists

## Testing
- `pnpm test`
- `npx -y tsc -p tsconfig.json`
- `npx -y pyright` *(fails: streamlit, matplotlib missing)*

------
https://chatgpt.com/codex/tasks/task_e_6883df7248dc8322a98c72c99461c218