### PR TITLE
Add documentation generator script and update tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5572,7 +5572,7 @@
     "path": "scripts/generate-docs.ts",
     "task": "Generate markdown docs from source comments",
     "test": "scripts/__tests__/generate-docs.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Archive completed ToDos to ZIPMEM",
@@ -6535,5 +6535,55 @@
     "task": "Provide memory governance enforcement",
     "test": "services/memory-governance/index.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Draft ZivilisationsSandboxen blueprint",
+    "path": "docs/blueprints/ZivilisationsSandboxen.md",
+    "task": "Blueprint for ancient megabuilding sandbox design",
+    "status": "open"
+  },
+  {
+    "commit": "Draft ClimateIntegration blueprint",
+    "path": "docs/blueprints/ClimateIntegration.md",
+    "task": "Comprehensive climate integration plan",
+    "status": "open"
+  },
+  {
+    "commit": "Document Keilschrift tech module",
+    "path": "docs/blueprints/KeilschriftTech.md",
+    "task": "Outline KI-based cuneiform techniques",
+    "status": "open"
+  },
+  {
+    "commit": "Add ShadowIntegration module skeleton",
+    "path": "packages/shadow-integration/index.ts",
+    "task": "Prototype for shadow integration features",
+    "status": "open"
+  },
+  {
+    "commit": "Add SelfReflectionAgent skeleton",
+    "path": "packages/self-reflection/src/index.ts",
+    "task": "Initial self-reflection agent implementation",
+    "test": "packages/self-reflection/src/index.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Implement TuringTest suite",
+    "path": "packages/agents/TuringTestSuite.ts",
+    "task": "Run basic Turing tests on agents",
+    "test": "packages/agents/TuringTestSuite.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Research Arctic gravity waves",
+    "path": "docs/research/ArcticGravityWaves.md",
+    "task": "Collect data on internal gravity waves in the Arctic",
+    "status": "open"
+  },
+  {
+    "commit": "Document Anthropic multiverse scenarios",
+    "path": "docs/research/AnthropicMultiverse.md",
+    "task": "Explore anthropic principles across multiverse models",
+    "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7116,7 +7116,7 @@
   path: scripts/generate-docs.ts
   task: Generate markdown docs from source comments
   test: scripts/__tests__/generate-docs.test.ts
-  status: open
+  status: done
 - commit: Archive completed ToDos to ZIPMEM
   path: scripts/archive-todos.ts
   task: Move solved tasks and docs into GenesisAeonZIPMEM
@@ -7822,4 +7822,37 @@
   task: Provide memory governance enforcement
   test: services/memory-governance/index.test.ts
   status: done
-
+- commit: Draft ZivilisationsSandboxen blueprint
+  path: docs/blueprints/ZivilisationsSandboxen.md
+  task: Blueprint for ancient megabuilding sandbox design
+  status: open
+- commit: Draft ClimateIntegration blueprint
+  path: docs/blueprints/ClimateIntegration.md
+  task: Comprehensive climate integration plan
+  status: open
+- commit: Document Keilschrift tech module
+  path: docs/blueprints/KeilschriftTech.md
+  task: Outline KI-based cuneiform techniques
+  status: open
+- commit: Add ShadowIntegration module skeleton
+  path: packages/shadow-integration/index.ts
+  task: Prototype for shadow integration features
+  status: open
+- commit: Add SelfReflectionAgent skeleton
+  path: packages/self-reflection/src/index.ts
+  task: Initial self-reflection agent implementation
+  test: packages/self-reflection/src/index.test.ts
+  status: open
+- commit: Implement TuringTest suite
+  path: packages/agents/TuringTestSuite.ts
+  task: Run basic Turing tests on agents
+  test: packages/agents/TuringTestSuite.test.ts
+  status: open
+- commit: Research Arctic gravity waves
+  path: docs/research/ArcticGravityWaves.md
+  task: Collect data on internal gravity waves in the Arctic
+  status: open
+- commit: Document Anthropic multiverse scenarios
+  path: docs/research/AnthropicMultiverse.md
+  task: Explore anthropic principles across multiverse models
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #802 from GenesisAeon/fgs7in-codex/implement-features-from-advancedtodo.yaml",
+  "lastCommit": "chore: sync progress",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -37,10 +37,6 @@
     },
     {
       "commit": "Add SoundResonanceVR module",
-      "status": "open"
-    },
-    {
-      "commit": "Create documentation generator",
       "status": "open"
     },
     {
@@ -177,6 +173,38 @@
     },
     {
       "commit": "Build Avatarraum Mandala UI",
+      "status": "open"
+    },
+    {
+      "commit": "Draft ZivilisationsSandboxen blueprint",
+      "status": "open"
+    },
+    {
+      "commit": "Draft ClimateIntegration blueprint",
+      "status": "open"
+    },
+    {
+      "commit": "Document Keilschrift tech module",
+      "status": "open"
+    },
+    {
+      "commit": "Add ShadowIntegration module skeleton",
+      "status": "open"
+    },
+    {
+      "commit": "Add SelfReflectionAgent skeleton",
+      "status": "open"
+    },
+    {
+      "commit": "Implement TuringTest suite",
+      "status": "open"
+    },
+    {
+      "commit": "Research Arctic gravity waves",
+      "status": "open"
+    },
+    {
+      "commit": "Document Anthropic multiverse scenarios",
       "status": "open"
     }
   ],
@@ -351,6 +379,10 @@
     },
     {
       "commit": "meta:update-progress – mark memory governance done",
+      "status": "done"
+    },
+    {
+      "commit": "meta:implement-doc-generator",
       "status": "done"
     }
   ],

--- a/scripts/__tests__/generate-docs.test.ts
+++ b/scripts/__tests__/generate-docs.test.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+import generateRepoDocs from '../generate-docs';
+
+describe('generateRepoDocs', () => {
+  it('generates docs for given files', () => {
+    const tmp = path.join(__dirname, '__tmp_docs');
+    const src = path.join(tmp, 'sample.ts');
+    fs.mkdirSync(tmp, { recursive: true });
+    fs.writeFileSync(src, '/** example */\nexport const x = 1;');
+    const out = generateRepoDocs([src], tmp, path.join(tmp, 'manifest.json'));
+    const outFile = out[src];
+    expect(fs.existsSync(outFile)).toBe(true);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -1,0 +1,17 @@
+import glob from 'glob';
+import path from 'path';
+import { generateManifest } from './autoDocManifest';
+
+export function generateRepoDocs(patterns: string[] = ['packages/**/*.ts'], outDir = 'docs/autodoc', manifestPath = path.join(outDir, 'manifest.json')) {
+  const files = patterns.flatMap(p => glob.sync(p, { ignore: ['**/*.test.ts', '**/__tests__/**'] }));
+  return generateManifest(files, outDir, manifestPath);
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const outDir = process.env.OUT_DIR || 'docs/autodoc';
+  const manifest = generateRepoDocs(args.length ? args : ['packages/**/*.ts'], outDir);
+  console.log(`Generated ${Object.keys(manifest).length} docs`);
+}
+
+export default generateRepoDocs;


### PR DESCRIPTION
## Summary
- implement `generate-docs.ts` and test
- mark documentation generator todo as done
- log progress and add blueprint tasks extracted from conversation

## Testing
- `npx pyright` *(fails: Import errors)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6884fb47b8b483229a52be4a07d2c43a