### PR TITLE
Implement ShadowIntegration skeleton

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6558,7 +6558,7 @@
     "commit": "Add ShadowIntegration module skeleton",
     "path": "packages/shadow-integration/index.ts",
     "task": "Prototype for shadow integration features",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add SelfReflectionAgent skeleton",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7837,7 +7837,7 @@
 - commit: Add ShadowIntegration module skeleton
   path: packages/shadow-integration/index.ts
   task: Prototype for shadow integration features
-  status: open
+  status: done
 - commit: Add SelfReflectionAgent skeleton
   path: packages/self-reflection/src/index.ts
   task: Initial self-reflection agent implementation

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -189,7 +189,7 @@
     },
     {
       "commit": "Add ShadowIntegration module skeleton",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add SelfReflectionAgent skeleton",

--- a/packages/shadow-integration/src/index.test.ts
+++ b/packages/shadow-integration/src/index.test.ts
@@ -1,0 +1,5 @@
+import { init } from './index';
+
+test('init returns status', () => {
+  expect(init()).toBe('shadow-integration ready');
+});

--- a/packages/shadow-integration/src/index.ts
+++ b/packages/shadow-integration/src/index.ts
@@ -1,0 +1,4 @@
+export const name = 'shadow-integration';
+export function init() {
+  return `${name} ready`;
+}


### PR DESCRIPTION
## Summary
- add ShadowIntegration skeleton with basic init function
- mark related tasks done in advancedToDo files
- update progress log

## Testing
- `npx -y pyright`
- `npx tsc -p tsconfig.json` *(failed: Cannot find type definition file for 'node')*
- `npx -y jest packages/shadow-integration/src/index.test.ts` *(failed: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_688503411fa88322b93a05e5c670a38a