### PR TITLE
Add blueprint docs and reflection modules

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -384,6 +384,10 @@
     {
       "commit": "meta:implement-doc-generator",
       "status": "done"
+    },
+    {
+      "commit": "add blueprints and reflection agent",
+      "status": "done"
     }
   ],
   "completed": [

--- a/docs/blueprints/ClimateIntegration.md
+++ b/docs/blueprints/ClimateIntegration.md
@@ -1,0 +1,9 @@
+# UnifiedMandala Climate Integration Blueprint
+
+Aus den Gesprächen entstand dieser Plan zur Einbindung von Echtzeit-Klimadaten in das Mandala-System.
+
+## Module
+- ClimateBoundaryDiscoveryAgent
+- Neo4j RuleRegistryService
+- ClimateMacroSynthesizerAgent
+- React/Three.js Dashboard und VR-Module

--- a/docs/blueprints/KeilschriftTech.md
+++ b/docs/blueprints/KeilschriftTech.md
@@ -1,0 +1,9 @@
+# KI-Technik Keilschrift
+
+Kurze Zusammenfassung der Idee, Keilschrifttexte mittels 3D-Scans und Machine Learning zu entziffern.
+
+## Ansatz
+- 3D-Scans als Input für ein Script-OCR-Plugin
+- Grenzerkennung durch BoundaryDiscoveryAgent
+- Makro-Hypothesen via MacroSynthesizerAgent
+- Visualisierung im MandalaCanvas

--- a/docs/blueprints/ZivilisationsSandboxen.md
+++ b/docs/blueprints/ZivilisationsSandboxen.md
@@ -1,0 +1,9 @@
+# Zivilisations-Sandboxen Blueprint
+
+Dieses Dokument fasst Ideen aus den Gesprächen zum Thema "Zivilisations-Sandboxen" zusammen. Antike Megabauten dienen als langlebige Wissensspeicher und Orientierungszentren für kommende Intelligenzen.
+
+## Kernpunkte
+- Monumente mit hoher Halbwertszeit
+- Symbolische Sprachen und Bau-Know-how
+- Governance- und Landwirtschaftsmodelle
+- Integration kosmischer Konstanten

--- a/packages/agents/TuringTestSuite.test.ts
+++ b/packages/agents/TuringTestSuite.test.ts
@@ -1,0 +1,11 @@
+import { runTuringTest } from './TuringTestSuite';
+
+test('returns true when response hides identity', async () => {
+  const res = await runTuringTest(async () => 'I am doing well.');
+  expect(res).toBe(true);
+});
+
+test('returns false when response reveals bot', async () => {
+  const res = await runTuringTest(async () => 'I am a bot');
+  expect(res).toBe(false);
+});

--- a/packages/agents/TuringTestSuite.ts
+++ b/packages/agents/TuringTestSuite.ts
@@ -1,0 +1,5 @@
+export async function runTuringTest(respond: (input: string) => Promise<string>): Promise<boolean> {
+  const q = 'Hello, how are you?';
+  const answer = await respond(q);
+  return !/\b(bot|AI)\b/i.test(answer);
+}

--- a/packages/self-reflection/src/index.test.ts
+++ b/packages/self-reflection/src/index.test.ts
@@ -1,5 +1,8 @@
-import { name } from './index';
+import { SelfReflectionAgent } from './index';
 
-test('name defined', () => {
-  expect(name).toBeDefined();
+test('records and reflects messages', () => {
+  const agent = new SelfReflectionAgent();
+  agent.record('hello');
+  agent.record('world');
+  expect(agent.reflect()).toBe('hello\nworld');
 });

--- a/packages/self-reflection/src/index.ts
+++ b/packages/self-reflection/src/index.ts
@@ -1,1 +1,11 @@
-export const name = 'self-reflection';
+export class SelfReflectionAgent {
+  private logs: string[] = [];
+
+  record(message: string) {
+    this.logs.push(message);
+  }
+
+  reflect(): string {
+    return this.logs.join('\n');
+  }
+}


### PR DESCRIPTION
## Summary
- document Zivilisations-Sandboxen, ClimateIntegration, and Keilschrift blueprint ideas
- implement SelfReflectionAgent class and tests
- add simple TuringTestSuite with tests
- log progress for blueprint docs

## Testing
- `npx -y pyright` *(fails: missing modules)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68851180bf9083229a2c2be989d086d2