### PR TITLE
Implement VR bridge and resonance module

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5516,7 +5516,7 @@
     "path": "packages/unifiedmandala-vr/VRBegegnungsraum.ts",
     "task": "Link VR space with MandalaCanvas for interactive view",
     "test": "packages/unifiedmandala-vr/VRBegegnungsraumCanvas.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add PantheonKnowledgeGraph service",
@@ -5558,7 +5558,7 @@
     "path": "packages/universum-simulationen/SoundResonanceVR.ts",
     "task": "Extend resonance module with VR/3D sound features",
     "test": "packages/universum-simulationen/SoundResonanceVR.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add BoundaryLawDiscoveryEngine",
@@ -6346,7 +6346,7 @@
     "commit": "Integrate VRBegegnungsraum with MandalaCanvas",
     "path": "packages/unifiedmandala-vr/VRBegegnungsraum.ts",
     "task": "Link VR space with MandalaCanvas for interactive view",
-    "status": "open",
+    "status": "done",
     "test": "packages/unifiedmandala-vr/VRBegegnungsraumCanvas.test.ts"
   },
   {
@@ -6354,7 +6354,7 @@
     "commit": "Add SoundResonanceVR module",
     "path": "packages/universum-simulationen/SoundResonanceVR.ts",
     "task": "Extend resonance module with VR/3D sound features",
-    "status": "open",
+    "status": "done",
     "test": "packages/universum-simulationen/SoundResonanceVR.test.ts"
   },
   {

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7076,7 +7076,7 @@
   path: packages/unifiedmandala-vr/VRBegegnungsraum.ts
   task: Link VR space with MandalaCanvas for interactive view
   test: packages/unifiedmandala-vr/VRBegegnungsraumCanvas.test.ts
-  status: open
+  status: done
 - commit: Add PantheonKnowledgeGraph service
   path: packages/pantheon/PantheonKnowledgeGraph.ts
   task: Store Pantheon relations in Neo4j and expose RuleExplorer API
@@ -7659,13 +7659,13 @@
   commit: Integrate VRBegegnungsraum with MandalaCanvas
   path: packages/unifiedmandala-vr/VRBegegnungsraum.ts
   task: Link VR space with MandalaCanvas for interactive view
-  status: open
+  status: done
   test: packages/unifiedmandala-vr/VRBegegnungsraumCanvas.test.ts
 - category: VR-Begegnungsraum
   commit: Add SoundResonanceVR module
   path: packages/universum-simulationen/SoundResonanceVR.ts
   task: Extend resonance module with VR/3D sound features
-  status: open
+  status: done
   test: packages/universum-simulationen/SoundResonanceVR.test.ts
 - category: VR-Begegnungsraum
   commit: Create VRAvatarHub component

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: fix progress",
+  "lastCommit": "chore: finalize progress",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -9,10 +9,6 @@
   "pendingTasks": [
     {
       "commit": "Pantheon EventBus migration",
-      "status": "open"
-    },
-    {
-      "commit": "Integrate VRBegegnungsraum with MandalaCanvas",
       "status": "open"
     },
     {
@@ -97,14 +93,6 @@
     },
     {
       "commit": "PantheonArchiveExporter",
-      "status": "open"
-    },
-    {
-      "commit": "Integrate VRBegegnungsraum with MandalaCanvas",
-      "status": "open"
-    },
-    {
-      "commit": "Add SoundResonanceVR module",
       "status": "open"
     },
     {

--- a/packages/agents/TuringTestSuite.test.ts
+++ b/packages/agents/TuringTestSuite.test.ts
@@ -1,11 +1,14 @@
+import { describe, it, expect } from 'vitest';
 import { runTuringTest } from './TuringTestSuite';
 
-test('returns true when response hides identity', async () => {
-  const res = await runTuringTest(async () => 'I am doing well.');
-  expect(res).toBe(true);
-});
+describe('runTuringTest', () => {
+  it('returns true when response hides identity', async () => {
+    const res = await runTuringTest(async () => 'I am doing well.');
+    expect(res).toBe(true);
+  });
 
-test('returns false when response reveals bot', async () => {
-  const res = await runTuringTest(async () => 'I am a bot');
-  expect(res).toBe(false);
+  it('returns false when response reveals bot', async () => {
+    const res = await runTuringTest(async () => 'I am a bot');
+    expect(res).toBe(false);
+  });
 });

--- a/packages/unifiedmandala-vr/VRBegegnungsraumCanvas.test.ts
+++ b/packages/unifiedmandala-vr/VRBegegnungsraumCanvas.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { VRBegegnungsraumCanvasBridge } from './VRBegegnungsraumCanvas';
+
+class DummyListener {
+  events: string[] = [];
+  onVREvents(events: string[]) { this.events.push(...events); }
+}
+
+describe('VRBegegnungsraumCanvasBridge', () => {
+  it('connects and forwards events', async () => {
+    const bridge = new VRBegegnungsraumCanvasBridge();
+    const listener = new DummyListener();
+    await bridge.connect('scene', listener);
+    expect(listener.events[0]).toBe('loaded:scene');
+  });
+});

--- a/packages/unifiedmandala-vr/VRBegegnungsraumCanvas.ts
+++ b/packages/unifiedmandala-vr/VRBegegnungsraumCanvas.ts
@@ -1,0 +1,14 @@
+import { VRBegegnungsraum } from './VRBegegnungsraum';
+
+export interface CanvasListener {
+  onVREvents(events: string[]): void;
+}
+
+export class VRBegegnungsraumCanvasBridge {
+  constructor(private room = new VRBegegnungsraum()) {}
+
+  async connect(url: string, listener: CanvasListener) {
+    const evt = await this.room.join(url);
+    listener.onVREvents([evt]);
+  }
+}

--- a/packages/unifiedmandala-vr/index.ts
+++ b/packages/unifiedmandala-vr/index.ts
@@ -3,5 +3,6 @@ export * from './VRBegegnungsraum';
 export * from './VRBegegnungsraumLobby';
 export * from './VRSceneLoader';
 export * from './FourierLayerVRConnector';
+export * from './VRBegegnungsraumCanvas';
 export { default as VRPyramidPortal } from './components/VRPyramidPortal';
 export { default as VRMeetingHall3D } from './components/VRMeetingHall3D';

--- a/packages/universum-simulationen/SoundResonanceVR.test.ts
+++ b/packages/universum-simulationen/SoundResonanceVR.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { soundResonanceVR } from './SoundResonanceVR';
+
+describe('soundResonanceVR', () => {
+  it('generates 3D resonance data', () => {
+    const data = soundResonanceVR(Math.PI, 1, 4);
+    expect(data).toHaveLength(4);
+    expect(data[0]).toHaveProperty('x');
+    expect(data[0]).toHaveProperty('y');
+    expect(data[0]).toHaveProperty('z');
+  });
+});

--- a/packages/universum-simulationen/SoundResonanceVR.ts
+++ b/packages/universum-simulationen/SoundResonanceVR.ts
@@ -1,0 +1,12 @@
+export function soundResonanceVR(freq: number, amp: number, steps: number): {x:number,y:number,z:number}[] {
+  const data: {x:number,y:number,z:number}[] = [];
+  for (let i = 0; i < steps; i++) {
+    const angle = (i / steps) * freq;
+    data.push({
+      x: Math.sin(angle) * amp,
+      y: Math.cos(angle) * amp,
+      z: Math.sin(angle * 0.5) * amp,
+    });
+  }
+  return data;
+}


### PR DESCRIPTION
## Summary
- add VRBegegnungsraumCanvas bridge and tests
- implement SoundResonanceVR module with tests
- update TuringTestSuite test
- export VR bridge in index
- mark related tasks as done in advancedToDo and progress

## Testing
- `pnpm test:agents`
- `npx pyright`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68860c2ce2388322a2afce467dc287c4