### PR TITLE
Update resonance modules and docs

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-27, in der Zeit des Morgen.
+Am 2025-07-27, in der Zeit des Tag.
 
-Symbolphase: Initiation (Fokus: C)
+Symbolphase: Aktivierung (Fokus: R)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -57,11 +57,13 @@ Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js`
 - `FourierLayerBridge` – verbindet die FourierLayer-Metriken mit der Pyramid UI.
 - `FrequencyMandala` – stellt Frequenz-Blumen als SVG dar.
 - `FrequencyMandala3D` – WebGL-Darstellung der Frequenz-Blumen.
+- `ResonanceAutoTuner` – passt Frequenzen anhand von Feedback automatisch an.
  - `FourierAPI` – REST-Schnittstelle für Fourier-Metriken (`/metrics`, `/analyze`).
 - `FourierMetricsCLI` – Kommandozeilenwerkzeug für Fourier-Berechnungen.
 - `FractalTaskRunner` – führt YAML-basierte Plugin-Workflows aus.
 - `EventBridge` – leitet CosmicTheoryAgent-Events an die UI weiter.
 - `PyramidVRMeetingRoom` – VR-Raum für mehrere Avatare.
+- `PantheonAvatarraum` – gemeinsamer VR-Raum für Pantheon-Agenten.
 - CosmicTheoryAgent liefert VR-Hooks für immersive Steuerung.
 - `AeonOrchestrator` – zentrale Steuerinstanz des Pantheon, verteilt Boundary-Regeln.
 - `PantheonPortalAnalytics` – zeichnet Portalzugriffe auf.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**FourierLayerBridge**](packages/unifiedmandala-ui/events/FourierLayerBridge.ts) – streams metrics to the Pyramid UI via WebSocket
 - [**FrequencyMandala**](packages/unifiedmandala-ui/components/FrequencyMandala.tsx) – visualizes Fourier frequency flowers
 - [**FrequencyMandala3D**](packages/unifiedmandala-ui/components/FrequencyMandala3D.tsx) – WebGL view of frequency flowers
+- [**ResonanceAutoTuner**](packages/resonance-modules/ResonanceAutoTuner.ts) – auto-adjusts resonance via feedback
  - [**FourierAPI**](packages/analysis/FourierAPI.ts) – exposes metrics via REST (`/metrics`, `/analyze`)
 - [**SelfReflectionAgent**](packages/agents/SelfReflectionAgent.ts) – system introspection helper
 - [**GrokAgent**](packages/agents/GrokAgent.ts) – simple pattern analyzer
@@ -65,6 +66,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**PantheonBoundaryBridge**](packages/pantheon/PantheonBoundaryBridge.ts) – verbindet Pantheon-Events mit BoundaryRuleDetector
 - [**PantheonExport Tool**](packages/pantheon/tools/PantheonExport.ts) – exportiert die vorhandenen Pantheon-Module als Datensatz
 - **VR-Begegnungsraum** – Avatar-Interaktion und Mandala-Szenen im WebXR-Modul
+- [**PantheonAvatarraum**](packages/unifiedmandala-vr/components/PantheonAvatarraum.tsx) – shared VR space for Pantheon agents
 - [**EventBridge**](packages/unifiedmandala-ui/events/EventBridge.ts) – verbindet CosmicTheoryAgent mit der Pyramid UI
 - [**PyramidVRMeetingRoom**](packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.tsx) – enables multi-avatar VR sessions
 - CosmicTheoryAgent now exposes **VR hooks** for immersive interactions

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5551,7 +5551,7 @@
     "path": "packages/unifiedmandala-vr/components/PantheonAvatarraum.tsx",
     "task": "VR Begegnungsraum for Pantheon agents",
     "test": "packages/unifiedmandala-vr/components/PantheonAvatarraum.test.tsx",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add SoundResonanceVR module",
@@ -5852,7 +5852,7 @@
     "path": "packages/resonance/ResonanceFeedbackModule.ts",
     "task": "Collect user feedback and convert to resonance metrics",
     "test": "packages/resonance/ResonanceFeedbackModule.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add PantheonSessionManager",
@@ -5992,7 +5992,7 @@
     "path": "packages/resonance/ResonanceAutoTuner.ts",
     "task": "Auto tune resonance modules via Fourier analysis",
     "test": "packages/resonance/ResonanceAutoTuner.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create BoundaryLawPatternGenerator",
@@ -6709,7 +6709,7 @@
     "path": "packages/pantheon/ZivilisationsSandbox",
     "task": "Provide simulation blueprint for ancient megabuilds",
     "test": "packages/pantheon/ZivilisationsSandbox.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Integrate Climate data into UnifiedMandala",
@@ -6779,7 +6779,7 @@
     "path": "packages/pantheon/ZivilisationsSandbox",
     "task": "Provide simulation blueprint for ancient megabuilds",
     "test": "packages/pantheon/ZivilisationsSandbox.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Integrate Climate data into UnifiedMandala",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7101,7 +7101,7 @@
   path: packages/unifiedmandala-vr/components/PantheonAvatarraum.tsx
   task: VR Begegnungsraum for Pantheon agents
   test: packages/unifiedmandala-vr/components/PantheonAvatarraum.test.tsx
-  status: open
+  status: done
 - commit: Add SoundResonanceVR module
   path: packages/universum-simulationen/SoundResonanceVR.ts
   task: Extend resonance module with VR/3D sound features
@@ -7317,7 +7317,7 @@
   path: packages/resonance/ResonanceFeedbackModule.ts
   task: Collect user feedback and convert to resonance metrics
   test: packages/resonance/ResonanceFeedbackModule.test.ts
-  status: open
+  status: done
 - commit: Add PantheonSessionManager
   path: packages/pantheon/PantheonSessionManager.ts
   task: Manage global session lifecycle for Pantheon modules
@@ -7342,7 +7342,7 @@
   path: packages/unifiedmandala-ui/components/FrequencyMandala3D.tsx
   task: 3D visualization of frequency mandala
   test: packages/unifiedmandala-ui/components/FrequencyMandala3D.test.tsx
-  status: open
+  status: done
 - commit: Add FourierAPI REST endpoint
   path: packages/analysis/FourierAPI.ts
   task: Serve Fourier metrics via Express
@@ -7357,7 +7357,7 @@
   path: packages/unifiedmandala-vr/components/PantheonAvatarraum.tsx
   task: VR Begegnungsraum for Pantheon agents
   test: packages/unifiedmandala-vr/components/__tests__/PantheonAvatarraum.test.tsx
-  status: open
+  status: done
 - commit: Implement ResonanceModuleOrchestrator
   path: packages/resonance-modules/ResonanceModuleOrchestrator.ts
   task: Coordinate extended resonance modules
@@ -7397,7 +7397,7 @@
   path: packages/resonance/ResonanceAutoTuner.ts
   task: Auto tune resonance modules via Fourier analysis
   test: packages/resonance/ResonanceAutoTuner.test.ts
-  status: open
+  status: done
 - commit: Create BoundaryLawPatternGenerator
   path: packages/boundary-engine/BoundaryLawPatternGenerator.ts
   task: Generate boundary patterns from datasets
@@ -7892,7 +7892,7 @@
   path: packages/pantheon/ZivilisationsSandbox
   task: Provide simulation blueprint for ancient megabuilds
   test: packages/pantheon/ZivilisationsSandbox.test.ts
-  status: open
+  status: done
 - commit: Integrate Climate data into UnifiedMandala
   path: packages/unifiedmandala-climate
   task: Advanced blueprint for climate integration

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: finalize progress",
+  "lastCommit": "chore: update chrono poem",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -13,10 +13,6 @@
     },
     {
       "commit": "Upgrade CosmicTheoryAgent",
-      "status": "open"
-    },
-    {
-      "commit": "Create PantheonAvatarraum VR space",
       "status": "open"
     },
     {
@@ -60,23 +56,7 @@
       "status": "open"
     },
     {
-      "commit": "ResonanceFeedbackModule",
-      "status": "open"
-    },
-    {
-      "commit": "Add FrequencyMandala3D component",
-      "status": "open"
-    },
-    {
-      "commit": "Create PantheonAvatarraum component",
-      "status": "open"
-    },
-    {
       "commit": "Add BoundaryLawSimulator",
-      "status": "open"
-    },
-    {
-      "commit": "Add ResonanceAutoTuner",
       "status": "open"
     },
     {
@@ -142,15 +122,15 @@
     {
       "commit": "Configure PyramidUI tests and deployment",
       "status": "open"
-    },
-    {
-      "commit": "Add ZivilisationsSandbox module",
-      "status": "open"
     }
   ],
   "progress": [
     {
       "commit": "Implement boundary manager modules",
+      "status": "done"
+    },
+    {
+      "commit": "Marked ZivilisationsSandbox and VR modules done",
       "status": "done"
     },
     {

--- a/packages/resonance/ResonanceAutoTuner.test.ts
+++ b/packages/resonance/ResonanceAutoTuner.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { ResonanceAutoTuner } from './ResonanceAutoTuner';
+
+describe('ResonanceAutoTuner wrapper', () => {
+  it('delegates tuning to core tuner', () => {
+    const tuner = new ResonanceAutoTuner();
+    const res = tuner.tune({ frequency: 1, intensity: 1 }, [0.5]);
+    expect(res.frequency).toBeGreaterThan(1);
+  });
+});

--- a/packages/resonance/ResonanceAutoTuner.ts
+++ b/packages/resonance/ResonanceAutoTuner.ts
@@ -1,0 +1,5 @@
+import { ResonanceAutoTuner as CoreTuner, ResonanceParameters } from '../resonance-modules/ResonanceAutoTuner';
+
+export { ResonanceParameters };
+
+export class ResonanceAutoTuner extends CoreTuner {}

--- a/packages/resonance/ResonanceFeedbackModule.test.ts
+++ b/packages/resonance/ResonanceFeedbackModule.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { ResonanceFeedbackModule } from './ResonanceFeedbackModule';
+
+describe('ResonanceFeedbackModule wrapper', () => {
+  it('records feedback', () => {
+    const mod = new ResonanceFeedbackModule();
+    mod.record(2);
+    expect(mod.average()).toBe(2);
+  });
+});

--- a/packages/resonance/ResonanceFeedbackModule.ts
+++ b/packages/resonance/ResonanceFeedbackModule.ts
@@ -1,0 +1,3 @@
+import { ResonanceFeedbackModule as CoreModule } from '../resonance-modules/ResonanceFeedbackModule';
+
+export class ResonanceFeedbackModule extends CoreModule {}


### PR DESCRIPTION
## Summary
- add wrapper modules for `ResonanceAutoTuner` and `ResonanceFeedbackModule`
- document `PantheonAvatarraum` and `ResonanceAutoTuner`
- mark implemented tasks as done in advanced todo lists
- sync chronological progress

## Testing
- `npx pyright` *(fails: Import errors)*
- `npx tsc -p tsconfig.json`
- `pnpm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68861cade07883228daa3d314de96b15