### PR TITLE
feat: add ResonanceModuleSynth

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -76,6 +76,7 @@ Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js`
 - `SelfReflectionAgent` – überwacht Logs und fasst Erkenntnisse zusammen.
 - `GrokAgent` – erkennt einfache Wortmuster.
 - `ShadowIntegration` – experimentelle Schnittstelle für Datentransfer.
+- `ResonanceModuleSynth` – erzeugt Audiosignale für Resonanzmodule.
 - `MemoryGovernance` – speichert Zustände mit Governance-Regeln.
 - `TuringOrchestrator` – führt minimale Turing-Tests aus.
 - `Climate Module` – integriert Klimadaten ins Mandala.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**useABLayout**](packages/unifiedmandala-ui/hooks/useABLayout.ts) – A/B-Tests mit CREP-Metrik
 - [**usePulse & HapticService**](packages/bio/HapticService.ts) – simulierte Biosensoren und haptisches Feedback
 - [**TonePlayground**](packages/unifiedmandala-ui/TonePlayground.ts) – experimentelle Klangsteuerung für Phi-Skalen
+- [**ResonanceModuleSynth**](packages/resonance-modules/ResonanceModuleSynth.ts) – erzeugt Audiosignale für Resonanzmodule
 - [**SigillinTimeline & InviteBanner**](packages/unifiedmandala-ui/components/SigillinTimeline.tsx) – Verlauf und Einladungsbanner
 - [**CREPTimeline**](packages/unifiedmandala-ui/components/CREPTimeline.tsx) – chronologische Ansicht der CREP-Ereignisse
 - [**BackupManager**](packages/cli-tools/BackupManager.ts) – einfache Dateisicherungen

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5789,7 +5789,7 @@
     "path": "packages/resonance-modules/ResonanceModuleSynth.ts",
     "task": "Sound synthesis layer for resonance modules",
     "test": "packages/resonance-modules/ResonanceModuleSynth.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add CosmicTheoryAgent introspection logs",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7272,7 +7272,7 @@
   path: packages/resonance-modules/ResonanceModuleSynth.ts
   task: Sound synthesis layer for resonance modules
   test: packages/resonance-modules/ResonanceModuleSynth.test.ts
-  status: open
+  status: done
 - commit: Add CosmicTheoryAgent introspection logs
   path: packages/agents/CosmicTheoryAgent.ts
   task: Introspective logging of FourierLayer metrics

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -45,7 +45,7 @@
     },
     {
       "commit": "Implement ResonanceModuleSynth",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add CosmicTheoryAgent introspection logs",

--- a/packages/resonance-modules/ResonanceModuleSynth.ts
+++ b/packages/resonance-modules/ResonanceModuleSynth.ts
@@ -1,0 +1,22 @@
+export interface SynthParams {
+  frequencies: number[];
+  gain: number;
+}
+
+export class ResonanceModuleSynth {
+  constructor(private sampleRate = 44100) {}
+
+  synthesize(params: SynthParams, lengthSeconds = 1): Float32Array {
+    const totalSamples = Math.floor(this.sampleRate * lengthSeconds);
+    const buffer = new Float32Array(totalSamples);
+    for (let i = 0; i < totalSamples; i++) {
+      const t = i / this.sampleRate;
+      let val = 0;
+      for (const f of params.frequencies) {
+        val += Math.sin(2 * Math.PI * f * t);
+      }
+      buffer[i] = (val / params.frequencies.length) * params.gain;
+    }
+    return buffer;
+  }
+}

--- a/packages/resonance-modules/__tests__/ResonanceModuleSynth.test.ts
+++ b/packages/resonance-modules/__tests__/ResonanceModuleSynth.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { ResonanceModuleSynth, SynthParams } from '../ResonanceModuleSynth';
+
+describe('ResonanceModuleSynth', () => {
+  it('generates a buffer for given frequencies', () => {
+    const synth = new ResonanceModuleSynth(1000);
+    const params: SynthParams = { frequencies: [10, 20], gain: 1 };
+    const buf = synth.synthesize(params, 0.1);
+    expect(buf.length).toBe(100);
+    const max = Math.max(...buf);
+    expect(max).toBeLessThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `ResonanceModuleSynth` with audio synthesis
- test coverage for new module
- mark ResonanceModuleSynth task done in `advancedToDo`
- update progress log
- reference new module in docs

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68861cade07883228daa3d314de96b15