### PR TITLE
Add unifiedmandala-neural example nets

### DIFF
--- a/unifiedmandala-neural/README.md
+++ b/unifiedmandala-neural/README.md
@@ -1,0 +1,20 @@
+# Unified Mandala Neural Networks
+
+Dieses Modul bündelt verschiedene neuronale Netztypen in einem Docker-Compose Setup.
+
+## Aufbau
+
+- **gnn_hgnn**: Beispiel für ein Graph Neural Network
+- **snn_haptic**: Spiking Neural Network zur Haptik-Simulation
+- **liquid_net**: Liquid Time-Constant Network
+- **kan_physics**: Kernel-based Approximation Network
+
+## Starten
+
+Alle Dienste lassen sich gemeinsam mit
+
+```bash
+docker-compose up --build
+```
+
+starten. Die Modelle können auch einzeln verwendet werden. Beispiel-Daten befinden sich unter `gnn_hgnn/data`.

--- a/unifiedmandala-neural/docker-compose.yml
+++ b/unifiedmandala-neural/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+services:
+  gnn_hgnn:
+    build: ./gnn_hgnn
+    volumes:
+      - ./gnn_hgnn/data:/app/data
+    command: python main.py
+    ports:
+      - "8001:8001"
+
+  snn_haptic:
+    build: ./snn_haptic
+    command: python snn_pilot.py
+    ports:
+      - "8002:8002"
+
+  liquid_net:
+    build: ./liquid_net
+    command: python liquid_train.py
+    ports:
+      - "8003:8003"
+
+  kan_physics:
+    build: ./kan_physics
+    command: python kan_simulation.py
+    ports:
+      - "8004:8004"

--- a/unifiedmandala-neural/gnn_hgnn/Dockerfile
+++ b/unifiedmandala-neural/gnn_hgnn/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "main.py"]

--- a/unifiedmandala-neural/gnn_hgnn/data/interactions.json
+++ b/unifiedmandala-neural/gnn_hgnn/data/interactions.json
@@ -1,0 +1,5 @@
+[
+  {"from": 0, "to": 1, "event": "resonates", "crep": 1.0},
+  {"from": 1, "to": 2, "event": "links", "crep": 0.8},
+  {"from": 2, "to": 0, "event": "references", "crep": 0.9}
+]

--- a/unifiedmandala-neural/gnn_hgnn/main.py
+++ b/unifiedmandala-neural/gnn_hgnn/main.py
@@ -1,0 +1,52 @@
+import torch
+from torch_geometric.data import Data
+from torch_geometric.nn import GCNConv
+import json
+
+with open('data/interactions.json') as f:
+    logs = json.load(f)
+
+
+def build_graph(logs):
+    nodes = set()
+    edges = []
+    for l in logs:
+        nodes.add(l['from'])
+        nodes.add(l['to'])
+        edges.append((l['from'], l['to']))
+    nodes = sorted(nodes)
+    node_map = {k: i for i, k in enumerate(nodes)}
+    edge_index = torch.tensor([[node_map[f], node_map[t]] for f, t in edges]).t().contiguous()
+    x = torch.randn(len(nodes), 8)
+    return Data(x=x, edge_index=edge_index)
+
+
+data = build_graph(logs)
+
+
+nclass = data.x.size(1)
+
+class GNN(torch.nn.Module):
+    def __init__(self, in_channels, hidden, out):
+        super().__init__()
+        self.conv1 = GCNConv(in_channels, hidden)
+        self.conv2 = GCNConv(hidden, out)
+
+    def forward(self, x, edge_index):
+        x = self.conv1(x, edge_index).relu()
+        x = self.conv2(x, edge_index)
+        return x
+
+
+model = GNN(nclass, 32, 8)
+optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+for epoch in range(50):
+    model.train()
+    optimizer.zero_grad()
+    out = model(data.x, data.edge_index)
+    loss = (out ** 2).mean()
+    loss.backward()
+    optimizer.step()
+    if epoch % 10 == 0:
+        print('Epoch', epoch, 'Loss:', loss.item())
+print('GNN trainiert.')

--- a/unifiedmandala-neural/gnn_hgnn/requirements.txt
+++ b/unifiedmandala-neural/gnn_hgnn/requirements.txt
@@ -1,0 +1,2 @@
+torch
+torch-geometric

--- a/unifiedmandala-neural/kan_physics/Dockerfile
+++ b/unifiedmandala-neural/kan_physics/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "kan_simulation.py"]

--- a/unifiedmandala-neural/kan_physics/kan_simulation.py
+++ b/unifiedmandala-neural/kan_physics/kan_simulation.py
@@ -1,0 +1,12 @@
+from kan_network import KANLayer
+import torch
+
+torch.manual_seed(0)
+data = torch.rand(1, 10)
+model = torch.nn.Sequential(
+    KANLayer(10, 64),
+    torch.nn.ReLU(),
+    KANLayer(64, 1)
+)
+output = model(data)
+print("KAN Output:", output)

--- a/unifiedmandala-neural/kan_physics/requirements.txt
+++ b/unifiedmandala-neural/kan_physics/requirements.txt
@@ -1,0 +1,2 @@
+torch
+kan-network

--- a/unifiedmandala-neural/liquid_net/Dockerfile
+++ b/unifiedmandala-neural/liquid_net/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "liquid_train.py"]

--- a/unifiedmandala-neural/liquid_net/liquid_train.py
+++ b/unifiedmandala-neural/liquid_net/liquid_train.py
@@ -1,0 +1,19 @@
+import torch
+from torch import nn, optim
+from liquid_time_constant_network import LTC
+
+X = torch.randn(16, 100, 32)
+Y = torch.randint(0, 3, (16,))
+
+model = LTC(input_size=32, hidden_size=64, output_size=3)
+optimizer = optim.Adam(model.parameters(), lr=1e-3)
+loss_fn = nn.CrossEntropyLoss()
+
+for epoch in range(5):
+    for i in range(X.size(0)):
+        pred = model(X[i])
+        loss = loss_fn(pred, Y[i].unsqueeze(0))
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+    print(f"Epoch {epoch} Loss: {loss.item()}")

--- a/unifiedmandala-neural/liquid_net/requirements.txt
+++ b/unifiedmandala-neural/liquid_net/requirements.txt
@@ -1,0 +1,2 @@
+torch
+liquid-time-constant-network

--- a/unifiedmandala-neural/snn_haptic/Dockerfile
+++ b/unifiedmandala-neural/snn_haptic/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "snn_pilot.py"]

--- a/unifiedmandala-neural/snn_haptic/requirements.txt
+++ b/unifiedmandala-neural/snn_haptic/requirements.txt
@@ -1,0 +1,3 @@
+torch
+norse
+numpy

--- a/unifiedmandala-neural/snn_haptic/snn_pilot.py
+++ b/unifiedmandala-neural/snn_haptic/snn_pilot.py
@@ -1,0 +1,23 @@
+import torch
+import norse.torch as norse
+import numpy as np
+
+input_signal = torch.tensor(np.random.rand(1, 100), dtype=torch.float32)
+
+class HapticSNN(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.cell = norse.LIFCell()
+
+    def forward(self, x):
+        mem = None
+        spikes = []
+        for t in range(x.size(1)):
+            spk, mem = self.cell(x[:, t], mem)
+            spikes.append(spk)
+        return torch.stack(spikes, dim=1)
+
+
+model = HapticSNN()
+spikes = model(input_signal)
+print("Spikes detected:", spikes.sum().item())


### PR DESCRIPTION
## Summary
- add `unifiedmandala-neural` with example GNN, SNN, Liquid and KAN networks
- Docker-compose to run the individual services
- usage instructions in README

## Testing
- `pnpm install`
- `poetry install --with test` *(fails: Poetry could not find a pyproject file)*
- `npx pyright unifiedmandala-neural` *(fails: missing packages)*
- `npx tsc -p tsconfig.json`
- `pnpm test` *(OOM failure)*
- `pnpm test:agents`

------
https://chatgpt.com/codex/tasks/task_e_688664cc56308322a6d16e5054d89289