### PR TITLE
Add orchestrator template

### DIFF
--- a/unifiedmandala-orchestrator/README.md
+++ b/unifiedmandala-orchestrator/README.md
@@ -1,0 +1,25 @@
+# UnifiedMandala Orchestrator
+
+Dieses Minimal-Setup stellt einen Scheduler und mehrere Microservices bereit, um
+Sigillin-Events an spezialisierte neuronale Netze weiterzuleiten.
+
+## Start
+
+```bash
+docker-compose up --build
+```
+
+## Sigillin-Event senden
+
+```bash
+curl -X POST http://localhost:9000/sigillin-event \
+  -H "Content-Type: application/json" \
+  -d '{"task_type":"graph_pattern","crep_score":0.77,"data":{"nodes":[]}}'
+```
+
+Logs zeigen CREP-Events und Routingentscheidungen.
+
+### Erweiterung
+
+* Eigene NN-Services in `nets/` ergänzen
+* Schwellenwerte in `orchestrator/pipeline_config.yaml` anpassen

--- a/unifiedmandala-orchestrator/docker-compose.yml
+++ b/unifiedmandala-orchestrator/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+services:
+  orchestrator:
+    build: ./orchestrator
+    ports:
+      - "9000:8000"
+  gnn_service:
+    build: ./nets/gnn_service
+    ports:
+      - "8001:8000"
+  hgnn_service:
+    build: ./nets/hgnn_service
+    ports:
+      - "8002:8000"
+  snn_service:
+    build: ./nets/snn_service
+    ports:
+      - "8003:8000"
+  liquidnet_service:
+    build: ./nets/liquidnet_service
+    ports:
+      - "8004:8000"
+  kan_service:
+    build: ./nets/kan_service
+    ports:
+      - "8005:8000"
+  npu_service:
+    build: ./nets/npu_service
+    ports:
+      - "8006:8000"

--- a/unifiedmandala-orchestrator/nets/gnn_service/Dockerfile
+++ b/unifiedmandala-orchestrator/nets/gnn_service/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/unifiedmandala-orchestrator/nets/gnn_service/main.py
+++ b/unifiedmandala-orchestrator/nets/gnn_service/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI, Request
+
+app = FastAPI()
+
+@app.post("/process")
+async def process(request: Request):
+    data = await request.json()
+    result = {"result": "GNN_SERVICE processed", "input_shape": len(data)}
+    return result

--- a/unifiedmandala-orchestrator/nets/gnn_service/requirements.txt
+++ b/unifiedmandala-orchestrator/nets/gnn_service/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/unifiedmandala-orchestrator/nets/hgnn_service/Dockerfile
+++ b/unifiedmandala-orchestrator/nets/hgnn_service/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/unifiedmandala-orchestrator/nets/hgnn_service/main.py
+++ b/unifiedmandala-orchestrator/nets/hgnn_service/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI, Request
+
+app = FastAPI()
+
+@app.post("/process")
+async def process(request: Request):
+    data = await request.json()
+    result = {"result": "HGNN_SERVICE processed", "input_shape": len(data)}
+    return result

--- a/unifiedmandala-orchestrator/nets/hgnn_service/requirements.txt
+++ b/unifiedmandala-orchestrator/nets/hgnn_service/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/unifiedmandala-orchestrator/nets/kan_service/Dockerfile
+++ b/unifiedmandala-orchestrator/nets/kan_service/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/unifiedmandala-orchestrator/nets/kan_service/main.py
+++ b/unifiedmandala-orchestrator/nets/kan_service/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI, Request
+
+app = FastAPI()
+
+@app.post("/process")
+async def process(request: Request):
+    data = await request.json()
+    result = {"result": "KAN_SERVICE processed", "input_shape": len(data)}
+    return result

--- a/unifiedmandala-orchestrator/nets/kan_service/requirements.txt
+++ b/unifiedmandala-orchestrator/nets/kan_service/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/unifiedmandala-orchestrator/nets/liquidnet_service/Dockerfile
+++ b/unifiedmandala-orchestrator/nets/liquidnet_service/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/unifiedmandala-orchestrator/nets/liquidnet_service/main.py
+++ b/unifiedmandala-orchestrator/nets/liquidnet_service/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI, Request
+
+app = FastAPI()
+
+@app.post("/process")
+async def process(request: Request):
+    data = await request.json()
+    result = {"result": "LIQUIDNET_SERVICE processed", "input_shape": len(data)}
+    return result

--- a/unifiedmandala-orchestrator/nets/liquidnet_service/requirements.txt
+++ b/unifiedmandala-orchestrator/nets/liquidnet_service/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/unifiedmandala-orchestrator/nets/npu_service/Dockerfile
+++ b/unifiedmandala-orchestrator/nets/npu_service/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/unifiedmandala-orchestrator/nets/npu_service/main.py
+++ b/unifiedmandala-orchestrator/nets/npu_service/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI, Request
+
+app = FastAPI()
+
+@app.post("/process")
+async def process(request: Request):
+    data = await request.json()
+    result = {"result": "NPU_SERVICE processed", "input_shape": len(data)}
+    return result

--- a/unifiedmandala-orchestrator/nets/npu_service/requirements.txt
+++ b/unifiedmandala-orchestrator/nets/npu_service/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/unifiedmandala-orchestrator/nets/snn_service/Dockerfile
+++ b/unifiedmandala-orchestrator/nets/snn_service/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/unifiedmandala-orchestrator/nets/snn_service/main.py
+++ b/unifiedmandala-orchestrator/nets/snn_service/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI, Request
+
+app = FastAPI()
+
+@app.post("/process")
+async def process(request: Request):
+    data = await request.json()
+    result = {"result": "SNN_SERVICE processed", "input_shape": len(data)}
+    return result

--- a/unifiedmandala-orchestrator/nets/snn_service/requirements.txt
+++ b/unifiedmandala-orchestrator/nets/snn_service/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/unifiedmandala-orchestrator/orchestrator/Dockerfile
+++ b/unifiedmandala-orchestrator/orchestrator/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/unifiedmandala-orchestrator/orchestrator/app.py
+++ b/unifiedmandala-orchestrator/orchestrator/app.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI, Request
+from sigillin_scheduler import SigillinScheduler
+
+app = FastAPI()
+scheduler = SigillinScheduler()
+
+@app.post("/sigillin-event")
+async def handle_event(request: Request):
+    event = await request.json()
+    result = scheduler.route(event)
+    return result

--- a/unifiedmandala-orchestrator/orchestrator/pipeline_config.yaml
+++ b/unifiedmandala-orchestrator/orchestrator/pipeline_config.yaml
@@ -1,0 +1,17 @@
+sigillin_map:
+  graph_pattern:    gnn_service
+  multi_relation:   hgnn_service
+  sensor_stream:    snn_service
+  language_seq:     transformer_service
+  time_series:      liquidnet_service
+  physics_sim:      kan_service
+  on_device_task:   npu_service
+
+crep_thresholds:
+  gnn_service: 0.60
+  hgnn_service: 0.65
+  snn_service: 0.55
+  transformer_service: 0.65
+  liquidnet_service: 0.60
+  kan_service: 0.70
+  npu_service: 0.50

--- a/unifiedmandala-orchestrator/orchestrator/requirements.txt
+++ b/unifiedmandala-orchestrator/orchestrator/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+requests
+PyYAML

--- a/unifiedmandala-orchestrator/orchestrator/sigillin_scheduler.py
+++ b/unifiedmandala-orchestrator/orchestrator/sigillin_scheduler.py
@@ -1,0 +1,28 @@
+import yaml
+import requests
+
+class SigillinScheduler:
+    def __init__(self, config_file='pipeline_config.yaml'):
+        with open(config_file) as f:
+            cfg = yaml.safe_load(f)
+        self.map = cfg['sigillin_map']
+        self.thresholds = cfg['crep_thresholds']
+
+    def pick_service(self, task_type, crep):
+        service = self.map.get(task_type)
+        threshold = self.thresholds.get(service, 0.6)
+        if crep >= threshold:
+            return service
+        return None
+
+    def route(self, sigillin_event):
+        # sigillin_event = {task_type, crep_score, data}
+        task_type = sigillin_event['task_type']
+        crep = sigillin_event.get('crep_score', 1.0)
+        service = self.pick_service(task_type, crep)
+        if not service:
+            print(f"[SKIP] CREP zu niedrig: {task_type} ({crep})")
+            return {"status": "skip", "reason": "low_crep"}
+        url = f"http://{service}:8000/process"
+        resp = requests.post(url, json=sigillin_event['data'])
+        return resp.json()


### PR DESCRIPTION
## Summary
- add orchestrator project with Docker services for Sigillin routing
- implement SigillinScheduler and REST endpoint
- stub GNN/HGNN/SNN/LiquidNet/KAN/NPU microservices
- provide docker compose and README with quickstart instructions

## Testing
- `pnpm install`
- `poetry install --with test` *(failed: no `pyproject.toml` found)*
- `npx pyright` *(errors: missing imports)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6886710f323c8322882d428fe5b3b3c6