### PR TITLE
Implement trauma detection in MemoryGovernanceService

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6537,6 +6537,13 @@
     "status": "done"
   },
   {
+    "commit": "Add trauma detection to MemoryGovernanceService",
+    "path": "services/memory-governance/index.ts",
+    "task": "detectTrauma method identifies negative memory entries",
+    "test": "services/memory-governance/index.test.ts",
+    "status": "done"
+  },
+  {
     "commit": "Draft ZivilisationsSandboxen blueprint",
     "path": "docs/blueprints/ZivilisationsSandboxen.md",
     "task": "Blueprint for ancient megabuilding sandbox design",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7822,6 +7822,11 @@
   task: Provide memory governance enforcement
   test: services/memory-governance/index.test.ts
   status: done
+- commit: Add trauma detection to MemoryGovernanceService
+  path: services/memory-governance/index.ts
+  task: detectTrauma method identifies negative memory entries
+  test: services/memory-governance/index.test.ts
+  status: done
 - commit: Draft ZivilisationsSandboxen blueprint
   path: docs/blueprints/ZivilisationsSandboxen.md
   task: Blueprint for ancient megabuilding sandbox design

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat(agents): add GrokAgent skeleton and update todo",
+  "lastCommit": "chore(progress): update progress log",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -331,6 +331,11 @@
     },
     {
       "commit": "Implement KIKeilschrift module",
+      "status": "done"
+    },
+    {
+      "featureId": "memory-governance",
+      "commit": "add trauma detection",
       "status": "done"
     }
   ],

--- a/packages/agents/GrokAgent.test.ts
+++ b/packages/agents/GrokAgent.test.ts
@@ -1,6 +1,9 @@
+import { describe, it, expect } from 'vitest';
 import { GrokAgent } from './GrokAgent';
 
-test('analyze counts words', () => {
-  const agent = new GrokAgent();
-  expect(agent.analyze('hello world')).toBe('Grokking 2 words');
+describe('GrokAgent', () => {
+  it('analyze counts words', () => {
+    const agent = new GrokAgent();
+    expect(agent.analyze('hello world')).toBe('Grokking 2 words');
+  });
 });

--- a/services/memory-governance/index.test.ts
+++ b/services/memory-governance/index.test.ts
@@ -9,3 +9,12 @@ test('enforceLimit triggers cleanup when limit exceeded', () => {
   governance.enforceLimit('daily', 1);
   expect(manager.get('daily').length).toBeLessThanOrEqual(1);
 });
+
+test('detectTrauma filters negative entries', () => {
+  const manager = new MemoryManager({ daily: 0, weekly: 0, longterm: 0 });
+  manager.add('daily', 'happy day');
+  manager.add('daily', 'deep trauma event');
+  const governance = new MemoryGovernanceService(manager);
+  const result = governance.detectTrauma('daily');
+  expect(result).toEqual(['deep trauma event']);
+});

--- a/services/memory-governance/index.ts
+++ b/services/memory-governance/index.ts
@@ -9,4 +9,9 @@ export class MemoryGovernanceService {
       this.manager["cleanup"](category as any);
     }
   }
+
+  detectTrauma(category: MemoryCategory): string[] {
+    const traumaRegex = /\b(angst|trauma|fear|panic|worry|sad)\b/i;
+    return this.manager.get(category).filter((t) => traumaRegex.test(t));
+  }
 }


### PR DESCRIPTION
## Summary
- add `detectTrauma` method in MemoryGovernanceService
- test trauma detection logic
- fix GrokAgent test for Vitest
- document trauma detection in advanced todo lists

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test`
- `pnpm run test:agents`


------
https://chatgpt.com/codex/tasks/task_e_68867cb80f048322bba7f06d9b39c3c3