### PR TITLE
Implement VR customization and resonance module

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -5845,14 +5845,14 @@
     "path": "packages/unifiedmandala-vr/VRAvatarCustomization.ts",
     "task": "Support custom avatars in VR Begegnungsraum",
     "test": "packages/unifiedmandala-vr/VRAvatarCustomization.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "ResonanceFeedbackModule",
     "path": "packages/resonance/ResonanceFeedbackModule.ts",
     "task": "Collect user feedback and convert to resonance metrics",
     "test": "packages/resonance/ResonanceFeedbackModule.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add PantheonSessionManager",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7312,12 +7312,12 @@
   path: packages/unifiedmandala-vr/VRAvatarCustomization.ts
   task: Support custom avatars in VR Begegnungsraum
   test: packages/unifiedmandala-vr/VRAvatarCustomization.test.ts
-  status: open
+  status: done
 - commit: ResonanceFeedbackModule
   path: packages/resonance/ResonanceFeedbackModule.ts
   task: Collect user feedback and convert to resonance metrics
   test: packages/resonance/ResonanceFeedbackModule.test.ts
-  status: open
+  status: done
 - commit: Add PantheonSessionManager
   path: packages/pantheon/PantheonSessionManager.ts
   task: Manage global session lifecycle for Pantheon modules

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: implement sandbox and testing modules",
+  "lastCommit": "feat: implement VR avatar customization and resonance feedback",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -17,14 +17,6 @@
     },
     {
       "commit": "PantheonArchiveExporter",
-      "status": "open"
-    },
-    {
-      "commit": "VRAvatarCustomization",
-      "status": "open"
-    },
-    {
-      "commit": "ResonanceFeedbackModule",
       "status": "open"
     },
     {
@@ -300,6 +292,14 @@
     },
     {
       "commit": "implement advanced modules",
+      "status": "done"
+    },
+    {
+      "commit": "meta:implement-features – VR avatar customization and resonance feedback",
+      "status": "done"
+    },
+    {
+      "commit": "meta:implement-features – VR avatar customization and resonance feedback",
       "status": "done"
     }
   ],

--- a/packages/resonance/ResonanceFeedbackModule.test.ts
+++ b/packages/resonance/ResonanceFeedbackModule.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { ResonanceFeedbackModule } from './ResonanceFeedbackModule';
+
+describe('ResonanceFeedbackModule', () => {
+  it('records and averages feedback', () => {
+    const mod = new ResonanceFeedbackModule();
+    mod.record(2);
+    mod.record(4);
+    expect(mod.average()).toBe(3);
+  });
+});

--- a/packages/resonance/ResonanceFeedbackModule.ts
+++ b/packages/resonance/ResonanceFeedbackModule.ts
@@ -1,0 +1,12 @@
+export class ResonanceFeedbackModule {
+  private feedback: number[] = [];
+
+  record(value: number) {
+    this.feedback.push(value);
+  }
+
+  average(): number {
+    if (this.feedback.length === 0) return 0;
+    return this.feedback.reduce((a, b) => a + b, 0) / this.feedback.length;
+  }
+}

--- a/packages/unifiedmandala-vr/VRAvatarCustomization.test.ts
+++ b/packages/unifiedmandala-vr/VRAvatarCustomization.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { VRAvatarCustomization } from './VRAvatarCustomization';
+
+describe('VRAvatarCustomization', () => {
+  it('merges and retrieves options', () => {
+    const c = new VRAvatarCustomization();
+    c.setOptions({ color: 'blue' });
+    c.setOptions({ accessory: 'hat' });
+    expect(c.getOptions()).toEqual({ color: 'blue', accessory: 'hat' });
+  });
+});

--- a/packages/unifiedmandala-vr/VRAvatarCustomization.ts
+++ b/packages/unifiedmandala-vr/VRAvatarCustomization.ts
@@ -1,0 +1,16 @@
+export interface AvatarOptions {
+  color?: string;
+  accessory?: string;
+}
+
+export class VRAvatarCustomization {
+  private options: AvatarOptions = {};
+
+  setOptions(opts: AvatarOptions) {
+    this.options = { ...this.options, ...opts };
+  }
+
+  getOptions(): AvatarOptions {
+    return this.options;
+  }
+}


### PR DESCRIPTION
## Summary
- add VRAvatarCustomization util with tests
- add ResonanceFeedbackModule with tests
- mark tasks as done in advancedToDo files
- log progress for implemented features

## Testing
- `pnpm install --frozen-lockfile`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68868904fd6c832298c96e5e4c80b32f