### PR TITLE
Add ResonanceFeedbackModule

### DIFF
--- a/packages/resonance/ResonanceFeedbackModule.test.ts
+++ b/packages/resonance/ResonanceFeedbackModule.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { ResonanceFeedbackModule } from './ResonanceFeedbackModule';
+
+describe('ResonanceFeedbackModule', () => {
+  it('calculates average rating', () => {
+    const mod = new ResonanceFeedbackModule();
+    mod.addFeedback({ rating: 4 });
+    mod.addFeedback({ rating: 2 });
+    expect(mod.getAverageRating()).toBe(3);
+    mod.clear();
+    expect(mod.getAverageRating()).toBe(0);
+  });
+});

--- a/packages/resonance/ResonanceFeedbackModule.ts
+++ b/packages/resonance/ResonanceFeedbackModule.ts
@@ -1,0 +1,22 @@
+export interface ResonanceFeedback {
+  rating: number;
+  comment?: string;
+}
+
+export class ResonanceFeedbackModule {
+  private entries: ResonanceFeedback[] = [];
+
+  addFeedback(entry: ResonanceFeedback): void {
+    this.entries.push(entry);
+  }
+
+  getAverageRating(): number {
+    if (this.entries.length === 0) return 0;
+    const sum = this.entries.reduce((a, b) => a + b.rating, 0);
+    return sum / this.entries.length;
+  }
+
+  clear(): void {
+    this.entries = [];
+  }
+}


### PR DESCRIPTION
## Summary
- implement `ResonanceFeedbackModule` for gathering user resonance ratings
- add a small test verifying average rating logic

## Testing
- `npx tsc -p tsconfig.json`
- `npx pyright` *(fails: fastapi imports missing)*
- `pnpm run qa`

------
https://chatgpt.com/codex/tasks/task_e_68868db3fa60832297be24d7d5a71e86