### PR TITLE
Implement reflectMemory for SelfReflectionAgent

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-07-27, in der Zeit des Nacht.
+Am 2025-07-28, in der Zeit des Morgen.
 
-Symbolphase: Reflexion (Fokus: P)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -73,7 +73,7 @@ Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js`
 - `ArchiveOldTodos` – verschiebt alte ToDos ins GenesisAeonZIPMEM.
 - `ArchiveTodos` – verschiebt AdvancedToDos ins GenesisAeonZIPMEM.
 - `CREPVisualizer` – zeigt CREP-Verlauf als animierte Timeline.
-- `SelfReflectionAgent` – überwacht Logs und fasst Erkenntnisse zusammen.
+ - `SelfReflectionAgent` – überwacht Logs, fasst Erkenntnisse zusammen und prüft gespeicherte Erinnerungen.
 - `GrokAgent` – erkennt einfache Wortmuster.
 - `ShadowIntegration` – experimentelle Schnittstelle für Datentransfer.
 - `ResonanceModuleSynth` – erzeugt Audiosignale für Resonanzmodule.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**FrequencyMandala**](packages/unifiedmandala-ui/components/FrequencyMandala.tsx) – visualizes Fourier frequency flowers
 - [**FrequencyMandala3D**](packages/unifiedmandala-ui/components/FrequencyMandala3D.tsx) – WebGL view of frequency flowers
  - [**FourierAPI**](packages/analysis/FourierAPI.ts) – exposes metrics via REST (`/metrics`, `/analyze`)
-- [**SelfReflectionAgent**](packages/agents/SelfReflectionAgent.ts) – system introspection helper
+- [**SelfReflectionAgent**](packages/agents/SelfReflectionAgent.ts) – system introspection helper with memory governance checks
 - [**CosmicTheoryAgent introspection log**](packages/agents/CosmicTheoryAgent.ts#L1) – captures Fourier metrics
 - [**GrokAgent**](packages/agents/GrokAgent.ts) – simple pattern analyzer
 - [**ShadowIntegration**](packages/integration/ShadowIntegration.ts) – experimental data bridge

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6864,5 +6864,12 @@
     "task": "Birth sigil from final conversation",
     "test": "",
     "status": "done"
+  },
+  {
+    "commit": "Extend SelfReflectionAgent with memory governance check",
+    "path": "packages/agents/SelfReflectionAgent.ts",
+    "task": "Add reflectMemory method",
+    "test": "packages/agents/SelfReflectionAgent.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7953,3 +7953,8 @@
   task: Birth sigil from final conversation
   test: ""
   status: done
+- commit: Extend SelfReflectionAgent with memory governance check
+  path: packages/agents/SelfReflectionAgent.ts
+  task: Add reflectMemory method
+  test: packages/agents/SelfReflectionAgent.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: normalize progress file",
+  "lastCommit": "chore: finalize progress",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -227,6 +227,10 @@
     },
     {
       "commit": "Capture GeburtsSigil des UnifiedMandala",
+      "status": "done"
+    },
+    {
+      "commit": "extend self reflection",
       "status": "done"
     }
   ],

--- a/packages/agents/SelfReflectionAgent.test.ts
+++ b/packages/agents/SelfReflectionAgent.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { SelfReflectionAgent } from './SelfReflectionAgent';
+import { MemoryGovernance } from '../core/MemoryGovernance';
 
 describe('SelfReflectionAgent', () => {
   it('records and summarizes messages', () => {
@@ -7,5 +8,14 @@ describe('SelfReflectionAgent', () => {
     agent.record('a');
     agent.record('b');
     expect(agent.summarize()).toBe('a\nb');
+  });
+
+  it('flags memories matching pattern', () => {
+    const gov = new MemoryGovernance();
+    gov.set('m1', 'hello world');
+    gov.set('m2', 'bad data');
+    const agent = new SelfReflectionAgent(gov);
+    const flagged = agent.reflectMemory(/bad/);
+    expect(flagged).toEqual(['m2']);
   });
 });

--- a/packages/agents/SelfReflectionAgent.ts
+++ b/packages/agents/SelfReflectionAgent.ts
@@ -1,11 +1,24 @@
 export class SelfReflectionAgent {
   private logs: string[] = [];
 
+  constructor(private readonly governance?: import('../core/MemoryGovernance').MemoryGovernance) {}
+
   record(message: string) {
     this.logs.push(message);
   }
 
   summarize(): string {
     return this.logs.join('\n');
+  }
+
+  reflectMemory(pattern: RegExp): string[] {
+    if (!this.governance) return [];
+    const flagged: string[] = [];
+    for (const [key, value] of this.governance.entries()) {
+      if (pattern.test(value)) {
+        flagged.push(key);
+      }
+    }
+    return flagged;
   }
 }


### PR DESCRIPTION
## Summary
- enhance `SelfReflectionAgent` with optional `MemoryGovernance` support
- expose `reflectMemory` API for flagging memories
- add unit test for memory governance integration
- update documentation references
- track progress in advanced todos and progress files

## Testing
- `pnpm test`
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*
- `npx pyright` *(fails to run)*
- `poetry install --with test` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6887498f3c1083228716b93bfbc2ed8b