### PR TITLE
Implement latest CREP hook and VR integration

### DIFF
--- a/packages/unifiedmandala-ui/components/VRBegegnungsraum.test.tsx
+++ b/packages/unifiedmandala-ui/components/VRBegegnungsraum.test.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import VRBegegnungsraum from './VRBegegnungsraum';
 
+global.fetch = jest.fn(() =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve({ value: 7 }) })
+) as any;
+
 describe('VRBegegnungsraum', () => {
-  it('renders label', () => {
+  it('renders label and crep value', async () => {
     render(<VRBegegnungsraum />);
     expect(screen.getByText('VR Raum')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('crep-value')).toHaveTextContent('CREP: 7'));
   });
 });

--- a/packages/unifiedmandala-ui/components/VRBegegnungsraum.tsx
+++ b/packages/unifiedmandala-ui/components/VRBegegnungsraum.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
+import { useLatestCREP } from '../hooks/useLatestCREP';
 
 export default function VRBegegnungsraum() {
-  return <div>VR Raum</div>;
+  const { value, error } = useLatestCREP();
+  return (
+    <div>
+      VR Raum
+      {value !== null && <div data-testid="crep-value">CREP: {value}</div>}
+      {error && <div data-testid="error">{error}</div>}
+    </div>
+  );
 }

--- a/packages/unifiedmandala-ui/hooks/useLatestCREP.test.ts
+++ b/packages/unifiedmandala-ui/hooks/useLatestCREP.test.ts
@@ -1,0 +1,16 @@
+import { renderHook, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useLatestCREP } from './useLatestCREP';
+
+globalThis.fetch = jest.fn(() =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve({ value: 42 }) })
+) as any;
+
+test('loads latest CREP value', async () => {
+  const { result } = renderHook(() => useLatestCREP());
+  await act(async () => {
+    await Promise.resolve();
+  });
+  expect(result.current.value).toBe(42);
+  expect(result.current.error).toBeNull();
+});

--- a/packages/unifiedmandala-ui/hooks/useLatestCREP.ts
+++ b/packages/unifiedmandala-ui/hooks/useLatestCREP.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+export function useLatestCREP() {
+  const [value, setValue] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    globalThis.fetch('/api/crep/latest')
+      .then(res => {
+        if (!res.ok) throw new Error('Failed to load');
+        return res.json();
+      })
+      .then(data => {
+        if (isMounted) setValue(data.value);
+      })
+      .catch(err => {
+        if (isMounted) setError(err.message);
+      });
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return { value, error };
+}


### PR DESCRIPTION
## Summary
- add `useLatestCREP` hook for retrieving the latest CREP value
- display latest CREP value in `VRBegegnungsraum`
- tests for the new hook and updated component

## Testing
- `pnpm test packages/unifiedmandala-ui/hooks/useLatestCREP.test.ts packages/unifiedmandala-ui/components/VRBegegnungsraum.test.tsx`
- `npx tsc -p tsconfig.json`
- `npx pyright` *(fails: Import warnings and typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6887498f3c1083228716b93bfbc2ed8b