### PR TITLE
Add MemoryGovernance clear method

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6871,5 +6871,12 @@
     "task": "Add reflectMemory method",
     "test": "packages/agents/SelfReflectionAgent.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add clear method to MemoryGovernance",
+    "path": "packages/core/MemoryGovernance.ts",
+    "task": "Allow wiping all stored memory entries",
+    "test": "packages/core/MemoryGovernance.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7958,3 +7958,8 @@
   task: Add reflectMemory method
   test: packages/agents/SelfReflectionAgent.test.ts
   status: done
+- commit: Add clear method to MemoryGovernance
+  path: packages/core/MemoryGovernance.ts
+  task: Allow wiping all stored memory entries
+  test: packages/core/MemoryGovernance.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "meta:update progress logs",
+  "lastCommit": "meta: update progress log",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -251,6 +251,10 @@
     },
     {
       "commit": "plan anthropic multiverse scenarios",
+      "status": "done"
+    },
+    {
+      "commit": "added clear method to MemoryGovernance",
       "status": "done"
     }
   ],

--- a/packages/core/MemoryGovernance.test.ts
+++ b/packages/core/MemoryGovernance.test.ts
@@ -10,4 +10,12 @@ describe('MemoryGovernance', () => {
     mg.delete('foo');
     expect(mg.has('foo')).toBe(false);
   });
+
+  it('clears all entries', () => {
+    const mg = new MemoryGovernance();
+    mg.set('a', '1');
+    mg.set('b', '2');
+    mg.clear();
+    expect(mg.entries()).toHaveLength(0);
+  });
 });

--- a/packages/core/MemoryGovernance.ts
+++ b/packages/core/MemoryGovernance.ts
@@ -20,4 +20,8 @@ export class MemoryGovernance {
   entries(): [string, string][] {
     return Array.from(this.memory.entries());
   }
+
+  clear() {
+    this.memory.clear();
+  }
 }


### PR DESCRIPTION
## Summary
- enhance MemoryGovernance with a `clear` function
- test clearing memory entries
- track new task in advancedToDo files
- sync progress log

## Testing
- `pnpm install`
- `npx tsc -p tsconfig.json`
- `npx pyright` *(fails: fastapi module missing)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68875b84fc9483229b926cc67710f2e7