### PR TITLE
Add timestamp logging and new tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6879,4 +6879,26 @@
     "test": "packages/core/MemoryGovernance.test.ts",
     "status": "done"
   }
+,
+{
+  "commit": "Integrate VRBegegnungsraum 3D handshake",
+  "path": "packages/unifiedmandala-vr/VRBegegnungsraum.ts",
+  "task": "Support WebXR handshake for multiuser sessions",
+  "test": "packages/unifiedmandala-vr/VRBegegnungsraum.test.ts",
+  "status": "open"
+},
+{
+  "commit": "Sync Pantheon boundary events",
+  "path": "packages/pantheon/PantheonBoundaryBridge.ts",
+  "task": "Emit boundary events to VR space and UI",
+  "test": "packages/pantheon/PantheonBoundaryBridge.test.ts",
+  "status": "open"
+},
+{
+  "commit": "Enhance ExtendedResonanceModule",
+  "path": "packages/resonance/ExtendedResonanceModule.ts",
+  "task": "Add amplitude and phase analysis",
+  "test": "packages/resonance/ExtendedResonanceModule.test.ts",
+  "status": "open"
+}
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7963,3 +7963,18 @@
   task: Allow wiping all stored memory entries
   test: packages/core/MemoryGovernance.test.ts
   status: done
+- commit: Integrate VRBegegnungsraum 3D handshake
+  path: packages/unifiedmandala-vr/VRBegegnungsraum.ts
+  task: Support WebXR handshake for multiuser sessions
+  test: packages/unifiedmandala-vr/VRBegegnungsraum.test.ts
+  status: open
+- commit: Sync Pantheon boundary events
+  path: packages/pantheon/PantheonBoundaryBridge.ts
+  task: Emit boundary events to VR space and UI
+  test: packages/pantheon/PantheonBoundaryBridge.test.ts
+  status: open
+- commit: Enhance ExtendedResonanceModule
+  path: packages/resonance/ExtendedResonanceModule.ts
+  task: Add amplitude and phase analysis
+  test: packages/resonance/ExtendedResonanceModule.test.ts
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "meta: update progress log",
+  "lastCommit": "feat: add timestamp to SelfReflectionAgent",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -255,6 +255,10 @@
     },
     {
       "commit": "added clear method to MemoryGovernance",
+      "status": "done"
+    },
+    {
+      "commit": "add timestamp to SelfReflectionAgent",
       "status": "done"
     }
   ],

--- a/packages/agents/SelfReflectionAgent.test.ts
+++ b/packages/agents/SelfReflectionAgent.test.ts
@@ -10,6 +10,12 @@ describe('SelfReflectionAgent', () => {
     expect(agent.summarize()).toBe('a\nb');
   });
 
+  it('records message with timestamp', () => {
+    const agent = new SelfReflectionAgent();
+    agent.recordWithTimestamp('c', 1);
+    expect(agent.summarize()).toBe('1:c');
+  });
+
   it('flags memories matching pattern', () => {
     const gov = new MemoryGovernance();
     gov.set('m1', 'hello world');

--- a/packages/agents/SelfReflectionAgent.ts
+++ b/packages/agents/SelfReflectionAgent.ts
@@ -7,6 +7,10 @@ export class SelfReflectionAgent {
     this.logs.push(message);
   }
 
+  recordWithTimestamp(message: string, timestamp: number = Date.now()) {
+    this.logs.push(`${timestamp}:${message}`);
+  }
+
   summarize(): string {
     return this.logs.join('\n');
   }


### PR DESCRIPTION
## Summary
- implement timestamp logging in `SelfReflectionAgent`
- cover new feature with tests
- log progress and new tasks for Pantheon, Boundary and VR modules

## Testing
- `npx pyright` *(fails: missing python deps)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type defs)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68877c4bb2c88322852ecb153886c1b5