### PR TITLE
Add clear method for Memory Governance

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6899,5 +6899,11 @@
     "task": "Add amplitude and phase analysis",
     "test": "packages/resonance/ExtendedResonanceModule.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add MemoryGovernanceService.clear method",
+    "path": "services/memory-governance/index.ts",
+    "task": "Allow clearing memory buckets",
+    "test": "services/memory-governance/index.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7978,3 +7978,7 @@
   task: Add amplitude and phase analysis
   test: packages/resonance/ExtendedResonanceModule.test.ts
   status: done
+- commit: Add MemoryGovernanceService.clear method
+  path: services/memory-governance/index.ts
+  task: Allow clearing memory buckets
+  test: services/memory-governance/index.test.ts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: sync progress",
+  "lastCommit": "chore: record commit",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -271,6 +271,10 @@
     },
     {
       "commit": "Enhance ExtendedResonanceModule",
+      "status": "done"
+    },
+    {
+      "commit": "add clear method to MemoryGovernance",
       "status": "done"
     }
   ],

--- a/services/memory-governance/index.test.ts
+++ b/services/memory-governance/index.test.ts
@@ -18,3 +18,13 @@ test('detectTrauma filters negative entries', () => {
   const result = governance.detectTrauma('daily');
   expect(result).toEqual(['deep trauma event']);
 });
+
+test('clear resets selected category', () => {
+  const manager = new MemoryManager({ daily: 0, weekly: 0, longterm: 0 });
+  manager.add('daily', 'one');
+  manager.add('weekly', 'two');
+  const governance = new MemoryGovernanceService(manager);
+  governance.clear('daily');
+  expect(manager.get('daily')).toEqual([]);
+  expect(manager.get('weekly')).toEqual(['two']);
+});

--- a/services/memory-governance/index.ts
+++ b/services/memory-governance/index.ts
@@ -14,4 +14,8 @@ export class MemoryGovernanceService {
     const traumaRegex = /\b(angst|trauma|fear|panic|worry|sad)\b/i;
     return this.manager.get(category).filter((t) => traumaRegex.test(t));
   }
+
+  clear(category?: MemoryCategory) {
+    this.manager.clear(category as any);
+  }
 }

--- a/services/memory-manager/index.ts
+++ b/services/memory-manager/index.ts
@@ -35,6 +35,16 @@ export class MemoryManager {
     return this.store[category].map(e => e.text);
   }
 
+  clear(category?: MemoryCategory) {
+    if (category) {
+      this.store[category] = [];
+      return;
+    }
+    (Object.keys(this.store) as MemoryCategory[]).forEach(cat => {
+      this.store[cat] = [];
+    });
+  }
+
   ingestFragments(files: string[]) {
     files.forEach((f) => {
       if (fs.existsSync(f)) {

--- a/services/memory-manager/test.ts
+++ b/services/memory-manager/test.ts
@@ -18,3 +18,13 @@ test('ingests fragments from file', () => {
   fs.unlinkSync(tmp);
   mm.stop();
 });
+
+test('clear removes data by category', () => {
+  const mm = new MemoryManager({ daily: 10, weekly: 20, longterm: 30 });
+  mm.add('daily', 'foo');
+  mm.add('weekly', 'bar');
+  mm.clear('daily');
+  expect(mm.get('daily')).toEqual([]);
+  expect(mm.get('weekly')).toEqual(['bar']);
+  mm.stop();
+});


### PR DESCRIPTION
## Summary
- enhance MemoryManager with `clear` function
- expose clear method via MemoryGovernanceService
- test clear operations for MemoryManager and governance service
- record progress in advanced files

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6887944b145c8322a5b68f5cc8bc757b