### PR TITLE
Add VR boundary conductor module

### DIFF
--- a/packages/agents/__tests__/CosmicTheoryAgent.spec.ts
+++ b/packages/agents/__tests__/CosmicTheoryAgent.spec.ts
@@ -9,7 +9,11 @@ vi.mock('@grpc/grpc-js', () => {
       constructor() {}
       makeServerStreamRequest(_p: any, _s: any, cb: any, _msg: any) {
         const emitter = new (require('events').EventEmitter)();
-        process.nextTick(() => cb(Buffer.from('{"val":1}')));
+        (emitter as any).cancel = () => {};
+        process.nextTick(() => {
+          const data = cb(Buffer.from('{"val":1}'));
+          emitter.emit('data', data);
+        });
         return emitter;
       }
     },

--- a/packages/unifiedmandala-vr/VRBoundaryConductor.test.ts
+++ b/packages/unifiedmandala-vr/VRBoundaryConductor.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { VRBegegnungsraum } from './VRBegegnungsraum';
+import { PantheonBoundaryBridge } from '../pantheon/PantheonBoundaryBridge';
+import { VRBoundaryConductor } from './VRBoundaryConductor';
+
+describe('VRBoundaryConductor', () => {
+  it('passes handshake events to boundary bridge', () => {
+    const vr = new VRBegegnungsraum();
+    let bridged: any[] | null = null;
+    const bridge = new PantheonBoundaryBridge(m => {
+      bridged = m;
+    });
+    const conductor = new VRBoundaryConductor(vr, bridge, [/^xr-/]);
+    conductor.start();
+    vr.handshake('peer');
+    expect(bridged).toEqual([{ rule: /^xr-/, occurrences: 1 }]);
+    conductor.stop();
+  });
+});

--- a/packages/unifiedmandala-vr/VRBoundaryConductor.ts
+++ b/packages/unifiedmandala-vr/VRBoundaryConductor.ts
@@ -1,0 +1,27 @@
+import { VRBegegnungsraum, HandshakeCallback } from './VRBegegnungsraum';
+import { PantheonBoundaryBridge } from '../pantheon/PantheonBoundaryBridge';
+
+export class VRBoundaryConductor {
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(
+    private vr: VRBegegnungsraum,
+    private bridge: PantheonBoundaryBridge,
+    private rules: (string | RegExp)[] = []
+  ) {}
+
+  start() {
+    const cb: HandshakeCallback = (id) => {
+      this.bridge.bridge(id, this.rules);
+    };
+    this.vr.onHandshake(cb);
+    this.unsubscribe = () => {
+      // remove listener by filtering
+      (this.vr as any).handshakeListeners = (this.vr as any).handshakeListeners.filter((fn: any) => fn !== cb);
+    };
+  }
+
+  stop() {
+    this.unsubscribe && this.unsubscribe();
+  }
+}

--- a/packages/unifiedmandala-vr/index.ts
+++ b/packages/unifiedmandala-vr/index.ts
@@ -8,3 +8,4 @@ export { default as VRPyramidPortal } from './components/VRPyramidPortal';
 export { default as VRMeetingHall3D } from './components/VRMeetingHall3D';
 export * from './VRAvatarCustomization';
 export { default as AvatarraumUI } from './AvatarraumUI';
+export * from './VRBoundaryConductor';


### PR DESCRIPTION
## Summary
- implement `VRBoundaryConductor` to link VR handshakes with boundary events
- export conductor from VR package
- adjust gRPC mock in `CosmicTheoryAgent` tests
- cover conductor via a new vitest test
- update progress tracking

## Testing
- `pnpm install --frozen-lockfile`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688799ff0f088322acbd66839578f321