### PR TITLE
Add MemoryManager category listing

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6905,5 +6905,12 @@
     "path": "services/memory-governance/index.ts",
     "task": "Allow clearing memory buckets",
     "test": "services/memory-governance/index.test.ts"
+  },
+  {
+    "commit": "Add getCategories to MemoryManager and governance",
+    "path": "services/memory-manager/index.ts",
+    "task": "Expose category list and governance accessor",
+    "test": "services/memory-manager/test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7822,6 +7822,11 @@
   task: Provide memory governance enforcement
   test: services/memory-governance/index.test.ts
   status: done
+- commit: Add getCategories to MemoryManager and governance
+  path: services/memory-manager/index.ts
+  task: Expose category list and governance accessor
+  test: services/memory-manager/test.ts
+  status: done
 - commit: Add trauma detection to MemoryGovernanceService
   path: services/memory-governance/index.ts
   task: detectTrauma method identifies negative memory entries

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: record commit",
+  "lastCommit": "chore: sync progress",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -389,6 +389,10 @@
     },
     {
       "commit": "implement feedback lobby and dispatcher update",
+      "status": "done"
+    },
+    {
+      "commit": "add getCategories methods",
       "status": "done"
     }
   ]

--- a/services/memory-governance/index.test.ts
+++ b/services/memory-governance/index.test.ts
@@ -28,3 +28,9 @@ test('clear resets selected category', () => {
   expect(manager.get('daily')).toEqual([]);
   expect(manager.get('weekly')).toEqual(['two']);
 });
+
+test('listCategories returns manager categories', () => {
+  const manager = new MemoryManager({ daily: 0, weekly: 0, longterm: 0 });
+  const governance = new MemoryGovernanceService(manager);
+  expect(governance.listCategories().sort()).toEqual(['daily', 'longterm', 'weekly']);
+});

--- a/services/memory-governance/index.ts
+++ b/services/memory-governance/index.ts
@@ -18,4 +18,8 @@ export class MemoryGovernanceService {
   clear(category?: MemoryCategory) {
     this.manager.clear(category as any);
   }
+
+  listCategories(): MemoryCategory[] {
+    return this.manager.getCategories();
+  }
 }

--- a/services/memory-manager/index.ts
+++ b/services/memory-manager/index.ts
@@ -35,6 +35,10 @@ export class MemoryManager {
     return this.store[category].map(e => e.text);
   }
 
+  getCategories(): MemoryCategory[] {
+    return Object.keys(this.store) as MemoryCategory[];
+  }
+
   clear(category?: MemoryCategory) {
     if (category) {
       this.store[category] = [];

--- a/services/memory-manager/test.ts
+++ b/services/memory-manager/test.ts
@@ -28,3 +28,9 @@ test('clear removes data by category', () => {
   expect(mm.get('weekly')).toEqual(['bar']);
   mm.stop();
 });
+
+test('getCategories lists all categories', () => {
+  const mm = new MemoryManager({ daily: 10, weekly: 20, longterm: 30 });
+  expect(mm.getCategories().sort()).toEqual(['daily', 'longterm', 'weekly']);
+  mm.stop();
+});


### PR DESCRIPTION
## Summary
- expose categories in MemoryManager and MemoryGovernanceService
- cover new behaviour with unit tests
- document task in advancedToDo files
- record progress

## Testing
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run` *(fails: CosmicTheoryAgent.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_688799ff0f088322acbd66839578f321