### PR TITLE
Add Pantheon boundary integration modules

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -69,6 +69,9 @@ Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js`
 - `PantheonExport Tool` – exportiert die vorhandenen Pantheon-Module als Datensatz
 - `PantheonFeedbackService` – koordiniert Feedback-Runden der Pantheon-Agenten
 - `VRBegegnungsraumLobby` – Handshake-Raum für WebXR-Sessions
+- `VRResonanceVisualizer` – farbige Darstellung der CREP-Intensität in VR
+- `PantheonAvatarHub` – verwaltet Avatare und Sessions im Pantheon-Raum
+- `ExtendedResonanceGateway` – leitet Boundary-Ereignisse an Resonanzmodule weiter
 - `GreekMathAeonDispatcher` – sicheres Dispatching mit Fehlerereignissen
 - `UnifiedMandalaVR` – Modulpaket mit AvatarManager, EthicsGuard und FourierLayerBridge.
 - `archiveSigil` – schreibt Sigil-Dateien in GenesisAeonZIPMEM.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**DocCommentsGenerator**](scripts/doc-comments-generator.ts) – erzeugt Markdown-Doku
 - [**ArchiveOldTodos**](scripts/archive-old-todos.ts) – verschiebt erledigte ToDos ins ZIPMEM
 - [**ArchiveTodos**](scripts/archive-todos.ts) – verschiebt erledigte AdvancedToDos ins ZIPMEM
+- [**ExtendedResonanceGateway**](packages/resonance/ExtendedResonanceGateway.ts) – verbindet Resonanzmodule mit Boundary-Events
+- [**PantheonAvatarHub**](packages/pantheon/PantheonAvatarHub.ts) – Avatarverwaltung für das VR-Pantheon
+- [**VRResonanceVisualizer**](packages/unifiedmandala-vr/VRResonanceVisualizer.ts) – zeigt CREP-Resonanz im VR-Raum an
+- [**Pantheon-Boundary Integration**](docs/boundary/PantheonBoundaryIntegration.md) – Überblick über neue Schnittstellen
 - [**CREP-Illumination**](CHRONOPOEM.md) – Chronopoem reflektiert aktuellen CREP-Zustand
 - [**SelfAuditModul**](packages/unifiedmandala-ui/components/SelfAuditModul.tsx) – analysiert die Repository-Struktur
 - [**AdminMetrics**](packages/unifiedmandala-ui/README.md) – zeigt CREP- und Sigillin-Kennzahlen

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6912,5 +6912,29 @@
     "task": "Expose category list and governance accessor",
     "test": "services/memory-manager/test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add ExtendedResonanceGateway",
+    "path": "packages/resonance/ExtendedResonanceGateway.ts",
+    "task": "Bridge resonance modules with boundary events",
+    "test": "packages/resonance/ExtendedResonanceGateway.test.ts"
+  },
+  {
+    "commit": "Add PantheonAvatarHub module",
+    "path": "packages/pantheon/PantheonAvatarHub.ts",
+    "task": "Manage avatars in VR Pantheon space",
+    "test": "packages/pantheon/PantheonAvatarHub.test.ts"
+  },
+  {
+    "commit": "Add VRResonanceVisualizer component",
+    "path": "packages/unifiedmandala-vr/VRResonanceVisualizer.ts",
+    "task": "Visualize CREP resonance in VR",
+    "test": "packages/unifiedmandala-vr/VRResonanceVisualizer.test.ts"
+  },
+  {
+    "commit": "Document Pantheon-Boundary integration plan",
+    "path": "docs/boundary/PantheonBoundaryIntegration.md",
+    "task": "Summarize integration blueprint from chats",
+    "test": ""
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7987,3 +7987,19 @@
   path: services/memory-governance/index.ts
   task: Allow clearing memory buckets
   test: services/memory-governance/index.test.ts
+- commit: Add ExtendedResonanceGateway
+  path: packages/resonance/ExtendedResonanceGateway.ts
+  task: Bridge resonance modules with boundary events
+  test: packages/resonance/ExtendedResonanceGateway.test.ts
+- commit: Add PantheonAvatarHub module
+  path: packages/pantheon/PantheonAvatarHub.ts
+  task: Manage avatars in VR Pantheon space
+  test: packages/pantheon/PantheonAvatarHub.test.ts
+- commit: Add VRResonanceVisualizer component
+  path: packages/unifiedmandala-vr/VRResonanceVisualizer.ts
+  task: Visualize CREP resonance in VR
+  test: packages/unifiedmandala-vr/VRResonanceVisualizer.test.ts
+- commit: Document Pantheon-Boundary integration plan
+  path: docs/boundary/PantheonBoundaryIntegration.md
+  task: Summarize integration blueprint from chats
+  test: ""

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: sync progress",
+  "lastCommit": "feat: add pantheon boundary integration modules",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -276,6 +276,9 @@
     {
       "commit": "add clear method to MemoryGovernance",
       "status": "done"
+    },
+    {
+      "commit": "added gateway and avatar hub"
     }
   ],
   "completed": [

--- a/docs/boundary/PantheonBoundaryIntegration.md
+++ b/docs/boundary/PantheonBoundaryIntegration.md
@@ -1,0 +1,10 @@
+# Pantheon-Boundary Integration
+
+Diese Notiz fasst die Chat-Planungen zu Boundary Laws, Pantheon und VR zusammen.
+
+- **BoundaryLawDiscoveryEngine** liefert erkannte Regeln an das Pantheon.
+- **PantheonAvatarHub** synchronisiert Avatare im VR-Begegnungsraum.
+- **ExtendedResonanceGateway** verbindet Resonanzmodule mit Boundary-Ereignissen.
+
+Weitere Details sind in den Gesprächen "CosmicTheoryAgent Code Erweiterung" und
+"AeonAI Pyramid-UI Konzept" beschrieben.

--- a/packages/pantheon/PantheonAvatarHub.test.ts
+++ b/packages/pantheon/PantheonAvatarHub.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { PantheonAvatarHub } from './PantheonAvatarHub';
+
+describe('PantheonAvatarHub', () => {
+  it('registers and lists avatars', () => {
+    const hub = new PantheonAvatarHub();
+    hub.register({ id: '1', name: 'A' });
+    expect(hub.list()).toHaveLength(1);
+  });
+});

--- a/packages/pantheon/PantheonAvatarHub.ts
+++ b/packages/pantheon/PantheonAvatarHub.ts
@@ -1,0 +1,16 @@
+export interface Avatar {
+  id: string;
+  name: string;
+}
+
+export class PantheonAvatarHub {
+  private avatars: Avatar[] = [];
+
+  register(a: Avatar) {
+    this.avatars.push(a);
+  }
+
+  list(): Avatar[] {
+    return this.avatars;
+  }
+}

--- a/packages/resonance/ExtendedResonanceGateway.test.ts
+++ b/packages/resonance/ExtendedResonanceGateway.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { ExtendedResonanceGateway, GatewayEvent } from './ExtendedResonanceGateway';
+
+describe('ExtendedResonanceGateway', () => {
+  it('emits events to listeners', () => {
+    const gateway = new ExtendedResonanceGateway();
+    const events: GatewayEvent[] = [];
+    gateway.on((e) => events.push(e));
+    gateway.emit({ type: 'test', payload: 1 });
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('test');
+  });
+});

--- a/packages/resonance/ExtendedResonanceGateway.ts
+++ b/packages/resonance/ExtendedResonanceGateway.ts
@@ -1,0 +1,16 @@
+export interface GatewayEvent {
+  type: string;
+  payload: any;
+}
+
+export class ExtendedResonanceGateway {
+  private listeners: ((e: GatewayEvent) => void)[] = [];
+
+  emit(event: GatewayEvent) {
+    this.listeners.forEach((l) => l(event));
+  }
+
+  on(cb: (e: GatewayEvent) => void) {
+    this.listeners.push(cb);
+  }
+}

--- a/packages/unifiedmandala-vr/VRResonanceVisualizer.test.ts
+++ b/packages/unifiedmandala-vr/VRResonanceVisualizer.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { VRResonanceVisualizer } from './VRResonanceVisualizer';
+
+describe('VRResonanceVisualizer', () => {
+  it('computes color', () => {
+    const v = new VRResonanceVisualizer();
+    expect(v.computeColor(0)).toBe('rgb(0,255,128)');
+  });
+});

--- a/packages/unifiedmandala-vr/VRResonanceVisualizer.ts
+++ b/packages/unifiedmandala-vr/VRResonanceVisualizer.ts
@@ -1,0 +1,8 @@
+export class VRResonanceVisualizer {
+  computeColor(crep: number): string {
+    const val = Math.max(0, Math.min(1, crep));
+    const r = Math.round(255 * val);
+    const g = Math.round(255 * (1 - val));
+    return `rgb(${r},${g},128)`;
+  }
+}


### PR DESCRIPTION
## Summary
- document Pantheon-Boundary Integration
- add PantheonAvatarHub to handle avatars
- add ExtendedResonanceGateway for boundary event bridging
- add VRResonanceVisualizer to display CREP resonance in VR
- update README and Handbuch
- track progress and todos

## Testing
- `npx pyright` *(fails: Import "fastapi" could not be resolved)*
- `npx tsc -p tsconfig.json`
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_68879e6c77f48322a061db5eeed83b7a