### PR TITLE
Add pantheon and VR task updates

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6936,5 +6936,137 @@
     "path": "docs/boundary/PantheonBoundaryIntegration.md",
     "task": "Summarize integration blueprint from chats",
     "test": ""
+  },
+  {
+    "commit": "Add Zivilisations-Sandbox simulation module",
+    "path": "packages/simulations/zivilisations-sandbox",
+    "task": "Simulate ancient megastructures",
+    "test": "packages/simulations/zivilisations-sandbox/ZivilisationSandbox.test.ts"
+  },
+  {
+    "commit": "Add ClimateIntegrationBlueprint",
+    "path": "packages/climate/ClimateIntegrationBlueprint.ts",
+    "task": "Integrate solar forcing data for climate module",
+    "test": "packages/climate/ClimateIntegrationBlueprint.test.ts"
+  },
+  {
+    "commit": "Implement Keilschrift translator",
+    "path": "packages/linguistics/KeilschriftTranslator.ts",
+    "task": "Translate cuneiform tablets",
+    "test": "packages/linguistics/KeilschriftTranslator.test.ts"
+  },
+  {
+    "commit": "Create GrokAgent module",
+    "path": "packages/agents/GrokAgent.ts",
+    "task": "Extract and apply Grok patterns",
+    "test": "packages/agents/GrokAgent.test.ts"
+  },
+  {
+    "commit": "Add ShadowIntegrations module",
+    "path": "packages/integration/ShadowIntegrations.ts",
+    "task": "Manage hidden integration flows",
+    "test": "packages/integration/ShadowIntegrations.test.ts"
+  },
+  {
+    "commit": "Add SelfReflectionAgent",
+    "path": "packages/agents/SelfReflectionAgent.ts",
+    "task": "Provide introspection for agent memory",
+    "test": "packages/agents/SelfReflectionAgent.test.ts"
+  },
+  {
+    "commit": "Add MemoryGovernancePolicy",
+    "path": "services/memory-governance/policy.ts",
+    "task": "Define memory retention governance rules",
+    "test": "services/memory-governance/policy.test.ts"
+  },
+  {
+    "commit": "Implement TuringTestSuite",
+    "path": "packages/testing/TuringTestSuite.ts",
+    "task": "Automated Turing tests for conversation agents",
+    "test": "packages/testing/TuringTestSuite.test.ts"
+  },
+  {
+    "commit": "Research ArcticGravityWaves",
+    "path": "docs/research/ArcticGravityWaves.md",
+    "task": "Document internal gravity wave impacts",
+    "test": ""
+  },
+  {
+    "commit": "Add MultiverseScenarioPlanner",
+    "path": "packages/simulations/MultiverseScenarioPlanner.ts",
+    "task": "Explore anthropic and multiverse scenarios",
+    "test": "packages/simulations/MultiverseScenarioPlanner.test.ts"
+  },
+  {
+    "commit": "Add VRMeetingRoom prototype",
+    "path": "packages/unifiedmandala-vr/VRMeetingRoom.ts",
+    "task": "Prototype VR space for agent encounters",
+    "test": "packages/unifiedmandala-vr/VRMeetingRoom.test.ts"
+  },
+  {
+    "commit": "Add Zivilisations-Sandbox simulation module",
+    "path": "packages/simulations/zivilisations-sandbox",
+    "task": "Simulate ancient megastructures",
+    "test": "packages/simulations/zivilisations-sandbox/ZivilisationSandbox.test.ts"
+  },
+  {
+    "commit": "Add ClimateIntegrationBlueprint",
+    "path": "packages/climate/ClimateIntegrationBlueprint.ts",
+    "task": "Integrate solar forcing data for climate module",
+    "test": "packages/climate/ClimateIntegrationBlueprint.test.ts"
+  },
+  {
+    "commit": "Implement Keilschrift translator",
+    "path": "packages/linguistics/KeilschriftTranslator.ts",
+    "task": "Translate cuneiform tablets",
+    "test": "packages/linguistics/KeilschriftTranslator.test.ts"
+  },
+  {
+    "commit": "Create GrokAgent module",
+    "path": "packages/agents/GrokAgent.ts",
+    "task": "Extract and apply Grok patterns",
+    "test": "packages/agents/GrokAgent.test.ts"
+  },
+  {
+    "commit": "Add ShadowIntegrations module",
+    "path": "packages/integration/ShadowIntegrations.ts",
+    "task": "Manage hidden integration flows",
+    "test": "packages/integration/ShadowIntegrations.test.ts"
+  },
+  {
+    "commit": "Add SelfReflectionAgent",
+    "path": "packages/agents/SelfReflectionAgent.ts",
+    "task": "Provide introspection for agent memory",
+    "test": "packages/agents/SelfReflectionAgent.test.ts"
+  },
+  {
+    "commit": "Add MemoryGovernancePolicy",
+    "path": "services/memory-governance/policy.ts",
+    "task": "Define memory retention governance rules",
+    "test": "services/memory-governance/policy.test.ts"
+  },
+  {
+    "commit": "Implement TuringTestSuite",
+    "path": "packages/testing/TuringTestSuite.ts",
+    "task": "Automated Turing tests for conversation agents",
+    "test": "packages/testing/TuringTestSuite.test.ts"
+  },
+  {
+    "commit": "Research ArcticGravityWaves",
+    "path": "docs/research/ArcticGravityWaves.md",
+    "task": "Document internal gravity wave impacts",
+    "test": ""
+  },
+  {
+    "commit": "Add MultiverseScenarioPlanner",
+    "path": "packages/simulations/MultiverseScenarioPlanner.ts",
+    "task": "Explore anthropic and multiverse scenarios",
+    "test": "packages/simulations/MultiverseScenarioPlanner.test.ts"
+  },
+  {
+    "commit": "Add VRMeetingRoom prototype",
+    "path": "packages/unifiedmandala-vr/VRMeetingRoom.ts",
+    "task": "Prototype VR space for agent encounters",
+    "test": "packages/unifiedmandala-vr/VRMeetingRoom.test.ts"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8003,3 +8003,47 @@
   path: docs/boundary/PantheonBoundaryIntegration.md
   task: Summarize integration blueprint from chats
   test: ""
+- commit: Add Zivilisations-Sandbox simulation module
+  path: packages/simulations/zivilisations-sandbox
+  task: Simulate ancient megastructures
+  test: packages/simulations/zivilisations-sandbox/ZivilisationSandbox.test.ts
+- commit: Add ClimateIntegrationBlueprint
+  path: packages/climate/ClimateIntegrationBlueprint.ts
+  task: Integrate solar forcing data for climate module
+  test: packages/climate/ClimateIntegrationBlueprint.test.ts
+- commit: Implement Keilschrift translator
+  path: packages/linguistics/KeilschriftTranslator.ts
+  task: Translate cuneiform tablets
+  test: packages/linguistics/KeilschriftTranslator.test.ts
+- commit: Create GrokAgent module
+  path: packages/agents/GrokAgent.ts
+  task: Extract and apply Grok patterns
+  test: packages/agents/GrokAgent.test.ts
+- commit: Add ShadowIntegrations module
+  path: packages/integration/ShadowIntegrations.ts
+  task: Manage hidden integration flows
+  test: packages/integration/ShadowIntegrations.test.ts
+- commit: Add SelfReflectionAgent
+  path: packages/agents/SelfReflectionAgent.ts
+  task: Provide introspection for agent memory
+  test: packages/agents/SelfReflectionAgent.test.ts
+- commit: Add MemoryGovernancePolicy
+  path: services/memory-governance/policy.ts
+  task: Define memory retention governance rules
+  test: services/memory-governance/policy.test.ts
+- commit: Implement TuringTestSuite
+  path: packages/testing/TuringTestSuite.ts
+  task: Automated Turing tests for conversation agents
+  test: packages/testing/TuringTestSuite.test.ts
+- commit: Research ArcticGravityWaves
+  path: docs/research/ArcticGravityWaves.md
+  task: Document internal gravity wave impacts
+  test: ""
+- commit: Add MultiverseScenarioPlanner
+  path: packages/simulations/MultiverseScenarioPlanner.ts
+  task: Explore anthropic and multiverse scenarios
+  test: packages/simulations/MultiverseScenarioPlanner.test.ts
+- commit: Add VRMeetingRoom prototype
+  path: packages/unifiedmandala-vr/VRMeetingRoom.ts
+  task: Prototype VR space for agent encounters
+  test: packages/unifiedmandala-vr/VRMeetingRoom.test.ts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add pantheon boundary integration modules",
+  "lastCommit": "feat: add VRMeetingRoom and sandbox tasks",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -279,6 +279,10 @@
     },
     {
       "commit": "added gateway and avatar hub"
+    },
+    {
+      "commit": "Append new advanced tasks from conversations",
+      "status": "done"
     }
   ],
   "completed": [


### PR DESCRIPTION
## Summary
- add Pantheon, Boundary and VR tasks to advancedToDo files
- log progress for newly extracted tasks

## Testing
- `pnpm install`
- `npx pyright` *(fails: missing modules)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6887b8a88cd08322b652e11663c26660