### PR TITLE
feat: add governance policy and multiverse planner

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -62,12 +62,15 @@ Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js`
 - `FractalTaskRunner` – führt YAML-basierte Plugin-Workflows aus.
 - `EventBridge` – leitet CosmicTheoryAgent-Events an die UI weiter.
 - `PyramidVRMeetingRoom` – VR-Raum für mehrere Avatare.
+- `VRMeetingRoom` – einfacher WebXR-Treffpunkt.
 - CosmicTheoryAgent liefert VR-Hooks für immersive Steuerung.
 - `AeonOrchestrator` – zentrale Steuerinstanz des Pantheon, verteilt Boundary-Regeln.
 - `PantheonPortalAnalytics` – zeichnet Portalzugriffe auf.
 - `PantheonBoundaryBridge` – verknüpft Pantheon-Ereignisse mit BoundaryRuleDetector
 - `PantheonExport Tool` – exportiert die vorhandenen Pantheon-Module als Datensatz
 - `PantheonFeedbackService` – koordiniert Feedback-Runden der Pantheon-Agenten
+- `MultiverseScenarioPlanner` – untersucht Multiversen-Szenarien.
+- `MemoryGovernancePolicy` – definiert Aufbewahrungsgrenzen.
 - `VRBegegnungsraumLobby` – Handshake-Raum für WebXR-Sessions
 - `VRResonanceVisualizer` – farbige Darstellung der CREP-Intensität in VR
 - `PantheonAvatarHub` – verwaltet Avatare und Sessions im Pantheon-Raum

--- a/README.md
+++ b/README.md
@@ -52,11 +52,15 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**ShadowIntegration**](packages/integration/ShadowIntegration.ts) – experimental data bridge
 - [**MemoryGovernance**](packages/core/MemoryGovernance.ts) – manage memory state
 - [**TuringOrchestrator**](packages/testing/TuringOrchestrator.ts) – run minimal Turing tests
+- [**TuringTestSuite**](packages/testing/TuringTestSuite.ts) – automated conversation Turing tests
 - [**Climate Module**](packages/unifiedmandala-climate/index.ts) – blueprint for climate data
 - [**Keilschrift Module**](packages/aeon-labs/keilschrift/index.ts) – cuneiform utilities
 - [**ZivilisationsSandbox**](packages/pantheon/ZivilisationsSandbox/index.ts) – simulate ancient builds
 - [**ArcticGravityWaves**](packages/research/ArcticGravityWaves.ts) – analyze gravity wave data
 - [**MultiverseScenario**](packages/pantheon/MultiverseScenario.ts) – scenario storage
+- [**MultiverseScenarioPlanner**](packages/simulations/MultiverseScenarioPlanner.ts) – explore multiverse variants
+- [**MemoryGovernancePolicy**](services/memory-governance/policy.ts) – governs memory retention
+- [**VRMeetingRoom**](packages/unifiedmandala-vr/VRMeetingRoom.ts) – simple WebXR meeting space
 - [**FourierMetricsCLI**](packages/cli-tools/FourierMetricsCLI.ts) – compute metrics from the command line
 - [**FractalTaskRunner**](packages/task-runner/FractalTaskRunner.ts) – executes YAML-defined plugin workflows
 - [**Fractal Runner CLI**](packages/agents/bin/fractal-runner.ts) – runs YAML task files with optional soundscape

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6977,13 +6977,15 @@
     "commit": "Add MemoryGovernancePolicy",
     "path": "services/memory-governance/policy.ts",
     "task": "Define memory retention governance rules",
-    "test": "services/memory-governance/policy.test.ts"
+    "test": "services/memory-governance/policy.test.ts",
+    "status": "done"
   },
   {
     "commit": "Implement TuringTestSuite",
     "path": "packages/testing/TuringTestSuite.ts",
     "task": "Automated Turing tests for conversation agents",
-    "test": "packages/testing/TuringTestSuite.test.ts"
+    "test": "packages/testing/TuringTestSuite.test.ts",
+    "status": "done"
   },
   {
     "commit": "Research ArcticGravityWaves",
@@ -6995,13 +6997,15 @@
     "commit": "Add MultiverseScenarioPlanner",
     "path": "packages/simulations/MultiverseScenarioPlanner.ts",
     "task": "Explore anthropic and multiverse scenarios",
-    "test": "packages/simulations/MultiverseScenarioPlanner.test.ts"
+    "test": "packages/simulations/MultiverseScenarioPlanner.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add VRMeetingRoom prototype",
     "path": "packages/unifiedmandala-vr/VRMeetingRoom.ts",
     "task": "Prototype VR space for agent encounters",
-    "test": "packages/unifiedmandala-vr/VRMeetingRoom.test.ts"
+    "test": "packages/unifiedmandala-vr/VRMeetingRoom.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add Zivilisations-Sandbox simulation module",
@@ -7043,13 +7047,15 @@
     "commit": "Add MemoryGovernancePolicy",
     "path": "services/memory-governance/policy.ts",
     "task": "Define memory retention governance rules",
-    "test": "services/memory-governance/policy.test.ts"
+    "test": "services/memory-governance/policy.test.ts",
+    "status": "done"
   },
   {
     "commit": "Implement TuringTestSuite",
     "path": "packages/testing/TuringTestSuite.ts",
     "task": "Automated Turing tests for conversation agents",
-    "test": "packages/testing/TuringTestSuite.test.ts"
+    "test": "packages/testing/TuringTestSuite.test.ts",
+    "status": "done"
   },
   {
     "commit": "Research ArcticGravityWaves",
@@ -7061,12 +7067,14 @@
     "commit": "Add MultiverseScenarioPlanner",
     "path": "packages/simulations/MultiverseScenarioPlanner.ts",
     "task": "Explore anthropic and multiverse scenarios",
-    "test": "packages/simulations/MultiverseScenarioPlanner.test.ts"
+    "test": "packages/simulations/MultiverseScenarioPlanner.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add VRMeetingRoom prototype",
     "path": "packages/unifiedmandala-vr/VRMeetingRoom.ts",
     "task": "Prototype VR space for agent encounters",
-    "test": "packages/unifiedmandala-vr/VRMeetingRoom.test.ts"
+    "test": "packages/unifiedmandala-vr/VRMeetingRoom.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add VRMeetingRoom and sandbox tasks",
+  "lastCommit": "feat: add memory governance policy and planner",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -282,6 +282,10 @@
     },
     {
       "commit": "Append new advanced tasks from conversations",
+      "status": "done"
+    },
+    {
+      "commit": "implement policy, turing suite, multiverse planner and VRMeetingRoom",
       "status": "done"
     }
   ],

--- a/packages/simulations/MultiverseScenarioPlanner.test.ts
+++ b/packages/simulations/MultiverseScenarioPlanner.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { MultiverseScenarioPlanner } from './MultiverseScenarioPlanner';
+
+describe('MultiverseScenarioPlanner', () => {
+  it('adds scenarios', () => {
+    const planner = new MultiverseScenarioPlanner();
+    planner.addScenario({ universeId: 'u1', parameters: { gravity: 9.8 }});
+    expect(planner.count()).toBe(1);
+  });
+});

--- a/packages/simulations/MultiverseScenarioPlanner.ts
+++ b/packages/simulations/MultiverseScenarioPlanner.ts
@@ -1,0 +1,16 @@
+export interface Scenario {
+  universeId: string;
+  parameters: Record<string, number>;
+}
+
+export class MultiverseScenarioPlanner {
+  private scenarios: Scenario[] = [];
+
+  addScenario(s: Scenario) {
+    this.scenarios.push(s);
+  }
+
+  count(): number {
+    return this.scenarios.length;
+  }
+}

--- a/packages/testing/TuringTestSuite.test.ts
+++ b/packages/testing/TuringTestSuite.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { runTuringSuite } from './TuringTestSuite';
+
+describe('runTuringSuite', () => {
+  it('passes when responses hide identity', async () => {
+    const result = await runTuringSuite(async () => 'Hello there');
+    expect(result).toBe(true);
+  });
+
+  it('fails when bot identity revealed', async () => {
+    const result = await runTuringSuite(async () => 'I am a bot');
+    expect(result).toBe(false);
+  });
+});

--- a/packages/testing/TuringTestSuite.ts
+++ b/packages/testing/TuringTestSuite.ts
@@ -1,0 +1,15 @@
+export async function runTuringSuite(
+  responder: (input: string) => Promise<string>,
+): Promise<boolean> {
+  const prompts = [
+    'Hello',
+    'What is 2 + 2?',
+  ];
+  for (const p of prompts) {
+    const r = await responder(p);
+    if (/\b(bot|AI)\b/i.test(r)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/unifiedmandala-vr/VRMeetingRoom.test.ts
+++ b/packages/unifiedmandala-vr/VRMeetingRoom.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { VRMeetingRoom } from './VRMeetingRoom';
+
+class DummyLoader {
+  loadCalled = false;
+  load() { this.loadCalled = true; return Promise.resolve(); }
+}
+
+describe('VRMeetingRoom', () => {
+  it('connect calls loader', async () => {
+    const loader = new DummyLoader();
+    const room = new VRMeetingRoom(loader as any);
+    await room.connect('url');
+    expect(loader.loadCalled).toBe(true);
+  });
+
+  it('broadcast returns peer messages', () => {
+    const room = new VRMeetingRoom({ load: () => Promise.resolve() } as any);
+    expect(room.broadcast('hi', ['a','b'])).toEqual(['a:hi','b:hi']);
+  });
+});

--- a/packages/unifiedmandala-vr/VRMeetingRoom.ts
+++ b/packages/unifiedmandala-vr/VRMeetingRoom.ts
@@ -1,0 +1,13 @@
+import { VRSceneLoader } from './VRSceneLoader';
+
+export class VRMeetingRoom {
+  constructor(private loader: VRSceneLoader = new VRSceneLoader()) {}
+
+  async connect(url: string) {
+    return this.loader.load(url);
+  }
+
+  broadcast(msg: string, peers: string[]): string[] {
+    return peers.map(p => `${p}:${msg}`);
+  }
+}

--- a/packages/unifiedmandala-vr/index.ts
+++ b/packages/unifiedmandala-vr/index.ts
@@ -9,3 +9,4 @@ export { default as VRMeetingHall3D } from './components/VRMeetingHall3D';
 export * from './VRAvatarCustomization';
 export { default as AvatarraumUI } from './AvatarraumUI';
 export * from './VRBoundaryConductor';
+export * from './VRMeetingRoom';

--- a/services/memory-governance/policy.test.ts
+++ b/services/memory-governance/policy.test.ts
@@ -1,0 +1,12 @@
+import { shouldCleanup, DefaultPolicy } from './policy';
+import { describe, it, expect } from 'vitest';
+
+describe('memory-governance policy', () => {
+  it('triggers cleanup when limit exceeded', () => {
+    expect(shouldCleanup('daily', 60)).toBe(true);
+  });
+
+  it('does not trigger cleanup when below limit', () => {
+    expect(shouldCleanup('weekly', 100)).toBe(false);
+  });
+});

--- a/services/memory-governance/policy.ts
+++ b/services/memory-governance/policy.ts
@@ -1,0 +1,21 @@
+import { MemoryCategory } from '../memory-manager';
+
+export interface MemoryGovernancePolicy {
+  retentionLimits: Record<MemoryCategory, number>;
+}
+
+export const DefaultPolicy: MemoryGovernancePolicy = {
+  retentionLimits: {
+    daily: 50,
+    weekly: 200,
+    longterm: 1000,
+  },
+};
+
+export function shouldCleanup(
+  category: MemoryCategory,
+  currentCount: number,
+  policy: MemoryGovernancePolicy = DefaultPolicy,
+): boolean {
+  return currentCount > policy.retentionLimits[category];
+}


### PR DESCRIPTION
## Summary
- add MemoryGovernancePolicy with retention limits
- create TuringTestSuite for automated conversation checks
- add MultiverseScenarioPlanner to explore multiverse worlds
- add VRMeetingRoom and export from VR package
- update docs and progress log

## Testing
- `npx pyright` *(fails: missing modules fastapi)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definition file for 'node')*
- `npx vitest run packages/unifiedmandala-vr/VRMeetingRoom.test.ts packages/simulations/MultiverseScenarioPlanner.test.ts packages/testing/TuringTestSuite.test.ts services/memory-governance/policy.test.ts` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_6887ccdb870883228654c44b04fa5c4f