### PR TITLE
Add climate and simulation modules

### DIFF
--- a/packages/climate/ClimateIntegrationBlueprint.test.ts
+++ b/packages/climate/ClimateIntegrationBlueprint.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { integrateSolarForcing } from './ClimateIntegrationBlueprint';
+
+describe('integrateSolarForcing', () => {
+  it('computes forcing based on averages', () => {
+    const forcing = integrateSolarForcing({irradiance:[1,1,1], albedo:[0.5,0.5,0.5]});
+    expect(forcing).toBeCloseTo(1 * (1-0.5));
+  });
+});

--- a/packages/climate/ClimateIntegrationBlueprint.ts
+++ b/packages/climate/ClimateIntegrationBlueprint.ts
@@ -1,0 +1,10 @@
+export interface SolarForcingData {
+  irradiance: number[];
+  albedo: number[];
+}
+
+export function integrateSolarForcing(data: SolarForcingData): number {
+  const avgIrradiance = data.irradiance.reduce((a,b)=>a+b,0) / data.irradiance.length;
+  const avgAlbedo = data.albedo.reduce((a,b)=>a+b,0) / data.albedo.length;
+  return avgIrradiance * (1 - avgAlbedo);
+}

--- a/packages/linguistics/KeilschriftTranslator.test.ts
+++ b/packages/linguistics/KeilschriftTranslator.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { toCuneiform, fromCuneiform } from './KeilschriftTranslator';
+
+describe('KeilschriftTranslator', () => {
+  it('roundtrips text', () => {
+    const c = toCuneiform('abc');
+    expect(fromCuneiform(c)).toBe('abc');
+  });
+});

--- a/packages/linguistics/KeilschriftTranslator.ts
+++ b/packages/linguistics/KeilschriftTranslator.ts
@@ -1,0 +1,10 @@
+const table: Record<string, string> = { a: '𒀀', b: '𒁀', c: '𒍝' };
+
+export function toCuneiform(text: string): string {
+  return text.split('').map(ch => table[ch] || ch).join('');
+}
+
+export function fromCuneiform(text: string): string {
+  const reverse = Object.fromEntries(Object.entries(table).map(([k,v])=>[v,k]));
+  return text.split('').map(ch => reverse[ch] || ch).join('');
+}

--- a/packages/simulations/MultiverseScenarioPlanner.test.ts
+++ b/packages/simulations/MultiverseScenarioPlanner.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { planNext } from './MultiverseScenarioPlanner';
+
+describe('MultiverseScenarioPlanner', () => {
+  it('selects highest probability scenario', () => {
+    const best = planNext([{id:'a',probability:0.2},{id:'b',probability:0.5}]);
+    expect(best.id).toBe('b');
+  });
+});

--- a/packages/simulations/MultiverseScenarioPlanner.ts
+++ b/packages/simulations/MultiverseScenarioPlanner.ts
@@ -1,0 +1,8 @@
+export interface Scenario {
+  id: string;
+  probability: number;
+}
+
+export function planNext(scenarios: Scenario[]): Scenario {
+  return scenarios.sort((a,b)=>b.probability-a.probability)[0];
+}

--- a/packages/simulations/zivilisations-sandbox/ZivilisationSandbox.test.ts
+++ b/packages/simulations/zivilisations-sandbox/ZivilisationSandbox.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { estimateStability } from './index';
+
+describe('ZivilisationSandbox', () => {
+  it('estimates stability via log of blocks', () => {
+    expect(estimateStability({name:'pyramid', blocks:1000})).toBeCloseTo(Math.log(1000));
+  });
+});

--- a/packages/simulations/zivilisations-sandbox/index.ts
+++ b/packages/simulations/zivilisations-sandbox/index.ts
@@ -1,0 +1,8 @@
+export interface Megastructure {
+  name: string;
+  blocks: number;
+}
+
+export function estimateStability(structure: Megastructure): number {
+  return Math.log(structure.blocks);
+}

--- a/packages/testing/TuringTestSuite.test.ts
+++ b/packages/testing/TuringTestSuite.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { isHumanLike } from './TuringTestSuite';
+
+describe('TuringTestSuite', () => {
+  it('flags short machine-like answers', () => {
+    expect(isHumanLike('yes')).toBe(false);
+  });
+  it('accepts longer natural text', () => {
+    expect(isHumanLike('Hello there, how are you?')).toBe(true);
+  });
+});

--- a/packages/testing/TuringTestSuite.ts
+++ b/packages/testing/TuringTestSuite.ts
@@ -1,0 +1,4 @@
+export function isHumanLike(answer: string): boolean {
+  const tokens = answer.split(/\s+/);
+  return tokens.length > 3 && /[A-Za-z]/.test(answer);
+}

--- a/packages/unifiedmandala-vr/VRMeetingRoom.test.ts
+++ b/packages/unifiedmandala-vr/VRMeetingRoom.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { VRMeetingRoom } from './VRMeetingRoom';
+
+describe('VRMeetingRoom', () => {
+  it('stores avatars that join', () => {
+    const room = new VRMeetingRoom();
+    room.join({id:'a', position:[0,0,0]});
+    expect(room.list()).toHaveLength(1);
+  });
+});

--- a/packages/unifiedmandala-vr/VRMeetingRoom.ts
+++ b/packages/unifiedmandala-vr/VRMeetingRoom.ts
@@ -1,0 +1,16 @@
+export interface Avatar {
+  id: string;
+  position: [number, number, number];
+}
+
+export class VRMeetingRoom {
+  private avatars: Avatar[] = [];
+
+  join(avatar: Avatar) {
+    this.avatars.push(avatar);
+  }
+
+  list(): Avatar[] {
+    return this.avatars;
+  }
+}

--- a/services/memory-governance/policy.test.ts
+++ b/services/memory-governance/policy.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { defaultPolicy } from './policy';
+
+describe('MemoryGovernancePolicy', () => {
+  it('provides default rules', () => {
+    expect(defaultPolicy.find(p=>p.category==='daily')?.maxAgeDays).toBe(7);
+  });
+});

--- a/services/memory-governance/policy.ts
+++ b/services/memory-governance/policy.ts
@@ -1,0 +1,11 @@
+export interface PolicyRule {
+  category: string;
+  maxAgeDays: number;
+  maxEntries: number;
+}
+
+export const defaultPolicy: PolicyRule[] = [
+  { category: 'daily', maxAgeDays: 7, maxEntries: 100 },
+  { category: 'weekly', maxAgeDays: 30, maxEntries: 200 },
+  { category: 'longterm', maxAgeDays: 365, maxEntries: 1000 }
+];


### PR DESCRIPTION
## Summary
- add new modules for climate integration and cuneiform translation
- sketch multiverse planner and zivilisations sandbox
- introduce VR meeting room and Turing test suite
- add memory governance policy service

## Testing
- `npx -y pyright` *(fails: multiple module import errors)*
- `npx tsc -p tsconfig.json` *(fails: missing node type definitions)*
- `pnpm -r test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887ccdb870883228654c44b04fa5c4f