### PR TITLE
Add PantheonBoundaryHarmonizer module

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7068,5 +7068,12 @@
     "path": "packages/unifiedmandala-vr/VRMeetingRoom.ts",
     "task": "Prototype VR space for agent encounters",
     "test": "packages/unifiedmandala-vr/VRMeetingRoom.test.ts"
+  },
+  {
+    "commit": "Add PantheonBoundaryHarmonizer module",
+    "path": "packages/pantheon/PantheonBoundaryHarmonizer.ts",
+    "task": "Harmonize boundary rules with Pantheon heuristics",
+    "test": "packages/pantheon/PantheonBoundaryHarmonizer.test.ts",
+    "status": "todo"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8047,3 +8047,8 @@
   path: packages/unifiedmandala-vr/VRMeetingRoom.ts
   task: Prototype VR space for agent encounters
   test: packages/unifiedmandala-vr/VRMeetingRoom.test.ts
+- commit: Add PantheonBoundaryHarmonizer module
+  path: packages/pantheon/PantheonBoundaryHarmonizer.ts
+  task: Harmonize boundary rules with Pantheon heuristics
+  test: packages/pantheon/PantheonBoundaryHarmonizer.test.ts
+  status: todo

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add VRMeetingRoom and sandbox tasks",
+  "lastCommit": "Add PantheonBoundaryHarmonizer module",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -283,6 +283,10 @@
     {
       "commit": "Append new advanced tasks from conversations",
       "status": "done"
+    },
+    {
+      "commit": "Add PantheonBoundaryHarmonizer module",
+      "status": "todo"
     }
   ],
   "completed": [

--- a/packages/pantheon/PantheonBoundaryHarmonizer.test.ts
+++ b/packages/pantheon/PantheonBoundaryHarmonizer.test.ts
@@ -1,0 +1,6 @@
+import { PantheonBoundaryHarmonizer } from './PantheonBoundaryHarmonizer';
+
+test('harmonize returns upper case resolved rule', () => {
+  const harmonizer = new PantheonBoundaryHarmonizer();
+  expect(harmonizer.harmonize('abc')).toBe('RESOLVED:ABC');
+});

--- a/packages/pantheon/PantheonBoundaryHarmonizer.ts
+++ b/packages/pantheon/PantheonBoundaryHarmonizer.ts
@@ -1,0 +1,7 @@
+import { resolveHarmonic } from '../boundary-engine/BoundaryHarmonicResolver';
+
+export class PantheonBoundaryHarmonizer {
+  harmonize(rule: string): string {
+    return resolveHarmonic(rule).toUpperCase();
+  }
+}


### PR DESCRIPTION
## Summary
- add new `PantheonBoundaryHarmonizer` and tests
- record new task in advanced todo files
- log progress for new harmonizer work

## Testing
- `npx pyright` *(fails: missing modules)*
- `npx tsc -p tsconfig.json` *(fails: missing @types/node)*
- `npx jest packages/pantheon/PantheonBoundaryHarmonizer.test.ts` *(fails: jest not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6887ccdb870883228654c44b04fa5c4f