### PR TITLE
Add CREP-priority todo extraction

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "self-reflection clear method",
+  "lastCommit": "generate todo prioritization",
   "fractalStep": "sync",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented VR handshake, boundary event emission and resonance analysis",
+  "notes": "Added CREP prioritization to generate-todo script",
   "pendingTasks": [],
   "progress": [
     {
@@ -298,6 +298,10 @@
     },
     {
       "commit": "Extract additional advanced tasks",
+      "status": "done"
+    },
+    {
+      "commit": "generate todo priority script",
       "status": "done"
     }
   ],

--- a/packages/conversation-analysis/generate-todo-from-convos.test.ts
+++ b/packages/conversation-analysis/generate-todo-from-convos.test.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import yaml from 'yaml';
+import { generateTodos } from './generate-todo-from-convos';
+
+test('extracts todos with priority and sorts', () => {
+  const tmpJson = 'tmp-convos.json';
+  const conv = [{ mapping: { a: { message: { content: { parts: ['Wir sollten Test 1 CREP: 0.8'] } } }, b: { message: { content: { parts: ['TODO implement feature CREP:0.2'] } } } } }];
+  fs.writeFileSync(tmpJson, JSON.stringify(conv));
+  const out = 'tmp-todos.yaml';
+  generateTodos([tmpJson], out);
+  const parsed = yaml.parse(fs.readFileSync(out, 'utf-8')) as any[];
+  fs.unlinkSync(tmpJson);
+  fs.unlinkSync(out);
+  expect(parsed[0].priority).toBeGreaterThan(parsed[1].priority);
+  expect(parsed.length).toBe(2);
+});

--- a/packages/conversation-analysis/generate-todo-from-convos.ts
+++ b/packages/conversation-analysis/generate-todo-from-convos.ts
@@ -5,18 +5,44 @@ export interface TodoItem {
   id: string;
   beschreibung: string;
   status: string;
+  /** CREP based priority, higher means more relevant */
+  priority: number;
 }
-
-export function generateTodos(input = 'docs/sigils/conversations.json', output = 'todo-sigil.yaml') {
-  const raw = fs.readFileSync(input, 'utf-8');
-  const data = JSON.parse(raw);
+export function generateTodos(inputs: string[] = ['docs/sigils/newadvancedconversations.json'], output = 'todo-sigil.yaml') {
   const todos: TodoItem[] = [];
-  (Array.isArray(data) ? data : []).forEach((item: any) => {
-    const text: string = item.text || '';
-    if (/wir sollten|TODO/i.test(text)) {
-      todos.push({ id: `todo-${todos.length + 1}`, beschreibung: text.trim(), status: 'offen' });
+  for (const file of inputs) {
+    if (!fs.existsSync(file)) continue;
+    const raw = fs.readFileSync(file, 'utf-8');
+    let data: any;
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      continue;
     }
-  });
+    (Array.isArray(data) ? data : []).forEach((item: any) => {
+      const mapping = item.mapping ? Object.values(item.mapping) : [];
+      for (const node of mapping as any[]) {
+        const msg = (node as any).message;
+        if (!msg) continue;
+        const content = msg.content;
+        const parts = Array.isArray(content?.parts) ? content.parts : typeof content === 'string' ? [content] : [];
+        for (const part of parts) {
+          if (typeof part !== 'string') continue;
+          if (/wir sollten|könnten wir|TODO/i.test(part)) {
+            const m = part.match(/CREP[:\s]*([0-9.]+)/i);
+            const priority = m ? parseFloat(m[1]) : 0;
+            todos.push({
+              id: `todo-${todos.length + 1}`,
+              beschreibung: part.trim(),
+              status: 'offen',
+              priority,
+            });
+          }
+        }
+      }
+    });
+  }
+  todos.sort((a, b) => b.priority - a.priority);
   fs.writeFileSync(output, yaml.stringify(todos));
 }
 

--- a/packages/conversation-analysis/index.ts
+++ b/packages/conversation-analysis/index.ts
@@ -1,3 +1,4 @@
 export const name = 'conversation-analysis';
 export * from './CREPConversationScanner';
 export * from './ChronoPoemExtractor';
+export * from './generate-todo-from-convos';


### PR DESCRIPTION
## Summary
- extend conversation todo extractor with CREP priority and newadvancedconversations input
- export new extractor from conversation-analysis package
- add unit test covering prioritization
- log progress for todo priority script in `advancedprogress.json`

## Testing
- `npx pyright` *(fails: missing modules)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definition file 'node')*
- `npx jest` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_6888935efd008322b364b832ce94491f