### PR TITLE
Add BoundaryLawExtractor and VR blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**PyramidVRMeetingRoom**](packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.tsx) – enables multi-avatar VR sessions
 - CosmicTheoryAgent now exposes **VR hooks** for immersive interactions
 - [**VR Pantheon Konzept**](docs/pantheon/VR-Begegnungsraum-Concept.md) – Konzept für kollaborative Treffen
+- [**VR-Begegnungsraum Blueprint**](docs/blueprints/VR-Begegnungsraum.md) – Raumstruktur und Fourier-Anbindung
 - [**PySR Service Client**](packages/agents/CosmicTheoryAgent.ts) – Regression via REST/gRPC
 - [**Sigil Archive Service**](services/sigil-archive/index.ts) – speichert Sigille und CREP-Fragmente
 - [**CREPVisualizer**](packages/unifiedmandala-ui/components/CREPVisualizer.tsx) – animierte Timeline der Mandala-Kristalle

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7127,20 +7127,20 @@
     "path": "docs/pantheon/manifest.yaml",
     "task": "Define YAML/JSON schema for Pantheon modules",
     "test": "",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Extract Boundary Law algorithms",
     "path": "packages/boundary-engine/BoundaryLawExtractor.ts",
     "task": "Parse boundary rules from blueprint docs",
     "test": "packages/boundary-engine/BoundaryLawExtractor.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Finalize VR-Begegnungsraum blueprint",
     "path": "docs/blueprints/VR-Begegnungsraum.md",
     "task": "Summarize room structure and Fourier integration steps",
     "test": "",
-    "status": "todo"
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8090,14 +8090,14 @@
   path: docs/pantheon/manifest.yaml
   task: Define YAML/JSON schema for Pantheon modules
   test: ""
-  status: todo
+  status: done
 - commit: Extract Boundary Law algorithms
   path: packages/boundary-engine/BoundaryLawExtractor.ts
   task: Parse boundary rules from blueprint docs
   test: packages/boundary-engine/BoundaryLawExtractor.test.ts
-  status: todo
+  status: done
 - commit: Finalize VR-Begegnungsraum blueprint
   path: docs/blueprints/VR-Begegnungsraum.md
   task: Summarize room structure and Fourier integration steps
   test: ""
-  status: todo
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,25 +1,12 @@
 {
-  "lastCommit": "chore: sync progress",
+  "lastCommit": "feat: add boundary law extractor and VR blueprint",
   "fractalStep": "sync",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
   "notes": "Added CREP prioritization to generate-todo script",
-  "pendingTasks": [
-    {
-      "commit": "Create Pantheon Manifest Schema",
-      "status": "todo"
-    },
-    {
-      "commit": "Extract Boundary Law algorithms",
-      "status": "todo"
-    },
-    {
-      "commit": "Finalize VR-Begegnungsraum blueprint",
-      "status": "todo"
-    }
-  ],
+  "pendingTasks": [],
   "progress": [
     {
       "commit": "Implement boundary manager modules",
@@ -471,6 +458,18 @@
     },
     {
       "commit": "enhance VRBegegnungsraumLobby handshake",
+      "status": "done"
+    },
+    {
+      "commit": "Create Pantheon Manifest Schema",
+      "status": "done"
+    },
+    {
+      "commit": "Extract Boundary Law algorithms",
+      "status": "done"
+    },
+    {
+      "commit": "Finalize VR-Begegnungsraum blueprint",
       "status": "done"
     }
   ]

--- a/docs/blueprints/VR-Begegnungsraum.md
+++ b/docs/blueprints/VR-Begegnungsraum.md
@@ -1,0 +1,16 @@
+# VR-Begegnungsraum Blueprint
+Dieses Dokument fasst die Raumstruktur und die Fourier-Integration zusammen.
+
+## Raumstruktur
+- Lobby zur Avatar-Auswahl
+- MandalaScene im Zentrum
+- Interaktive Artefakte für Boundary- und Pantheonmodule
+- CREP-Dashboard an jeder Station
+
+## Fourier-Integration
+- *FourierLayerBridge* koppelt Audioschichten an die Szene
+- Wellenmuster erzeugen visuelles Feedback
+- Daten des CosmicTheoryAgent modulieren die Frequenzen
+- WebXR-Werkzeuge ermöglichen Hands-on-Interaktionen
+
+Dieses Blueprint dient als Ausgangspunkt für die Implementation des VR-Raums.

--- a/docs/pantheon/manifest.yaml
+++ b/docs/pantheon/manifest.yaml
@@ -1,0 +1,15 @@
+modules:
+  - id: cosmic-theory-agent
+    name: CosmicTheoryAgent
+    description: Kernmodul für kosmische Analysen
+    entry: packages/agents/CosmicTheoryAgent.ts
+    depends_on:
+      - aeon-core
+      - crep-engine
+  - id: pyramid-ui
+    name: PyramidUI
+    description: React/Three.js Benutzeroberfläche
+    entry: packages/unifiedmandala-ui/index.ts
+    depends_on:
+      - aeon-core
+      - boundary-engine

--- a/packages/boundary-engine/BoundaryLawExtractor.test.ts
+++ b/packages/boundary-engine/BoundaryLawExtractor.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import { BoundaryLawExtractor } from './BoundaryLawExtractor';
+
+describe('BoundaryLawExtractor', () => {
+  it('parses boundary_rule blocks', () => {
+    const file = 'tmp_rule.md';
+    fs.writeFileSync(
+      file,
+      '\n```yaml\nboundary_rule:\n  name: TestRule\n  domain: test\n```\n'
+    );
+    const ext = new BoundaryLawExtractor([file]);
+    const rules = ext.extract();
+    expect(rules[0].name).toBe('TestRule');
+    fs.unlinkSync(file);
+  });
+});

--- a/packages/boundary-engine/BoundaryLawExtractor.ts
+++ b/packages/boundary-engine/BoundaryLawExtractor.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+export interface BoundaryLaw {
+  name: string;
+  system_1?: string;
+  system_2?: string;
+  domain?: string;
+  signature?: string;
+  emergent_effects?: string[];
+  macro_recurrence?: string[];
+}
+
+export class BoundaryLawExtractor {
+  constructor(private files: string[]) {}
+
+  extract(): BoundaryLaw[] {
+    const rules: BoundaryLaw[] = [];
+    for (const file of this.files) {
+      const text = fs.readFileSync(file, 'utf8');
+      const matches = text.match(/```yaml[\s\S]*?boundary_rule:[\s\S]*?```/g);
+      if (!matches) continue;
+      for (const block of matches) {
+        const clean = block.replace(/```yaml|```/g, '');
+        const data = yaml.load(clean.trim()) as any;
+        if (data && typeof data === 'object' && 'boundary_rule' in data) {
+          rules.push(data.boundary_rule as BoundaryLaw);
+        }
+      }
+    }
+    return rules;
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,10 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['packages/agents/**/*.{test,spec}.ts'],
+    include: [
+      'packages/agents/**/*.{test,spec}.ts',
+      'packages/boundary-engine/**/*.{test,spec}.ts'
+    ],
     environment: 'node'
   }
 });


### PR DESCRIPTION
## Summary
- create `BoundaryLawExtractor` to parse boundary rules from docs
- document VR-Begegnungsraum blueprint
- define basic Pantheon manifest schema
- register boundary-engine tests in vitest config
- update advanced TODO lists and progress log

## Testing
- `npx -y pyright` *(fails: missing modules)*
- `npx -y tsc -p tsconfig.json` *(fails: cannot find type definitions)*
- `pnpm install`
- `npx -y vitest run packages/boundary-engine/BoundaryLawExtractor.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6888bb7c86308322bc60ba394d3182e8