### PR TITLE
Implement Pantheon feedback round

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**PantheonBoundaryBridge**](packages/pantheon/PantheonBoundaryBridge.ts) – verbindet Pantheon-Events mit BoundaryRuleDetector
 - [**PantheonExport Tool**](packages/pantheon/tools/PantheonExport.ts) – exportiert die vorhandenen Pantheon-Module als Datensatz
 - [**PantheonFeedbackService**](packages/pantheon/PantheonFeedbackService.ts) – gather feedback across agents
+- Supports `coordinateRound` to run a callback over gathered messages
 - [**VRBegegnungsraumLobby**](packages/unifiedmandala-vr/VRBegegnungsraumLobby.ts) – lobby handshake for VR sessions
 - [**GreekMathAeonDispatcher**](packages/core/GreekMathAeonDispatcher.ts) – safe dispatch with error events
+- Uses an internal `EventEmitter` to avoid global side effects
 - **VR-Begegnungsraum** – Avatar-Interaktion und Mandala-Szenen im WebXR-Modul
 - [**EventBridge**](packages/unifiedmandala-ui/events/EventBridge.ts) – verbindet CosmicTheoryAgent mit der Pyramid UI
 - [**PyramidVRMeetingRoom**](packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.tsx) – enables multi-avatar VR sessions

--- a/advancedToDo_parts/advancedToDo.part10.json
+++ b/advancedToDo_parts/advancedToDo.part10.json
@@ -4,7 +4,7 @@
     "path": "packages/pantheon/PantheonFeedbackService.ts",
     "task": "Coordinate GPT feedback round with Pantheon agents",
     "test": "packages/pantheon/PantheonFeedbackService.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add PoetryErrorBoundary component",
@@ -32,7 +32,7 @@
     "path": "packages/core/GreekMathAeonDispatcher.ts",
     "task": "Emit dispatcher:error event via try/catch wrapper",
     "test": "packages/core/GreekMathAeonDispatcher.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement BoundaryWaveFieldVisualizer",

--- a/advancedToDo_parts/advancedToDo.part10.yaml
+++ b/advancedToDo_parts/advancedToDo.part10.yaml
@@ -2,7 +2,7 @@
   path: packages/pantheon/PantheonFeedbackService.ts
   task: Coordinate GPT feedback round with Pantheon agents
   test: packages/pantheon/PantheonFeedbackService.test.ts
-  status: open
+  status: done
 - commit: Add PoetryErrorBoundary component
   path: packages/unifiedmandala-ui/components/PoetryErrorBoundary.tsx
   task: Show ChronoPoem on errors when poetry mode active
@@ -22,7 +22,7 @@
   path: packages/core/GreekMathAeonDispatcher.ts
   task: Emit dispatcher:error event via try/catch wrapper
   test: packages/core/GreekMathAeonDispatcher.test.ts
-  status: open
+  status: done
 - commit: Implement BoundaryWaveFieldVisualizer
   path: packages/unifiedmandala-boundary/BoundaryWaveFieldVisualizer.ts
   task: Visualize boundary wave interference patterns

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add boundary law extractor and VR blueprint",
+  "lastCommit": "feat: implement feedback round and dispatcher",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -314,6 +314,14 @@
     },
     {
       "commit": "Create VRResonanceHub",
+      "status": "done"
+    },
+    {
+      "commit": "Implement PantheonFeedbackRound",
+      "status": "done"
+    },
+    {
+      "commit": "Add EventEmitter-based dispatcher",
       "status": "done"
     }
   ],

--- a/packages/boundary-engine/__tests__/BoundaryLawSimulator.test.ts
+++ b/packages/boundary-engine/__tests__/BoundaryLawSimulator.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { BoundaryLawSimulator } from '../BoundaryLawSimulator';
 
 describe('BoundaryLawSimulator', () => {

--- a/packages/boundary-engine/__tests__/rule_registry_service.test.ts
+++ b/packages/boundary-engine/__tests__/rule_registry_service.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import request from 'supertest';
 import { createRuleRegistryService } from '../rule_registry_service/registry_api';
 import { GraphDBPersistence } from '../GraphDBPersistence';

--- a/packages/core/GreekMathAeonDispatcher.test.ts
+++ b/packages/core/GreekMathAeonDispatcher.test.ts
@@ -5,7 +5,7 @@ describe('GreekMathAeonDispatcher', () => {
   it('emits error', () => {
     const dispatcher = new GreekMathAeonDispatcher();
     const spy = vi.fn();
-    process.on('dispatcher:error', spy);
+    dispatcher.emitter.on('dispatcher:error', spy);
     dispatcher.dispatch(() => { throw new Error('x'); });
     expect(spy).toHaveBeenCalled();
   });
@@ -13,7 +13,7 @@ describe('GreekMathAeonDispatcher', () => {
   it('returns result and emits on failure', () => {
     const dispatcher = new GreekMathAeonDispatcher();
     const spy = vi.fn();
-    process.on('dispatcher:error', spy);
+    dispatcher.emitter.on('dispatcher:error', spy);
     const ok = dispatcher.dispatchWithResult(() => 42);
     expect(ok).toBe(42);
     const fail = dispatcher.dispatchWithResult(() => { throw new Error('x'); });

--- a/packages/core/GreekMathAeonDispatcher.ts
+++ b/packages/core/GreekMathAeonDispatcher.ts
@@ -1,11 +1,13 @@
+import { EventEmitter } from 'events';
+
 export class GreekMathAeonDispatcher {
+  readonly emitter = new EventEmitter();
+
   dispatch(fn: () => void) {
     try {
       fn();
     } catch (err) {
-      if (typeof process !== 'undefined') {
-        process.emit('dispatcher:error', err);
-      }
+      this.emitter.emit('dispatcher:error', err);
     }
   }
 
@@ -13,9 +15,7 @@ export class GreekMathAeonDispatcher {
     try {
       return fn();
     } catch (err) {
-      if (typeof process !== 'undefined') {
-        process.emit('dispatcher:error', err);
-      }
+      this.emitter.emit('dispatcher:error', err);
       return null;
     }
   }

--- a/packages/pantheon/PantheonFeedbackService.test.ts
+++ b/packages/pantheon/PantheonFeedbackService.test.ts
@@ -11,4 +11,10 @@ describe('PantheonFeedbackService', () => {
     const svc = new PantheonFeedbackService();
     expect(svc.gatherFeedback(['a', 'b'])).toEqual(['feedback:a', 'feedback:b']);
   });
+
+  it('coordinates round via callback', () => {
+    const svc = new PantheonFeedbackService();
+    const result = svc.coordinateRound(['a'], m => m.toUpperCase());
+    expect(result).toEqual(['FEEDBACK:A']);
+  });
 });

--- a/packages/pantheon/PantheonFeedbackService.ts
+++ b/packages/pantheon/PantheonFeedbackService.ts
@@ -6,4 +6,11 @@ export class PantheonFeedbackService {
   gatherFeedback(agents: string[]): string[] {
     return agents.map(a => this.collectFeedback(a));
   }
+
+  coordinateRound(
+    agents: string[],
+    responder: (msg: string) => string
+  ): string[] {
+    return this.gatherFeedback(agents).map(responder);
+  }
 }


### PR DESCRIPTION
## Summary
- add coordinateRound helper for PantheonFeedbackService and test
- switch GreekMathAeonDispatcher to EventEmitter with updated tests
- fix missing vitest imports in boundary-engine tests
- document new capabilities in README
- mark remaining advancedToDo items as done
- update advancedprogress

## Testing
- `npx tsc -p tsconfig.json`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6888c27d40c0832290d08f6de332cf29