### PR TITLE
Implement VRExperienceRoom and ResonanceMapping

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7146,14 +7146,14 @@
   {
     "commit": "Add VRExperienceRoom component",
     "path": "packages/unifiedmandala-vr/VRExperienceRoom.tsx",
-    "status": "open",
+    "status": "done",
     "task": "Immersive VR space for Pantheon and Boundary exploration",
     "test": "packages/unifiedmandala-vr/VRExperienceRoom.test.tsx"
   },
   {
     "commit": "Implement ResonanceMapping module",
     "path": "packages/resonance/ResonanceMapping.ts",
-    "status": "open",
+    "status": "done",
     "task": "Multi-dimensional resonance mapping with Fourier transforms",
     "test": "packages/resonance/ResonanceMapping.test.ts"
   }

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8103,11 +8103,11 @@
   status: done
 - commit: Add VRExperienceRoom component
   path: packages/unifiedmandala-vr/VRExperienceRoom.tsx
-  status: open
+  status: done
   task: Immersive VR space for Pantheon and Boundary exploration
   test: packages/unifiedmandala-vr/VRExperienceRoom.test.tsx
 - commit: Implement ResonanceMapping module
   path: packages/resonance/ResonanceMapping.ts
-  status: open
+  status: done
   task: Multi-dimensional resonance mapping with Fourier transforms
   test: packages/resonance/ResonanceMapping.test.ts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: implement feedback round and dispatcher",
+  "lastCommit": "feat: add VRExperienceRoom and ResonanceMapping",
   "fractalStep": "sync",
   "openBranches": [
     "work"

--- a/packages/resonance/ResonanceMapping.test.ts
+++ b/packages/resonance/ResonanceMapping.test.ts
@@ -1,0 +1,14 @@
+
+import { ResonanceMapping } from './ResonanceMapping';
+
+describe('ResonanceMapping', () => {
+  it('aggregates Fourier amplitudes', () => {
+    const rm = new ResonanceMapping();
+    const res = rm.map([
+      [1,0,0,0],
+      [0,1,0,0]
+    ]);
+    expect(res.length).toBe(4);
+    expect(res[0]).toBeGreaterThan(0);
+  });
+});

--- a/packages/resonance/ResonanceMapping.ts
+++ b/packages/resonance/ResonanceMapping.ts
@@ -1,0 +1,30 @@
+export class ResonanceMapping {
+  private dft(values: number[]): number[] {
+    const n = values.length;
+    const result: number[] = [];
+    for (let k = 0; k < n; k++) {
+      let re = 0;
+      let im = 0;
+      for (let t = 0; t < n; t++) {
+        const angle = (2 * Math.PI * t * k) / n;
+        re += values[t] * Math.cos(angle);
+        im -= values[t] * Math.sin(angle);
+      }
+      result.push(Math.sqrt(re * re + im * im) / n);
+    }
+    return result;
+  }
+
+  map(matrix: number[][]): number[] {
+    if (matrix.length === 0) return [];
+    const transforms = matrix.map(row => this.dft(row));
+    const width = transforms[0].length;
+    const agg = new Array(width).fill(0);
+    transforms.forEach(t => {
+      for (let i = 0; i < width; i++) {
+        agg[i] += t[i];
+      }
+    });
+    return agg.map(v => v / transforms.length);
+  }
+}

--- a/packages/unifiedmandala-vr/VRExperienceRoom.test.tsx
+++ b/packages/unifiedmandala-vr/VRExperienceRoom.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import VRExperienceRoom from './VRExperienceRoom';
+
+global.WebSocket = class { close() {} constructor(public url: string) {} } as any;
+
+jest.mock('./VRBegegnungsraum', () => {
+  return { VRBegegnungsraum: class { join() { return Promise.resolve('ok'); } handshake() {} onHandshake() {} } };
+});
+
+jest.mock('./VRBoundaryConductor', () => {
+  return { VRBoundaryConductor: class { constructor() {} start() {} stop() {} } };
+});
+
+jest.mock('../pantheon/PantheonBoundaryBridge', () => {
+  return { PantheonBoundaryBridge: class {} };
+});
+
+test('renders VR experience room', () => {
+  const { getByLabelText } = render(<VRExperienceRoom url="scene.glb" />);
+  expect(getByLabelText('vr-experience-room')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-vr/VRExperienceRoom.tsx
+++ b/packages/unifiedmandala-vr/VRExperienceRoom.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect } from 'react';
+import { VRBegegnungsraum } from './VRBegegnungsraum';
+import { VRBoundaryConductor } from './VRBoundaryConductor';
+import { PantheonBoundaryBridge } from '../pantheon/PantheonBoundaryBridge';
+
+export interface VRExperienceRoomProps {
+  url: string;
+  rules?: (string | RegExp)[];
+}
+
+export default function VRExperienceRoom({ url, rules = [] }: VRExperienceRoomProps) {
+  const vrRef = React.useRef<VRBegegnungsraum>();
+  if (!vrRef.current) {
+    vrRef.current = new VRBegegnungsraum();
+  }
+  const bridgeRef = React.useRef<PantheonBoundaryBridge>();
+  if (!bridgeRef.current) {
+    bridgeRef.current = new PantheonBoundaryBridge();
+  }
+  const conductorRef = React.useRef<VRBoundaryConductor>();
+  if (!conductorRef.current) {
+    conductorRef.current = new VRBoundaryConductor(vrRef.current, bridgeRef.current, rules);
+  }
+
+  useEffect(() => {
+    const conductor = conductorRef.current!;
+    conductor.start();
+    vrRef.current!.join(url);
+    return () => conductor.stop();
+  }, [url, rules]);
+
+  return (
+    <div aria-label="vr-experience-room">
+      VR Experience Room
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `VRExperienceRoom` React component for immersive Pantheon/Boundary exploration
- add `ResonanceMapping` utility with Fourier aggregation
- mark related tasks as done in `advancedToDo`
- add unit tests for the new modules

## Testing
- `pnpm test packages/unifiedmandala-vr/VRExperienceRoom.test.tsx packages/resonance/ResonanceMapping.test.ts`
- `npx tsc -p tsconfig.json`
- `npx pyright` *(fails: Import errors and undefined names)*

------
https://chatgpt.com/codex/tasks/task_e_6888cc5a24288322b1a013385e2985cc