### PR TITLE
Update docs with UI overlay components

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -215,6 +215,9 @@ GPTEventHub.emit('orakel:says', { content: 'Hallo Welt' });
 - `CREPToDoPrioritizer` – stuft Aufgaben nach Emergenz ein.
 - `CREPConvoHeatmap` – React-Komponente zur Visualisierung von CREP-Schwankungen.
 - `NullmembranSIHeatmap` – zeigt die Verteilung von S_I-Werten rund um die Nullmembran.
+- `HeatmapWidget` – zeigt CREP-Aktivität pro Tag als Heatmap
+- `OnboardingModal` – kurze Einführung beim ersten Besuch
+- `HaikuOverlay` – zufällig erscheinende Haikus zur Inspiration
 - `ImpactDashboard` – Dashboard mit MandalaNetworkView und AgentHeatmap.
 - `CustomRegionGallery` – Galerieansicht für Regionen.
 - `ProjectListView` – Listenansicht für Social-Good-Projekte.

--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**ChatPanel**](packages/unifiedmandala-ui/components/ChatPanel.tsx) – einfacher GPT-gestützter Chat mit CREP-Logging
 - [**CREPStatsCard**](packages/unifiedmandala-ui/components/CREPStatsCard.tsx) – zeigt Durchschnitts-CREP mit Mini-Chart
 - [**NullmembranSIHeatmap**](packages/unifiedmandala-ui/components/NullmembranSIHeatmap.tsx) – visualisiert S_I-Verteilung als Heatmap
+- [**HeatmapWidget**](packages/unifiedmandala-ui/components/HeatmapWidget.tsx) – zeigt CREP-Aktivität als Heatmap
+- [**OnboardingModal**](packages/unifiedmandala-ui/components/OnboardingModal.tsx) – begrüßt neue Nutzende mit Ritualhinweisen
+- [**HaikuOverlay**](packages/unifiedmandala-ui/components/HaikuOverlay.tsx) – blendet zufällige Haikus ein
 - `/impulse/:idx/crep` – Route zum Aktualisieren der CREP-Metriken
 - [**ArchetypeDecoderAgent**](packages/agents/ArchetypeDecoderAgent.ts) – extrahiert Archetypen aus Beschreibungen
 - [**SigillinInterpreterAgent**](packages/agents/SigillinInterpreterAgent.ts) – erkennt Sigillin-Symbole


### PR DESCRIPTION
## Summary
- document UI overlay components in README and Handbuch
- add HeatmapWidget, OnboardingModal and HaikuOverlay bullet points

## Testing
- `npx -y pyright` *(fails: Import "fastapi" could not be resolved)*
- `npx -y tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_688907c2cb488322925fd5b2a5124f19