### PR TITLE
Update docs and progress for Blackbox modules

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -412,4 +412,18 @@ Weitere Beispiele und GIF-Demos findest du im [Wiki](https://github.com/GenesisA
 Weitere Infos zur Pipeline findest du in [docs/demo/POC-Run-Guide.md](docs/demo/POC-Run-Guide.md).
 Ein SVG-Beispiel liegt unter [`docs/assets/unified-mandala.svg`](docs/assets/unified-mandala.svg).
 
+## Blackbox Resonanz
+
+Die Blackbox-Module stellen einen experimentellen Resonanzraum bereit. Im Manifest
+[manifest/blackbox-manifest.md](manifest/blackbox-manifest.md) findest du eine
+Übersicht der Komponenten:
+
+- **BlackboxMandala** – interaktive CREP-Visualisierung
+- **BlackboxMirrorBoard** – Spiegel für Eingaben und Reflexionen
+- **CREPStatsCard** und **HeatmapWidget** – zeigen Metriken und Aktivität
+- **OnboardingModal** und **HaikuOverlay** – begleiten den Einstieg poetisch
+
+Die ethischen Leitlinien werden im Dokument
+[manifest/crep-open-ethik.md](manifest/crep-open-ethik.md) erläutert.
+
 Das `CHRONOPOEM.md` entsteht automatisch – und kann bei jedem Commit erneuert werden.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**HeatmapWidget**](packages/unifiedmandala-ui/components/HeatmapWidget.tsx) – zeigt CREP-Aktivität als Heatmap
 - [**OnboardingModal**](packages/unifiedmandala-ui/components/OnboardingModal.tsx) – begrüßt neue Nutzende mit Ritualhinweisen
 - [**HaikuOverlay**](packages/unifiedmandala-ui/components/HaikuOverlay.tsx) – blendet zufällige Haikus ein
+- [**BlackboxMirrorBoard**](packages/unifiedmandala-ui/components/BlackboxMirrorBoard.tsx) – reflektiert Eingaben im Blackbox-Modus
 - `/impulse/:idx/crep` – Route zum Aktualisieren der CREP-Metriken
 - [**ArchetypeDecoderAgent**](packages/agents/ArchetypeDecoderAgent.ts) – extrahiert Archetypen aus Beschreibungen
 - [**SigillinInterpreterAgent**](packages/agents/SigillinInterpreterAgent.ts) – erkennt Sigillin-Symbole

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7177,5 +7177,26 @@
     "task": "Fetch or simulate temperature data for climate features",
     "test": "packages/unifiedmandala-climate/ClimateDataBridge.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Create BlackboxMirrorBoard component",
+    "path": "packages/unifiedmandala-ui/components/BlackboxMirrorBoard.tsx",
+    "task": "Mirror user input and reflections in Blackbox UI",
+    "test": "packages/unifiedmandala-ui/components/BlackboxMirrorBoard.test.tsx",
+    "status": "planned"
+  },
+  {
+    "commit": "Document Blackbox resonance modules",
+    "path": "manifest/blackbox-manifest.md",
+    "task": "Summarize Blackbox UI components and usage",
+    "test": "",
+    "status": "done"
+  },
+  {
+    "commit": "Document CREP Open-Ethik guidelines",
+    "path": "manifest/crep-open-ethik.md",
+    "task": "Outline open ethics workflow for CREP modules",
+    "test": "",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8126,3 +8126,18 @@
   task: Fetch or simulate temperature data for climate features
   test: packages/unifiedmandala-climate/ClimateDataBridge.test.ts
   status: done
+- commit: Create BlackboxMirrorBoard component
+  path: packages/unifiedmandala-ui/components/BlackboxMirrorBoard.tsx
+  task: Mirror user input and reflections in Blackbox UI
+  test: packages/unifiedmandala-ui/components/BlackboxMirrorBoard.test.tsx
+  status: planned
+- commit: Document Blackbox resonance modules
+  path: manifest/blackbox-manifest.md
+  task: Summarize Blackbox UI components and usage
+  test: ""
+  status: done
+- commit: Document CREP Open-Ethik guidelines
+  path: manifest/crep-open-ethik.md
+  task: Outline open ethics workflow for CREP modules
+  test: ""
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore(progress): update lastCommit",
+  "lastCommit": "docs: add blackbox manifest",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -339,6 +339,18 @@
     {
       "commit": "Add ClimateDataBridge module",
       "status": "done"
+    },
+    {
+      "commit": "Document Blackbox resonance modules",
+      "status": "done"
+    },
+    {
+      "commit": "Document CREP Open-Ethik guidelines",
+      "status": "done"
+    },
+    {
+      "commit": "Plan BlackboxMirrorBoard component",
+      "status": "planned"
     }
   ],
   "completed": [

--- a/manifest/blackbox-manifest.md
+++ b/manifest/blackbox-manifest.md
@@ -1,0 +1,11 @@
+# Blackbox Resonance Manifest
+
+This manifest summarizes the Blackbox Resonance modules anchored in the Mandala core.
+
+- **BlackboxMandala** – visualizes CREP resonances in an interactive canvas.
+- **BlackboxMirrorBoard** – mirrors user input and reflection layers.
+- **CREPStatsCard** – shows accumulated CREP metrics.
+- **HeatmapWidget** – renders resonance heatmaps over time.
+- **OnboardingModal** – guides new users through the Blackbox interface.
+- **HaikuOverlay** – displays poetic prompts during onboarding.
+

--- a/manifest/crep-open-ethik.md
+++ b/manifest/crep-open-ethik.md
@@ -1,0 +1,8 @@
+# CREP Open-Ethik Manifest
+
+This document outlines the open-ethics guidelines for the CREP collective modules.
+
+- Encourage community feedback loops.
+- Visualize ethical resonance using the HeatmapWidget.
+- Provide transparency through the BlackboxMirrorBoard.
+


### PR DESCRIPTION
## Summary
- document Blackbox resonance modules
- add CREP Open-Ethik manifest
- list BlackboxMirrorBoard component in README and Handbuch
- register new tasks in advanced todo lists and progress

## Testing
- `npx -y pyright` *(fails: missing dependencies)*
- `npx -y tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68891271a0608322b5521e0ffc76dce0