### PR TITLE
Add gzip line reversal utility

### DIFF
--- a/packages/shared-utils/README.md
+++ b/packages/shared-utils/README.md
@@ -17,3 +17,4 @@ Gemeinsame Hilfsfunktionen für UnifiedMandala.
 - **scanTodoComments** – findet TODO-Kommentare in Quelltexten
 - **isFragmentProcessed**, **markFragmentProcessed** und **listProcessedFragments** –
   protokollieren bearbeitete Conversation-Fragmente
+- **decompressReverseLines** – entpackt gzip-Dateien zeilenweise und kehrt jede Zeile um

--- a/packages/shared-utils/decompressReverseLines.ts
+++ b/packages/shared-utils/decompressReverseLines.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import zlib from 'zlib';
+import readline from 'readline';
+
+/**
+ * Decompress a gzip file, reverse each line, and write the result to another file using streams.
+ * @param input Path to the gzip-compressed input file.
+ * @param output Path to the output file to write reversed lines.
+ */
+export async function decompressReverseLines(input: string, output: string): Promise<void> {
+  const readStream = fs.createReadStream(input).pipe(zlib.createGunzip());
+  const rl = readline.createInterface({ input: readStream, crlfDelay: Infinity });
+  const writeStream = fs.createWriteStream(output);
+
+  for await (const line of rl) {
+    const reversed = [...line].reverse().join('');
+    writeStream.write(reversed + '\n');
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    rl.on('close', resolve);
+    rl.on('error', reject);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    writeStream.end(() => resolve());
+    writeStream.on('error', reject);
+  });
+}
+
+if (require.main === module) {
+  const [input, output] = process.argv.slice(2);
+  if (!input || !output) {
+    console.error('Usage: decompressReverseLines <input.gz> <output.txt>');
+    process.exit(1);
+  }
+  decompressReverseLines(input, output).catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/shared-utils/index.ts
+++ b/packages/shared-utils/index.ts
@@ -17,3 +17,4 @@ export * from './conversationAnalyzer';
 export * from './advancedConversation';
 export * from './RestClient';
 export * from './MandalaCoreLicense';
+export * from './decompressReverseLines';

--- a/tests/decompress_reverse_lines_test.rb
+++ b/tests/decompress_reverse_lines_test.rb
@@ -1,0 +1,19 @@
+require 'minitest/autorun'
+require 'zlib'
+require 'tempfile'
+
+class DecompressReverseLinesTest < Minitest::Test
+  def test_decompress_and_reverse
+    Dir.mktmpdir do |dir|
+      input_txt = File.join(dir, 'input.txt')
+      gzip_file = File.join(dir, 'input.txt.gz')
+      output_txt = File.join(dir, 'output.txt')
+      File.write(input_txt, "hello\nworld\n")
+      Zlib::GzipWriter.open(gzip_file) { |gz| gz.write File.read(input_txt) }
+
+      system("npx ts-node packages/shared-utils/decompressReverseLines.ts #{gzip_file} #{output_txt}")
+      result = File.read(output_txt)
+      assert_equal "olleh\ndlrow\n", result
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add `decompressReverseLines` utility for reversing lines of a gzip file
- export new util from shared-utils
- document util in package README
- add Ruby test covering CLI behavior

## Testing
- `npx -y pyright`
- `npx -y tsc -p tsconfig.json`
- `pnpm test` *(fails: enforceLimit triggers cleanup when limit exceeded)*
- `ruby tests/decompress_reverse_lines_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_68891d6e5cec8322850fe211724bf224