### PR TITLE
Update advanced ToDo with new VR and Mandala tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7198,5 +7198,47 @@
     "task": "Outline open ethics workflow for CREP modules",
     "test": "",
     "status": "done"
+  },
+  {
+    "commit": "Create MandalaReader module",
+    "path": "packages/mandala-reader/MandalaReader.ts",
+    "task": "Analyze SVG and bitmap Mandalas and export structured JSON",
+    "test": "packages/mandala-reader/MandalaReader.test.ts",
+    "status": "planned"
+  },
+  {
+    "commit": "Add MandalaFlowDashboard",
+    "path": "packages/unifiedmandala-ui/components/MandalaFlowDashboard.tsx",
+    "task": "Dashboard with ResonancePlotter and animated MandalaFlow canvas",
+    "test": "packages/unifiedmandala-ui/components/MandalaFlowDashboard.test.tsx",
+    "status": "planned"
+  },
+  {
+    "commit": "Add SigillinBubbles component",
+    "path": "packages/unifiedmandala-ui/components/SigillinBubbles.tsx",
+    "task": "Interactive Sigillin bubbles with framer-motion",
+    "test": "packages/unifiedmandala-ui/components/SigillinBubbles.test.tsx",
+    "status": "planned"
+  },
+  {
+    "commit": "Enhance AgentDispatcher with ErrorBoundary and priority queue",
+    "path": "packages/agents/AgentDispatcher.ts",
+    "task": "Add error boundary wrapper and priority-based task dispatch",
+    "test": "packages/agents/AgentDispatcher.test.ts",
+    "status": "planned"
+  },
+  {
+    "commit": "Create PantheonBegegnungsraum VR component",
+    "path": "packages/unifiedmandala-vr/components/PantheonBegegnungsraum.tsx",
+    "task": "3D VR meeting room for Pantheon modules",
+    "test": "packages/unifiedmandala-vr/components/PantheonBegegnungsraum.test.tsx",
+    "status": "planned"
+  },
+  {
+    "commit": "Add ExtendedResonanceBlueprint",
+    "path": "packages/resonance-modules/ExtendedResonanceBlueprint.ts",
+    "task": "Blueprint for advanced resonance microservices",
+    "test": "packages/resonance-modules/ExtendedResonanceBlueprint.test.ts",
+    "status": "planned"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8141,3 +8141,33 @@
   task: Outline open ethics workflow for CREP modules
   test: ""
   status: done
+- commit: Create MandalaReader module
+  path: packages/mandala-reader/MandalaReader.ts
+  task: Analyze SVG and bitmap Mandalas and export structured JSON
+  test: packages/mandala-reader/MandalaReader.test.ts
+  status: planned
+- commit: Add MandalaFlowDashboard
+  path: packages/unifiedmandala-ui/components/MandalaFlowDashboard.tsx
+  task: Dashboard with ResonancePlotter and animated MandalaFlow canvas
+  test: packages/unifiedmandala-ui/components/MandalaFlowDashboard.test.tsx
+  status: planned
+- commit: Add SigillinBubbles component
+  path: packages/unifiedmandala-ui/components/SigillinBubbles.tsx
+  task: Interactive Sigillin bubbles with framer-motion
+  test: packages/unifiedmandala-ui/components/SigillinBubbles.test.tsx
+  status: planned
+- commit: Enhance AgentDispatcher with ErrorBoundary and priority queue
+  path: packages/agents/AgentDispatcher.ts
+  task: Add error boundary wrapper and priority-based task dispatch
+  test: packages/agents/AgentDispatcher.test.ts
+  status: planned
+- commit: Create PantheonBegegnungsraum VR component
+  path: packages/unifiedmandala-vr/components/PantheonBegegnungsraum.tsx
+  task: 3D VR meeting room for Pantheon modules
+  test: packages/unifiedmandala-vr/components/PantheonBegegnungsraum.test.tsx
+  status: planned
+- commit: Add ExtendedResonanceBlueprint
+  path: packages/resonance-modules/ExtendedResonanceBlueprint.ts
+  task: Blueprint for advanced resonance microservices
+  test: packages/resonance-modules/ExtendedResonanceBlueprint.test.ts
+  status: planned

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -356,6 +356,10 @@
     {
       "commit": "Plan BlackboxMirrorBoard component",
       "status": "planned"
+    },
+    {
+      "commit": "extract MandalaReader and VR tasks",
+      "status": "done"
     }
   ],
   "completed": [


### PR DESCRIPTION
## Summary
- extract new action items from `newadvancedconversations.json`
- append MandalaReader, MandalaFlowDashboard and related tasks
- log progress update for extraction step

## Testing
- `npx -y pyright`
- `npx -y tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68892577715883229a2a56a262f04d4d