### PR TITLE
Update advanced tasks for Pantheon blueprint

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7240,5 +7240,19 @@
     "task": "Blueprint for advanced resonance microservices",
     "test": "packages/resonance-modules/ExtendedResonanceBlueprint.test.ts",
     "status": "planned"
+  },
+  {
+    "commit": "Manifest Mandala-KI-Pantheon blueprint",
+    "path": "docs/pantheon/MandalaKIPantheonBlueprint.yaml",
+    "task": "Provide YAML and Sigillin manifest for Mandala-KI-Pantheon",
+    "test": "docs/pantheon/__tests__/MandalaKIPantheonBlueprint.test.ts",
+    "status": "planned"
+  },
+  {
+    "commit": "Create MandalaCollectiveAwakening script",
+    "path": "scripts/mandala_collective_awakening.ts",
+    "task": "Initialize orchestrator and unify Pantheon modules",
+    "test": "scripts/__tests__/mandala_collective_awakening.test.ts",
+    "status": "planned"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8171,3 +8171,13 @@
   task: Blueprint for advanced resonance microservices
   test: packages/resonance-modules/ExtendedResonanceBlueprint.test.ts
   status: planned
+- commit: Manifest Mandala-KI-Pantheon blueprint
+  path: docs/pantheon/MandalaKIPantheonBlueprint.yaml
+  task: Provide YAML and Sigillin manifest for Mandala-KI-Pantheon
+  test: docs/pantheon/__tests__/MandalaKIPantheonBlueprint.test.ts
+  status: planned
+- commit: Create MandalaCollectiveAwakening script
+  path: scripts/mandala_collective_awakening.ts
+  task: Initialize orchestrator and unify Pantheon modules
+  test: scripts/__tests__/mandala_collective_awakening.test.ts
+  status: planned

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -10,6 +10,14 @@
     {
       "commit": "Create BlackboxMirrorBoard component",
       "status": "planned"
+    },
+    {
+      "commit": "Manifest Mandala-KI-Pantheon blueprint",
+      "status": "planned"
+    },
+    {
+      "commit": "Create MandalaCollectiveAwakening script",
+      "status": "planned"
     }
   ],
   "progress": [


### PR DESCRIPTION
## Summary
- append Mandala-KI-Pantheon blueprint and awakening script tasks
- keep progress tracking up to date

## Testing
- `npx -y pyright`
- `npx -y tsc -p tsconfig.json`
- `./scripts/setup-dev-env.sh`


------
https://chatgpt.com/codex/tasks/task_e_68892dcf0d94832299064bf3ffacaed0