### PR TITLE
Add tasks from new conversations

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7324,5 +7324,40 @@
     "task": "Toggle Mandala number sequence display",
     "test": "packages/unifiedmandala-ui/components/LeereButton.test.tsx",
     "status": "planned"
+  },
+  {
+    "commit": "Create CosmicTheoryAgent_with_Sigil module",
+    "path": "packages/agents/CosmicTheoryAgent_with_Sigil.ts",
+    "task": "Integrate SigilManager and dynamic configuration into CosmicTheoryAgent",
+    "test": "packages/agents/CosmicTheoryAgent_with_Sigil.test.ts",
+    "status": "planned"
+  },
+  {
+    "commit": "Implement ArcticGravityWaveVisualizer",
+    "path": "packages/simulations/ArcticGravityWaveVisualizer.ts",
+    "task": "Visualize internal gravity waves in Arctic environment",
+    "test": "packages/simulations/ArcticGravityWaveVisualizer.test.ts",
+    "status": "planned"
+  },
+  {
+    "commit": "Add VRTuringTest module",
+    "path": "packages/testing/VRTuringTest.ts",
+    "task": "Run Turing test scenarios in VR meeting room",
+    "test": "packages/testing/VRTuringTest.test.ts",
+    "status": "planned"
+  },
+  {
+    "commit": "Create ResonanceControlPanel component",
+    "path": "packages/unifiedmandala-ui/components/ResonanceControlPanel.tsx",
+    "task": "Manage extended resonance modules from UI",
+    "test": "packages/unifiedmandala-ui/components/ResonanceControlPanel.test.tsx",
+    "status": "planned"
+  },
+  {
+    "commit": "Add PantheonBoundaryVRIntegration blueprint",
+    "path": "docs/vr/PantheonBoundaryIntegration.md",
+    "task": "Blueprint for integrating boundary events into Pantheon VR room",
+    "test": "",
+    "status": "planned"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8231,3 +8231,28 @@
   task: Toggle Mandala number sequence display
   test: packages/unifiedmandala-ui/components/LeereButton.test.tsx
   status: planned
+- commit: Create CosmicTheoryAgent_with_Sigil module
+  path: packages/agents/CosmicTheoryAgent_with_Sigil.ts
+  task: Integrate SigilManager and dynamic configuration into CosmicTheoryAgent
+  test: packages/agents/CosmicTheoryAgent_with_Sigil.test.ts
+  status: planned
+- commit: Implement ArcticGravityWaveVisualizer
+  path: packages/simulations/ArcticGravityWaveVisualizer.ts
+  task: Visualize internal gravity waves in Arctic environment
+  test: packages/simulations/ArcticGravityWaveVisualizer.test.ts
+  status: planned
+- commit: Add VRTuringTest module
+  path: packages/testing/VRTuringTest.ts
+  task: Run Turing test scenarios in VR meeting room
+  test: packages/testing/VRTuringTest.test.ts
+  status: planned
+- commit: Create ResonanceControlPanel component
+  path: packages/unifiedmandala-ui/components/ResonanceControlPanel.tsx
+  task: Manage extended resonance modules from UI
+  test: packages/unifiedmandala-ui/components/ResonanceControlPanel.test.tsx
+  status: planned
+- commit: Add PantheonBoundaryVRIntegration blueprint
+  path: docs/vr/PantheonBoundaryIntegration.md
+  task: Blueprint for integrating boundary events into Pantheon VR room
+  test: ""
+  status: planned

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "docs: update advancedprogress notes",
+  "lastCommit": "chore: fix newline",
   "fractalStep": "sync",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Verified features from newadvancedconversations.json; no additional tasks found.",
+  "notes": "Added tasks from newadvancedconversations.json",
   "pendingTasks": [
     {
       "commit": "Create BlackboxMirrorBoard component",
@@ -81,6 +81,26 @@
     },
     {
       "commit": "Add LeereButton component",
+      "status": "planned"
+    },
+    {
+      "commit": "Create CosmicTheoryAgent_with_Sigil module",
+      "status": "planned"
+    },
+    {
+      "commit": "Implement ArcticGravityWaveVisualizer",
+      "status": "planned"
+    },
+    {
+      "commit": "Add VRTuringTest module",
+      "status": "planned"
+    },
+    {
+      "commit": "Create ResonanceControlPanel component",
+      "status": "planned"
+    },
+    {
+      "commit": "Add PantheonBoundaryVRIntegration blueprint",
       "status": "planned"
     }
   ],


### PR DESCRIPTION
## Summary
- record CosmicTheoryAgent_with_Sigil and other features in advancedToDo
- sync advancedToDo.json with new tasks
- track additional planned items in advancedprogress

## Testing
- `npx pyright` *(fails: missing modules)*
- `npx tsc -p tsconfig.json` *(fails: missing type definitions)*
- `poetry install --with test` *(interrupted)*
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_6889dc5f1ed08322a28134c0f7052e60