### PR TITLE
Add tasks from advanced conversations

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7380,5 +7380,33 @@
     "task": "Use registerHistogram and registerCounter",
     "test": "packages/agents/CosmicTheoryAgent.test.ts",
     "status": "planned"
+  },
+  {
+    "commit": "Create FraktalLabCLI script",
+    "path": "tools/fraktal-lab-cli.ts",
+    "task": "CLI to run all layer plugins concurrently as Future Resonance stack",
+    "test": "tools/fraktal-lab-cli.test.ts",
+    "status": "planned"
+  },
+  {
+    "commit": "Add VRFourierIntegration blueprint",
+    "path": "docs/blueprints/VRFourierIntegration.md",
+    "task": "Blueprint for integrating FourierLayer into VR Begegnungsraum",
+    "test": "docs/blueprints/VRFourierIntegration.test.ts",
+    "status": "planned"
+  },
+  {
+    "commit": "Add TrikayaMandalaVisualization component",
+    "path": "packages/unifiedmandala-ui/components/TrikayaMandalaVisualization.tsx",
+    "task": "Visualizes Trikaya concept with three interwoven layers",
+    "test": "packages/unifiedmandala-ui/components/TrikayaMandalaVisualization.test.tsx",
+    "status": "planned"
+  },
+  {
+    "commit": "Add PantheonBoundaryLawExplorer service",
+    "path": "packages/boundary-engine/PantheonBoundaryLawExplorer.ts",
+    "task": "Explore boundary laws for Pantheon modules",
+    "test": "packages/boundary-engine/PantheonBoundaryLawExplorer.test.ts",
+    "status": "planned"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8271,3 +8271,23 @@
   task: Use registerHistogram and registerCounter
   test: packages/agents/CosmicTheoryAgent.test.ts
   status: planned
+- commit: Create FraktalLabCLI script
+  path: tools/fraktal-lab-cli.ts
+  task: CLI to run all layer plugins concurrently as Future Resonance stack
+  test: tools/fraktal-lab-cli.test.ts
+  status: planned
+- commit: Add VRFourierIntegration blueprint
+  path: docs/blueprints/VRFourierIntegration.md
+  task: Blueprint for integrating FourierLayer into VR Begegnungsraum
+  test: docs/blueprints/VRFourierIntegration.test.ts
+  status: planned
+- commit: Add TrikayaMandalaVisualization component
+  path: packages/unifiedmandala-ui/components/TrikayaMandalaVisualization.tsx
+  task: Visualizes Trikaya concept with three interwoven layers
+  test: packages/unifiedmandala-ui/components/TrikayaMandalaVisualization.test.tsx
+  status: planned
+- commit: Add PantheonBoundaryLawExplorer service
+  path: packages/boundary-engine/PantheonBoundaryLawExplorer.ts
+  task: Explore boundary laws for Pantheon modules
+  test: packages/boundary-engine/PantheonBoundaryLawExplorer.test.ts
+  status: planned

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "chore: add CosmicTheoryAgent cache and metrics tasks",
+  "lastCommit": "chore: add FraktalLab and Trikaya tasks",
   "fractalStep": "sync",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added CosmicTheoryAgent cache, breaker and metrics tasks",
+  "notes": "Added FraktalLab CLI, VR Fourier blueprint, Trikaya visualization and Pantheon boundary explorer",
   "pendingTasks": [
     {
       "commit": "Create BlackboxMirrorBoard component",
@@ -109,6 +109,22 @@
     },
     {
       "commit": "Instrument CosmicTheoryAgent metrics",
+      "status": "planned"
+    },
+    {
+      "commit": "Create FraktalLabCLI script",
+      "status": "planned"
+    },
+    {
+      "commit": "Add VRFourierIntegration blueprint",
+      "status": "planned"
+    },
+    {
+      "commit": "Add TrikayaMandalaVisualization component",
+      "status": "planned"
+    },
+    {
+      "commit": "Add PantheonBoundaryLawExplorer service",
       "status": "planned"
     }
   ],


### PR DESCRIPTION
## Summary
- integrate new tasks from `docs/sigils/newadvancedconversations.json`
- record FraktalLab CLI, VR Fourier blueprint, Trikaya visualization and Pantheon boundary explorer in ToDo files
- note new tasks in `advancedprogress.json`

## Testing
- `npx -y pyright`
- `npx -y tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6889eda6c94c83229436566859a1bb47