### PR TITLE
Fix MemoryGovernanceService cleanup logic

### DIFF
--- a/services/memory-governance/index.ts
+++ b/services/memory-governance/index.ts
@@ -6,7 +6,9 @@ export class MemoryGovernanceService {
   enforceLimit(category: MemoryCategory, maxEntries: number) {
     const entries = this.manager.get(category);
     if (entries.length > maxEntries) {
-      this.manager["cleanup"](category as any);
+      const trimmed = entries.slice(-maxEntries);
+      this.manager.clear(category as any);
+      trimmed.forEach((e) => this.manager.add(category, e));
     }
   }
 


### PR DESCRIPTION
## Summary
- enforce maxEntries limit in `MemoryGovernanceService`
- ensure cleanup removes oldest entries

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688b6086f53c8322899e2eaca1dbd015