### PR TITLE
Add fractal todo extractor

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "update:advanced-todo": "node scripts/update-advanced-todo.js",
     "update:code-todos": "node scripts/update-code-todos.js",
     "update:newadvanced-todo": "node scripts/update-newadvanced-todo.js",
+    "update:fractal-todo": "node scripts/update-fractal-todo.js",
     "export:crep-docs": "node scripts/export-crep-docs.js",
     "symbolzeit:run": "node scripts/symbolzeit-runner.js",
     "generate:next-sigil": "node scripts/generate-next-sigil.js",

--- a/packages/shared-utils/index.ts
+++ b/packages/shared-utils/index.ts
@@ -18,3 +18,4 @@ export * from './advancedConversation';
 export * from './RestClient';
 export * from './MandalaCoreLicense';
 export * from './decompressReverseLines';
+export * from './sigillinFractalTodo';

--- a/packages/shared-utils/sigillinFractalTodo.test.ts
+++ b/packages/shared-utils/sigillinFractalTodo.test.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import yaml from 'yaml';
+import { updateFractalTodos } from './sigillinFractalTodo';
+
+test('updates todo files from sigillin fractal_path', () => {
+  const sig = 'tmp-sigil.yaml';
+  fs.writeFileSync(sig, 'fractal_path:\n - A Task\n - Another Task\n');
+  const yml = 'tmp-adv.yaml';
+  const json = 'tmp-adv.json';
+  updateFractalTodos(sig, yml, json);
+  const yParsed = yaml.parse(fs.readFileSync(yml, 'utf8')) as any[];
+  const jParsed = JSON.parse(fs.readFileSync(json, 'utf8')) as any[];
+  fs.unlinkSync(sig); fs.unlinkSync(yml); fs.unlinkSync(json);
+  expect(yParsed[0].task).toBe('A Task');
+  expect(jParsed.length).toBe(2);
+});

--- a/packages/shared-utils/sigillinFractalTodo.ts
+++ b/packages/shared-utils/sigillinFractalTodo.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+import YAML from 'yaml';
+
+export interface FractalTodoEntry {
+  commit: string;
+  path: string;
+  task: string;
+  test: string;
+  status?: string;
+}
+
+export function extractFractalTodos(sigillinFile: string): string[] {
+  if (!fs.existsSync(sigillinFile)) return [];
+  const data = YAML.parse(fs.readFileSync(sigillinFile, 'utf8')) as any;
+  const list = Array.isArray(data?.fractal_path) ? data.fractal_path : [];
+  return list.filter((v: any) => typeof v === 'string');
+}
+
+export function updateFractalTodos(
+  sigillinFile: string,
+  yamlFile = path.resolve(__dirname, '../../advancedToDo.yaml'),
+  jsonFile = path.resolve(__dirname, '../../advancedToDo.json')
+): FractalTodoEntry[] {
+  const todos = extractFractalTodos(sigillinFile);
+  const entries: FractalTodoEntry[] = todos.map(t => ({
+    commit: t,
+    path: '',
+    task: t,
+    test: '',
+    status: 'offen'
+  }));
+  const loadYaml = (f: string) => (fs.existsSync(f) ? YAML.parse(fs.readFileSync(f, 'utf8')) : []);
+  const loadJson = (f: string) => (fs.existsSync(f) ? JSON.parse(fs.readFileSync(f, 'utf8')) : []);
+  const merge = (a: FractalTodoEntry[], b: FractalTodoEntry[]) => {
+    const known = new Set(a.map(e => e.commit));
+    for (const e of b) {
+      if (!known.has(e.commit)) {
+        a.push(e);
+        known.add(e.commit);
+      }
+    }
+    return a;
+  };
+  const yamlData = merge(loadYaml(yamlFile), entries);
+  const jsonData = merge(loadJson(jsonFile), entries);
+  fs.writeFileSync(yamlFile, YAML.stringify(yamlData));
+  fs.writeFileSync(jsonFile, JSON.stringify(jsonData, null, 2));
+  return entries;
+}

--- a/scripts/update-fractal-todo.js
+++ b/scripts/update-fractal-todo.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+const path = require('path');
+let { updateFractalTodos } = require('../packages/shared-utils/sigillinFractalTodo');
+const { updateProgress } = require('./update-advancedprogress.js');
+
+const sigFile = path.join(__dirname, '../docs/sigils/2025-07-30-codex-fraktal-init.yaml');
+const yamlFile = path.join(__dirname, '../advancedToDo.yaml');
+const jsonFile = path.join(__dirname, '../advancedToDo.json');
+
+const entries = updateFractalTodos(sigFile, yamlFile, jsonFile);
+console.log(`advancedToDo updated with ${entries.length} fractal tasks.`);
+updateProgress('sync');


### PR DESCRIPTION
## Summary
- create `sigillinFractalTodo` utility to extract `fractal_path` tasks from Sigillin YAML
- add tests for the new extractor
- export module in `shared-utils`
- add script `update-fractal-todo` with npm script entry

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/shared-utils/sigillinFractalTodo.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_688b70119d2483228e74eec01d12c245