### PR TITLE
Add tasks from advanced chat extraction

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7570,5 +7570,54 @@
     "path": "advancedToDo.yaml",
     "task": "Optimales Sigillin generieren und FraktalRun starten",
     "test": ""
+  },
+  {
+    "commit": "Integrate MistralAPI agent",
+    "path": "packages/agents/mistral-api-agent",
+    "task": "Build FastAPI wrapper for Mistral OpenAPI spec and register service",
+    "test": "packages/agents/mistral-api-agent/MistralAPI.test.ts",
+    "status": "planned"
+  },
+  {
+    "commit": "Add Claude service integration",
+    "path": "services/claude_service",
+    "task": "Provide Claude code service and orchestrator config",
+    "test": "services/claude_service/claude_service.test.ts",
+    "status": "planned"
+  },
+  {
+    "commit": "Introduce Mistral Code Agent helper",
+    "path": "packages/agents/mistral-code-agent",
+    "task": "Support code generation via Mistral API",
+    "test": "packages/agents/mistral-code-agent/MistralCodeAgent.test.ts",
+    "status": "planned"
+  },
+  {
+    "commit": "Extend Archiv Menschheitsspuren dataset",
+    "path": "docs/archive/archiv-menschheitsspuren.md",
+    "task": "Document additional archaeological findings from conversation",
+    "test": "",
+    "status": "planned"
+  },
+  {
+    "commit": "Add archive maintenance script",
+    "path": "scripts/archive-menschheitsspuren.js",
+    "task": "Append new entries to archiv dataset automatically",
+    "test": "scripts/archive-menschheitsspuren.test.js",
+    "status": "planned"
+  },
+  {
+    "commit": "Generate framework summary report",
+    "path": "docs/FrameworkReport.md",
+    "task": "Summarize UnifiedMandala architecture and future plans",
+    "test": "",
+    "status": "planned"
+  },
+  {
+    "commit": "Add framework report generator script",
+    "path": "scripts/generate-framework-report.js",
+    "task": "Auto-generate framework report from repo analysis",
+    "test": "scripts/generate-framework-report.test.js",
+    "status": "planned"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8562,3 +8562,38 @@
   path: advancedToDo.yaml
   task: Optimales Sigillin generieren und FraktalRun starten
   test: ""
+- commit: Integrate MistralAPI agent
+  path: packages/agents/mistral-api-agent
+  task: Build FastAPI wrapper for Mistral OpenAPI spec and register service
+  test: packages/agents/mistral-api-agent/MistralAPI.test.ts
+  status: planned
+- commit: Add Claude service integration
+  path: services/claude_service
+  task: Provide Claude code service and orchestrator config
+  test: services/claude_service/claude_service.test.ts
+  status: planned
+- commit: Introduce Mistral Code Agent helper
+  path: packages/agents/mistral-code-agent
+  task: Support code generation via Mistral API
+  test: packages/agents/mistral-code-agent/MistralCodeAgent.test.ts
+  status: planned
+- commit: Extend Archiv Menschheitsspuren dataset
+  path: docs/archive/archiv-menschheitsspuren.md
+  task: Document additional archaeological findings from conversation
+  test: ""
+  status: planned
+- commit: Add archive maintenance script
+  path: scripts/archive-menschheitsspuren.js
+  task: Append new entries to archiv dataset automatically
+  test: scripts/archive-menschheitsspuren.test.js
+  status: planned
+- commit: Generate framework summary report
+  path: docs/FrameworkReport.md
+  task: Summarize UnifiedMandala architecture and future plans
+  test: ""
+  status: planned
+- commit: Add framework report generator script
+  path: scripts/generate-framework-report.js
+  task: Auto-generate framework report from repo analysis
+  test: scripts/generate-framework-report.test.js
+  status: planned

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -126,6 +126,34 @@
     {
       "commit": "Add PantheonBoundaryLawExplorer service",
       "status": "planned"
+    },
+    {
+      "commit": "Integrate MistralAPI agent",
+      "status": "planned"
+    },
+    {
+      "commit": "Add Claude service integration",
+      "status": "planned"
+    },
+    {
+      "commit": "Introduce Mistral Code Agent helper",
+      "status": "planned"
+    },
+    {
+      "commit": "Extend Archiv Menschheitsspuren dataset",
+      "status": "planned"
+    },
+    {
+      "commit": "Add archive maintenance script",
+      "status": "planned"
+    },
+    {
+      "commit": "Generate framework summary report",
+      "status": "planned"
+    },
+    {
+      "commit": "Add framework report generator script",
+      "status": "planned"
     }
   ],
   "progress": [
@@ -302,7 +330,7 @@
       "status": "done"
     },
     {
-      "commit": "meta:update-progress – mark memory governance done",
+      "commit": "meta:update-progress \u2013 mark memory governance done",
       "status": "done"
     },
     {
@@ -499,67 +527,67 @@
   "featureLog": [
     {
       "featureId": "open-ethik-dashboard",
-      "commit": "meta:implement-features – open-ethik-dashboard",
+      "commit": "meta:implement-features \u2013 open-ethik-dashboard",
       "status": "done"
     },
     {
       "featureId": "implicit-todos",
-      "commit": "meta:extract-features – implicit todo extraction",
+      "commit": "meta:extract-features \u2013 implicit todo extraction",
       "status": "done"
     },
     {
       "featureId": "zivilisations-sandboxen",
-      "commit": "meta:extract-features – Zivilisations-Sandboxen",
+      "commit": "meta:extract-features \u2013 Zivilisations-Sandboxen",
       "status": "done"
     },
     {
       "featureId": "climate-integration",
-      "commit": "meta:extract-features – climate integration",
+      "commit": "meta:extract-features \u2013 climate integration",
       "status": "done"
     },
     {
       "featureId": "keilschrift",
-      "commit": "meta:extract-features – keilschrift",
+      "commit": "meta:extract-features \u2013 keilschrift",
       "status": "done"
     },
     {
       "featureId": "grok-agent",
-      "commit": "meta:implement-features – grok agent skeleton",
+      "commit": "meta:implement-features \u2013 grok agent skeleton",
       "status": "done"
     },
     {
       "featureId": "shadow-integration",
-      "commit": "meta:extract-features – shadow integration",
+      "commit": "meta:extract-features \u2013 shadow integration",
       "status": "done"
     },
     {
       "featureId": "self-reflection",
-      "commit": "meta:extract-features – self reflection",
+      "commit": "meta:extract-features \u2013 self reflection",
       "status": "done"
     },
     {
       "featureId": "memory-governance",
-      "commit": "meta:extract-features – memory governance",
+      "commit": "meta:extract-features \u2013 memory governance",
       "status": "done"
     },
     {
       "featureId": "turing-tests",
-      "commit": "meta:extract-features – turing tests",
+      "commit": "meta:extract-features \u2013 turing tests",
       "status": "done"
     },
     {
       "featureId": "schwerewellen",
-      "commit": "meta:extract-features – schwerewellen",
+      "commit": "meta:extract-features \u2013 schwerewellen",
       "status": "done"
     },
     {
       "featureId": "anthropic-multiversum",
-      "commit": "meta:extract-features – anthropic multiversum",
+      "commit": "meta:extract-features \u2013 anthropic multiversum",
       "status": "done"
     },
     {
       "featureId": "memory-governance",
-      "commit": "meta:implement-features – memory governance service",
+      "commit": "meta:implement-features \u2013 memory governance service",
       "status": "done"
     },
     {


### PR DESCRIPTION
## Summary
- append new ToDo items in advancedToDo.yaml/json based on advanced conversations
- log new planned tasks in advancedprogress.json

## Testing
- `npx pyright` *(fails: missing imports)*
- `npx tsc -p tsconfig.json` *(fails: cannot find node types)*

------
https://chatgpt.com/codex/tasks/task_e_688b759f79488322a7dbf446adc87a62