### PR TITLE
Add test feedback tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7620,4 +7620,23 @@
     "test": "scripts/generate-framework-report.test.js",
     "status": "planned"
   }
+  ,{
+    "commit": "Create UnifiedMandala test feedback report",
+    "path": "docs/unifiedmandala_test_report.md",
+    "task": "Summarize program test results and feedback from conversation",
+    "test": "",
+    "status": "planned"
+  },{
+    "commit": "Add semantic-release configuration",
+    "path": ".releaserc.yaml",
+    "task": "Enable SemVer versioning with semantic-release for core packages",
+    "test": "scripts/semantic-release.test.js",
+    "status": "planned"
+  },{
+    "commit": "Provide automated test script",
+    "path": "scripts/run-program-tests.sh",
+    "task": "Run project tests and compile unified report",
+    "test": "scripts/run-program-tests.test.sh",
+    "status": "planned"
+  }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8597,3 +8597,18 @@
   task: Auto-generate framework report from repo analysis
   test: scripts/generate-framework-report.test.js
   status: planned
+- commit: Create UnifiedMandala test feedback report
+  path: docs/unifiedmandala_test_report.md
+  task: Summarize program test results and feedback from conversation
+  test: ""
+  status: planned
+- commit: Add semantic-release configuration
+  path: .releaserc.yaml
+  task: Enable SemVer versioning with semantic-release for core packages
+  test: scripts/semantic-release.test.js
+  status: planned
+- commit: Provide automated test script
+  path: scripts/run-program-tests.sh
+  task: Run project tests and compile unified report
+  test: scripts/run-program-tests.test.sh
+  status: planned


### PR DESCRIPTION
## Summary
- extract tasks from "Programm testen Feedback" conversation
- note tasks in advancedToDo.yaml and advancedToDo.json

## Testing
- `npx -y pyright`
- `npx -y tsc -p tsconfig.json`
- `poetry install --with test`
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_688b7ab429a8832295ad045796c26c16