### PR TITLE
Update advanced ToDos from conversations

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7639,4 +7639,41 @@
     "test": "scripts/run-program-tests.test.sh",
     "status": "planned"
   }
+  ,{
+    "commit": "Refactor CREPManager with async file operations",
+    "path": "packages/crep-engine/CREPManager.ts",
+    "task": "Use asynchronous file handling and reduce complexity per feedback",
+    "test": "packages/crep-engine/CREPManager.async.test.ts",
+    "status": "planned"
+  },{
+    "commit": "Add English documentation for international audience",
+    "path": "docs/README.en.md",
+    "task": "Provide English summary of README and key documents",
+    "test": "",
+    "status": "planned"
+  },{
+    "commit": "Create onboarding video tutorial",
+    "path": "docs/tutorials/onboarding-video.md",
+    "task": "Step-by-step developer onboarding with video links",
+    "test": "",
+    "status": "planned"
+  },{
+    "commit": "Document example use cases",
+    "path": "docs/use-cases.md",
+    "task": "Describe concrete UnifiedMandala application scenarios",
+    "test": "",
+    "status": "planned"
+  },{
+    "commit": "Community outreach plan",
+    "path": "docs/community/outreach-plan.md",
+    "task": "Outline strategy for partnerships and funding opportunities",
+    "test": "",
+    "status": "planned"
+  },{
+    "commit": "Improve QA workflow script",
+    "path": "scripts/qa-enhanced.sh",
+    "task": "Automate pnpm run qa and summarize results",
+    "test": "scripts/qa-enhanced.test.sh",
+    "status": "planned"
+  }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8612,3 +8612,33 @@
   task: Run project tests and compile unified report
   test: scripts/run-program-tests.test.sh
   status: planned
+- commit: Refactor CREPManager with async file operations
+  path: packages/crep-engine/CREPManager.ts
+  task: Use asynchronous file handling and reduce complexity per feedback
+  test: packages/crep-engine/CREPManager.async.test.ts
+  status: planned
+- commit: Add English documentation for international audience
+  path: docs/README.en.md
+  task: Provide English summary of README and key documents
+  test: ""
+  status: planned
+- commit: Create onboarding video tutorial
+  path: docs/tutorials/onboarding-video.md
+  task: Step-by-step developer onboarding with video links
+  test: ""
+  status: planned
+- commit: Document example use cases
+  path: docs/use-cases.md
+  task: Describe concrete UnifiedMandala application scenarios
+  test: ""
+  status: planned
+- commit: Community outreach plan
+  path: docs/community/outreach-plan.md
+  task: Outline strategy for partnerships and funding opportunities
+  test: ""
+  status: planned
+- commit: Improve QA workflow script
+  path: scripts/qa-enhanced.sh
+  task: Automate pnpm run qa and summarize results
+  test: scripts/qa-enhanced.test.sh
+  status: planned


### PR DESCRIPTION
## Summary
- add tasks from chat "Programm testen Feedback" such as refactoring CREPManager and QA workflow improvements
- include docs tasks from chat "Erweiterung Archiv Menschheitsspuren" and "Framework Bericht Zusammenfassung"
- ensure advancedToDo lists English docs, onboarding video, use cases and outreach plan

## Testing
- `npx pyright` *(fails: many missing modules and errors)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definition file for 'node')*
- `poetry install --with test`
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_688b836a4b8c83228ea15db4b2d855a0