### PR TITLE
Add tasks extracted from advanced chat logs

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7619,61 +7619,103 @@
     "task": "Auto-generate framework report from repo analysis",
     "test": "scripts/generate-framework-report.test.js",
     "status": "planned"
-  }
-  ,{
+  },
+  {
     "commit": "Create UnifiedMandala test feedback report",
     "path": "docs/unifiedmandala_test_report.md",
     "task": "Summarize program test results and feedback from conversation",
     "test": "",
     "status": "planned"
-  },{
+  },
+  {
     "commit": "Add semantic-release configuration",
     "path": ".releaserc.yaml",
     "task": "Enable SemVer versioning with semantic-release for core packages",
     "test": "scripts/semantic-release.test.js",
     "status": "planned"
-  },{
+  },
+  {
     "commit": "Provide automated test script",
     "path": "scripts/run-program-tests.sh",
     "task": "Run project tests and compile unified report",
     "test": "scripts/run-program-tests.test.sh",
     "status": "planned"
-  }
-  ,{
+  },
+  {
     "commit": "Refactor CREPManager with async file operations",
     "path": "packages/crep-engine/CREPManager.ts",
     "task": "Use asynchronous file handling and reduce complexity per feedback",
     "test": "packages/crep-engine/CREPManager.async.test.ts",
     "status": "planned"
-  },{
+  },
+  {
     "commit": "Add English documentation for international audience",
     "path": "docs/README.en.md",
     "task": "Provide English summary of README and key documents",
     "test": "",
     "status": "planned"
-  },{
+  },
+  {
     "commit": "Create onboarding video tutorial",
     "path": "docs/tutorials/onboarding-video.md",
     "task": "Step-by-step developer onboarding with video links",
     "test": "",
     "status": "planned"
-  },{
+  },
+  {
     "commit": "Document example use cases",
     "path": "docs/use-cases.md",
     "task": "Describe concrete UnifiedMandala application scenarios",
     "test": "",
     "status": "planned"
-  },{
+  },
+  {
     "commit": "Community outreach plan",
     "path": "docs/community/outreach-plan.md",
     "task": "Outline strategy for partnerships and funding opportunities",
     "test": "",
     "status": "planned"
-  },{
+  },
+  {
     "commit": "Improve QA workflow script",
     "path": "scripts/qa-enhanced.sh",
     "task": "Automate pnpm run qa and summarize results",
     "test": "scripts/qa-enhanced.test.sh",
+    "status": "planned"
+  },
+  {
+    "commit": "Document offline testing workflow and ToDo sync",
+    "path": "docs/offline/README.md",
+    "task": "Add docker-compose setup, Node troubleshooting, and scripts for syncing ToDos",
+    "test": "",
+    "status": "planned"
+  },
+  {
+    "commit": "Expand early human traces archive",
+    "path": "docs/Archiv_Menschheitsspuren.md",
+    "task": "Compile scientifically documented archaeological hints as discussed in chat",
+    "test": "",
+    "status": "planned"
+  },
+  {
+    "commit": "Implement Memory Feedback Loop with new archives",
+    "path": "services/memory-manager",
+    "task": "Integrate aeon-fraktalurs and aeon-resoecho and design feedback loop",
+    "test": "",
+    "status": "planned"
+  },
+  {
+    "commit": "Improve documentation and onboarding demo",
+    "path": "docs",
+    "task": "Add tutorials, examples, and public demo site for easier onboarding",
+    "test": "",
+    "status": "planned"
+  },
+  {
+    "commit": "Standardize external API and integrate datasets",
+    "path": "packages/api",
+    "task": "Provide stable REST API for metrics and gamification, integrate real data sources",
+    "test": "",
     "status": "planned"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8642,3 +8642,28 @@
   task: Automate pnpm run qa and summarize results
   test: scripts/qa-enhanced.test.sh
   status: planned
+- commit: Document offline testing workflow and ToDo sync
+  path: docs/offline/README.md
+  task: Add docker-compose setup, Node troubleshooting, and scripts for syncing ToDos
+  test: ""
+  status: planned
+- commit: Expand early human traces archive
+  path: docs/Archiv_Menschheitsspuren.md
+  task: Compile scientifically documented archaeological hints as discussed in chat
+  test: ""
+  status: planned
+- commit: Implement Memory Feedback Loop with new archives
+  path: services/memory-manager
+  task: Integrate aeon-fraktalurs and aeon-resoecho and design feedback loop
+  test: ""
+  status: planned
+- commit: Improve documentation and onboarding demo
+  path: docs
+  task: Add tutorials, examples, and public demo site for easier onboarding
+  test: ""
+  status: planned
+- commit: Standardize external API and integrate datasets
+  path: packages/api
+  task: Provide stable REST API for metrics and gamification, integrate real data sources
+  test: ""
+  status: planned


### PR DESCRIPTION
## Summary
- update advancedToDo files with tasks derived from conversation logs

## Testing
- `npx pyright` *(fails: npm error canceled)*
- `npx tsc -p tsconfig.json` *(fails: cannot find node type)*
- `poetry install --with test` *(failed: installation interrupted)*
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688b8a2b8ce083229c7b9f4f2a7f512d