### PR TITLE
Update advanced tasks from chat logs

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7801,5 +7801,47 @@
     "task": "Summarize repository state and planned features with improvement proposals",
     "test": "",
     "status": "planned"
+  },
+  {
+    "commit": "Add refresh-handbook script",
+    "path": "scripts/refresh-handbook.js",
+    "task": "Automatically regenerate the handbook from source comments",
+    "test": "scripts/__tests__/refresh-handbook.test.js",
+    "status": "planned"
+  },
+  {
+    "commit": "Provide setup-unifiedmandala installer",
+    "path": "scripts/setup-unifiedmandala.sh",
+    "task": "Install dependencies and configure environment",
+    "test": "scripts/__tests__/setup-unifiedmandala.test.sh",
+    "status": "planned"
+  },
+  {
+    "commit": "Implement Sigillin Loader component",
+    "path": "packages/unifiedmandala-ui/components/SigillinLoader.tsx",
+    "task": "Import and filter Sigillin files via UI",
+    "test": "packages/unifiedmandala-ui/components/SigillinLoader.test.tsx",
+    "status": "planned"
+  },
+  {
+    "commit": "Expand MasterCanvas nodes",
+    "path": "config/sigillin_nodes.json",
+    "task": "Add new nodes from roadmap and update MasterCanvas display",
+    "test": "packages/unifiedmandala-ui/components/MasterCanvas.test.tsx",
+    "status": "planned"
+  },
+  {
+    "commit": "Add symbolzeit base configuration",
+    "path": "config/symbolzeit.yaml",
+    "task": "Provide default symbolzeit phases with customizable times",
+    "test": "packages/core/__tests__/symbolzeit-config.test.ts",
+    "status": "planned"
+  },
+  {
+    "commit": "Create GPT-Synapse module",
+    "path": "packages/gpt-bridges/GPTSynapse.ts",
+    "task": "Interface between Aeon system and external GPT services",
+    "test": "packages/gpt-bridges/GPTSynapse.test.ts",
+    "status": "planned"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8553,7 +8553,6 @@
     den Sprint-Plan.\n4. Teile dieses Sigillin in \n   - #dev-codex\n   -
     #mandala-core\n   - #agent-integration\n\n**finished_successfully**"}'
   test: ""
-
 - commit: Add Codex Fraktal Sigillin file
   path: docs/sigils/2023-11-21-codex-fraktal-sigil-001.yaml
   task: Erzeuge Sigillin codex-fraktal-sigil-001 zur Initialisierung
@@ -8674,7 +8673,8 @@
   status: planned
 - commit: Standardize external API and integrate datasets
   path: packages/api
-  task: Provide stable REST API for metrics and gamification, integrate real data sources
+  task: Provide stable REST API for metrics and gamification, integrate real data
+    sources
   test: ""
   status: planned
 - commit: Enforce ToDo sync before commits
@@ -8726,4 +8726,34 @@
   path: docs/Framework-Bericht.md
   task: Summarize repository state and planned features with improvement proposals
   test: ""
+  status: planned
+- commit: Add refresh-handbook script
+  path: scripts/refresh-handbook.js
+  task: Automatically regenerate the handbook from source comments
+  test: scripts/__tests__/refresh-handbook.test.js
+  status: planned
+- commit: Provide setup-unifiedmandala installer
+  path: scripts/setup-unifiedmandala.sh
+  task: Install dependencies and configure environment
+  test: scripts/__tests__/setup-unifiedmandala.test.sh
+  status: planned
+- commit: Implement Sigillin Loader component
+  path: packages/unifiedmandala-ui/components/SigillinLoader.tsx
+  task: Import and filter Sigillin files via UI
+  test: packages/unifiedmandala-ui/components/SigillinLoader.test.tsx
+  status: planned
+- commit: Expand MasterCanvas nodes
+  path: config/sigillin_nodes.json
+  task: Add new nodes from roadmap and update MasterCanvas display
+  test: packages/unifiedmandala-ui/components/MasterCanvas.test.tsx
+  status: planned
+- commit: Add symbolzeit base configuration
+  path: config/symbolzeit.yaml
+  task: Provide default symbolzeit phases with customizable times
+  test: packages/core/__tests__/symbolzeit-config.test.ts
+  status: planned
+- commit: Create GPT-Synapse module
+  path: packages/gpt-bridges/GPTSynapse.ts
+  task: Interface between Aeon system and external GPT services
+  test: packages/gpt-bridges/GPTSynapse.test.ts
   status: planned

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #919 from GenesisAeon/dlap95-codex/extract-tasks-and-features-for-advancedtodo",
+  "lastCommit": "Fix formatting",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -257,6 +257,30 @@
     },
     {
       "commit": "Create framework status report",
+      "status": "planned"
+    },
+    {
+      "commit": "Add refresh-handbook script",
+      "status": "planned"
+    },
+    {
+      "commit": "Provide setup-unifiedmandala installer",
+      "status": "planned"
+    },
+    {
+      "commit": "Implement Sigillin Loader component",
+      "status": "planned"
+    },
+    {
+      "commit": "Expand MasterCanvas nodes",
+      "status": "planned"
+    },
+    {
+      "commit": "Add symbolzeit base configuration",
+      "status": "planned"
+    },
+    {
+      "commit": "Create GPT-Synapse module",
       "status": "planned"
     }
   ],


### PR DESCRIPTION
## Summary
- add new tasks from analysis chats to advancedToDo.yaml
- sync advancedToDo.json
- normalize advancedprogress.json newline

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_688b9ebca14483228937ef50064e1d08