### PR TITLE
Implement initial API service and onboarding demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ _Bring dein Licht ins Mandala – jede Linie zählt._
 
 Du möchtest beitragen? Bitte lies zuerst die [CONTRIBUTING.md](CONTRIBUTING.md) und [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) – sie enthalten unseren Community-Standard, den Review-Prozess und Branch-Workflow.
 Ein kompakter Einstieg findet sich im [Community Onboarding Guide](docs/CommunityOnboarding.md).
+Für eine schnelle Demo siehe auch [Onboarding Demo](docs/onboarding-demo.md).
 
 Deine Idee, deine Story, dein Sigillin sind willkommen! Jeder Pull Request ist eine neue Linie im Mandala.
 

--- a/docs/onboarding-demo.md
+++ b/docs/onboarding-demo.md
@@ -1,0 +1,18 @@
+# Onboarding Demo
+
+Dieses kurze Tutorial zeigt den Einstieg in UnifiedMandala anhand eines simplen Ablaufs.
+
+1. **Repository klonen und Abhängigkeiten installieren**
+   ```bash
+   git clone https://github.com/GenesisAeon/unified-mandala.git
+   cd unified-mandala
+   ./scripts/setup-unifiedmandala.sh
+   ```
+2. **Lokalen Entwicklungsserver starten**
+   ```bash
+   pnpm dev
+   ```
+3. **Beispielhafte UI-Demo öffnen**
+   Rufe `http://localhost:3000` im Browser auf. Du siehst eine minimalistische Oberfläche, die die CREP-Werte in Echtzeit visualisiert.
+
+Weitere Details findest du im [Community Onboarding Guide](CommunityOnboarding.md).

--- a/packages/api/data/gamification.json
+++ b/packages/api/data/gamification.json
@@ -1,0 +1,7 @@
+{
+  "badges": 5,
+  "leaderboard": [
+    {"user": "alice", "score": 100},
+    {"user": "bob", "score": 80}
+  ]
+}

--- a/packages/api/data/metrics.json
+++ b/packages/api/data/metrics.json
@@ -1,0 +1,5 @@
+{
+  "activeUsers": 42,
+  "tasksCompleted": 128,
+  "averageCREP": 0.73
+}

--- a/packages/api/index.test.ts
+++ b/packages/api/index.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import supertest from 'supertest';
+import { createServer } from './index';
+
+let server: any;
+let request: any;
+
+beforeAll(async () => {
+  const app = await createServer();
+  server = app.listen();
+  request = supertest(server);
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe('API endpoints', () => {
+  it('returns metrics data', async () => {
+    const res = await request.get('/metrics');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('activeUsers');
+  });
+
+  it('returns gamification data', async () => {
+    const res = await request.get('/gamification');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('badges');
+  });
+});

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1,0 +1,30 @@
+import express from 'express';
+import path from 'path';
+import fs from 'fs/promises';
+
+export async function createServer() {
+  const app = express();
+
+  app.get('/metrics', async (_req, res) => {
+    const file = path.join(__dirname, 'data', 'metrics.json');
+    const data = await fs.readFile(file, 'utf8');
+    res.json(JSON.parse(data));
+  });
+
+  app.get('/gamification', async (_req, res) => {
+    const file = path.join(__dirname, 'data', 'gamification.json');
+    const data = await fs.readFile(file, 'utf8');
+    res.json(JSON.parse(data));
+  });
+
+  return app;
+}
+
+if (require.main === module) {
+  createServer().then(app => {
+    const port = process.env.PORT || 3001;
+    app.listen(port, () => {
+      console.log(`API server listening on ${port}`);
+    });
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,8 @@ export default defineConfig({
   test: {
     include: [
       'packages/agents/**/*.{test,spec}.ts',
-      'packages/boundary-engine/**/*.{test,spec}.ts'
+      'packages/boundary-engine/**/*.{test,spec}.ts',
+      'packages/api/**/*.{test,spec}.ts'
     ],
     environment: 'node'
   }


### PR DESCRIPTION
## Summary
- add onboarding demo documentation
- implement simple API package serving metrics and gamification data
- include API tests in vitest config
- link onboarding demo from README

## Testing
- `npx -y pyright`
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*
- `npx vitest run` *(failed: npm error canceled)*
- `npm test --silent` *(failed: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bc7a9d36483228c3dc2183f712157