### PR TITLE
Implement docs for manager and CLI tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7751,14 +7751,14 @@
     "path": "packages/cli-tools",
     "task": "Refine docs for SigillinOnDemandGenerator and backup utilities",
     "test": "",
-    "status": "planned"
+    "status": "done"
   },
   {
     "commit": "Clarify Manager versus Orchestrator roles",
     "path": "packages/aeon-genesisos",
     "task": "Define responsibilities and naming for Manager and Orchestrator modules",
     "test": "",
-    "status": "planned"
+    "status": "done"
   },
   {
     "commit": "Add unit tests for core agents",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8690,11 +8690,12 @@
   path: packages/cli-tools
   task: Refine docs for SigillinOnDemandGenerator and backup utilities
   test: ""
-  status: planned
+  status: done
 - commit: Clarify Manager versus Orchestrator roles
   path: packages/aeon-genesisos
   task: Define responsibilities and naming for Manager and Orchestrator modules
   test: ""
+  status: done
 - commit: Add unit tests for core agents
   path: packages/agents
   task: Cover Navigator, CREPEvaluator and HexaAgentSystem with tests

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add UnifiedLogger and core agent tests",
+  "lastCommit": "chore: update progress log",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -125,22 +125,6 @@
     },
     {
       "commit": "Update ToDos from advanced conversations",
-      "status": "planned"
-    },
-    {
-      "commit": "Document CLI tools for sigil and backup",
-      "status": "planned"
-    },
-    {
-      "commit": "Clarify Manager versus Orchestrator roles",
-      "status": "planned"
-    },
-    {
-      "commit": "Add unit tests for core agents",
-      "status": "planned"
-    },
-    {
-      "commit": "Centralize logging",
       "status": "planned"
     }
   ],
@@ -651,6 +635,14 @@
     },
     {
       "commit": "Implement MandalaReader module",
+      "status": "done"
+    },
+    {
+      "commit": "Document CLI tools for sigil and backup",
+      "status": "done"
+    },
+    {
+      "commit": "Clarify Manager versus Orchestrator roles",
       "status": "done"
     }
   ]

--- a/packages/aeon-genesisos/README.md
+++ b/packages/aeon-genesisos/README.md
@@ -1,3 +1,11 @@
 # Aeon GenesisOS
 
 Basissystem der CREP-Engine mit Symbolzeit und dynamischer Zustandslogik.
+
+## Manager vs. Orchestrator
+
+Im Kontext von **Aeon GenesisOS** sind *Manager* f\xFCr die Kapselung einzelner Zust\xE4nde oder Datenquellen zust\xE4ndig. Ein Manager besitzt eine klar definierte Aufgabe (z.B. CREP-Werte verwalten) und stellt daf\xFCr Methoden bereit.
+
+Ein *Orchestrator* hingegen koordiniert mehrere Manager oder Services und verbindet deren Abl\xE4ufe zu einem gr\xF6\xDFeren Prozess. Orchestratoren k\xF6nnen Aufgaben delegieren und Ergebnisse zusammenf\xFChren.
+
+Kurz gesagt: **Manager** \u2013 Verwaltung eines bestimmten Bereichs, **Orchestrator** \u2013 Ablaufsteuerung \u00FCber verschiedene Manager hinweg.

--- a/packages/cli-tools/README.md
+++ b/packages/cli-tools/README.md
@@ -10,3 +10,23 @@ Sammlung von Befehlen zur Arbeit mit Sigillin- und CREP-Daten.
 - **sigillin-cli.js list-open-tasks** – listet offene Tasks aus `advancedToDo.yaml`
 
 - **SigillinValidator.ts** – Prüft eine Sigillin-Datei gegen das Schema
+
+### SigillinOnDemandGenerator
+
+Einfache Utility, um spontan Sigillin-Dateien zu erzeugen:
+
+```bash
+node SigillinOnDemandGenerator.js "Meine Phrase" > my-sigil.json
+```
+
+### Backup Utilities
+
+Der `BackupManager` (in `packages/shared-utils`) kann Dateien in ein `.backup`-Verzeichnis kopieren. Beispiel:
+
+```ts
+import { BackupManager } from 'shared-utils/BackupManager';
+const bm = new BackupManager();
+bm.backupFile('important.yaml');
+```
+
+Diese Funktionen eignen sich, um Sigillin oder Konfigurationsdateien regelm\xE4\xDFig zu sichern.


### PR DESCRIPTION
## Summary
- document Manager vs Orchestrator in aeon-genesisos README
- extend CLI tool README with SigillinOnDemand and backup utilities
- mark related tasks as done in advancedToDo lists
- update progress log

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688bd99834a48322aa905b82a0e0e5fc