### PR TITLE
Implement LeereButton and number sequence docs

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7309,7 +7309,7 @@
     "path": "docs/mandala/MandalaNumberSequence.md",
     "task": "Document Mandala number sequence interactions and LeereButton",
     "test": "docs/mandala/__tests__/MandalaNumberSequence.test.ts",
-    "status": "planned"
+    "status": "done"
   },
   {
     "commit": "Implement MandalaNumberEngine",
@@ -7323,7 +7323,7 @@
     "path": "packages/unifiedmandala-ui/components/LeereButton.tsx",
     "task": "Toggle Mandala number sequence display",
     "test": "packages/unifiedmandala-ui/components/LeereButton.test.tsx",
-    "status": "planned"
+    "status": "done"
   },
   {
     "commit": "Create CosmicTheoryAgent_with_Sigil module",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8220,7 +8220,7 @@
   path: docs/mandala/MandalaNumberSequence.md
   task: Document Mandala number sequence interactions and LeereButton
   test: docs/mandala/__tests__/MandalaNumberSequence.test.ts
-  status: planned
+  status: done
 - commit: Implement MandalaNumberEngine
   path: packages/mandala-core/MandalaNumberEngine.ts
   task: Generate and analyze number sequences for Mandala modules
@@ -8230,7 +8230,7 @@
   path: packages/unifiedmandala-ui/components/LeereButton.tsx
   task: Toggle Mandala number sequence display
   test: packages/unifiedmandala-ui/components/LeereButton.test.tsx
-  status: planned
+  status: done
 - commit: Create CosmicTheoryAgent_with_Sigil module
   path: packages/agents/CosmicTheoryAgent_with_Sigil.ts
   task: Integrate SigilManager and dynamic configuration into CosmicTheoryAgent

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -45,7 +45,7 @@
     },
     {
       "commit": "Document MandalaNumberSequence blueprint",
-      "status": "planned"
+      "status": "done"
     },
     {
       "commit": "Implement MandalaNumberEngine",
@@ -53,7 +53,7 @@
     },
     {
       "commit": "Add LeereButton component",
-      "status": "planned"
+      "status": "done"
     },
     {
       "commit": "Create CosmicTheoryAgent_with_Sigil module",

--- a/docs/mandala/MandalaNumberSequence.md
+++ b/docs/mandala/MandalaNumberSequence.md
@@ -1,0 +1,9 @@
+# Mandala Number Sequence
+
+Dieses Dokument beschreibt die geplante Zahlensequenz-Interaktion innerhalb des Mandala-UI.\
+Der Nutzer kann „Nummern anzeigen“ und „Nummern ausblenden“, gesteuert 
+über den LeereButton.
+
+## Interaktion
+- Beim Aktivieren des LeereButton werden besondere Mandala-Zahlensequenzen eingeblendet.
+- Ein erneuter Klick blendet die Sequenz wieder aus.

--- a/docs/mandala/__tests__/MandalaNumberSequence.test.ts
+++ b/docs/mandala/__tests__/MandalaNumberSequence.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+
+describe('MandalaNumberSequence doc', () => {
+  it('contains interaction section', () => {
+    const content = fs.readFileSync(require.resolve('../MandalaNumberSequence.md'), 'utf8');
+    expect(content).toMatch(/## Interaktion/);
+  });
+});

--- a/packages/unifiedmandala-ui/components/LeereButton.test.tsx
+++ b/packages/unifiedmandala-ui/components/LeereButton.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LeereButton from './LeereButton';
+
+test('toggles label and calls callback', () => {
+  const cb = jest.fn();
+  render(<LeereButton onToggle={cb} />);
+  const btn = screen.getByLabelText('toggle-number-sequence');
+  expect(btn).toHaveTextContent('Nummern anzeigen');
+  fireEvent.click(btn);
+  expect(btn).toHaveTextContent('Nummern ausblenden');
+  expect(cb).toHaveBeenCalledWith(true);
+  fireEvent.click(btn);
+  expect(btn).toHaveTextContent('Nummern anzeigen');
+  expect(cb).toHaveBeenCalledWith(false);
+});

--- a/packages/unifiedmandala-ui/components/LeereButton.tsx
+++ b/packages/unifiedmandala-ui/components/LeereButton.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from 'react';
+
+export interface LeereButtonProps {
+  onToggle?: (visible: boolean) => void;
+}
+
+const LeereButton: React.FC<LeereButtonProps> = ({ onToggle }) => {
+  const [visible, setVisible] = useState(false);
+  const toggle = () => {
+    const next = !visible;
+    setVisible(next);
+    onToggle?.(next);
+  };
+  return (
+    <button aria-label="toggle-number-sequence" onClick={toggle}>
+      {visible ? 'Nummern ausblenden' : 'Nummern anzeigen'}
+    </button>
+  );
+};
+
+export default LeereButton;


### PR DESCRIPTION
## Summary
- add LeereButton UI component with toggle callback and tests
- document Mandala number sequence and add accompanying test
- mark related tasks as done in advanced todo files

## Testing
- `npx pyright` *(fails: multiple errors)*
- `npx tsc -p tsconfig.json`
- `npm test -- -w=2` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688c8ba6a3e88322b28b4e9e821e041b