### PR TITLE
Implement resonance blueprint

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7232,14 +7232,14 @@
     "path": "packages/unifiedmandala-vr/components/PantheonBegegnungsraum.tsx",
     "task": "3D VR meeting room for Pantheon modules",
     "test": "packages/unifiedmandala-vr/components/PantheonBegegnungsraum.test.tsx",
-    "status": "planned"
+    "status": "done"
   },
   {
     "commit": "Add ExtendedResonanceBlueprint",
     "path": "packages/resonance-modules/ExtendedResonanceBlueprint.ts",
     "task": "Blueprint for advanced resonance microservices",
     "test": "packages/resonance-modules/ExtendedResonanceBlueprint.test.ts",
-    "status": "planned"
+    "status": "done"
   },
   {
     "commit": "Manifest Mandala-KI-Pantheon blueprint",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8165,12 +8165,12 @@
   path: packages/unifiedmandala-vr/components/PantheonBegegnungsraum.tsx
   task: 3D VR meeting room for Pantheon modules
   test: packages/unifiedmandala-vr/components/PantheonBegegnungsraum.test.tsx
-  status: planned
+  status: done
 - commit: Add ExtendedResonanceBlueprint
   path: packages/resonance-modules/ExtendedResonanceBlueprint.ts
   task: Blueprint for advanced resonance microservices
   test: packages/resonance-modules/ExtendedResonanceBlueprint.test.ts
-  status: planned
+  status: done
 - commit: Manifest Mandala-KI-Pantheon blueprint
   path: docs/pantheon/MandalaKIPantheonBlueprint.yaml
   task: Provide YAML and Sigillin manifest for Mandala-KI-Pantheon

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -9,11 +9,11 @@
   "pendingTasks": [
     {
       "commit": "Create PantheonBegegnungsraum VR component",
-      "status": "planned"
+      "status": "done"
     },
     {
       "commit": "Add ExtendedResonanceBlueprint",
-      "status": "planned"
+      "status": "done"
     }
   ],
   "progress": [

--- a/packages/resonance-modules/ExtendedResonanceBlueprint.test.ts
+++ b/packages/resonance-modules/ExtendedResonanceBlueprint.test.ts
@@ -1,0 +1,11 @@
+import { ExtendedResonanceBlueprint } from './ExtendedResonanceBlueprint';
+
+describe('ExtendedResonanceBlueprint', () => {
+  it('contains services with endpoints', () => {
+    expect(ExtendedResonanceBlueprint.length).toBeGreaterThan(0);
+    for (const svc of ExtendedResonanceBlueprint) {
+      expect(svc.endpoint).toMatch(/^\//);
+      expect(typeof svc.name).toBe('string');
+    }
+  });
+});

--- a/packages/resonance-modules/ExtendedResonanceBlueprint.ts
+++ b/packages/resonance-modules/ExtendedResonanceBlueprint.ts
@@ -1,0 +1,18 @@
+export interface ResonanceService {
+  name: string;
+  description: string;
+  endpoint: string;
+}
+
+export const ExtendedResonanceBlueprint: ResonanceService[] = [
+  {
+    name: 'AeonMythOS',
+    description: 'Mythic pattern analysis and narrative synthesis',
+    endpoint: '/mythos'
+  },
+  {
+    name: 'AeonSigilNet',
+    description: 'Sigil network interactions and resonance exchange',
+    endpoint: '/sigilnet'
+  }
+];


### PR DESCRIPTION
## Summary
- add `ExtendedResonanceBlueprint` module defining resonance services
- test blueprint with Jest
- mark Pantheon VR component and blueprint tasks done in advancedToDo files
- update progress tracker for completed tasks

## Testing
- `npx pyright` *(fails: LIFCell not known, etc.)*
- `npx tsc -p tsconfig.json`
- `npx jest packages/resonance-modules/ExtendedResonanceBlueprint.test.ts --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_688cd6af2c708322a2cb4090587822f5