### PR TITLE
Add ExtendedResonanceBlueprint module

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7232,14 +7232,14 @@
     "path": "packages/unifiedmandala-vr/components/PantheonBegegnungsraum.tsx",
     "task": "3D VR meeting room for Pantheon modules",
     "test": "packages/unifiedmandala-vr/components/PantheonBegegnungsraum.test.tsx",
-    "status": "planned"
+    "status": "done"
   },
   {
     "commit": "Add ExtendedResonanceBlueprint",
     "path": "packages/resonance-modules/ExtendedResonanceBlueprint.ts",
     "task": "Blueprint for advanced resonance microservices",
     "test": "packages/resonance-modules/ExtendedResonanceBlueprint.test.ts",
-    "status": "planned"
+    "status": "done"
   },
   {
     "commit": "Manifest Mandala-KI-Pantheon blueprint",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8165,12 +8165,12 @@
   path: packages/unifiedmandala-vr/components/PantheonBegegnungsraum.tsx
   task: 3D VR meeting room for Pantheon modules
   test: packages/unifiedmandala-vr/components/PantheonBegegnungsraum.test.tsx
-  status: planned
+  status: done
 - commit: Add ExtendedResonanceBlueprint
   path: packages/resonance-modules/ExtendedResonanceBlueprint.ts
   task: Blueprint for advanced resonance microservices
   test: packages/resonance-modules/ExtendedResonanceBlueprint.test.ts
-  status: planned
+  status: done
 - commit: Manifest Mandala-KI-Pantheon blueprint
   path: docs/pantheon/MandalaKIPantheonBlueprint.yaml
   task: Provide YAML and Sigillin manifest for Mandala-KI-Pantheon

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,21 +1,12 @@
 {
-  "lastCommit": "feat: extend archive and test reports",
+  "lastCommit": "Merge pull request #936 from GenesisAeon/0rblai-codex/implement-tasks-and-features-from-advancedtodo",
   "fractalStep": "sync",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
   "notes": "UnifiedLogger added; core agents covered by tests",
-  "pendingTasks": [
-    {
-      "commit": "Create PantheonBegegnungsraum VR component",
-      "status": "planned"
-    },
-    {
-      "commit": "Add ExtendedResonanceBlueprint",
-      "status": "planned"
-    }
-  ],
+  "pendingTasks": [],
   "progress": [
     {
       "commit": "Implement boundary manager modules",

--- a/packages/resonance-modules/ExtendedResonanceBlueprint.ts
+++ b/packages/resonance-modules/ExtendedResonanceBlueprint.ts
@@ -1,0 +1,17 @@
+import yaml from 'js-yaml';
+
+export interface ResonanceBlueprint {
+  service: string;
+  endpoints: string[];
+  metrics: string[];
+}
+
+export class ExtendedResonanceBlueprint {
+  static create(service: string, endpoints: string[], metrics: string[] = []): ResonanceBlueprint {
+    return { service, endpoints, metrics };
+  }
+
+  static toYAML(bp: ResonanceBlueprint): string {
+    return yaml.dump(bp);
+  }
+}

--- a/packages/resonance-modules/__tests__/ExtendedResonanceBlueprint.test.ts
+++ b/packages/resonance-modules/__tests__/ExtendedResonanceBlueprint.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { ExtendedResonanceBlueprint, ResonanceBlueprint } from '../ExtendedResonanceBlueprint';
+import yaml from 'js-yaml';
+
+describe('ExtendedResonanceBlueprint', () => {
+  it('creates YAML blueprint', () => {
+    const bp: ResonanceBlueprint = ExtendedResonanceBlueprint.create('svc', ['/a', '/b'], ['latency']);
+    const out = ExtendedResonanceBlueprint.toYAML(bp);
+    const doc = yaml.load(out) as any;
+    expect(doc.service).toBe('svc');
+    expect(doc.endpoints).toEqual(['/a', '/b']);
+    expect(doc.metrics).toEqual(['latency']);
+  });
+});


### PR DESCRIPTION
## Summary
- add `ExtendedResonanceBlueprint` module and tests
- mark Pantheon VR room and blueprint tasks as done
- update progress tracking

## Testing
- `npx pyright` *(fails: 108 errors)*
- `npx tsc -p tsconfig.json`
- `pnpm test`
- `pnpm run test:agents`

------
https://chatgpt.com/codex/tasks/task_e_688cd6af2c708322a2cb4090587822f5