### PR TITLE
Add TODO items from advanced conversations

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-01, in der Zeit des Tag.
+Am 2025-08-01, in der Zeit des Abend.
 
-Symbolphase: Aktivierung (Fokus: R)
+Symbolphase: Integration (Fokus: E)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7843,5 +7843,131 @@
     "task": "Interface between Aeon system and external GPT services",
     "test": "packages/gpt-bridges/GPTSynapse.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Test and Feedback for repository",
+    "path": "scripts/test-feedback.md",
+    "task": "Run full test suite and compile feedback report",
+    "test": "pnpm test",
+    "status": "open"
+  },
+  {
+    "commit": "Add extended human traces archive dataset",
+    "path": "docs/archaeology/archiv-menschheitsspuren.md",
+    "task": "Document additional archaeological evidence",
+    "test": "docs/archaeology/archive.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add UnifiedMandala framework report",
+    "path": "docs/Framework-Bericht.md",
+    "task": "Summarize repository status with improvement suggestions",
+    "test": "docs/Framework-Bericht.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Generate skeleton modules from PLAN-ANCHOR",
+    "path": "tasks/sigillin_skeleton.yaml",
+    "task": "Create initial module stubs based on PLAN-ANCHOR",
+    "test": "tasks/sigillin_skeleton.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Enhance MandalaCanvas and CREPVisualizer UI",
+    "path": "packages/unifiedmandala-ui/components",
+    "task": "Add buttons for modules and visuals for CREP timeline",
+    "test": "packages/unifiedmandala-ui/components/UIEnhancements.test.tsx",
+    "status": "open"
+  },
+  {
+    "commit": "Add governance workflow",
+    "path": ".github/workflows/governance.yml",
+    "task": "Setup GovernanceAgent checks and peer review workflow",
+    "test": "tests/governanceWorkflow.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Initialize DeepScience experiment suite",
+    "path": "packages/experiments/DeepScience",
+    "task": "Start automated stress tests and CREP tuning",
+    "test": "packages/experiments/DeepScience/experiment.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add wiki sync script",
+    "path": "scripts/wiki-sync.js",
+    "task": "Synchronize modules with UnifiedMandala Wiki",
+    "test": "scripts/wiki-sync.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Integrate Mistral Code Agent support",
+    "path": "packages/agents/mistral-code-agent",
+    "task": "Ensure Mistral Code Agent is available for code generation",
+    "test": "packages/agents/mistral-code-agent/MistralCodeAgent.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Test and Feedback for repository",
+    "path": "scripts/test-feedback.md",
+    "task": "Run full test suite and compile feedback report",
+    "test": "pnpm test",
+    "status": "open"
+  },
+  {
+    "commit": "Add extended human traces archive dataset",
+    "path": "docs/archaeology/archiv-menschheitsspuren.md",
+    "task": "Document additional archaeological evidence",
+    "test": "docs/archaeology/archive.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add UnifiedMandala framework report",
+    "path": "docs/Framework-Bericht.md",
+    "task": "Summarize repository status with improvement suggestions",
+    "test": "docs/Framework-Bericht.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Generate skeleton modules from PLAN-ANCHOR",
+    "path": "tasks/sigillin_skeleton.yaml",
+    "task": "Create initial module stubs based on PLAN-ANCHOR",
+    "test": "tasks/sigillin_skeleton.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Enhance MandalaCanvas and CREPVisualizer UI",
+    "path": "packages/unifiedmandala-ui/components",
+    "task": "Add buttons for modules and visuals for CREP timeline",
+    "test": "packages/unifiedmandala-ui/components/UIEnhancements.test.tsx",
+    "status": "open"
+  },
+  {
+    "commit": "Add governance workflow",
+    "path": ".github/workflows/governance.yml",
+    "task": "Setup GovernanceAgent checks and peer review workflow",
+    "test": "tests/governanceWorkflow.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Initialize DeepScience experiment suite",
+    "path": "packages/experiments/DeepScience",
+    "task": "Start automated stress tests and CREP tuning",
+    "test": "packages/experiments/DeepScience/experiment.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Add wiki sync script",
+    "path": "scripts/wiki-sync.js",
+    "task": "Synchronize modules with UnifiedMandala Wiki",
+    "test": "scripts/wiki-sync.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Integrate Mistral Code Agent support",
+    "path": "packages/agents/mistral-code-agent",
+    "task": "Ensure Mistral Code Agent is available for code generation",
+    "test": "packages/agents/mistral-code-agent/MistralCodeAgent.test.ts",
+    "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8756,3 +8756,48 @@
   task: Interface between Aeon system and external GPT services
   test: packages/gpt-bridges/GPTSynapse.test.ts
   status: done
+- commit: Test and Feedback for repository
+  path: scripts/test-feedback.md
+  task: Run full test suite and compile feedback report
+  test: pnpm test
+  status: open
+- commit: Add extended human traces archive dataset
+  path: docs/archaeology/archiv-menschheitsspuren.md
+  task: Document additional archaeological evidence
+  test: docs/archaeology/archive.test.ts
+  status: open
+- commit: Add UnifiedMandala framework report
+  path: docs/Framework-Bericht.md
+  task: Summarize repository status with improvement suggestions
+  test: docs/Framework-Bericht.test.ts
+  status: open
+- commit: Generate skeleton modules from PLAN-ANCHOR
+  path: tasks/sigillin_skeleton.yaml
+  task: Create initial module stubs based on PLAN-ANCHOR
+  test: tasks/sigillin_skeleton.test.ts
+  status: open
+- commit: Enhance MandalaCanvas and CREPVisualizer UI
+  path: packages/unifiedmandala-ui/components
+  task: Add buttons for modules and visuals for CREP timeline
+  test: packages/unifiedmandala-ui/components/UIEnhancements.test.tsx
+  status: open
+- commit: Add governance workflow
+  path: .github/workflows/governance.yml
+  task: Setup GovernanceAgent checks and peer review workflow
+  test: tests/governanceWorkflow.test.ts
+  status: open
+- commit: Initialize DeepScience experiment suite
+  path: packages/experiments/DeepScience
+  task: Start automated stress tests and CREP tuning
+  test: packages/experiments/DeepScience/experiment.test.ts
+  status: open
+- commit: Add wiki sync script
+  path: scripts/wiki-sync.js
+  task: Synchronize modules with UnifiedMandala Wiki
+  test: scripts/wiki-sync.test.ts
+  status: open
+- commit: Integrate Mistral Code Agent support
+  path: packages/agents/mistral-code-agent
+  task: Ensure Mistral Code Agent is available for code generation
+  test: packages/agents/mistral-code-agent/MistralCodeAgent.test.ts
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: extend archive and test reports",
+  "lastCommit": "chore: update progress meta",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -8,12 +8,40 @@
   "notes": "UnifiedLogger added; core agents covered by tests",
   "pendingTasks": [
     {
-      "commit": "Create PantheonBegegnungsraum VR component",
-      "status": "done"
+      "commit": "Test and Feedback for repository",
+      "status": "open"
     },
     {
-      "commit": "Add ExtendedResonanceBlueprint",
-      "status": "done"
+      "commit": "Add extended human traces archive dataset",
+      "status": "open"
+    },
+    {
+      "commit": "Add UnifiedMandala framework report",
+      "status": "open"
+    },
+    {
+      "commit": "Generate skeleton modules from PLAN-ANCHOR",
+      "status": "open"
+    },
+    {
+      "commit": "Enhance MandalaCanvas and CREPVisualizer UI",
+      "status": "open"
+    },
+    {
+      "commit": "Add governance workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Initialize DeepScience experiment suite",
+      "status": "open"
+    },
+    {
+      "commit": "Add wiki sync script",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Mistral Code Agent support",
+      "status": "open"
     }
   ],
   "progress": [


### PR DESCRIPTION
## Summary
- extract tasks from three conversations
- append structured tasks in advancedToDo.yaml
- extend advancedToDo.json with same tasks
- update progress metadata via commit hooks

## Testing
- `npx pyright` *(fails: 108 errors)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_688d0274f7a8832296cc7454b8cc3789