### PR TITLE
Add MandalaNetworkView MVP task

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-01, in der Zeit des Nacht.
+Am 2025-08-02, in der Zeit des Morgen.
 
-Symbolphase: Reflexion (Fokus: P)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8130,5 +8130,12 @@
     "task": "Include analysis and improvement suggestions from Framework Bericht conversation",
     "test": "docs/Framework-Bericht.test.ts",
     "status": "open"
+  },
+  {
+    "commit": "Finalize MandalaNetworkView MVP",
+    "path": "packages/unifiedmandala-ui/components/MandalaNetworkView.tsx",
+    "task": "Implement Sigillin interaction and CREP visualization for funding demo",
+    "test": "packages/unifiedmandala-ui/components/MandalaNetworkView.test.tsx",
+    "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8913,6 +8913,12 @@
   status: open
 - commit: Update Framework-Bericht summary
   path: docs/Framework-Bericht.md
-  task: Include analysis and improvement suggestions from Framework Bericht conversation
+  task: Include analysis and improvement suggestions from Framework Bericht
+    conversation
   test: docs/Framework-Bericht.test.ts
+  status: open
+- commit: Finalize MandalaNetworkView MVP
+  path: packages/unifiedmandala-ui/components/MandalaNetworkView.tsx
+  task: Implement Sigillin interaction and CREP visualization for funding demo
+  test: packages/unifiedmandala-ui/components/MandalaNetworkView.test.tsx
   status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: update progress metadata",
+  "lastCommit": "Merge pull request #945 from GenesisAeon/codex/extract-tasks-and-features-from-chats",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -133,6 +133,10 @@
     },
     {
       "commit": "Update Framework-Bericht summary",
+      "status": "open"
+    },
+    {
+      "commit": "Finalize MandalaNetworkView MVP",
       "status": "open"
     }
   ],


### PR DESCRIPTION
## Summary
- capture MandalaNetworkView MVP requirement in repo's advanced ToDo lists
- sync progress metadata and chronopoem

## Testing
- `npx pyright` *(fails: missing modules and optional call errors)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_688dc32edf148322af9d0f4c9894c841