### PR TITLE
docs: add ethics whitepaper

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8087,7 +8087,7 @@
     "path": "docs/ethics/ETHICS_WHITEPAPER.md",
     "task": "Document governance mechanisms and trustworthy AI guidelines",
     "test": "docs/ethics/ethics.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Document Mistral Code Agent",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8885,7 +8885,7 @@
   path: docs/ethics/ETHICS_WHITEPAPER.md
   task: Document governance mechanisms and trustworthy AI guidelines
   test: docs/ethics/ethics.test.ts
-  status: open
+  status: done
 - commit: Document Mistral Code Agent
   path: README.md
   task: Add usage section for Mistral Code Agent

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -53,7 +53,7 @@
     },
     {
       "commit": "Create ethics whitepaper",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Integrate historical dataset",
@@ -435,6 +435,10 @@
     },
     {
       "commit": "extract MandalaReader and VR tasks",
+      "status": "done"
+    },
+    {
+      "commit": "Create ethics whitepaper",
       "status": "done"
     }
   ],

--- a/docs/ethics/ETHICS_WHITEPAPER.md
+++ b/docs/ethics/ETHICS_WHITEPAPER.md
@@ -1,0 +1,10 @@
+# Ethics Whitepaper
+
+## Governance Mechanisms
+
+To ensure responsible development of the Unified Mandala project, governance mechanisms define decision paths, accountability checkpoints and transparent escalation routes. These mechanisms coordinate agents, enforce community policies and align technical evolution with shared values.
+
+## Trustworthy AI Guidelines
+
+The project follows trustworthy AI guidelines that emphasise safety, explainability and human oversight. All agent contributions, including those from the Mistral Code Agent, are reviewed for compliance with these principles before integration.
+

--- a/docs/ethics/ethics.test.ts
+++ b/docs/ethics/ethics.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('Ethics Whitepaper', () => {
+  const content = readFileSync(join(__dirname, 'ETHICS_WHITEPAPER.md'), 'utf8');
+
+  it('mentions governance mechanisms and trustworthy AI', () => {
+    expect(content).toContain('Governance Mechanisms');
+    expect(content).toContain('Trustworthy AI Guidelines');
+  });
+});


### PR DESCRIPTION
## Summary
- add governance mechanisms and trustworthy AI guidelines whitepaper
- record completion of ethics whitepaper task in advanced todo and progress trackers

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false`
- `pnpm test docs/ethics/ethics.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688ddad72b848322ad46a3dcb55de2ed