### PR TITLE
feat: add deep repo analysis script

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8073,7 +8073,7 @@
     "path": "scripts/deep-repo-analysis.ts",
     "task": "Analyze packages for code quality and risk issues",
     "test": "scripts/deep-repo-analysis.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Event bus load tests",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8875,7 +8875,7 @@
   path: scripts/deep-repo-analysis.ts
   task: Analyze packages for code quality and risk issues
   test: scripts/deep-repo-analysis.test.ts
-  status: open
+  status: done
 - commit: Event bus load tests
   path: tests/event-bus/load.test.ts
   task: Benchmark event bus performance under high concurrency

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -28,10 +28,6 @@
       "status": "open"
     },
     {
-      "commit": "Deep repo package analysis",
-      "status": "open"
-    },
-    {
       "commit": "Event bus load tests",
       "status": "open"
     },
@@ -419,6 +415,10 @@
     },
     {
       "commit": "Create ethics whitepaper",
+      "status": "done"
+    },
+    {
+      "commit": "Deep repo package analysis",
       "status": "done"
     }
   ],

--- a/scripts/deep-repo-analysis.test.ts
+++ b/scripts/deep-repo-analysis.test.ts
@@ -1,0 +1,36 @@
+import { analyzePackages, suggestFixes, PackageReport } from './deep-repo-analysis';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import os from 'os';
+import path from 'path';
+
+describe('analyzePackages', () => {
+  it('detects risky dependencies', () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), 'repo-'));
+    const packagesDir = path.join(tmp, 'packages', 'demo');
+    mkdirSync(packagesDir, { recursive: true });
+    writeFileSync(
+      path.join(packagesDir, 'package.json'),
+      JSON.stringify({ name: 'demo', dependencies: { safe: '1.0.0', risky: '*' } })
+    );
+    const reports = analyzePackages(tmp);
+    expect(reports).toEqual([{ name: 'demo', dependencies: 2, risky: ['risky'] }]);
+  });
+});
+
+describe('suggestFixes', () => {
+  it('uses agent when risky deps exist', async () => {
+    const agent = { createSnippet: jest.fn().mockResolvedValue('fix') };
+    const report: PackageReport = { name: 'demo', dependencies: 1, risky: ['risky'] };
+    const res = await suggestFixes(agent, report);
+    expect(agent.createSnippet).toHaveBeenCalled();
+    expect(res).toBe('fix');
+  });
+
+  it('skips agent when no risks', async () => {
+    const agent = { createSnippet: jest.fn() };
+    const report: PackageReport = { name: 'demo', dependencies: 0, risky: [] };
+    const res = await suggestFixes(agent, report);
+    expect(agent.createSnippet).not.toHaveBeenCalled();
+    expect(res).toBeNull();
+  });
+});

--- a/scripts/deep-repo-analysis.ts
+++ b/scripts/deep-repo-analysis.ts
@@ -1,0 +1,44 @@
+import { readdirSync, readFileSync, existsSync } from 'fs';
+import path from 'path';
+import { MistralCodeAgent } from '../packages/agents/mistral-code-agent';
+import { MistralAPI } from '../packages/agents/mistral-api-agent';
+
+export interface PackageReport {
+  name: string;
+  dependencies: number;
+  risky: string[];
+}
+
+export function analyzePackages(baseDir: string): PackageReport[] {
+  const packagesDir = path.join(baseDir, 'packages');
+  const dirs = readdirSync(packagesDir, { withFileTypes: true }).filter(d => d.isDirectory());
+  const reports: PackageReport[] = [];
+  for (const dir of dirs) {
+    const pkgPath = path.join(packagesDir, dir.name, 'package.json');
+    if (!existsSync(pkgPath)) continue;
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+    const deps = Object.entries(pkg.dependencies ?? {});
+    const risky = deps.filter(([, ver]) => ver === '*' || ver === 'latest').map(([dep]) => dep);
+    reports.push({ name: pkg.name ?? dir.name, dependencies: deps.length, risky });
+  }
+  return reports;
+}
+
+export async function suggestFixes(agent: { createSnippet(prompt: string): Promise<string> }, report: PackageReport): Promise<string | null> {
+  if (!report.risky.length) return null;
+  const prompt = `Package ${report.name} has risky dependencies: ${report.risky.join(', ')}. Provide mitigation steps.`;
+  return agent.createSnippet(prompt);
+}
+
+if (require.main === module) {
+  const reports = analyzePackages(process.cwd());
+  if (process.env.MISTRAL_API_KEY) {
+    const api = new MistralAPI(process.env.MISTRAL_API_URL || "https://api.mistral.ai", process.env.MISTRAL_API_KEY!);
+    const agent = new MistralCodeAgent(api);
+    Promise.all(
+      reports.map(async r => ({ ...r, suggestion: await suggestFixes(agent, r) }))
+    ).then(res => console.log(JSON.stringify(res, null, 2)));
+  } else {
+    console.log(JSON.stringify(reports, null, 2));
+  }
+}


### PR DESCRIPTION
## Summary
- add deep-repo-analysis script to scan packages and flag risky dependency versions
- integrate optional Mistral Code Agent suggestions for mitigation steps
- record completion in advanced ToDo and progress tracking

## Testing
- `pnpm exec pyright`
- `pnpm exec tsc -p tsconfig.json --diagnostics`
- `npx jest scripts/deep-repo-analysis.test.ts --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_688df63899148322b5bb650172ce7b70