### PR TITLE
feat: enhance mistral service config

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ npx ts-node packages/agents/mistral-code-agent/index.ts "print('hello')"
 
 Der Agent liefert den von Mistral erzeugten Code auf STDOUT und unterstützt so explorative Entwicklungsrunden.
 
+Der dazugehörige [Mistral Service](services/mistral_service) leitet Code-Snippets an die API weiter und nutzt `MISTRAL_API_KEY` sowie optional `MISTRAL_API_BASE` für die Ziel-URL.
+
 ## 📦 Paketstruktur
 
 ```bash

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: integrate mistral agent and extend archive",
+  "lastCommit": "feat: enhance mistral service config",
   "fractalStep": "sync",
   "openBranches": [
     "work"
@@ -587,6 +587,10 @@
     },
     {
       "commit": "Clarify Manager versus Orchestrator roles",
+      "status": "done"
+    },
+    {
+      "commit": "Enhance Mistral service with env config",
       "status": "done"
     }
   ]

--- a/services/mistral_service/index.ts
+++ b/services/mistral_service/index.ts
@@ -6,10 +6,15 @@ const router = express.Router();
 router.post('/code', async (req, res) => {
   const { snippet } = req.body || {};
   if (!snippet) return res.status(400).json({ error: 'snippet required' });
+  const base = process.env.MISTRAL_API_BASE || 'https://api.mistral.ai/v1';
+  const key = process.env.MISTRAL_API_KEY;
   try {
-    const resp = await fetch('https://api.mistral.ai/v1/code', {
+    const resp = await fetch(`${base}/code`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(key ? { Authorization: `Bearer ${key}` } : {})
+      },
       body: JSON.stringify({ snippet })
     });
     const data = await (resp as any).json();

--- a/services/mistral_service/mistral.test.ts
+++ b/services/mistral_service/mistral.test.ts
@@ -1,6 +1,16 @@
+import { TextEncoder, TextDecoder } from 'util';
+// polyfill before importing supertest
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).TextEncoder = TextEncoder;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).TextDecoder = TextDecoder;
+
 import router from './index';
 import express from 'express';
 import request from 'supertest';
+import fetch from 'node-fetch';
+
+jest.mock('node-fetch', () => jest.fn());
 
 const app = express();
 app.use(express.json());
@@ -8,4 +18,19 @@ app.use('/', router);
 
 test('returns 400 without snippet', async () => {
   await request(app).post('/code').expect(400);
+});
+
+test('forwards snippet with auth header', async () => {
+  process.env.MISTRAL_API_KEY = 'test-key';
+  (fetch as unknown as jest.Mock).mockResolvedValue({ json: () => Promise.resolve({ ok: true }) });
+  await request(app).post('/code').send({ snippet: 'echo' }).expect(200);
+  expect(fetch).toHaveBeenCalledWith(
+    'https://api.mistral.ai/v1/code',
+    expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer test-key'
+      })
+    })
+  );
 });

--- a/services/mistral_service/openapi.yaml
+++ b/services/mistral_service/openapi.yaml
@@ -2,6 +2,12 @@ openapi: 3.0.0
 info:
   title: Mistral Code Agent
   version: 0.1.0
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
 paths:
   /code:
     post:
@@ -22,3 +28,5 @@ paths:
             application/json:
               schema:
                 type: object
+      security:
+        - ApiKeyAuth: []


### PR DESCRIPTION
## Summary
- make Mistral service configurable via `MISTRAL_API_BASE` and `MISTRAL_API_KEY`
- document and test the service endpoint and its auth flow
- record progress for the new service configuration

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest services/mistral_service/mistral.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688dfd2bac008322a15c777cbb19dda4