### PR TITLE
feat: sync historical archive dataset

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8108,7 +8108,7 @@
     "path": "scripts/historical-data-sync.ts",
     "task": "Import external archaeological data into archive",
     "test": "scripts/historical-data-sync.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create interactive archaeologic map",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8900,7 +8900,7 @@
   path: scripts/historical-data-sync.ts
   task: Import external archaeological data into archive
   test: scripts/historical-data-sync.test.ts
-  status: open
+  status: done
 - commit: Create interactive archaeologic map
   path: packages/unifiedmandala-ui/components/ArchiveMap.tsx
   task: Visualize Archiv Menschheitsspuren data on an interactive map

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -32,10 +32,6 @@
       "status": "open"
     },
     {
-      "commit": "Integrate historical dataset",
-      "status": "open"
-    },
-    {
       "commit": "Create interactive archaeologic map",
       "status": "open"
     },
@@ -591,6 +587,10 @@
     },
     {
       "commit": "Enhance Mistral service with env config",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate historical dataset",
       "status": "done"
     }
   ]

--- a/docs/archive/archiv-menschheitsspuren.md
+++ b/docs/archive/archiv-menschheitsspuren.md
@@ -28,6 +28,8 @@ Dieses Archiv sammelt nach und nach wissenschaftlich belegte Funde, die im Laufe
 - **Baalbek Trilithon, Libanon** – ca. 2.000 BP – gigantische Steinquader im mediterranen Klima.
 - **Bimini Road, Bahamas** – ca. 11.000 BP – versunkene Steinformationen im subtropischen Meer.
 
+- **Çatalhöyük, Türkei** – ca. 7.500 BP – frühe neolithische Stadt, gemäßigtes Kontinentalklima.
+- **Monte Verde, Chile** – ca. 14.500 BP – prä-Clovis Siedlung in feuchtem Küstenklima.
 ## Klimatische und kosmische Ereignisse
 
 Die klimatischen Bedingungen und kosmischen Ereignisse haben großen Einfluss auf die Entwicklung früher Kulturen. Die folgenden Punkte ergänzen die Fundliste:
@@ -36,4 +38,3 @@ Die klimatischen Bedingungen und kosmischen Ereignisse haben großen Einfluss au
 - **Magnetischer Sturm (ca. 42.000 BP)** – bekannte Laschamp-Exkursion könnte Einfluss auf Umweltbedingungen gehabt haben.
 
 Weitere Einträge können durch das Skript `archive-menschheitsspuren.js` automatisch angefügt werden.
-

--- a/docs/archive/archive.test.ts
+++ b/docs/archive/archive.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
+import { describe, it, expect } from 'vitest';
 
 describe('Archiv Menschheitsspuren', () => {
   const archivePath = join(__dirname, 'archiv-menschheitsspuren.md');
@@ -20,7 +21,9 @@ describe('Archiv Menschheitsspuren', () => {
       'Qesem Cave',
       'White Sands',
       'Attirampakkam',
-      'Gunung Padang'
+      'Gunung Padang',
+      'Çatalhöyük',
+      'Monte Verde'
     ];
     for (const e of entries) {
       expect(content).toContain(e);

--- a/docs/archive/historical-data.json
+++ b/docs/archive/historical-data.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "Çatalhöyük, Türkei",
+    "age": "ca. 7.500 BP",
+    "note": "frühe neolithische Stadt, gemäßigtes Kontinentalklima"
+  },
+  {
+    "name": "Monte Verde, Chile",
+    "age": "ca. 14.500 BP",
+    "note": "prä-Clovis Siedlung in feuchtem Küstenklima"
+  }
+]

--- a/scripts/historical-data-sync.test.ts
+++ b/scripts/historical-data-sync.test.ts
@@ -1,0 +1,26 @@
+import { syncHistoricalData } from './historical-data-sync';
+import { mkdtempSync, copyFileSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, it, expect } from 'vitest';
+
+const datasetPath = join(__dirname, '..', 'docs', 'archive', 'historical-data.json');
+const archiveSource = join(
+  __dirname,
+  '..',
+  'docs',
+  'archive',
+  'archiv-menschheitsspuren.md'
+);
+
+describe('historical-data-sync', () => {
+  it('appends new dataset entries to archive', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'archive-'));
+    const target = join(tempDir, 'archiv.md');
+    copyFileSync(archiveSource, target);
+    syncHistoricalData(datasetPath, target);
+    const content = readFileSync(target, 'utf8');
+    expect(content).toContain('Çatalhöyük');
+    expect(content).toContain('Monte Verde');
+  });
+});

--- a/scripts/historical-data-sync.ts
+++ b/scripts/historical-data-sync.ts
@@ -1,0 +1,47 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+interface HistoricalEntry {
+  name: string;
+  age: string;
+  note: string;
+}
+
+export function syncHistoricalData(
+  sourcePath: string,
+  archivePath: string
+): void {
+  const dataset: HistoricalEntry[] = JSON.parse(
+    readFileSync(sourcePath, 'utf8')
+  );
+  const archiveContent = readFileSync(archivePath, 'utf8');
+  const lines = archiveContent.trimEnd().split('\n');
+  const markerIndex = lines.findIndex((l) => l.startsWith('## Klimatische'));
+  const insertIndex = markerIndex === -1 ? lines.length : markerIndex;
+
+  const newLines: string[] = [];
+  for (const entry of dataset) {
+    if (archiveContent.includes(entry.name)) {
+      continue;
+    }
+    newLines.push(
+      `- **${entry.name}** – ${entry.age} – ${entry.note}.`
+    );
+  }
+
+  if (newLines.length > 0) {
+    lines.splice(insertIndex, 0, ...newLines);
+    writeFileSync(archivePath, lines.join('\n') + '\n');
+  }
+}
+
+if (require.main === module) {
+  const source =
+    process.argv[2] ||
+    join(__dirname, '..', 'docs', 'archive', 'historical-data.json');
+  const target =
+    process.argv[3] ||
+    join(__dirname, '..', 'docs', 'archive', 'archiv-menschheitsspuren.md');
+  syncHistoricalData(source, target);
+  console.log('Historical dataset synchronized');
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,9 @@ export default defineConfig({
     include: [
       'packages/agents/**/*.{test,spec}.ts',
       'packages/boundary-engine/**/*.{test,spec}.ts',
-      'packages/api/**/*.{test,spec}.ts'
+      'packages/api/**/*.{test,spec}.ts',
+      'scripts/**/*.{test,spec}.ts',
+      'docs/**/*.{test,spec}.ts'
     ],
     environment: 'node'
   }


### PR DESCRIPTION
## Summary
- add historical-data-sync script and sample dataset
- expand vitest config and tests for archive updates
- mark historical dataset integration task complete in tracking files

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx vitest run scripts/historical-data-sync.test.ts docs/archive/archive.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688e538ed3388322ba7262c4c937e5ed