### PR TITLE
feat(onboarding): add agent service selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,4 +143,5 @@ package-lock.json
 docs/sigils/todo-from-convos.yaml
 codex/website.yaml
 mandala-chronik.yaml
+user-config/
 .aeoncache

--- a/config/agent-services.yaml
+++ b/config/agent-services.yaml
@@ -1,0 +1,11 @@
+sigillin_map:
+  local-chatbot: local-chatbot
+  mistral: external-mistral
+  claude: external-claude
+  vicuna: external-vicuna
+
+crep_thresholds:
+  local-chatbot: 0.5
+  mistral: 0.6
+  claude: 0.6
+  vicuna: 0.6

--- a/config/onboarding/services.yaml
+++ b/config/onboarding/services.yaml
@@ -1,0 +1,21 @@
+services:
+  - id: local-chatbot
+    name: "Local AI Chatbot"
+    type: local
+    endpoint: "/api/local-chat"
+    default_enabled: true
+  - id: mistral
+    name: "Mistral 7B"
+    type: external
+    endpoint: "/api/external-mistral"
+    default_enabled: false
+  - id: claude
+    name: "Anthropic Claude"
+    type: external
+    endpoint: "/api/external-claude"
+    default_enabled: false
+  - id: vicuna
+    name: "Vicuna-13B"
+    type: external
+    endpoint: "/api/external-vicuna"
+    default_enabled: false

--- a/scripts/aeon.sh
+++ b/scripts/aeon.sh
@@ -19,6 +19,7 @@ function show_help() {
     chronopoem      – Erzeugt poetische Commit-Signatur
     setup           – Führt das Setup-Ritual aus
     onboarding      – Zeigt das Onboarding-Ritual
+    onboard_services – Wählt aktivierte Agentendienste
     help            – Diese Hilfe"
 }
 function chronopoem() {
@@ -33,11 +34,15 @@ function onboarding() {
   echo -e "\n${yellow}Aktueller Chronopoem:${reset}"
   chronopoem
 }
+function onboard_services() {
+  node "$ROOT_DIR/scripts/onboard-services.js"
+}
 case "$1" in
   sigil_invoke) sigil_invoke ;;
   cycle_start) cycle_start ;;
   chronopoem) chronopoem ;;
   setup) setup ;;
   onboarding) onboarding ;;
+  onboard_services) onboard_services ;;
   help|*) show_help ;;
 esac

--- a/scripts/onboard-services.js
+++ b/scripts/onboard-services.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const yaml = require('yaml');
+const readline = require('readline');
+
+const servicesFile = path.resolve(__dirname, '../config/onboarding/services.yaml');
+const outDir = path.resolve(__dirname, '../user-config');
+const outFile = path.join(outDir, 'services_selected.yaml');
+
+const data = yaml.parse(fs.readFileSync(servicesFile, 'utf8'));
+const services = data.services || [];
+
+console.log('Verfügbare Dienste:');
+services.forEach((s, idx) => {
+  const ext = s.type === 'external' ? ' (extern)' : '';
+  console.log(`${idx + 1}. ${s.name}${ext}`);
+});
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+rl.question('Nummern auswählen (z.B. 1,3): ', answer => {
+  const ids = answer
+    .split(',')
+    .map(str => parseInt(str.trim(), 10) - 1)
+    .filter(i => i >= 0 && i < services.length)
+    .map(i => services[i].id);
+
+  if (!fs.existsSync(outDir)) {
+    fs.mkdirSync(outDir, { recursive: true });
+  }
+  fs.writeFileSync(outFile, yaml.stringify({ selected: ids }), 'utf8');
+  console.log(`\n✅ Dienste konfiguriert: ${ids.join(', ')}`);
+  rl.close();
+});

--- a/scripts/onboarding-ritual.md
+++ b/scripts/onboarding-ritual.md
@@ -7,14 +7,16 @@ Bitte führe folgende Schritte aus:
    `git clone ...`
 2. **Installiere Abhängigkeiten:**  
    `pnpm install`
-3. **Starte das Setup-Ritual:**  
+3. **Starte das Setup-Ritual:**
    `./scripts/setup-unifiedmandala.sh`
-4. **Aktiviere den Zyklus:**  
+4. **Wähle deine Agentendienste:**
+   `./scripts/aeon.sh onboard_services`
+5. **Aktiviere den Zyklus:**
    `./scripts/aeon.sh cycle_start`
-5. **Lies den poetischen Ursprung:**
+6. **Lies den poetischen Ursprung:**
    `./scripts/aeon.sh chronopoem`
-6. **Oder direkt:**
+7. **Oder direkt:**
    `./scripts/aeon.sh onboarding`
-7. **Lass dich von den Symbolen führen...**
+8. **Lass dich von den Symbolen führen...**
 
 Möge Resonanz und Klarheit deinen Pfad begleiten!


### PR DESCRIPTION
## Summary
- add service mapping and thresholds for agent orchestration
- provide dataset of available chat agents
- allow onboarding script to select which services are active

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_688e5dd4efa4832298bad4414a800f79