### PR TITLE
feat(onboarding): add service selection modal

### DIFF
--- a/packages/unifiedmandala-ui/components/OnboardingModal.test.tsx
+++ b/packages/unifiedmandala-ui/components/OnboardingModal.test.tsx
@@ -3,12 +3,17 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import OnboardingModal from './OnboardingModal';
 
-test('walks through steps and calls onComplete', () => {
+test('selects services after steps and calls onComplete with ids', () => {
   const onComplete = jest.fn();
-  render(<OnboardingModal open={true} steps={["Step1","Step2"]} onComplete={onComplete} />);
+  const services = [
+    { id: 'local-chatbot', name: 'Local', type: 'local', default_enabled: true },
+  ];
+  render(
+    <OnboardingModal open={true} steps={["Step1"]} services={services} onComplete={onComplete} />
+  );
   expect(screen.getByText('Step1')).toBeInTheDocument();
-  fireEvent.click(screen.getByRole('button'));
-  expect(screen.getByText('Step2')).toBeInTheDocument();
-  fireEvent.click(screen.getByRole('button'));
-  expect(onComplete).toHaveBeenCalled();
+  fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+  expect(screen.getByText('Dienste auswählen:')).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: 'Fertig' }));
+  expect(onComplete).toHaveBeenCalledWith(['local-chatbot']);
 });

--- a/packages/unifiedmandala-ui/components/OnboardingModal.tsx
+++ b/packages/unifiedmandala-ui/components/OnboardingModal.tsx
@@ -1,25 +1,79 @@
 import React, { useState } from 'react';
+import fs from 'fs';
+import path from 'path';
+import yaml from 'yaml';
+
+interface ServiceOption {
+  id: string;
+  name: string;
+  type?: string;
+  default_enabled?: boolean;
+}
+
+const servicesFile = path.resolve(
+  __dirname,
+  '../../../config/onboarding/services.yaml'
+);
+let defaultServices: ServiceOption[] = [];
+try {
+  const raw = fs.readFileSync(servicesFile, 'utf8');
+  defaultServices = (yaml.parse(raw).services as ServiceOption[]) || [];
+} catch {
+  defaultServices = [];
+}
 
 interface OnboardingModalProps {
   open: boolean;
   steps: string[];
-  onComplete: () => void;
+  onComplete: (selected: string[]) => void;
+  services?: ServiceOption[];
 }
 
-const OnboardingModal: React.FC<OnboardingModalProps> = ({ open, steps, onComplete }) => {
+const OnboardingModal: React.FC<OnboardingModalProps> = ({
+  open,
+  steps,
+  onComplete,
+  services = defaultServices,
+}) => {
   const [index, setIndex] = useState(0);
+  const [selected, setSelected] = useState<string[]>(
+    services.filter(s => s.default_enabled).map(s => s.id)
+  );
   if (!open) return null;
+  const toggle = (id: string) => {
+    setSelected(prev =>
+      prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]
+    );
+  };
   const next = () => {
-    if (index < steps.length - 1) {
+    if (index < steps.length) {
       setIndex(index + 1);
     } else {
-      onComplete();
+      onComplete(selected);
     }
   };
+  const isStepPhase = index < steps.length;
   return (
     <div role="dialog" aria-modal="true" className="onboarding-modal">
-      <p>{steps[index]}</p>
-      <button onClick={next}>{index < steps.length - 1 ? 'Weiter' : 'Fertig'}</button>
+      {isStepPhase ? (
+        <p>{steps[index]}</p>
+      ) : (
+        <div>
+          <p>Dienste auswählen:</p>
+          {services.map(s => (
+            <label key={s.id} style={{ display: 'block' }}>
+              <input
+                type="checkbox"
+                checked={selected.includes(s.id)}
+                onChange={() => toggle(s.id)}
+              />
+              {s.name}
+              {s.type === 'external' ? ' (extern)' : ''}
+            </label>
+          ))}
+        </div>
+      )}
+      <button onClick={next}>{isStepPhase ? 'Weiter' : 'Fertig'}</button>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- extend onboarding modal with service selection step
- load agent services from YAML config
- test selecting services during onboarding

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/unifiedmandala-ui/components/OnboardingModal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688e618c0dac8322ab177cb609331aea