### PR TITLE
feat(ui): add mandala dashboard sync view

### DIFF
--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -85,7 +85,7 @@ todos:
     status: erledigt
   - id: todo-29
     beschreibung: "mandala-dashboard.tsx zur Visualisierung des Synchronstatus aller Module erstellen"
-    status: offen
+    status: erledigt
   - id: todo-30
     beschreibung: "codex-memory-kernel.ts zur Verwaltung eines persistenten Referenz-Gedächtnisses entwickeln"
     status: offen

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8179,5 +8179,12 @@
     "task": "Run QuantumTheoryAgent program tests and collect feedback",
     "test": "scripts/quantum-agent-feedback.test.ts",
     "status": "open"
+  },
+  {
+    "commit": "Add Mandala Dashboard component",
+    "path": "packages/unifiedmandala-ui/components/MandalaDashboard.tsx",
+    "task": "Visualize sync status of modules",
+    "test": "packages/unifiedmandala-ui/components/MandalaDashboard.test.tsx",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8952,3 +8952,8 @@
   task: Run QuantumTheoryAgent program tests and collect feedback
   test: scripts/quantum-agent-feedback.test.ts
   status: open
+- commit: Add Mandala Dashboard component
+  path: packages/unifiedmandala-ui/components/MandalaDashboard.tsx
+  task: Visualize sync status of modules
+  test: packages/unifiedmandala-ui/components/MandalaDashboard.test.tsx
+  status: done

--- a/packages/unifiedmandala-ui/components/MandalaDashboard.test.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaDashboard.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MandalaDashboard, { ModuleStatus } from './MandalaDashboard';
+
+test('renders module names and statuses', () => {
+  const modules: ModuleStatus[] = [
+    { name: 'core', status: 'synced' },
+    { name: 'ui', status: 'pending' },
+  ];
+  render(<MandalaDashboard modules={modules} />);
+  expect(screen.getByText('core:')).toBeInTheDocument();
+  expect(screen.getByText('ui:')).toBeInTheDocument();
+  expect(screen.getAllByTestId('sync-status')).toHaveLength(2);
+});

--- a/packages/unifiedmandala-ui/components/MandalaDashboard.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaDashboard.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import SyncStatus from './SyncStatus';
+
+export interface ModuleStatus {
+  name: string;
+  status: 'synced' | 'pending' | 'error';
+}
+
+interface MandalaDashboardProps {
+  modules: ModuleStatus[];
+}
+
+const MandalaDashboard: React.FC<MandalaDashboardProps> = ({ modules }) => (
+  <div aria-label="Mandala Dashboard">
+    <h3>Module Synchronisation</h3>
+    <ul>
+      {modules.map((m) => (
+        <li key={m.name}>
+          <span>{m.name}:</span> <SyncStatus status={m.status} />
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default MandalaDashboard;


### PR DESCRIPTION
## Summary
- visualize module sync status with new MandalaDashboard component
- document dashboard feature in advanced and legacy ToDo lists

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json --listFiles`
- `npx jest packages/unifiedmandala-ui/components/MandalaDashboard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688e81b7748483229aa40c4e5484aad9