### PR TITLE
feat: add dry agent CI

### DIFF
--- a/.github/workflows/agents_ci.yaml
+++ b/.github/workflows/agents_ci.yaml
@@ -1,0 +1,16 @@
+name: Agents CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+      - run: pnpm install
+      - run: pnpm ts-node scripts/run-dry-agents.ts

--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -67,7 +67,7 @@ todos:
     status: erledigt
   - id: todo-23
     beschreibung: "GitHub Action agents_ci.yaml einrichten, die runDryAgent.ts ausführt"
-    status: offen
+    status: erledigt
   - id: todo-24
     beschreibung: "CodexZentral.yaml als Masterindex aller Module anlegen"
     status: erledigt

--- a/scripts/run-dry-agents.ts
+++ b/scripts/run-dry-agents.ts
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+import { runDryAgent } from '../packages/shared-utils/runDryAgent';
+
+function extractAgentNames(markdown: string): string[] {
+  const regex = /Agent:\s*([A-Za-z0-9]+)/g;
+  const names: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(markdown)) !== null) {
+    names.push(match[1]);
+  }
+  return names;
+}
+
+const agentsPath = path.join(__dirname, '..', 'AGENTS.md');
+const content = fs.readFileSync(agentsPath, 'utf8');
+const names = extractAgentNames(content);
+
+names.forEach((name) => {
+  const logs = runDryAgent({ name, simulate: () => {} });
+  logs.forEach((msg) => console.log(msg));
+});


### PR DESCRIPTION
## Summary
- add `agents_ci` GitHub workflow to dry-run agents
- script parses `AGENTS.md` and runs each agent with `runDryAgent`
- mark todo-23 as completed

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json --extendedDiagnostics`
- `pnpm test packages/shared-utils/runDryAgent.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688e81b7748483229aa40c4e5484aad9