### PR TITLE
Add archaeologic archive map component

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -201,6 +201,7 @@ GPTEventHub.emit('orakel:says', { content: 'Hallo Welt' });
 - Module für narrative KI-Simulationen.
 ### unifiedmandala-ui (Auswahl)
 - `MandalaNetworkView` – Visualisierung der Sigillin-Knoten als D3-Graph.
+- `ArchiveMap` – Interaktive Karte der Archiv Menschheitsspuren.
 - `CREPChart` – Linienchart für CREP-Werte.
 - `CREPStatsCard` – zeigt Durchschnitts-CREP mit kleinem Chart.
 - `CREPTimeline` – zeigt historische CREP-Einträge als Liste.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**Sigillin-Logik**](docs/sigils/SIGILLIN_GENESIS.md) – Heimkehr-Trigger, Symbolphasen, SigillinMap
 - [**Symbolzeit-Modulator**](packages/shared-utils/symbolzeitModulator.ts) – morgen, tag, abend, nacht
 - [**MandalaNetworkView**](packages/unifiedmandala-ui/components/MandalaNetworkView.tsx) – Visualisierung aller Sigillin-Knoten und CREP-Felder
+- [**ArchiveMap**](packages/unifiedmandala-ui/components/ArchiveMap.tsx) – Interaktive Karte der Archiv Menschheitsspuren
 - [**SigillinLoader**](packages/unifiedmandala-ui/components/SigillinLoader.tsx) – Import & Filter von Sigillin-Dateien
 - [**AutoDoc & Manifest-Generator**](packages/crep-engine/autoDocGeneration.ts) – Dokumentation auf Knopfdruck
 - [**FourierLayer Analyse**](packages/analysis/FourierLayer.ts) – Frequenzbasierte Emergenzbewertung

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6935,7 +6935,8 @@
     "commit": "Document Pantheon-Boundary integration plan",
     "path": "docs/boundary/PantheonBoundaryIntegration.md",
     "task": "Summarize integration blueprint from chats",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Add Zivilisations-Sandbox simulation module",
@@ -8115,7 +8116,7 @@
     "path": "packages/unifiedmandala-ui/components/ArchiveMap.tsx",
     "task": "Visualize Archiv Menschheitsspuren data on an interactive map",
     "test": "packages/unifiedmandala-ui/components/ArchiveMap.test.tsx",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Analyze test results automatically",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8003,6 +8003,7 @@
   path: docs/boundary/PantheonBoundaryIntegration.md
   task: Summarize integration blueprint from chats
   test: ""
+  status: done
 - commit: Add Zivilisations-Sandbox simulation module
   path: packages/simulations/zivilisations-sandbox
   task: Simulate ancient megastructures
@@ -8905,7 +8906,7 @@
   path: packages/unifiedmandala-ui/components/ArchiveMap.tsx
   task: Visualize Archiv Menschheitsspuren data on an interactive map
   test: packages/unifiedmandala-ui/components/ArchiveMap.test.tsx
-  status: open
+  status: done
 - commit: Analyze test results automatically
   path: scripts/feedback-analyzer.ts
   task: Parse test logs and generate summarized feedback report

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add wiki sync script",
-  "fractalStep": "wiki-sync",
+  "lastCommit": "feat: add archive map component",
+  "fractalStep": "archive-map",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Wiki sync script implemented; next: interactive archaeologic map",
+  "notes": "Archive map component implemented; next: finalize MandalaNetworkView",
   "pendingTasks": [
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
@@ -21,10 +21,6 @@
     },
     {
       "commit": "Initialize DeepScience experiment suite",
-      "status": "open"
-    },
-    {
-      "commit": "Create interactive archaeologic map",
       "status": "open"
     },
     {
@@ -591,6 +587,14 @@
     },
     {
       "commit": "Integrate historical dataset",
+      "status": "done"
+    },
+    {
+      "commit": "Document Pantheon-Boundary integration plan",
+      "status": "done"
+    },
+    {
+      "commit": "Create interactive archaeologic map",
       "status": "done"
     }
   ]

--- a/docs/boundary/PantheonBoundaryIntegration.md
+++ b/docs/boundary/PantheonBoundaryIntegration.md
@@ -5,6 +5,8 @@ Diese Notiz fasst die Chat-Planungen zu Boundary Laws, Pantheon und VR zusammen.
 - **BoundaryLawDiscoveryEngine** liefert erkannte Regeln an das Pantheon.
 - **PantheonAvatarHub** synchronisiert Avatare im VR-Begegnungsraum.
 - **ExtendedResonanceGateway** verbindet Resonanzmodule mit Boundary-Ereignissen.
+- **PantheonBoundaryBridge** überträgt Boundary-Ereignisse in VR-Raum und UI.
+- **VRResonanceVisualizer** zeigt CREP-Resonanz, die durch Boundary-Events ausgelöst wird.
 
 Weitere Details sind in den Gesprächen "CosmicTheoryAgent Code Erweiterung" und
 "AeonAI Pyramid-UI Konzept" beschrieben.

--- a/packages/unifiedmandala-ui/components/ArchiveMap.test.tsx
+++ b/packages/unifiedmandala-ui/components/ArchiveMap.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ArchiveMap, { ArchiveSite } from './ArchiveMap';
+
+test('renders sites and triggers callback', () => {
+  const sites: ArchiveSite[] = [
+    { id: '1', name: 'Pumapunku', lat: -16.551, lon: -68.673 },
+  ];
+  const onSelect = jest.fn();
+  render(<ArchiveMap sites={sites} onSelect={onSelect} />);
+  const marker = screen.getByRole('button', { name: 'Pumapunku' });
+  expect(marker).toBeInTheDocument();
+  fireEvent.click(marker);
+  expect(onSelect).toHaveBeenCalledWith(sites[0]);
+});

--- a/packages/unifiedmandala-ui/components/ArchiveMap.tsx
+++ b/packages/unifiedmandala-ui/components/ArchiveMap.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export interface ArchiveSite {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+}
+
+interface ArchiveMapProps {
+  sites: ArchiveSite[];
+  onSelect?: (site: ArchiveSite) => void;
+}
+
+const width = 800;
+const height = 400;
+
+const project = (lat: number, lon: number) => ({
+  x: ((lon + 180) / 360) * width,
+  y: ((90 - lat) / 180) * height,
+});
+
+const ArchiveMap: React.FC<ArchiveMapProps> = ({ sites, onSelect }) => (
+  <svg width={width} height={height} aria-label="Archiv Menschheitsspuren Karte">
+    {sites.map((s) => {
+      const { x, y } = project(s.lat, s.lon);
+      return (
+        <circle
+          key={s.id}
+          cx={x}
+          cy={y}
+          r={5}
+          fill="#e74c3c"
+          role="button"
+          aria-label={s.name}
+          onClick={() => onSelect?.(s)}
+        />
+      );
+    })}
+  </svg>
+);
+
+export default ArchiveMap;

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -38,3 +38,4 @@ export { default as HaikuOverlay } from './components/HaikuOverlay';
 export { default as BlackboxMandala } from './components/BlackboxMandala';
 export { default as MandalaCanvas } from './components/MandalaCanvas';
 export { default as AIUI } from './components/AIUI';
+export { default as ArchiveMap } from './components/ArchiveMap';


### PR DESCRIPTION
## Summary
- build ArchiveMap component to visualize archaeologic sites with clickable markers
- expand Pantheon-Boundary integration notes and export ArchiveMap
- mark corresponding tasks as completed in advanced ToDo and progress files

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/unifiedmandala-ui/components/ArchiveMap.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688e907f6f888322b173f43384ea1ca3