### PR TITLE
feat: add AntimatterQubitMonitor to QuantumTheoryAgent

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8144,7 +8144,7 @@
     "path": "packages/agents/QuantumTheoryAgent.ts",
     "task": "Monitor antimatter qubit CPT delta and emit anomalies",
     "test": "packages/agents/QuantumTheoryAgent.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create antimatter qubit microservice",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8927,7 +8927,7 @@
   path: packages/agents/QuantumTheoryAgent.ts
   task: Monitor antimatter qubit CPT delta and emit anomalies
   test: packages/agents/QuantumTheoryAgent.test.ts
-  status: open
+  status: done
 - commit: Create antimatter qubit microservice
   path: services/antimatter_service/main.py
   task: Fetch latest antimatter qubit measurements via API

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add archive map component",
-  "fractalStep": "archive-map",
+  "lastCommit": "feat: add AntimatterQubitMonitor to QuantumTheoryAgent",
+  "fractalStep": "quantum-agent",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Archive map component implemented; next: finalize MandalaNetworkView",
+  "notes": "AntimatterQubitMonitor integrated; next: create antimatter microservice and CPT detector",
   "pendingTasks": [
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
@@ -25,10 +25,6 @@
     },
     {
       "commit": "Finalize MandalaNetworkView MVP",
-      "status": "open"
-    },
-    {
-      "commit": "Add AntimatterQubitMonitor to QuantumTheoryAgent",
       "status": "open"
     },
     {
@@ -595,6 +591,10 @@
     },
     {
       "commit": "Create interactive archaeologic map",
+      "status": "done"
+    },
+    {
+      "commit": "Add AntimatterQubitMonitor to QuantumTheoryAgent",
       "status": "done"
     }
   ]

--- a/docs/Framework-Bericht.md
+++ b/docs/Framework-Bericht.md
@@ -31,7 +31,7 @@ Der Agent unter `packages/agents/QuantumTheoryAgent.ts` bildet die Basis für qu
 
 **Aktuell**
 - Beobachtung grundlegender CREP-Werte.
+- AntimatterQubitMonitor zur CPT-Anomalieerkennung.
 
 **Geplant**
-- Erweiterung um einen `AntimatterQubitMonitor` zur CPT-Anomalieerkennung.
 - Aufbau einer Test-Feedback-Schleife via `scripts/quantum-agent-feedback.ts`.

--- a/packages/agents/QuantumTheoryAgent.test.ts
+++ b/packages/agents/QuantumTheoryAgent.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { QuantumTheoryAgent } from './QuantumTheoryAgent';
+
+describe('QuantumTheoryAgent', () => {
+  it('emits anomaly when CPT delta exceeds threshold', () => {
+    const agent = new QuantumTheoryAgent(0.5);
+    const events: any[] = [];
+    agent.onAnomaly(m => events.push(m));
+    agent.observe({ cptDelta: 0.8 });
+    expect(events).toHaveLength(1);
+    expect(events[0].cptDelta).toBe(0.8);
+  });
+
+  it('does not emit anomaly for safe measurements', () => {
+    const agent = new QuantumTheoryAgent(1);
+    const events: any[] = [];
+    agent.onAnomaly(m => events.push(m));
+    agent.observe({ cptDelta: 0.4 });
+    expect(events).toHaveLength(0);
+  });
+});

--- a/packages/agents/QuantumTheoryAgent.ts
+++ b/packages/agents/QuantumTheoryAgent.ts
@@ -1,0 +1,37 @@
+import { EventEmitter } from 'events';
+
+export interface QubitMeasurement {
+  /** Difference between matter and antimatter CPT states */
+  cptDelta: number;
+  timestamp?: number;
+}
+
+export class AntimatterQubitMonitor extends EventEmitter {
+  constructor(private readonly threshold = 0.1) {
+    super();
+  }
+
+  record(measurement: QubitMeasurement) {
+    if (Math.abs(measurement.cptDelta) > this.threshold) {
+      this.emit('anomaly', measurement);
+    }
+  }
+}
+
+export class QuantumTheoryAgent {
+  private readonly monitor: AntimatterQubitMonitor;
+
+  constructor(threshold = 0.1, monitor?: AntimatterQubitMonitor) {
+    this.monitor = monitor ?? new AntimatterQubitMonitor(threshold);
+  }
+
+  observe(measurement: QubitMeasurement) {
+    this.monitor.record(measurement);
+  }
+
+  onAnomaly(listener: (m: QubitMeasurement) => void) {
+    this.monitor.on('anomaly', listener);
+  }
+}
+
+export default QuantumTheoryAgent;

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -53,3 +53,4 @@ export * from './CosmicTheoryAgent';
 export * from './ArchivAeon';
 export * from './mistral-api-agent';
 export * from './mistral-code-agent';
+export * from './QuantumTheoryAgent';


### PR DESCRIPTION
## Summary
- add QuantumTheoryAgent with AntimatterQubitMonitor to flag CPT anomalies
- expose QuantumTheoryAgent and document monitor in Framework-Bericht
- update advanced progress and todo tracking for new feature

## Testing
- `npx vitest run packages/agents/QuantumTheoryAgent.test.ts`
- `npx pyright && echo pyright_ok`
- `npx tsc -p tsconfig.json && echo tsc_ok`


------
https://chatgpt.com/codex/tasks/task_e_688e945e26948322a5f9504d71c3b0b3