### PR TITLE
feat: add antimatter qubit microservice

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8150,8 +8150,8 @@
     "commit": "Create antimatter qubit microservice",
     "path": "services/antimatter_service/main.py",
     "task": "Fetch latest antimatter qubit measurements via API",
-    "test": "services/antimatter_service/main.test.py",
-    "status": "open"
+    "test": "services/antimatter_service/main_test.py",
+    "status": "done"
   },
   {
     "commit": "Configure CPT anomaly emergence detection",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8931,8 +8931,8 @@
 - commit: Create antimatter qubit microservice
   path: services/antimatter_service/main.py
   task: Fetch latest antimatter qubit measurements via API
-  test: services/antimatter_service/main.test.py
-  status: open
+  test: services/antimatter_service/main_test.py
+  status: done
 - commit: Configure CPT anomaly emergence detection
   path: config/emergence-detector.yaml
   task: Add CPT-Anomaly trigger for antimatter qubit monitoring

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add AntimatterQubitMonitor to QuantumTheoryAgent",
+  "lastCommit": "feat: add antimatter qubit microservice",
   "fractalStep": "quantum-agent",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "AntimatterQubitMonitor integrated; next: create antimatter microservice and CPT detector",
+  "notes": "Antimatter microservice added; next: configure CPT detector and link Archiv dataset",
   "pendingTasks": [
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
@@ -25,10 +25,6 @@
     },
     {
       "commit": "Finalize MandalaNetworkView MVP",
-      "status": "open"
-    },
-    {
-      "commit": "Create antimatter qubit microservice",
       "status": "open"
     },
     {
@@ -595,6 +591,10 @@
     },
     {
       "commit": "Add AntimatterQubitMonitor to QuantumTheoryAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Create antimatter qubit microservice",
       "status": "done"
     }
   ]

--- a/services/antimatter_service/__init__.py
+++ b/services/antimatter_service/__init__.py
@@ -1,0 +1,1 @@
+"""Antimatter qubit microservice package."""

--- a/services/antimatter_service/main.py
+++ b/services/antimatter_service/main.py
@@ -1,0 +1,30 @@
+"""Antimatter qubit microservice.
+
+Provides a small helper to fetch the latest
+antimatter qubit measurements from a remote API endpoint.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import requests
+
+DEFAULT_API_URL = "https://example.com/antimatter"
+
+def fetch_latest_measurements(api_url: str = DEFAULT_API_URL) -> Dict[str, Any]:
+    """Retrieve the latest antimatter qubit measurements.
+
+    Parameters
+    ----------
+    api_url:
+        Endpoint that returns JSON payload with measurement data.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Parsed JSON response from the API.
+    """
+    response = requests.get(api_url, timeout=10)
+    response.raise_for_status()
+    return response.json()

--- a/services/antimatter_service/main_test.py
+++ b/services/antimatter_service/main_test.py
@@ -1,0 +1,21 @@
+"""Tests for the antimatter qubit microservice."""
+
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from antimatter_service.main import fetch_latest_measurements  # type: ignore
+
+
+def test_fetch_latest_measurements_returns_json() -> None:
+    """Ensure the helper returns parsed JSON data."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"value": 3.14}
+    mock_response.raise_for_status.return_value = None
+
+    with patch("antimatter_service.main.requests.get", return_value=mock_response) as mock_get:
+        data = fetch_latest_measurements("http://test/api")
+
+        assert data == {"value": 3.14}
+        mock_get.assert_called_once_with("http://test/api", timeout=10)


### PR DESCRIPTION
## Summary
- add Python microservice for fetching antimatter qubit measurements
- cover microservice with unit test
- record completion in advancedToDo and progress tracker

## Testing
- `pytest services/antimatter_service/main_test.py`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_688e97d6771c83229321e312eaa53176