### PR TITLE
feat: add PactDepthGatekeeper role management

### DIFF
--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -187,7 +187,7 @@ todos:
     status: erledigt
   - id: todo-63
     beschreibung: "Rollenverwaltung im PactDepthGatekeeper implementieren"
-    status: offen
+    status: erledigt
   - id: todo-64
     beschreibung: "Dokumentationslinks je Agent in Agents.md ergänzen"
     status: erledigt

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "feat: add antimatter qubit microservice",
-  "fractalStep": "quantum-agent",
+  "lastCommit": "feat: implement PactDepthGatekeeper roles",
+  "fractalStep": "pact-depth-gatekeeper",
   "openBranches": [
     "work"
   ],
@@ -595,6 +595,11 @@
     },
     {
       "commit": "Create antimatter qubit microservice",
+      "status": "done"
+    }
+    ,
+    {
+      "commit": "Implement PactDepthGatekeeper role management",
       "status": "done"
     }
   ]

--- a/docs/agents/PactDepthGatekeeper.md
+++ b/docs/agents/PactDepthGatekeeper.md
@@ -3,10 +3,14 @@
 ## Responsibilities
 - Regelt Zugriffe abhängig von der ermittelten Tiefe.
 - Nutzt `pact-depth-rules.ts` sowie `activatedSigillin.json`.
+- Verarbeitet Rollen und erlaubt nur autorisierte Zugriffe.
 
 ## Parameters
 - `minLnSum` – erforderliche Mindesttiefe (Standard: 16).
 - `role` – Rolle des anfragenden Nutzers.
+
+## Role Access
+Nur Nutzer mit der Rolle `admin` erhalten Zugriff. `developer` und `guest` werden auch bei ausreichender Tiefe abgewiesen.
 
 ## Example usage
 ```bash

--- a/pact-depth-gatekeeper.ts
+++ b/pact-depth-gatekeeper.ts
@@ -1,0 +1,23 @@
+import { gatekeep, Role } from './pact-depth-rules';
+
+function parseArgs(): { depth: number; role: Role } {
+  const args = process.argv.slice(2);
+  const depthArg = args.find(a => a.startsWith('--depth'));
+  const roleArg = args.find(a => a.startsWith('--role'));
+
+  const depth = depthArg ? Number(depthArg.split('=')[1]) : NaN;
+  const role = roleArg ? (roleArg.split('=')[1] as Role) : undefined;
+
+  if (isNaN(depth) || !role) {
+    console.error('Usage: node pact-depth-gatekeeper.js --depth=<number> --role=<admin|developer|guest>');
+    process.exit(1);
+  }
+
+  return { depth, role };
+}
+
+if (require.main === module) {
+  const { depth, role } = parseArgs();
+  const result = gatekeep(depth, role);
+  console.log(result);
+}

--- a/pact-depth-rules.ts
+++ b/pact-depth-rules.ts
@@ -1,0 +1,31 @@
+export type Role = 'admin' | 'developer' | 'guest';
+
+export interface GatekeeperOptions {
+  /** Mindesttiefe, die erforderlich ist, um Zugriff zu erhalten. */
+  minLnSum?: number;
+  /** Liste der Rollen, die Zugriff erhalten. */
+  allowedRoles?: Role[];
+}
+
+const defaultOptions: Required<GatekeeperOptions> = {
+  minLnSum: 16,
+  allowedRoles: ['admin'],
+};
+
+/**
+ * Prüft, ob für die angegebene Tiefe und Rolle Zugriff gewährt wird.
+ */
+export function hasAccess(depth: number, role: Role, options: GatekeeperOptions = {}): boolean {
+  const { minLnSum, allowedRoles } = { ...defaultOptions, ...options };
+  if (depth < minLnSum) return false;
+  return allowedRoles.includes(role);
+}
+
+/**
+ * Ermittelt eine textuelle Antwort auf Basis der Zugriffsentscheidung.
+ */
+export function gatekeep(depth: number, role: Role, options: GatekeeperOptions = {}): string {
+  return hasAccess(depth, role, options)
+    ? 'Zugriff gewährt'
+    : 'Zugriff verweigert';
+}

--- a/tests/pact-depth-gatekeeper.test.ts
+++ b/tests/pact-depth-gatekeeper.test.ts
@@ -1,0 +1,15 @@
+import { hasAccess } from '../pact-depth-rules';
+
+describe('PactDepthGatekeeper', () => {
+  it('allows admin above depth threshold', () => {
+    expect(hasAccess(17, 'admin')).toBe(true);
+  });
+
+  it('denies insufficient depth', () => {
+    expect(hasAccess(10, 'admin')).toBe(false);
+  });
+
+  it('denies non-admin roles', () => {
+    expect(hasAccess(20, 'developer')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add pact-depth rules and CLI for role-aware depth checks
- document PactDepthGatekeeper role access and mark task done
- record progress in advancedprogress

## Testing
- `pnpm install --frozen-lockfile`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest tests/pact-depth-gatekeeper.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688e9fe10ddc8322b07bf3c7226b0709