### PR TITLE
feat: configure CPT anomaly emergence detection

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -339,7 +339,8 @@ codexbuild/               # Build-Skripte und Deploy-Hilfen
 codex-sync/              # Antwortsystem für Vorschläge
 ci/                      # Test- und Pipeline-Konfigurationen
 config/                  # Zentrale YAML- und Env-Dateien
-  └── interfaces.yaml       # API-Endpunkte der Plattform
+  ├── interfaces.yaml       # API-Endpunkte der Plattform
+  ├── emergence-detector.yaml  # CPT-Anomalie-Trigger für Antimaterie-Qubits
   ├── memory-manager.yaml  # Cleanup-Interval Konfiguration
   ├── memory-job-example.yaml # Vorlage für MemoryManager-Jobs
   └── memory-jobs/            # Weitere Job-Templates

--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ codexbuild/               # Build-Skripte und Deploy-Hilfen
 codex-sync/              # Antwortsystem für Vorschläge
 ci/                      # Test- und Pipeline-Konfigurationen
 config/                  # Zentrale YAML- und Env-Dateien
-  └── interfaces.yaml       # API-Endpunkte der Plattform
+  ├── interfaces.yaml       # API-Endpunkte der Plattform
+  ├── emergence-detector.yaml  # CPT-Anomalie-Trigger für Antimaterie-Qubits
   ├── memory-manager.yaml  # Cleanup-Interval Konfiguration
   ├── memory-job-example.yaml # Vorlage für MemoryManager-Jobs
   └── memory-jobs/            # Weitere Job-Templates

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8158,7 +8158,7 @@
     "path": "config/emergence-detector.yaml",
     "task": "Add CPT-Anomaly trigger for antimatter qubit monitoring",
     "test": "tests/emergence-detector.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Link Archiv dataset to QuantumTheoryAgent",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8937,7 +8937,7 @@
   path: config/emergence-detector.yaml
   task: Add CPT-Anomaly trigger for antimatter qubit monitoring
   test: tests/emergence-detector.test.ts
-  status: open
+  status: done
 - commit: Link Archiv dataset to QuantumTheoryAgent
   path: scripts/quantum-archive-ingest.ts
   task: Connect Menschheitsspuren records to QuantumTheoryAgent analysis

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: implement PactDepthGatekeeper roles",
-  "fractalStep": "pact-depth-gatekeeper",
+  "lastCommit": "feat: configure CPT anomaly emergence detection",
+  "fractalStep": "emergence-detector",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Antimatter microservice added; next: configure CPT detector and link Archiv dataset",
+  "notes": "CPT detector configured; next: link Archiv dataset and setup feedback loop",
   "pendingTasks": [
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
@@ -25,10 +25,6 @@
     },
     {
       "commit": "Finalize MandalaNetworkView MVP",
-      "status": "open"
-    },
-    {
-      "commit": "Configure CPT anomaly emergence detection",
       "status": "open"
     },
     {
@@ -596,8 +592,11 @@
     {
       "commit": "Create antimatter qubit microservice",
       "status": "done"
-    }
-    ,
+    },
+    {
+      "commit": "Configure CPT anomaly emergence detection",
+      "status": "done"
+    },
     {
       "commit": "Implement PactDepthGatekeeper role management",
       "status": "done"

--- a/config/emergence-detector.yaml
+++ b/config/emergence-detector.yaml
@@ -1,0 +1,8 @@
+schema_version: 1.0
+description: CPT-Anomalie-Trigger für Antimaterie-Qubit-Überwachung
+triggers:
+  - id: cpt-anomaly
+    source: antimatter-qubit-monitor
+    cpt_delta_threshold: 0.002
+    action: emit
+    event: cpt_anomaly_detected

--- a/tests/emergence-detector.test.ts
+++ b/tests/emergence-detector.test.ts
@@ -1,0 +1,17 @@
+/* @jest-environment node */
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+describe('emergence detector configuration', () => {
+  it('defines CPT anomaly trigger for antimatter qubit monitor', () => {
+    const config = yaml.load(
+      fs.readFileSync('config/emergence-detector.yaml', 'utf8')
+    ) as any;
+    expect(Array.isArray(config.triggers)).toBe(true);
+    const cpt = config.triggers.find((t: any) => t.id === 'cpt-anomaly');
+    expect(cpt).toBeDefined();
+    expect(cpt.source).toBe('antimatter-qubit-monitor');
+    expect(cpt.event).toBe('cpt_anomaly_detected');
+    expect(cpt.cpt_delta_threshold).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add CPT anomaly trigger configuration for antimatter qubits
- validate emergence-detector YAML via new Jest test
- document new config and update progress tracker

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest tests/emergence-detector.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688ea3982ba08322b8e1499ea6777e93