### PR TITLE
feat: add codex memory kernel

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -92,6 +92,7 @@ Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js`
 - `ShadowIntegration` – experimentelle Schnittstelle für Datentransfer.
 - `ResonanceModuleSynth` – erzeugt Audiosignale für Resonanzmodule.
 - `MemoryGovernance` – speichert Zustände mit Governance-Regeln.
+- `CodexMemoryKernel` – persistiert MemoryManager-Zustände als Referenzgedächtnis.
 - `TuringOrchestrator` – führt minimale Turing-Tests aus.
 - `Climate Module` – integriert Klimadaten ins Mandala.
 - `KIKeilschrift` – Werkzeuge zur Keilschrift-Verarbeitung.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**GrokAgent**](packages/agents/GrokAgent.ts) – simple pattern analyzer
 - [**ShadowIntegration**](packages/integration/ShadowIntegration.ts) – experimental data bridge
 - [**MemoryGovernance**](packages/core/MemoryGovernance.ts) – manage memory state
+- [**CodexMemoryKernel**](services/codex-memory-kernel.ts) – persists reference memory to disk
 - [**TuringOrchestrator**](packages/testing/TuringOrchestrator.ts) – run minimal Turing tests
 - [**TuringTestSuite**](packages/testing/TuringTestSuite.ts) – automated conversation Turing tests
 - [**Climate Module**](packages/unifiedmandala-climate/index.ts) – blueprint for climate data

--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -88,7 +88,7 @@ todos:
     status: erledigt
   - id: todo-30
     beschreibung: "codex-memory-kernel.ts zur Verwaltung eines persistenten Referenz-Gedächtnisses entwickeln"
-    status: offen
+    status: erledigt
   - id: todo-31
     beschreibung: "generate-todo-from-convos.ts implementieren, um aus conversations.json ToDos abzuleiten"
     status: offen

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add governance workflow and AI policy check",
-  "fractalStep": "governance-workflow",
+  "lastCommit": "feat: add codex memory kernel",
+  "fractalStep": "codex-memory-kernel",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Governance workflow added; next: link Archiv dataset and setup feedback loop",
+  "notes": "Codex memory kernel implemented; next: finalize MandalaNetworkView MVP and link Archiv dataset",
   "pendingTasks": [
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
@@ -600,10 +600,13 @@
     {
       "commit": "Implement PactDepthGatekeeper role management",
       "status": "done"
-    }
-    ,
+    },
     {
       "commit": "Add governance workflow and policy checks",
+      "status": "done"
+    },
+    {
+      "commit": "Add codex memory kernel",
       "status": "done"
     }
   ]

--- a/services/codex-memory-kernel.test.ts
+++ b/services/codex-memory-kernel.test.ts
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+import { CodexMemoryKernel } from './codex-memory-kernel';
+
+test('persists and loads memory entries', () => {
+  const temp = path.join(__dirname, 'tmp-memory.json');
+  try {
+    if (fs.existsSync(temp)) fs.unlinkSync(temp);
+    const kernel1 = new CodexMemoryKernel(temp);
+    kernel1.add('daily', 'hello');
+    kernel1.stop();
+    expect(fs.existsSync(temp)).toBe(true);
+    const kernel2 = new CodexMemoryKernel(temp);
+    expect(kernel2.get('daily')).toContain('hello');
+    kernel2.stop();
+  } finally {
+    if (fs.existsSync(temp)) fs.unlinkSync(temp);
+  }
+});

--- a/services/codex-memory-kernel.ts
+++ b/services/codex-memory-kernel.ts
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import { MemoryManager, MemoryCategory } from './memory-manager';
+
+export class CodexMemoryKernel {
+  constructor(
+    private file = 'codex-memory.json',
+    private manager = new MemoryManager()
+  ) {
+    this.load();
+  }
+
+  add(category: MemoryCategory, text: string) {
+    this.manager.add(category, text);
+    this.save();
+  }
+
+  get(category: MemoryCategory) {
+    return this.manager.get(category);
+  }
+
+  load() {
+    if (fs.existsSync(this.file)) {
+      const data = JSON.parse(fs.readFileSync(this.file, 'utf8')) as Record<MemoryCategory, string[]>;
+      Object.entries(data).forEach(([cat, entries]) => {
+        entries.forEach((e) => this.manager.add(cat as MemoryCategory, e));
+      });
+    }
+  }
+
+  save() {
+    const data: Record<MemoryCategory, string[]> = {} as any;
+    this.manager.getCategories().forEach((cat) => {
+      data[cat] = this.manager.get(cat);
+    });
+    fs.writeFileSync(this.file, JSON.stringify(data, null, 2), 'utf8');
+  }
+
+  stop() {
+    this.manager.stop();
+  }
+}
+
+export default CodexMemoryKernel;


### PR DESCRIPTION
## Summary
- add CodexMemoryKernel for persisting MemoryManager state
- document new memory kernel in README and Handbuch
- mark codex-memory-kernel todo as erledigt and track progress

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test services/codex-memory-kernel.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688f065234148322b36bdaabc93ad39a