### PR TITLE
feat: add depth sigil generator

### DIFF
--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -193,7 +193,7 @@ todos:
     status: erledigt
   - id: todo-65
     beschreibung: "depth-sigil-generator.ts zur Erstellung von Sigillin-Dateien aus Tiefenwerten entwickeln"
-    status: offen
+    status: erledigt
   - id: todo-66
     beschreibung: "crep-depth-router.ts implementieren, um Prozesse anhand der Faktortiefe zu lenken"
     status: offen

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8180,5 +8180,12 @@
     "task": "Visualize sync status of modules",
     "test": "packages/unifiedmandala-ui/components/MandalaDashboard.test.tsx",
     "status": "done"
+  },
+  {
+    "commit": "Add depth-sigil generator script",
+    "path": "scripts/depth-sigil-generator.ts",
+    "task": "Generate Sigillin files from depth values",
+    "test": "scripts/depth-sigil-generator.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8958,3 +8958,8 @@
   task: Visualize sync status of modules
   test: packages/unifiedmandala-ui/components/MandalaDashboard.test.tsx
   status: done
+- commit: Add depth-sigil generator script
+  path: scripts/depth-sigil-generator.ts
+  task: Generate Sigillin files from depth values
+  test: scripts/depth-sigil-generator.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add codex memory kernel",
-  "fractalStep": "codex-memory-kernel",
+  "lastCommit": "feat: implement depth sigil generator",
+  "fractalStep": "depth-sigil-generator",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Codex memory kernel implemented; next: finalize MandalaNetworkView MVP and link Archiv dataset",
+  "notes": "Depth sigil generator script added; next: finalize MandalaNetworkView MVP and link Archiv dataset",
   "pendingTasks": [
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
@@ -607,6 +607,10 @@
     },
     {
       "commit": "Add codex memory kernel",
+      "status": "done"
+    },
+    {
+      "commit": "Implement depth-sigil generator script",
       "status": "done"
     }
   ]

--- a/scripts/depth-sigil-generator.test.ts
+++ b/scripts/depth-sigil-generator.test.ts
@@ -1,0 +1,14 @@
+import fs from 'fs';
+import path from 'path';
+import { generateDepthSigil } from './depth-sigil-generator';
+
+describe('generateDepthSigil', () => {
+  const tempDir = path.join('docs', 'sigils');
+  it('creates a sigillin file with depth metadata', () => {
+    const file = generateDepthSigil(42, tempDir);
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(data.id).toBe('depth-42');
+    expect(data.depth).toBe(42);
+    fs.unlinkSync(file);
+  });
+});

--- a/scripts/depth-sigil-generator.ts
+++ b/scripts/depth-sigil-generator.ts
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import path from 'path';
+import { SigillinGenerator } from '../packages/genesis-sigillin-core/SigillinGenerator';
+
+/**
+ * Generates a Sigillin JSON file representing a depth value.
+ * @param depth numeric depth value
+ * @param outDir directory to write file to (default docs/sigils)
+ * @returns path to written file
+ */
+export function generateDepthSigil(depth: number, outDir = path.join('docs', 'sigils')): string {
+  const id = `depth-${depth}`;
+  const sig = SigillinGenerator(id, 'crep-trigger', 'draft', 'depth-sigil-generator');
+  (sig as any).depth = depth;
+  const filePath = path.join(outDir, `${id}.json`);
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(sig, null, 2));
+  return filePath;
+}
+
+if (require.main === module) {
+  const depthArg = process.argv[2];
+  if (!depthArg) {
+    console.error('Usage: depth-sigil-generator <depth> [outDir]');
+    process.exit(1);
+  }
+  const depth = Number(depthArg);
+  if (isNaN(depth)) {
+    console.error('Depth must be a number');
+    process.exit(1);
+  }
+  const dir = process.argv[3];
+  const file = generateDepthSigil(depth, dir);
+  console.log(`Generated ${file}`);
+}


### PR DESCRIPTION
## Summary
- add script to generate Sigillin JSON files from depth values
- test depth-sigil generator
- document completion in todo and progress trackers

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npm test scripts/depth-sigil-generator.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688f0c5cdb64832293998fba393b865b