### PR TITLE
feat: finalize MandalaNetworkView interactions

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8130,7 +8130,7 @@
     "path": "packages/unifiedmandala-ui/components/MandalaNetworkView.tsx",
     "task": "Implement Sigillin interaction and CREP visualization for funding demo",
     "test": "packages/unifiedmandala-ui/components/MandalaNetworkView.test.tsx",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add AntimatterQubitMonitor to QuantumTheoryAgent",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8922,7 +8922,7 @@
   path: packages/unifiedmandala-ui/components/MandalaNetworkView.tsx
   task: Implement Sigillin interaction and CREP visualization for funding demo
   test: packages/unifiedmandala-ui/components/MandalaNetworkView.test.tsx
-  status: open
+  status: done
 - commit: Add AntimatterQubitMonitor to QuantumTheoryAgent
   path: packages/agents/QuantumTheoryAgent.ts
   task: Monitor antimatter qubit CPT delta and emit anomalies

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add DeepScience experiment suite and improve sendemail hook",
-  "fractalStep": "deep-science-experiment",
+  "lastCommit": "feat: finalize MandalaNetworkView interactions",
+  "fractalStep": "mandala-networkview",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "DeepScience experiment suite initialized and sendemail hook validated; next: finalize MandalaNetworkView MVP and link Archiv dataset",
+  "notes": "MandalaNetworkView MVP finalized with interactive node details; next: link Archiv dataset and setup QuantumTheoryAgent feedback",
   "pendingTasks": [
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
@@ -25,7 +25,7 @@
     },
     {
       "commit": "Finalize MandalaNetworkView MVP",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Link Archiv dataset to QuantumTheoryAgent",

--- a/packages/unifiedmandala-ui/components/MandalaNetworkView.test.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaNetworkView.test.tsx
@@ -1,4 +1,5 @@
 // d3 ist ESM-only, daher hier minimal gemockt
+const mockOn = jest.fn();
 jest.mock('d3', () => ({
   select: () => ({
     selectAll: () => ({ remove: jest.fn() }),
@@ -11,6 +12,7 @@ jest.mock('d3', () => ({
       append: jest.fn().mockReturnThis(),
       text: jest.fn().mockReturnThis(),
       call: jest.fn().mockReturnThis(),
+      on: mockOn,
     }),
   }),
   forceSimulation: () => ({ force: jest.fn().mockReturnThis(), on: jest.fn() }),
@@ -34,4 +36,9 @@ test('renders svg and filter options', () => {
   // one option per type plus "Alle"
   const options = screen.getAllByRole('option');
   expect(options.length).toBeGreaterThan(2);
+});
+
+test('shows placeholder when no node is selected', () => {
+  render(<MandalaNetworkView />);
+  expect(screen.getByTestId('node-details')).toHaveTextContent('No node selected');
 });

--- a/packages/unifiedmandala-ui/components/MandalaNetworkView.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaNetworkView.tsx
@@ -28,6 +28,7 @@ export const MandalaNetworkView: React.FC = () => {
   const svgRef = useRef<SVGSVGElement>(null);
   const [filterType, setFilterType] = useState<string>('all');
   const [filterLevel, setFilterLevel] = useState<string>('all');
+  const [selectedNode, setSelectedNode] = useState<MandalaNode | null>(null);
   // verfügbare Sigillin-Typen für die Filter-UI ermitteln
   const types = Array.from(new Set(nodesData.map(n => n.type)));
 
@@ -99,7 +100,8 @@ export const MandalaNetworkView: React.FC = () => {
             d.fx = null;
             d.fy = null;
           })
-      );
+      )
+      .on('click', (_, d) => setSelectedNode(d));
 
     const label = svg.append("g")
       .selectAll("text")
@@ -178,6 +180,17 @@ export const MandalaNetworkView: React.FC = () => {
       <button onClick={handleExportSVG} className="mt-4 p-2 bg-blue-600 text-white rounded-lg shadow">
         Export as SVG
       </button>
+      {selectedNode ? (
+        <div data-testid="node-details" className="mt-4 p-2 border rounded text-center">
+          <div className="font-bold">{selectedNode.label}</div>
+          <div>
+            C:{selectedNode.crep.C} R:{selectedNode.crep.R} E:{selectedNode.crep.E} P:{selectedNode.crep.P}
+          </div>
+          {selectedNode.poetry && <div className="italic">{selectedNode.poetry}</div>}
+        </div>
+      ) : (
+        <div data-testid="node-details" className="mt-4 text-sm text-gray-600">No node selected</div>
+      )}
       <Tooltip id="node-tooltip" data-testid="tooltip-anchor" />
     </div>
   );


### PR DESCRIPTION
## Summary
- add interactive node selection and details to MandalaNetworkView
- record MandalaNetworkView completion in advanced task trackers

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest packages/unifiedmandala-ui/components/MandalaNetworkView.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_688f153e90c88322ab8803534b575096