### PR TITLE
feat: add PLAN-ANCHOR skeleton modules

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7867,20 +7867,6 @@
     "status": "done"
   },
   {
-    "commit": "Generate skeleton modules from PLAN-ANCHOR",
-    "path": "tasks/sigillin_skeleton.yaml",
-    "task": "Create initial module stubs based on PLAN-ANCHOR",
-    "test": "tasks/sigillin_skeleton.test.ts",
-    "status": "done"
-  },
-  {
-    "commit": "Enhance MandalaCanvas and CREPVisualizer UI",
-    "path": "packages/unifiedmandala-ui/components",
-    "task": "Add buttons for modules and visuals for CREP timeline",
-    "test": "packages/unifiedmandala-ui/components/UIEnhancements.test.tsx",
-    "status": "done"
-  },
-  {
     "commit": "Initialize DeepScience experiment suite",
     "path": "packages/experiments/DeepScience",
     "task": "Start automated stress tests and CREP tuning",
@@ -7927,7 +7913,7 @@
     "path": "tasks/sigillin_skeleton.yaml",
     "task": "Create initial module stubs based on PLAN-ANCHOR",
     "test": "tasks/sigillin_skeleton.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Enhance MandalaCanvas and CREPVisualizer UI",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8776,7 +8776,7 @@
   path: tasks/sigillin_skeleton.yaml
   task: Create initial module stubs based on PLAN-ANCHOR
   test: tasks/sigillin_skeleton.test.ts
-  status: open
+  status: done
 - commit: Enhance MandalaCanvas and CREPVisualizer UI
   path: packages/unifiedmandala-ui/components
   task: Add buttons for modules and visuals for CREP timeline

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,15 +1,15 @@
 {
-  "lastCommit": "feat: update kontext from new conversations",
-  "fractalStep": "kontext-sync",
+  "lastCommit": "feat: add PLAN-ANCHOR skeleton modules",
+  "fractalStep": "sigillin-skeleton",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Enhanced kontext updater to consume newadvancedconversations; marked kontext sync task as complete; next: setup QuantumTheoryAgent feedback",
+  "notes": "Created sigillin skeleton module stubs from PLAN-ANCHOR; next: enhance MandalaCanvas UI",
   "pendingTasks": [
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Enhance MandalaCanvas and CREPVisualizer UI",
@@ -37,6 +37,10 @@
     }
   ],
   "progress": [
+    {
+      "commit": "Generate skeleton modules from PLAN-ANCHOR",
+      "status": "done"
+    },
     {
       "commit": "Link Archiv dataset to QuantumTheoryAgent",
       "status": "done"

--- a/tasks/sigillin_skeleton.test.ts
+++ b/tasks/sigillin_skeleton.test.ts
@@ -1,0 +1,8 @@
+import fs from 'fs';
+import { parse } from 'yaml';
+
+test('sigillin skeleton has modules list', () => {
+  const file = fs.readFileSync('tasks/sigillin_skeleton.yaml', 'utf8');
+  const data = parse(file) as any;
+  expect(Array.isArray(data.modules)).toBe(true);
+});

--- a/tasks/sigillin_skeleton.yaml
+++ b/tasks/sigillin_skeleton.yaml
@@ -1,0 +1,7 @@
+modules:
+  - id: plan-anchor-core
+    description: Core module stub generated from PLAN-ANCHOR reference
+    status: stub
+  - id: plan-anchor-ui
+    description: UI binding stub for PLAN-ANCHOR integration
+    status: stub


### PR DESCRIPTION
## Summary
- scaffold sigillin skeleton modules from PLAN-ANCHOR
- record completion in advanced ToDos and progress log

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_688f289e03188322be5b710df3006f79