### PR TITLE
feat: enhance MandalaCanvas and CREPVisualizer UI

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7920,7 +7920,7 @@
     "path": "packages/unifiedmandala-ui/components",
     "task": "Add buttons for modules and visuals for CREP timeline",
     "test": "packages/unifiedmandala-ui/components/UIEnhancements.test.tsx",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add governance workflow",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8781,7 +8781,7 @@
   path: packages/unifiedmandala-ui/components
   task: Add buttons for modules and visuals for CREP timeline
   test: packages/unifiedmandala-ui/components/UIEnhancements.test.tsx
-  status: open
+  status: done
 - commit: Add governance workflow
   path: .github/workflows/governance.yml
   task: Setup GovernanceAgent checks and peer review workflow

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add PLAN-ANCHOR skeleton modules",
-  "fractalStep": "sigillin-skeleton",
+  "lastCommit": "feat: enhance MandalaCanvas and CREPVisualizer UI",
+  "fractalStep": "quantum-agent-feedback",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Created sigillin skeleton module stubs from PLAN-ANCHOR; next: enhance MandalaCanvas UI",
+  "notes": "Enhanced MandalaCanvas with module buttons and added CREP timeline axis; next: Setup QuantumTheoryAgent test feedback loop",
   "pendingTasks": [
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
@@ -13,7 +13,7 @@
     },
     {
       "commit": "Enhance MandalaCanvas and CREPVisualizer UI",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add governance workflow",
@@ -39,6 +39,10 @@
   "progress": [
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
+      "status": "done"
+    },
+    {
+      "commit": "Enhance MandalaCanvas and CREPVisualizer UI",
       "status": "done"
     },
     {

--- a/packages/unifiedmandala-ui/components/CREPVisualizer.tsx
+++ b/packages/unifiedmandala-ui/components/CREPVisualizer.tsx
@@ -11,6 +11,7 @@ const CREPVisualizer: React.FC<Props> = ({ history }) => {
   useEffect(() => {
     if (!ref.current) return;
     const svg = ref.current;
+    while (svg.firstChild) svg.removeChild(svg.firstChild);
     let x = 0;
     history.forEach((e) => {
       const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
@@ -22,6 +23,13 @@ const CREPVisualizer: React.FC<Props> = ({ history }) => {
       svg.appendChild(rect);
       x += 3;
     });
+    const axis = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    axis.setAttribute('x1', '0');
+    axis.setAttribute('y1', '50');
+    axis.setAttribute('x2', String(history.length * 3));
+    axis.setAttribute('y2', '50');
+    axis.setAttribute('stroke', '#333');
+    svg.appendChild(axis);
   }, [history]);
 
   return <svg ref={ref} width={300} height={60} aria-label="CREP Visualizer" />;

--- a/packages/unifiedmandala-ui/components/MandalaCanvas.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaCanvas.tsx
@@ -4,9 +4,11 @@ import { useEffect, useRef } from 'react';
 export interface MandalaCanvasProps {
   boundaryRules: string[];
   pantheonEvents: string[];
+  modules?: string[];
+  onModuleSelect?: (module: string) => void;
 }
 
-const MandalaCanvas: React.FC<MandalaCanvasProps> = ({ boundaryRules, pantheonEvents }) => {
+const MandalaCanvas: React.FC<MandalaCanvasProps> = ({ boundaryRules, pantheonEvents, modules = [], onModuleSelect }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
@@ -26,6 +28,11 @@ const MandalaCanvas: React.FC<MandalaCanvasProps> = ({ boundaryRules, pantheonEv
       <canvas ref={canvasRef} width={200} height={200} />
       <div data-testid="rule-count">{boundaryRules.length}</div>
       <div data-testid="event-count">{pantheonEvents.length}</div>
+      {modules.map((m) => (
+        <button key={m} onClick={() => onModuleSelect?.(m)}>
+          {m}
+        </button>
+      ))}
     </div>
   );
 };

--- a/packages/unifiedmandala-ui/components/UIEnhancements.test.tsx
+++ b/packages/unifiedmandala-ui/components/UIEnhancements.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MandalaCanvas from './MandalaCanvas';
+import CREPVisualizer from './CREPVisualizer';
+
+test('MandalaCanvas calls onModuleSelect when module button clicked', () => {
+  const onSelect = jest.fn();
+  const { getByText } = render(
+    <MandalaCanvas boundaryRules={[]} pantheonEvents={[]} modules={['m1']} onModuleSelect={onSelect} />
+  );
+  fireEvent.click(getByText('m1'));
+  expect(onSelect).toHaveBeenCalledWith('m1');
+});
+
+test('CREPVisualizer renders timeline axis', () => {
+  const { getByLabelText } = render(
+    <CREPVisualizer history={[{ timestamp: new Date(1), C: 1, R: 1, E: 1, P: 1 }]} />
+  );
+  const svg = getByLabelText('CREP Visualizer');
+  expect(svg.querySelector('line')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add module selection buttons to MandalaCanvas component
- draw timeline axis in CREPVisualizer and clear previous renders
- cover new UI behavior with dedicated UIEnhancements test and update progress docs

## Testing
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `pnpm test packages/unifiedmandala-ui/components/UIEnhancements.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688f2ddd83c08322b48b9a73fe6fa913