### PR TITLE
feat: add QuantumTheoryAgent feedback loop

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -22,6 +22,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
   mit aktuellem `update_time` erzeugt.
 Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js` und aktualisiere `advancedToDo.json` sowie `advancedprogress.json`.
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
+- QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`
 
 > **TL;DR**
 > - Installation: `./scripts/setup-unifiedmandala.sh`

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**MandalaNetworkView**](packages/unifiedmandala-ui/components/MandalaNetworkView.tsx) – Visualisierung aller Sigillin-Knoten und CREP-Felder
 - [**ArchiveMap**](packages/unifiedmandala-ui/components/ArchiveMap.tsx) – Interaktive Karte der Archiv Menschheitsspuren
 - [**QuantumArchiv-Ingest**](scripts/quantum-archive-ingest.ts) – verbindet das Archiv Menschheitsspuren mit dem QuantumTheoryAgent zur Anomalieerkennung
+- [**QuantumAgent Feedback Loop**](scripts/quantum-agent-feedback.ts) – sammelt Testergebnisse des QuantumTheoryAgent
 - [**SigillinLoader**](packages/unifiedmandala-ui/components/SigillinLoader.tsx) – Import & Filter von Sigillin-Dateien
 - [**AutoDoc & Manifest-Generator**](packages/crep-engine/autoDocGeneration.ts) – Dokumentation auf Knopfdruck
 - [**FourierLayer Analyse**](packages/analysis/FourierLayer.ts) – Frequenzbasierte Emergenzbewertung

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8158,7 +8158,7 @@
     "path": "scripts/quantum-agent-feedback.ts",
     "task": "Run QuantumTheoryAgent program tests and collect feedback",
     "test": "scripts/quantum-agent-feedback.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add Mandala Dashboard component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8952,7 +8952,7 @@
   path: scripts/quantum-agent-feedback.ts
   task: Run QuantumTheoryAgent program tests and collect feedback
   test: scripts/quantum-agent-feedback.test.ts
-  status: open
+  status: done
 - commit: Add Mandala Dashboard component
   path: packages/unifiedmandala-ui/components/MandalaDashboard.tsx
   task: Visualize sync status of modules

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: enhance MandalaCanvas and CREPVisualizer UI",
-  "fractalStep": "quantum-agent-feedback",
+  "lastCommit": "feat: add QuantumTheoryAgent test feedback loop",
+  "fractalStep": "review-newadvancedconvos",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Enhanced MandalaCanvas with module buttons and added CREP timeline axis; next: Setup QuantumTheoryAgent test feedback loop",
+  "notes": "QuantumTheoryAgent feedback script implemented; next: review new advanced conversations",
   "pendingTasks": [
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
@@ -33,10 +33,14 @@
     },
     {
       "commit": "Setup QuantumTheoryAgent test feedback loop",
-      "status": "open"
+      "status": "done"
     }
   ],
   "progress": [
+    {
+      "commit": "Setup QuantumTheoryAgent test feedback loop",
+      "status": "done"
+    },
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
       "status": "done"

--- a/scripts/quantum-agent-feedback.test.ts
+++ b/scripts/quantum-agent-feedback.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { runQuantumAgentTests } from './quantum-agent-feedback';
+
+function mockRunner() {
+  return `PASS QuantumTheoryAgent emits anomaly\nFAIL QuantumTheoryAgent handles safe measurements`;
+}
+
+describe('runQuantumAgentTests', () => {
+  it('summarizes vitest output', () => {
+    const summary = runQuantumAgentTests(mockRunner);
+    expect(summary).toEqual({ total: 2, passed: 1, failed: 1 });
+  });
+});

--- a/scripts/quantum-agent-feedback.ts
+++ b/scripts/quantum-agent-feedback.ts
@@ -1,0 +1,19 @@
+import { spawnSync } from 'child_process';
+import { analyzeTestLog, FeedbackSummary } from './feedback-analyzer';
+
+export function runQuantumAgentTests(runCommand: () => string = defaultRunCommand): FeedbackSummary {
+  const output = runCommand();
+  return analyzeTestLog(output);
+}
+
+function defaultRunCommand(): string {
+  const result = spawnSync('npx', ['vitest', 'run', 'packages/agents/QuantumTheoryAgent.test.ts'], {
+    encoding: 'utf8'
+  });
+  return `${result.stdout ?? ''}${result.stderr ?? ''}`;
+}
+
+if (require.main === module) {
+  const summary = runQuantumAgentTests();
+  console.log(JSON.stringify(summary, null, 2));
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,8 @@ export default defineConfig({
     include: [
       'packages/agents/**/*.{test,spec}.ts',
       'packages/boundary-engine/**/*.{test,spec}.ts',
-      'packages/api/**/*.{test,spec}.ts'
+      'packages/api/**/*.{test,spec}.ts',
+      'scripts/**/*.{test,spec}.ts'
     ],
     environment: 'node'
   }


### PR DESCRIPTION
## Summary
- add `quantum-agent-feedback` script to run QuantumTheoryAgent tests and summarize results
- track completion in advanced todo/progress and document script in README and Handbuch
- enable script tests by extending vitest config

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/quantum-agent-feedback.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688f34124df483228853ce29d382e825