### PR TITLE
feat(ui): add SigillinFractalVisualizer component

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -212,6 +212,7 @@ GPTEventHub.emit('orakel:says', { content: 'Hallo Welt' });
 - `CREPTriggerPanel` – Buttons zum Auslösen von CREP-Ereignissen.
 - `LiveCREPPanel` – Kombiniert Trigger und Chart für Live-Daten.
 - `SigillinLoader` – Lädt Sigillin-Dateien und filtert Einträge.
+- `SigillinFractalVisualizer` – Generiert einfache Fraktalkunst aus Sigillin-Daten.
 - `SelfAuditModul` – Zeigt Kennzahlen aus `selfAnalyzer`.
 - `useSymbolzeit` – liest Symbolphasen aus der YAML und steuert Farben dynamisch.
 - `useBreakpoint` – erkennt mobile Ansichten für responsive Layouts.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**SelfAuditModul**](packages/unifiedmandala-ui/components/SelfAuditModul.tsx) – analysiert die Repository-Struktur
 - [**AdminMetrics**](packages/unifiedmandala-ui/README.md) – zeigt CREP- und Sigillin-Kennzahlen
 - [**SigillinViewer & SigillinMap**](packages/unifiedmandala-ui/components/SigillinMap.tsx) – Übersicht und Detailansicht aller Sigillin
+- [**SigillinFractalVisualizer**](packages/unifiedmandala-ui/components/SigillinFractalVisualizer.tsx) – Fraktalkunst aus Sigillin-Daten
 - [**SymbolicWayfinder & SoforthilfeOverlay**](packages/unifiedmandala-ui/components/SymbolicWayfinder.tsx) – Navigation und Hilfedialoge
 - [**CREPChart & CREPTriggerPanel**](packages/unifiedmandala-ui/components/CREPChart.tsx) – CREP-Historie und Steuerung
 - [**CREPTestHarness**](packages/unifiedmandala-ui/components/CREPTestHarness.tsx) – UI zum Durchspielen von CREP-Werten

--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -4,7 +4,7 @@ todos:
     status: erledigt
   - id: todo-2
     beschreibung: "Fraktalkunst-Visualizer f\xC3\xBCr Sigillin-Daten in der UI integrieren"
-    status: offen
+    status: erledigt
   - id: todo-3
     beschreibung: "Innovationsplanung-Modul auf Basis der conversations.json entwickeln"
     status: offen

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add codex-sync script",
-  "fractalStep": "implement-codex-sync",
+  "lastCommit": "feat: add SigillinFractalVisualizer component",
+  "fractalStep": "integrate-sigillin-fractal-visualizer",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added codex-sync script with sigillin hashing; continue reviewing new advanced conversations",
+  "notes": "Added SigillinFractalVisualizer and updated ToDo; next implement innovationsplanung module",
   "pendingTasks": [
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
@@ -36,7 +36,11 @@
       "status": "done"
     }
   ],
-  "progress": [
+"progress": [
+    {
+      "commit": "Add Sigillin Fractal Visualizer component",
+      "status": "done"
+    },
     {
       "commit": "implement generate-todo-from-convos script",
       "status": "done"

--- a/packages/unifiedmandala-ui/components/SigillinFractalVisualizer.test.tsx
+++ b/packages/unifiedmandala-ui/components/SigillinFractalVisualizer.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SigillinFractalVisualizer from './SigillinFractalVisualizer';
+
+test('renders fractal pieces for each sigil', () => {
+  const data = [
+    { id: 'a', value: 1 },
+    { id: 'b', value: 2 },
+  ];
+  render(<SigillinFractalVisualizer sigillinData={data} />);
+  const pieces = screen.getAllByTestId('fractal-piece');
+  expect(pieces).toHaveLength(2);
+});

--- a/packages/unifiedmandala-ui/components/SigillinFractalVisualizer.tsx
+++ b/packages/unifiedmandala-ui/components/SigillinFractalVisualizer.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface SigillinFractalVisualizerProps {
+  sigillinData: Array<{ id: string; value: number }>;
+}
+
+const SigillinFractalVisualizer: React.FC<SigillinFractalVisualizerProps> = ({ sigillinData }) => (
+  <div aria-label="Sigillin Fraktalkunst">
+    {sigillinData.map(sigil => (
+      <div
+        key={sigil.id}
+        data-testid="fractal-piece"
+        style={{
+          width: 20,
+          height: 20,
+          margin: 2,
+          backgroundColor: `hsl(${(sigil.value * 40) % 360}, 70%, 50%)`,
+          transform: `scale(${1 + sigil.value * 0.1})`,
+        }}
+      />
+    ))}
+  </div>
+);
+
+export default SigillinFractalVisualizer;

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -39,3 +39,4 @@ export { default as BlackboxMandala } from './components/BlackboxMandala';
 export { default as MandalaCanvas } from './components/MandalaCanvas';
 export { default as AIUI } from './components/AIUI';
 export { default as ArchiveMap } from './components/ArchiveMap';
+export { default as SigillinFractalVisualizer } from './components/SigillinFractalVisualizer';


### PR DESCRIPTION
## Summary
- add `SigillinFractalVisualizer` UI component with test
- export visualizer and mark ToDo as complete
- document new feature in README/Handbuch and update fractal progress

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx jest packages/unifiedmandala-ui/components/SigillinFractalVisualizer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688f496d9b9c8322b7489782682bafb2