### PR TITLE
feat: add crep flow synchronizer

### DIFF
--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -100,7 +100,7 @@ todos:
     status: erledigt
   - id: todo-34
     beschreibung: "crep-flow-synchronizer.ts implementieren für CREP-Datenabgleich zwischen Repositories"
-    status: offen
+    status: erledigt
   - id: todo-35
     beschreibung: "symbolic-context-injector.ts erstellen, um symbolische Informationen in den Codex zu injizieren"
     status: offen
@@ -111,7 +111,7 @@ todos:
     beschreibung: "emergence_signal_hub.ts zur Koordination von CREP- und Sigillin-Signalen bauen"
     status: offen
   - id: todo-38
-    beschreibung: "GenesisOS-Modul \"KernelGPT-DriverBuilder\" vorbereiten"
+    beschreibung: 'GenesisOS-Modul "KernelGPT-DriverBuilder" vorbereiten'
     status: offen
   - id: todo-39
     beschreibung: "Proof of Concept: USB-Tastatur als Sigillin-Device einbinden"

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,9 @@
 {
-  "lastCommit": "feat: add CREPTooltip component",
-  "fractalStep": "implement-crep-tooltip",
-  "openBranches": [
-    "work"
-  ],
+  "lastCommit": "feat: add crep-flow-synchronizer script",
+  "fractalStep": "implement-crep-flow-synchronizer",
+  "openBranches": ["work"],
   "mergeConflicts": [],
-  "notes": "Added CREPTooltip component; next implement CREPInfoModal",
+  "notes": "Added CREP flow synchronizer; next implement symbolic-context-injector",
   "pendingTasks": [
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
@@ -36,7 +34,7 @@
       "status": "done"
     },
     {
-      "commit": "Implement CREPInfoModal component",
+      "commit": "Implement symbolic-context-injector module",
       "status": "open"
     }
   ],
@@ -432,6 +430,10 @@
     {
       "commit": "Add CREPTooltip component",
       "status": "done"
+    },
+    {
+      "commit": "add crep-flow-synchronizer script",
+      "status": "done"
     }
   ],
   "completed": [
@@ -663,6 +665,10 @@
     },
     {
       "commit": "Integrate nucleon scanner with crep engine",
+      "status": "done"
+    },
+    {
+      "commit": "add crep-flow-synchronizer script",
       "status": "done"
     }
   ]

--- a/scripts/crep-flow-synchronizer.test.ts
+++ b/scripts/crep-flow-synchronizer.test.ts
@@ -1,0 +1,30 @@
+import { mkdtempSync, writeFileSync, readFileSync } from "fs";
+import os from "os";
+import path from "path";
+import { syncCREP } from "./crep-flow-synchronizer";
+
+describe("syncCREP", () => {
+  it("merges source into target", () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "crep-test-"));
+    const source = path.join(tmp, "source");
+    const target = path.join(tmp, "target");
+    const fs = require("fs");
+    fs.mkdirSync(source);
+    fs.mkdirSync(target);
+    writeFileSync(
+      path.join(source, "crep.json"),
+      JSON.stringify({ score: 0.8, events: ["a"] }),
+    );
+    writeFileSync(
+      path.join(target, "crep.json"),
+      JSON.stringify({ score: 0.5, notes: ["old"] }),
+    );
+
+    syncCREP(source, target);
+
+    const result = JSON.parse(
+      readFileSync(path.join(target, "crep.json"), "utf8"),
+    );
+    expect(result).toEqual({ score: 0.8, notes: ["old"], events: ["a"] });
+  });
+});

--- a/scripts/crep-flow-synchronizer.ts
+++ b/scripts/crep-flow-synchronizer.ts
@@ -1,0 +1,32 @@
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import path from "path";
+
+export interface CREPData {
+  [key: string]: any;
+}
+
+export function syncCREP(sourceDir: string, targetDir: string) {
+  const sourcePath = path.join(sourceDir, "crep.json");
+  const targetPath = path.join(targetDir, "crep.json");
+  if (!existsSync(sourcePath)) {
+    throw new Error(`Source file not found: ${sourcePath}`);
+  }
+  const sourceData: CREPData = JSON.parse(readFileSync(sourcePath, "utf8"));
+  let targetData: CREPData = {};
+  if (existsSync(targetPath)) {
+    targetData = JSON.parse(readFileSync(targetPath, "utf8"));
+  }
+  const merged = { ...targetData, ...sourceData };
+  writeFileSync(targetPath, JSON.stringify(merged, null, 2));
+}
+
+if (require.main === module) {
+  const [source, target] = process.argv.slice(2);
+  if (!source || !target) {
+    console.error(
+      "Usage: ts-node crep-flow-synchronizer.ts <sourceDir> <targetDir>",
+    );
+    process.exit(1);
+  }
+  syncCREP(source, target);
+}


### PR DESCRIPTION
## Summary
- add script to sync CREP data between repositories
- record new fractal step and pending task in advancedprogress
- mark crep-flow-synchronizer todo as completed

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_688f97b3fd588322b09c22b9077d979e