### PR TITLE
docs: track metacommit tags for next tasks

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,9 +1,11 @@
 {
   "lastCommit": "feat: add crep-flow-synchronizer script",
   "fractalStep": "implement-crep-flow-synchronizer",
-  "openBranches": ["work"],
+  "openBranches": [
+    "work"
+  ],
   "mergeConflicts": [],
-  "notes": "Added CREP flow synchronizer; next implement symbolic-context-injector",
+  "notes": "Parsed Sigillin sessions; next setup semantic-release and symbolic-context-injector",
   "pendingTasks": [
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
@@ -35,6 +37,14 @@
     },
     {
       "commit": "Implement symbolic-context-injector module",
+      "status": "open"
+    },
+    {
+      "commit": "Setup semantic-release pipeline",
+      "status": "open"
+    },
+    {
+      "commit": "Configure Docker Compose deployment",
       "status": "open"
     }
   ],
@@ -671,5 +681,8 @@
       "commit": "add crep-flow-synchronizer script",
       "status": "done"
     }
+  ],
+  "metacommitTags": [
+    "meta:extract-features"
   ]
 }


### PR DESCRIPTION
## Summary
- track metacommit tags in `advancedprogress.json`
- queue CI/CD and deployment setup tasks for next fractal step

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_688f9e62fe24832295d95e9960b8e1cb