### PR TITLE
feat(core): add symbolic context injector

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**ShadowIntegration**](packages/integration/ShadowIntegration.ts) – experimental data bridge
 - [**MemoryGovernance**](packages/core/MemoryGovernance.ts) – manage memory state
 - [**CodexMemoryKernel**](services/codex-memory-kernel.ts) – persists reference memory to disk
+- [**SymbolicContextInjector**](packages/core/SymbolicContextInjector.ts) – injiziert symbolische Informationen in den Codex
 - [**TuringOrchestrator**](packages/testing/TuringOrchestrator.ts) – run minimal Turing tests
 - [**TuringTestSuite**](packages/testing/TuringTestSuite.ts) – automated conversation Turing tests
 - [**Climate Module**](packages/unifiedmandala-climate/index.ts) – blueprint for climate data

--- a/ToDo.yaml
+++ b/ToDo.yaml
@@ -103,7 +103,7 @@ todos:
     status: erledigt
   - id: todo-35
     beschreibung: "symbolic-context-injector.ts erstellen, um symbolische Informationen in den Codex zu injizieren"
-    status: offen
+    status: erledigt
   - id: todo-36
     beschreibung: "sigillin_bridge_engine.ts konzipieren für Sigillin-basierte Verbindungen"
     status: offen

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add crep-flow-synchronizer script",
-  "fractalStep": "implement-crep-flow-synchronizer",
+  "lastCommit": "feat: implement symbolic-context-injector module",
+  "fractalStep": "implement-symbolic-context-injector",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Parsed Sigillin sessions; next setup semantic-release and symbolic-context-injector",
+  "notes": "Symbolic context injector added; next setup semantic-release and docker compose deployment",
   "pendingTasks": [
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
@@ -37,7 +37,7 @@
     },
     {
       "commit": "Implement symbolic-context-injector module",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Setup semantic-release pipeline",
@@ -679,6 +679,10 @@
     },
     {
       "commit": "add crep-flow-synchronizer script",
+      "status": "done"
+    },
+    {
+      "commit": "Implement symbolic-context-injector module",
       "status": "done"
     }
   ],

--- a/packages/core/SymbolicContextInjector.test.ts
+++ b/packages/core/SymbolicContextInjector.test.ts
@@ -1,0 +1,15 @@
+import { SymbolicContextInjector } from './SymbolicContextInjector';
+
+describe('SymbolicContextInjector', () => {
+  it('injects single symbol into context', () => {
+    const injector = new SymbolicContextInjector();
+    injector.inject('alpha', 42);
+    expect(injector.get('alpha')).toBe(42);
+  });
+
+  it('merges multiple entries', () => {
+    const injector = new SymbolicContextInjector({ beta: 'init' });
+    injector.injectAll({ gamma: true });
+    expect(injector.getContext()).toEqual({ beta: 'init', gamma: true });
+  });
+});

--- a/packages/core/SymbolicContextInjector.ts
+++ b/packages/core/SymbolicContextInjector.ts
@@ -1,0 +1,24 @@
+export class SymbolicContextInjector {
+  private context: Record<string, unknown>;
+
+  constructor(initial: Record<string, unknown> = {}) {
+    this.context = { ...initial };
+  }
+
+  inject(symbol: string, value: unknown): void {
+    this.context[symbol] = value;
+  }
+
+  injectAll(entries: Record<string, unknown>): void {
+    this.context = { ...this.context, ...entries };
+  }
+
+  get(symbol: string): unknown {
+    return this.context[symbol];
+  }
+
+  getContext(): Record<string, unknown> {
+    return { ...this.context };
+  }
+}
+export default SymbolicContextInjector;


### PR DESCRIPTION
## Summary
- add `SymbolicContextInjector` utility for merging symbolic context into the codex
- document injector in README and mark related todo complete
- update progress tracker for symbolic context work

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright packages/core/SymbolicContextInjector.ts packages/core/SymbolicContextInjector.test.ts`
- `npx tsc -p tsconfig.json`
- `npx jest packages/core/SymbolicContextInjector.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688fa2174a408322b00396ae51e2b723