### PR TITLE
feat: add codeagent scaffolding

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -311,7 +311,7 @@ packages/
   ├── pkg/chem             # Reaction kinetics simulation
   ├── pkg/mind             # Hybrid symbolic & neural agents
   ├── pkg/sonifier         # CREP-to-MIDI music generator
-  ├── pkg/codeagent        # Language-specific code agents
+  ├── go-agent/pkg/codeagent        # Language-specific code agents
   ├── art                 # Sonification & AI-Art
   ├── shared-utils              # Hilfsfunktionen für alle Pakete
   │   └── RestClient.ts         # einfacher REST-Helper
@@ -324,7 +324,7 @@ packages/
   │   └── pkg/hooks         # Event Hook Publisher
   ├── mandala              # Aktiviert Mandala-Kollektive
   ├── orchestrator         # Steuert Boundary- und Pantheon-Dienste
-  ├── cmd/mandala-codeagent.go  # Beispiel-CLI für CodeAgent
+  ├── go-agent/cmd/mandala-codeagent  # CLI entrypoint for CodeAgent
   ├── services/vector-indexer # Embedding generator service
   ├── services/sigil-trigger  # Beobachtet Sigillin-Änderungen
   ├── services/memorymesh     # Region-Archive und Reflexionsdienste

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**SymbolicContextInjector**](packages/core/SymbolicContextInjector.ts) – injiziert symbolische Informationen in den Codex
 - [**TuringOrchestrator**](packages/testing/TuringOrchestrator.ts) – run minimal Turing tests
 - [**TuringTestSuite**](packages/testing/TuringTestSuite.ts) – automated conversation Turing tests
+- [**CodeAgent**](go-agent/pkg/codeagent) – scaffold for language-aware automation with CLI support
 - [**Climate Module**](packages/unifiedmandala-climate/index.ts) – blueprint for climate data
 - [**Keilschrift Module**](packages/aeon-labs/keilschrift/index.ts) – cuneiform utilities
 - [**ZivilisationsSandbox**](packages/pantheon/ZivilisationsSandbox/index.ts) – simulate ancient builds

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -771,9 +771,10 @@
   },
   {
     "commit": "Add CodeAgent scaffolding",
-    "path": "pkg/codeagent",
+    "path": "go-agent/pkg/codeagent",
     "task": "Skeleton for language agents and CLI",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Add C-Tutor skeleton",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8976,3 +8976,8 @@
   task: Bridge conversation memories with phi analysis
   test: packages/nukleon-scanner/CREPBridge.test.ts
   status: done
+- commit: Add CodeAgent scaffolding
+  path: go-agent/pkg/codeagent
+  task: Skeleton for language agents and CLI
+  test: go-agent/pkg/codeagent/agent_test.go
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add crep-depth-router script",
-  "fractalStep": "implement-crep-depth-router",
+  "lastCommit": "feat: add codeagent scaffolding",
+  "fractalStep": "implement-codeagent-scaffolding",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented crep-depth-router script; marked go-agent tasks done",
+  "notes": "Implemented CodeAgent scaffolding and CLI",
   "pendingTasks": [
     {
       "commit": "Generate skeleton modules from PLAN-ANCHOR",
@@ -447,6 +447,10 @@
     },
     {
       "commit": "Implement crep-depth-router script",
+      "status": "done"
+    },
+    {
+      "commit": "Add CodeAgent scaffolding",
       "status": "done"
     }
   ],

--- a/cmd/mandala-codeagent.go
+++ b/cmd/mandala-codeagent.go
@@ -1,7 +1,0 @@
-package main
-
-import "fmt"
-
-func main() {
-    fmt.Println("mandala-codeagent placeholder")
-}

--- a/go-agent/cmd/mandala-codeagent/main.go
+++ b/go-agent/cmd/mandala-codeagent/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "github.com/unified-mandala/go-agent/pkg/codeagent"
+
+func main() {
+    codeagent.RunCLI()
+}
+

--- a/go-agent/pkg/codeagent/agent.go
+++ b/go-agent/pkg/codeagent/agent.go
@@ -1,0 +1,18 @@
+package codeagent
+
+// Agent provides a minimal language-aware code agent.
+type Agent struct {
+    Name string
+}
+
+// New creates a new Agent with the given name.
+func New(name string) *Agent {
+    return &Agent{Name: name}
+}
+
+// Run executes the provided code snippet.
+// Currently it simply returns the snippet unchanged.
+func (a *Agent) Run(code string) string {
+    return code
+}
+

--- a/go-agent/pkg/codeagent/agent_test.go
+++ b/go-agent/pkg/codeagent/agent_test.go
@@ -1,0 +1,12 @@
+package codeagent
+
+import "testing"
+
+func TestAgentRun(t *testing.T) {
+    a := New("tester")
+    got := a.Run("echo")
+    if got != "echo" {
+        t.Fatalf("expected echo, got %s", got)
+    }
+}
+

--- a/go-agent/pkg/codeagent/cli.go
+++ b/go-agent/pkg/codeagent/cli.go
@@ -1,0 +1,18 @@
+package codeagent
+
+import (
+    "flag"
+    "fmt"
+)
+
+// RunCLI parses command-line flags and runs the agent.
+func RunCLI() {
+    name := flag.String("name", "CodeAgent", "agent name")
+    code := flag.String("code", "", "code snippet to run")
+    flag.Parse()
+
+    agent := New(*name)
+    result := agent.Run(*code)
+    fmt.Print(result)
+}
+


### PR DESCRIPTION
## Summary
- scaffold minimal CodeAgent package with CLI runner
- document CodeAgent in README and Handbuch
- mark CodeAgent task as complete in advancedToDo and progress log

## Testing
- `go test ./pkg/codeagent` (inside go-agent)
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_688fb0ec47ac83229ee81057647de056