### PR TITLE
feat: enhance memory governance clearing

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6917,7 +6917,8 @@
     "commit": "Add MemoryGovernanceService.clear method",
     "path": "services/memory-governance/index.ts",
     "task": "Allow clearing memory buckets",
-    "test": "services/memory-governance/index.test.ts"
+    "test": "services/memory-governance/index.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add getCategories to MemoryManager and governance",
@@ -6930,19 +6931,22 @@
     "commit": "Add ExtendedResonanceGateway",
     "path": "packages/resonance/ExtendedResonanceGateway.ts",
     "task": "Bridge resonance modules with boundary events",
-    "test": "packages/resonance/ExtendedResonanceGateway.test.ts"
+    "test": "packages/resonance/ExtendedResonanceGateway.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add PantheonAvatarHub module",
     "path": "packages/pantheon/PantheonAvatarHub.ts",
     "task": "Manage avatars in VR Pantheon space",
-    "test": "packages/pantheon/PantheonAvatarHub.test.ts"
+    "test": "packages/pantheon/PantheonAvatarHub.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add VRResonanceVisualizer component",
     "path": "packages/unifiedmandala-vr/VRResonanceVisualizer.ts",
     "task": "Visualize CREP resonance in VR",
-    "test": "packages/unifiedmandala-vr/VRResonanceVisualizer.test.ts"
+    "test": "packages/unifiedmandala-vr/VRResonanceVisualizer.test.ts",
+    "status": "done"
   },
   {
     "commit": "Document Pantheon-Boundary integration plan",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -7997,18 +7997,22 @@
   path: services/memory-governance/index.ts
   task: Allow clearing memory buckets
   test: services/memory-governance/index.test.ts
+  status: done
 - commit: Add ExtendedResonanceGateway
   path: packages/resonance/ExtendedResonanceGateway.ts
   task: Bridge resonance modules with boundary events
   test: packages/resonance/ExtendedResonanceGateway.test.ts
+  status: done
 - commit: Add PantheonAvatarHub module
   path: packages/pantheon/PantheonAvatarHub.ts
   task: Manage avatars in VR Pantheon space
   test: packages/pantheon/PantheonAvatarHub.test.ts
+  status: done
 - commit: Add VRResonanceVisualizer component
   path: packages/unifiedmandala-vr/VRResonanceVisualizer.ts
   task: Visualize CREP resonance in VR
   test: packages/unifiedmandala-vr/VRResonanceVisualizer.test.ts
+  status: done
 - commit: Document Pantheon-Boundary integration plan
   path: docs/boundary/PantheonBoundaryIntegration.md
   task: Summarize integration blueprint from chats

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Draft Friendship system concept",
+  "lastCommit": "Finalize MemoryGovernanceService clear method",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Expanded friendship system concept and updated docs",
+  "notes": "Enhanced memory governance clearing and marked resonance tasks as done",
   "pendingTasks": [],
   "progress": [
     {
@@ -790,6 +790,10 @@
     },
     {
       "commit": "Draft Friendship system concept",
+      "status": "done"
+    },
+    {
+      "commit": "Finalize MemoryGovernanceService clear method",
       "status": "done"
     }
   ],

--- a/services/memory-governance/index.test.ts
+++ b/services/memory-governance/index.test.ts
@@ -24,9 +24,21 @@ test('clear resets selected category', () => {
   manager.add('daily', 'one');
   manager.add('weekly', 'two');
   const governance = new MemoryGovernanceService(manager);
-  governance.clear('daily');
+  const removed = governance.clear('daily');
+  expect(removed).toBe(1);
   expect(manager.get('daily')).toEqual([]);
   expect(manager.get('weekly')).toEqual(['two']);
+});
+
+test('clear without category wipes all entries', () => {
+  const manager = new MemoryManager({ daily: 0, weekly: 0, longterm: 0 });
+  manager.add('daily', 'one');
+  manager.add('weekly', 'two');
+  const governance = new MemoryGovernanceService(manager);
+  const removed = governance.clear();
+  expect(removed).toBe(2);
+  expect(manager.get('daily')).toEqual([]);
+  expect(manager.get('weekly')).toEqual([]);
 });
 
 test('listCategories returns manager categories', () => {

--- a/services/memory-governance/index.ts
+++ b/services/memory-governance/index.ts
@@ -17,8 +17,18 @@ export class MemoryGovernanceService {
     return this.manager.get(category).filter((t) => traumaRegex.test(t));
   }
 
-  clear(category?: MemoryCategory) {
-    this.manager.clear(category as any);
+  clear(category?: MemoryCategory): number {
+    if (category) {
+      const count = this.manager.get(category).length;
+      this.manager.clear(category);
+      return count;
+    }
+    let count = 0;
+    this.listCategories().forEach((cat) => {
+      count += this.manager.get(cat).length;
+    });
+    this.manager.clear();
+    return count;
   }
 
   listCategories(): MemoryCategory[] {


### PR DESCRIPTION
## Summary
- allow `MemoryGovernanceService.clear` to report number of entries removed and wipe all categories
- record completion of related resonance and pantheon tasks in advanced todo tracking
- log fractal progress for memory governance update

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test services/memory-governance/index.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688fe647f6cc832288fbd4f6b07da08c