### PR TITLE
Add analyzer for new advanced conversations

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -22,6 +22,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - Über `scripts/generate-next-sigil.js` wird nach jedem Zyklus ein neues Sigil
   mit aktuellem `update_time` erzeugt.
 Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js` und aktualisiere `advancedToDo.json` sowie `advancedprogress.json`.
+- Gesprächsstatistiken aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
 - QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
   synchronisiere ToDo-Dateien vor großen Commits mit
   `scripts/sync-todo-progress.js`.
 - Freundschaftssystem-Konzept siehe [docs/friendship-system.md](docs/friendship-system.md)
+- Gesprächsstatistiken aus neuen Chat-Logs: `ts-node scripts/analyze-newadvanced-conversations.ts`
 
 ## 🚀 Features
 

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Finalize MemoryGovernanceService clear method",
+  "lastCommit": "Add analyzer for new advanced conversations",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Enhanced memory governance clearing and marked resonance tasks as done",
+  "notes": "Enhanced memory governance clearing and marked resonance tasks as done; added analyzer for new advanced conversation logs",
   "pendingTasks": [],
   "progress": [
     {
@@ -794,6 +794,10 @@
     },
     {
       "commit": "Finalize MemoryGovernanceService clear method",
+      "status": "done"
+    },
+    {
+      "commit": "Add analyzer for new advanced conversations",
       "status": "done"
     }
   ],

--- a/scripts/analyze-newadvanced-conversations.test.ts
+++ b/scripts/analyze-newadvanced-conversations.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { analyzeNewAdvancedConversations } from './analyze-newadvanced-conversations';
+
+describe('analyzeNewAdvancedConversations', () => {
+  it('summarizes sample conversation data', () => {
+    const file = path.join(__dirname, '../tests/fixtures/newadvanced-sample.json');
+    const stats = analyzeNewAdvancedConversations(file);
+    expect(stats.conversationCount).toBe(1);
+    expect(stats.messageCount).toBe(1);
+    expect(stats.authorCounts.user).toBe(1);
+  });
+});

--- a/scripts/analyze-newadvanced-conversations.ts
+++ b/scripts/analyze-newadvanced-conversations.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env ts-node
+import fs from 'fs';
+import path from 'path';
+
+export interface ConversationStats {
+  conversationCount: number;
+  messageCount: number;
+  authorCounts: Record<string, number>;
+}
+
+export function analyzeNewAdvancedConversations(filePath: string): ConversationStats {
+  const raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  let messageCount = 0;
+  const authorCounts: Record<string, number> = {};
+  raw.forEach((session: any) => {
+    const nodes = Object.values(session.mapping || {});
+    nodes.forEach((node: any) => {
+      const msg = node.message;
+      if (msg && msg.author) {
+        messageCount++;
+        const role = msg.author.role || 'unknown';
+        authorCounts[role] = (authorCounts[role] || 0) + 1;
+      }
+    });
+  });
+  return {
+    conversationCount: raw.length,
+    messageCount,
+    authorCounts,
+  };
+}
+
+if (require.main === module) {
+  const file = process.argv[2] || path.join(__dirname, '../docs/sigils/newadvancedconversations.json');
+  const stats = analyzeNewAdvancedConversations(file);
+  console.log(`Conversations: ${stats.conversationCount}`);
+  console.log(`Messages: ${stats.messageCount}`);
+  console.log('Authors:', stats.authorCounts);
+}

--- a/tests/fixtures/newadvanced-sample.json
+++ b/tests/fixtures/newadvanced-sample.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "Sample",
+    "mapping": {
+      "node1": {
+        "id": "node1",
+        "message": {
+          "author": { "role": "user" },
+          "content": { "content_type": "text", "parts": ["hello"] }
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add TypeScript utility to summarize `docs/sigils/newadvancedconversations.json`
- document new analyzer in README and Handbuch
- record progress for analyzer feature

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/analyze-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6890426f485c832282a15bb488177069