### PR TITLE
feat(shared-utils): extract implicit conversation todos

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8207,5 +8207,12 @@
     "task": "Bridge conversation memories with phi analysis",
     "test": "packages/nukleon-scanner/CREPBridge.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Support implicit TODO extraction",
+    "path": "packages/shared-utils/advancedTodoUpdater.ts",
+    "task": "Include implicit conversation cues when updating advancedToDo",
+    "test": "packages/shared-utils/advancedTodoUpdater.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8997,3 +8997,8 @@
   task: Skeleton for language agents and CLI
   test: go-agent/pkg/codeagent/agent_test.go
   status: done
+- commit: Support implicit TODO extraction
+  path: packages/shared-utils/advancedTodoUpdater.ts
+  task: Include implicit conversation cues when updating advancedToDo
+  test: packages/shared-utils/advancedTodoUpdater.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,13 +1,13 @@
 {
-  "lastCommit": "Mark universe-sim tasks complete",
+  "lastCommit": "Support implicit TODO extraction",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Marked universe-sim tasks as done in advancedToDo; continue auditing remaining entries",
+  "notes": "Extended advancedTodoUpdater to parse implicit conversation tasks",
   "pendingTasks": [
-    "Audit remaining advancedToDo items for status alignment"
+    "Validate implicit todo extraction results"
   ],
   "progress": [
     {
@@ -808,6 +808,10 @@
     },
     {
       "commit": "Mark universe-sim tasks complete",
+      "status": "done"
+    },
+    {
+      "commit": "Support implicit TODO extraction",
       "status": "done"
     }
   ],

--- a/packages/shared-utils/advancedTodoUpdater.js
+++ b/packages/shared-utils/advancedTodoUpdater.js
@@ -1,15 +1,24 @@
 const fs = require('fs');
 const YAML = require('yaml');
-const { extractTodosFromConversations } = require('./conversationAnalyzer');
+const { extractTodosFromConversations, extractImplicitTodosFromConversations } = require('./conversationAnalyzer');
 
-function updateAdvancedTodo(convFile, yamlFile, jsonFile) {
+function updateAdvancedTodo(convFile, yamlFile, jsonFile, options = {}) {
+  const { includeImplicit = false, maxEntries } = options;
   const todos = extractTodosFromConversations(convFile);
-  const entries = Array.from(new Set(todos)).map(t => ({
+  if (includeImplicit) {
+    todos.push(...extractImplicitTodosFromConversations(convFile));
+  }
+  const clean = t => t.replace(/^[*\-]\s*/, '').replace(/【.*?】/g, '').trim();
+  const isValid = t => /\w{3}/.test(t) && t.split(/\s+/).length >= 3 && t.length <= 120 && !t.startsWith('.') && !t.includes('http') && /[a-zA-Z0-9)]$/.test(t);
+  let entries = Array.from(new Set(todos.map(clean))).filter(isValid).map(t => ({
     commit: t,
     path: '',
     task: t,
     test: ''
   }));
+  if (typeof maxEntries === 'number') {
+    entries = entries.slice(0, maxEntries);
+  }
 
   const loadYaml = f => {
     if (fs.existsSync(f)) {

--- a/packages/shared-utils/advancedTodoUpdater.test.ts
+++ b/packages/shared-utils/advancedTodoUpdater.test.ts
@@ -12,8 +12,9 @@ describe('updateAdvancedTodo', () => {
   beforeAll(() => {
     if (!fs.existsSync(tmp)) fs.mkdirSync(tmp);
     const data = [
-      { id: 'c1', mapping: { root: { message: { content: { parts: ['Test'] } } }, node2: { message: { content: { parts: ['// TODO: first task'] } } } } },
-      { id: 'c2', mapping: { root: { message: { content: { parts: ['# TODO second task'] } } } } }
+      { id: 'c1', mapping: { root: { message: { content: { parts: ['Test'] } } }, node2: { message: { content: { parts: ['// TODO: first sample task'] } } } } },
+      { id: 'c2', mapping: { root: { message: { content: { parts: ['# TODO second sample task'] } } } } },
+      { id: 'c3', mapping: { root: { message: { content: { parts: ['Wir sollten zusätzliche Tests schreiben'] } } } } }
     ];
     fs.writeFileSync(conv, JSON.stringify(data), 'utf8');
   });
@@ -22,12 +23,20 @@ describe('updateAdvancedTodo', () => {
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 
-  test('extracts todos and writes files', () => {
-    const entries = updateAdvancedTodo(conv, yml, json);
-    expect(entries.length).toBe(2);
+  test('extracts explicit and implicit todos and writes files', () => {
+    const entries = updateAdvancedTodo(conv, yml, json, { includeImplicit: true });
+    expect(entries.length).toBe(3);
     const yamlOut = fs.readFileSync(yml, 'utf8');
     const jsonOut = JSON.parse(fs.readFileSync(json, 'utf8'));
-    expect(yamlOut).toContain('first task');
-    expect(jsonOut[0].task).toBe('first task');
+    expect(yamlOut).toContain('first sample task');
+    expect(yamlOut).toContain('zusätzliche Tests schreiben');
+    expect(jsonOut[0].task).toBe('first sample task');
+  });
+
+  test('limits number of entries when maxEntries set', () => {
+    const yml2 = path.join(tmp, 'todo2.yaml');
+    const json2 = path.join(tmp, 'todo2.json');
+    const entries = updateAdvancedTodo(conv, yml2, json2, { includeImplicit: true, maxEntries: 2 });
+    expect(entries.length).toBe(2);
   });
 });

--- a/packages/shared-utils/advancedTodoUpdater.ts
+++ b/packages/shared-utils/advancedTodoUpdater.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import YAML from 'yaml';
 import path from 'path';
-import { extractTodosFromConversations } from './conversationAnalyzer';
+import { extractTodosFromConversations, extractImplicitTodosFromConversations } from './conversationAnalyzer';
 
 export interface AdvancedTodoEntry {
   commit: string;
@@ -10,12 +10,33 @@ export interface AdvancedTodoEntry {
   test: string;
 }
 
-export function updateAdvancedTodo(convFile: string, yamlFile: string, jsonFile: string): AdvancedTodoEntry[] {
+export interface UpdateOptions {
+  includeImplicit?: boolean;
+  maxEntries?: number;
+}
+
+export function updateAdvancedTodo(
+  convFile: string,
+  yamlFile: string,
+  jsonFile: string,
+  options: UpdateOptions = {}
+): AdvancedTodoEntry[] {
+  const { includeImplicit = false, maxEntries } = options;
   const todos = extractTodosFromConversations(convFile);
+  if (includeImplicit) {
+    todos.push(...extractImplicitTodosFromConversations(convFile));
+  }
 
-  const isValid = (t: string) => /[a-zA-Z0-9]{3}/.test(t);
+  const clean = (t: string) => t.replace(/^[*\-]\s*/, '').replace(/【.*?】/g, '').trim();
+  const isValid = (t: string) =>
+    /\w{3}/.test(t) &&
+    t.split(/\s+/).length >= 3 &&
+    t.length <= 120 &&
+    !t.startsWith('.') &&
+    !t.includes('http') &&
+    /[a-zA-Z0-9)]$/.test(t);
 
-  const entries: AdvancedTodoEntry[] = Array.from(new Set(todos))
+  let entries: AdvancedTodoEntry[] = Array.from(new Set(todos.map(clean)))
     .filter(isValid)
     .map((t) => ({
       commit: t,
@@ -23,6 +44,10 @@ export function updateAdvancedTodo(convFile: string, yamlFile: string, jsonFile:
       task: t,
       test: ''
     }));
+
+  if (typeof maxEntries === 'number') {
+    entries = entries.slice(0, maxEntries);
+  }
 
   const loadYaml = (f: string): AdvancedTodoEntry[] => {
     if (fs.existsSync(f)) {

--- a/scripts/update-advanced-from-newconvos.js
+++ b/scripts/update-advanced-from-newconvos.js
@@ -1,10 +1,13 @@
 const path = require('path');
 const { updateAdvancedTodo } = require('../packages/shared-utils/advancedTodoUpdater');
 
-function updateFromNewConvos(convPath = path.join(__dirname, '../docs/sigils/newadvancedconversations.json'),
-                             yamlPath = path.join(__dirname, '../advancedToDo.yaml'),
-                             jsonPath = path.join(__dirname, '../advancedToDo.json')) {
-  updateAdvancedTodo(convPath, yamlPath, jsonPath);
+function updateFromNewConvos(
+  convPath = path.join(__dirname, '../docs/sigils/newadvancedconversations.json'),
+  yamlPath = path.join(__dirname, '../advancedToDo.yaml'),
+  jsonPath = path.join(__dirname, '../advancedToDo.json'),
+  options = { includeImplicit: true }
+) {
+  updateAdvancedTodo(convPath, yamlPath, jsonPath, options);
   console.log(`Updated advancedToDo files from ${path.basename(convPath)}`);
 }
 

--- a/scripts/update-advanced-todo.js
+++ b/scripts/update-advanced-todo.js
@@ -10,5 +10,5 @@ const convFile = path.join(__dirname, '../docs/sigils/advancedconversations.json
 const yamlFile = path.join(__dirname, '../advancedToDo.yaml');
 const jsonFile = path.join(__dirname, '../advancedToDo.json');
 
-const entries = updateAdvancedTodo(convFile, yamlFile, jsonFile);
+const entries = updateAdvancedTodo(convFile, yamlFile, jsonFile, { includeImplicit: true });
 console.log(`advancedToDo updated with ${entries.length} tasks.`);

--- a/scripts/update-newadvanced-todo.js
+++ b/scripts/update-newadvanced-todo.js
@@ -7,6 +7,6 @@ const convFile = path.join(__dirname, '../docs/sigils/newadvancedconversations.j
 const yamlFile = path.join(__dirname, '../advancedToDo.yaml');
 const jsonFile = path.join(__dirname, '../advancedToDo.json');
 
-const entries = updateAdvancedTodo(convFile, yamlFile, jsonFile);
+const entries = updateAdvancedTodo(convFile, yamlFile, jsonFile, { includeImplicit: true });
 console.log(`advancedToDo updated with ${entries.length} tasks from newadvancedconversations.json.`);
 updateProgress('sync');


### PR DESCRIPTION
## Summary
- expand advancedTodoUpdater to parse implicit conversation tasks, validate entries, and cap result count
- enable implicit extraction in todo update scripts
- document new capability in advanced ToDo and progress logs

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest packages/shared-utils/advancedTodoUpdater.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6890653660dc8322a4dca35b76885401