### PR TITLE
docs: expand PantheonBoundary VR blueprint

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7387,7 +7387,7 @@
     "path": "docs/vr/PantheonBoundaryIntegration.md",
     "task": "Blueprint for integrating boundary events into Pantheon VR room",
     "test": "",
-    "status": "planned"
+    "status": "done"
   },
   {
     "commit": "Enhance CosmicTheoryAgent caching with LRUCache",

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,15 +1,19 @@
 {
-  "lastCommit": "Implement RBAC and policy management",
+  "lastCommit": "Expand PantheonBoundaryVRIntegration blueprint",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added YAML-based RBAC policy loader and authorization checks",
+  "notes": "Expanded Pantheon-Boundary VR blueprint; next: improve onboarding docs and enforce ToDo sync",
   "pendingTasks": [
     "Validate implicit todo extraction results",
     "Add KEDA and HPA scaling",
-    "Implement multi agent coordination handler"
+    "Implement multi agent coordination handler",
+    "Improve documentation and onboarding demo",
+    "Standardize external API and integrate datasets",
+    "Enforce ToDo sync before commits",
+    "Update ToDos from advanced conversations"
   ],
   "progress": [
     {
@@ -550,6 +554,10 @@
     },
     {
       "commit": "Add run-demo script",
+      "status": "done"
+    },
+    {
+      "commit": "Expand PantheonBoundaryVRIntegration blueprint",
       "status": "done"
     }
   ],

--- a/docs/vr/PantheonBoundaryIntegration.md
+++ b/docs/vr/PantheonBoundaryIntegration.md
@@ -1,3 +1,25 @@
 # Pantheon Boundary VR Integration
 
-Kurzer Plan zur Einbindung von Boundary-Ereignissen in den VR Raum.
+Dieses Blueprint beschreibt, wie Ereignisse aus der Boundary-Engine in den Pantheon-VR-Raum gelangen und dort erlebbar werden.
+
+## Übersicht
+- Abonnement des Boundary-Event-Streams
+- Übersetzung der Ereignisse in VR-taugliche Signale (Visuals, Audio)
+- Weiterleitung an aktive Pantheon-Sitzungen
+
+## Integrationsfluss
+1. Die Boundary-Engine veröffentlicht ein Ereignis (z.\u00a0B. Wellenkamm, Anomalie, Resonanzverschiebung).
+2. **PantheonBoundaryBridge** transformiert die Nutzlast in ein VR-Schema.
+3. Das Gateway sendet das Ereignis \u00fcber WebSocket an alle verbundenen VR-Clients.
+4. Der VR-Raum rendert entsprechende Sigillin-Markierungen oder Klanghinweise.
+
+## Validierung
+- Staging-VR-Raum mit Boundary-Stream koppeln und Ereignisfluss pr\u00fcfen.
+- Ereignis-IDs im Sitzungsprotokoll persistieren, um Replays zu erm\u00f6glichen.
+- Test `docs/vr/__tests__/PantheonBoundaryIntegration.test.ts` stellt sicher, dass die Dokumentation vorhanden ist.
+- Weitere Tests k\u00f6nnen WebSocket-Nachrichten simulieren und die Darstellung verifizieren.
+
+## N\u00e4chste Schritte
+- Onboarding-Demo erstellen, die Boundary-Ereignisse im VR-Raum zeigt.
+- REST/gRPC-Schnittstellen zwischen Boundary-Engine und Pantheon-UI vereinheitlichen.
+


### PR DESCRIPTION
## Summary
- detail PantheonBoundary VR integration blueprint and validation strategy
- mark related advanced ToDo entry as done
- record progress and next tasks in advancedprogress

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test docs/vr/__tests__/PantheonBoundaryIntegration.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68909934a268832299b261dc5ea8de8c