### PR TITLE
Finalize C-Tutor and JavaHamster skeletons

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -789,13 +789,15 @@
     "commit": "Add C-Tutor skeleton",
     "path": "apps/c-tutor",
     "task": "Interactive C learning tool placeholder",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Add JavaHamster AI skeleton",
     "path": "apps/java-hamster-ai",
     "task": "Gamified C learning pendant",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Add WeightedDispatcher",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -558,10 +558,12 @@
   path: apps/c-tutor
   task: Interactive C learning tool placeholder
   test: ""
+  status: done
 - commit: Add JavaHamster AI skeleton
   path: apps/java-hamster-ai
   task: Gamified C learning pendant
   test: ""
+  status: done
 - commit: Add WeightedDispatcher
   path: packages/agents/WeightedDispatcher.ts
   task: Priority based dispatching

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Expand PantheonBoundaryVRIntegration blueprint",
+  "lastCommit": "Finalize C-Tutor and JavaHamster skeletons",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Expanded Pantheon-Boundary VR blueprint; next: improve onboarding docs and enforce ToDo sync",
+  "notes": "Fixed CLI placeholders for learning app skeletons; next: improve onboarding docs and enforce ToDo sync",
   "pendingTasks": [
     "Validate implicit todo extraction results",
     "Add KEDA and HPA scaling",
@@ -826,6 +826,10 @@
     },
     {
       "commit": "Implement RBAC and policy management",
+      "status": "done"
+    },
+    {
+      "commit": "Finalize C-Tutor and JavaHamster skeletons",
       "status": "done"
     }
   ],

--- a/apps/c-tutor/cli.js
+++ b/apps/c-tutor/cli.js
@@ -1,1 +1,4 @@
-#!/usr/bin/env node\nconsole.log("c-tutor placeholder");
+#!/usr/bin/env node
+
+console.log("c-tutor placeholder");
+

--- a/apps/java-hamster-ai/cli.js
+++ b/apps/java-hamster-ai/cli.js
@@ -1,1 +1,4 @@
-#!/usr/bin/env node\nconsole.log("java-hamster-ai placeholder");
+#!/usr/bin/env node
+
+console.log("java-hamster-ai placeholder");
+


### PR DESCRIPTION
## Summary
- normalize CLI placeholders for c-tutor and java-hamster-ai learning apps
- mark C-Tutor and JavaHamster AI skeleton tasks complete in advanced todo trackers
- log progress for finalized skeletons in advancedprogress

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6890b580dff48322b937812c15e861fe