### PR TITLE
feat: expand agent registry

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -908,7 +908,8 @@
     "commit": "Add agent registry YAML",
     "path": "agents.yaml",
     "task": "Store all agent types centrally",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Gamification API routes",

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Finalize C-Tutor and JavaHamster skeletons",
+  "lastCommit": "Add central agent registry",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Fixed CLI placeholders for learning app skeletons; next: improve onboarding docs and enforce ToDo sync",
+  "notes": "Expanded agents.yaml with Codex agents; next: tackle KEDA/HPA scaling and coordination handler",
   "pendingTasks": [
     "Validate implicit todo extraction results",
     "Add KEDA and HPA scaling",
@@ -558,6 +558,10 @@
     },
     {
       "commit": "Expand PantheonBoundaryVRIntegration blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Add central agent registry",
       "status": "done"
     }
   ],

--- a/agents.yaml
+++ b/agents.yaml
@@ -7,3 +7,52 @@ agents:
     description: "Generiert Go-Code-Snippets via GPT"
     endpoint: "/codeagent/go/generate"
     example: "curl -X POST /codeagent/go/generate -d '{\"description\":\"hello\"}'"
+  - id: codex-audit
+    description: "Emergenz pr\u00fcfen und Sigillin zuweisen"
+    start: mandala-sync.ts
+    docs: docs/agents/CodexAuditAgent.md
+  - id: evolver-gpt
+    description: "Generiert alternative Pfade und poetische Entscheidungen"
+    start: codexwork.yaml
+    docs: docs/agents/EvolverGPT.md
+  - id: fragment-mapper
+    description: "Ordnet Gespr\u00e4chsfragmente zu Modulen und Themen"
+    start: fragmented_conversation.json
+    docs: docs/agents/FragmentMapper.md
+  - id: sync-runner
+    description: "Synchronisiert CREP-Zust\u00e4nde und erkennt Kollisionen"
+    start: codexsync.yaml
+    docs: docs/agents/SyncRunner.md
+  - id: pact-depth-gatekeeper
+    description: "Zugangskontrolle via Tiefe und Sigillin"
+    start: pact-depth-rules.ts
+    docs: docs/agents/PactDepthGatekeeper.md
+  - id: depth-bundle-exporter
+    description: "Exportiert Sigillin Depth Bundles"
+    start: export_depth_bundle
+    outputs:
+      - sigillin_depth_bundle.sigil.json
+      - depth_index.md
+      - irrational_matrix.wav
+      - "mandala_depth_*.svg"
+    docs: docs/agents/DepthBundleExporter.md
+  - id: pattern-reactivator
+    description: "Reaktiviert ruhende Aufgabenketten bei niedrigem CREP"
+    start: pattern-reactivator.ts
+    docs: docs/agents/PatternReactivator.md
+  - id: genesis-aeon-navigator
+    description: "Steuert Phasenwechsel im Genesis-Aeon"
+    start: genesis-aeon-navigator.ts
+    docs: docs/agents/GenesisAeonNavigator.md
+  - id: vision-context-integrator
+    description: "Verteilt Vision und Strategie"
+    start: vision-context-integrator.ts
+    docs: docs/agents/VisionContextIntegrator.md
+  - id: strategic-agent-coordinator
+    description: "Schreibt strategy-overview.json aus AGENTS.md"
+    start: strategic-agent-coordinator.ts
+    docs: docs/agents/StrategicAgentCoordinator.md
+  - id: quality-assurance-agent
+    description: "F\u00fchrt Lint- und Test-Suites aus"
+    start: qa-test-runner.ts
+    docs: docs/agents/QualityAssuranceAgent.md


### PR DESCRIPTION
## Summary
- centralize Codex agent definitions in `agents.yaml`
- mark agent registry task complete in `advancedToDo.json`
- log agent registry work in `advancedprogress.json`

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6890b90f89308322b3bdbf35a0d1fb38