### PR TITLE
Add KEDA and HPA scaling for NATS queues

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -25,6 +25,7 @@ Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js`
 - Gesprächsstatistiken aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
 - QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`
+- KEDA/HPA Skalierung unter `deployment/keda` für NATS Queue-Length
 
 > **TL;DR**
 > - Installation: `./scripts/setup-unifiedmandala.sh`

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**Fractal Runner CLI**](packages/agents/bin/fractal-runner.ts) – runs YAML task files with optional soundscape
 - [**React Starter**](packages/unifiedmandala-ui/ReactStarter.tsx) – Tailwind/Vite skeleton setup
 - **Aeon Orchestrator** – koordiniert Pantheon-Agenten und streamt Boundary-Regeln
+- [**KEDA/HPA Skalierung**](deployment/keda) – skaliert mandala-worker anhand der NATS Queue-Length
 - [**PantheonPortalAnalytics**](packages/pantheon/PantheonPortalAnalytics.ts) – track portal usage
 - [**PantheonBoundaryBridge**](packages/pantheon/PantheonBoundaryBridge.ts) – verbindet Pantheon-Events mit BoundaryRuleDetector
 - [**PantheonExport Tool**](packages/pantheon/tools/PantheonExport.ts) – exportiert die vorhandenen Pantheon-Module als Datensatz

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -556,7 +556,8 @@
     "commit": "Add KEDA and HPA scaling",
     "path": "deployment/keda",
     "task": "Trigger scaling based on NATS queue length",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Implement RBAC and policy management",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -394,6 +394,7 @@
   path: deployment/keda
   task: Trigger scaling based on NATS queue length
   test: ""
+  status: done
 - commit: Implement RBAC and policy management
   path: internal/auth
   task: Enforce YAML policies for handlers

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,14 +1,13 @@
 {
-  "lastCommit": "Update shared schema utilities",
+  "lastCommit": "Add KEDA and HPA scaling configuration",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Aligned ToDo sync and conversation parsing tasks; next: validate implicit todo extraction results, add KEDA/HPA scaling, implement multi agent coordination handler.",
+  "notes": "Aligned ToDo sync and conversation parsing tasks; next: validate implicit todo extraction results, implement multi agent coordination handler.",
   "pendingTasks": [
     "Validate implicit todo extraction results",
-    "Add KEDA and HPA scaling",
     "Implement multi agent coordination handler"
   ],
   "progress": [
@@ -574,6 +573,10 @@
     },
     {
       "commit": "Update ToDos from advanced conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Add KEDA and HPA scaling configuration",
       "status": "done"
     }
   ],

--- a/deployment/keda/hpa.yaml
+++ b/deployment/keda/hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: mandala-worker-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: mandala-worker
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
+

--- a/deployment/keda/scaledobject.yaml
+++ b/deployment/keda/scaledobject.yaml
@@ -1,0 +1,19 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: mandala-worker-scaledobject
+spec:
+  scaleTargetRef:
+    name: mandala-worker
+  pollingInterval: 30
+  cooldownPeriod: 300
+  minReplicaCount: 1
+  maxReplicaCount: 10
+  triggers:
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "http://nats.monitoring:8222"
+      streamName: tasks
+      consumerName: worker
+      pendingMessages: "100"
+


### PR DESCRIPTION
## Summary
- configure KEDA ScaledObject and HPA to scale `mandala-worker` based on NATS queue length
- document new scaling config in README and Handbuch
- record completion in advanced ToDo and progress trackers

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: many missing attribute errors in virtualenv packages)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68911ae625dc832282650bcc67295fdf