### PR TITLE
feat: extend conversation analyzer with time range

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -22,7 +22,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - Über `scripts/generate-next-sigil.js` wird nach jedem Zyklus ein neues Sigil
   mit aktuellem `update_time` erzeugt.
 Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js` und aktualisiere `advancedToDo.json` sowie `advancedprogress.json`.
-- Gesprächsstatistiken aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
+- Gesprächsstatistiken (inkl. Zeitspanne) aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
 - QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`
 - KEDA/HPA Skalierung unter `deployment/keda` für NATS Queue-Length

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
   synchronisiere ToDo-Dateien vor großen Commits mit
   `scripts/sync-todo-progress.js`.
 - Freundschaftssystem-Konzept siehe [docs/friendship-system.md](docs/friendship-system.md)
-- Gesprächsstatistiken aus neuen Chat-Logs: `ts-node scripts/analyze-newadvanced-conversations.ts`
+- Gesprächsstatistiken (inkl. Zeitspanne) aus neuen Chat-Logs: `ts-node scripts/analyze-newadvanced-conversations.ts`
 
 ## 🚀 Features
 

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,14 +1,15 @@
 {
-  "lastCommit": "Add KEDA and HPA scaling configuration",
+  "lastCommit": "Add conversation time-range stats to analyzer",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Aligned ToDo sync and conversation parsing tasks; next: validate implicit todo extraction results, implement multi agent coordination handler.",
+  "notes": "Extended conversation analyzer with time range metrics; next: integrate stats into dashboards. Aligned ToDo sync and conversation parsing tasks; next: validate implicit todo extraction results, implement multi agent coordination handler.",
   "pendingTasks": [
     "Validate implicit todo extraction results",
-    "Implement multi agent coordination handler"
+    "Implement multi agent coordination handler",
+    "Integrate conversation stats into dashboards"
   ],
   "progress": [
     {
@@ -853,6 +854,10 @@
     },
     {
       "commit": "Update shared schema utilities",
+      "status": "done"
+    },
+    {
+      "commit": "Add conversation time-range stats to analyzer",
       "status": "done"
     }
   ],

--- a/scripts/analyze-newadvanced-conversations.test.ts
+++ b/scripts/analyze-newadvanced-conversations.test.ts
@@ -9,5 +9,8 @@ describe('analyzeNewAdvancedConversations', () => {
     expect(stats.conversationCount).toBe(1);
     expect(stats.messageCount).toBe(1);
     expect(stats.authorCounts.user).toBe(1);
+    expect(stats.averageMessagesPerConversation).toBe(1);
+    expect(stats.timeRange.start).toBe(1234567890);
+    expect(stats.timeRange.end).toBe(1234567890);
   });
 });

--- a/scripts/analyze-newadvanced-conversations.ts
+++ b/scripts/analyze-newadvanced-conversations.ts
@@ -6,12 +6,16 @@ export interface ConversationStats {
   conversationCount: number;
   messageCount: number;
   authorCounts: Record<string, number>;
+  averageMessagesPerConversation: number;
+  timeRange: { start: number | null; end: number | null };
 }
 
 export function analyzeNewAdvancedConversations(filePath: string): ConversationStats {
   const raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
   let messageCount = 0;
   const authorCounts: Record<string, number> = {};
+  let minTime: number | null = null;
+  let maxTime: number | null = null;
   raw.forEach((session: any) => {
     const nodes = Object.values(session.mapping || {});
     nodes.forEach((node: any) => {
@@ -20,6 +24,11 @@ export function analyzeNewAdvancedConversations(filePath: string): ConversationS
         messageCount++;
         const role = msg.author.role || 'unknown';
         authorCounts[role] = (authorCounts[role] || 0) + 1;
+        const ct = (msg as any).create_time;
+        if (typeof ct === 'number') {
+          minTime = minTime === null ? ct : Math.min(minTime, ct);
+          maxTime = maxTime === null ? ct : Math.max(maxTime, ct);
+        }
       }
     });
   });
@@ -27,6 +36,8 @@ export function analyzeNewAdvancedConversations(filePath: string): ConversationS
     conversationCount: raw.length,
     messageCount,
     authorCounts,
+    averageMessagesPerConversation: raw.length ? messageCount / raw.length : 0,
+    timeRange: { start: minTime, end: maxTime },
   };
 }
 

--- a/tests/fixtures/newadvanced-sample.json
+++ b/tests/fixtures/newadvanced-sample.json
@@ -6,6 +6,7 @@
         "id": "node1",
         "message": {
           "author": { "role": "user" },
+          "create_time": 1234567890,
           "content": { "content_type": "text", "parts": ["hello"] }
         }
       }


### PR DESCRIPTION
## Summary
- extend conversation analyzer to compute average messages per conversation and timestamp range
- document new stats output in Handbuch and README
- record progress for conversation analyzer enhancement

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/analyze-newadvanced-conversations.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6891249383708322b0ab4b1383410c6e