### PR TITLE
feat: enable grok agent learning

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -6996,13 +6996,15 @@
     "commit": "Create GrokAgent module",
     "path": "packages/agents/GrokAgent.ts",
     "task": "Extract and apply Grok patterns",
-    "test": "packages/agents/GrokAgent.test.ts"
+    "test": "packages/agents/GrokAgent.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add ShadowIntegrations module",
     "path": "packages/integration/ShadowIntegrations.ts",
     "task": "Manage hidden integration flows",
-    "test": "packages/integration/ShadowIntegrations.test.ts"
+    "test": "packages/integration/ShadowIntegrations.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add SelfReflectionAgent",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8052,10 +8052,12 @@
   path: packages/agents/GrokAgent.ts
   task: Extract and apply Grok patterns
   test: packages/agents/GrokAgent.test.ts
+- status: done
 - commit: Add ShadowIntegrations module
   path: packages/integration/ShadowIntegrations.ts
   task: Manage hidden integration flows
   test: packages/integration/ShadowIntegrations.test.ts
+- status: done
 - commit: Add SelfReflectionAgent
   path: packages/agents/SelfReflectionAgent.ts
   task: Provide introspection for agent memory

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Add conversation time-range stats to analyzer",
+  "lastCommit": "Enable GrokAgent learning and ShadowIntegrations cleanup",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
@@ -858,6 +858,10 @@
     },
     {
       "commit": "Add conversation time-range stats to analyzer",
+      "status": "done"
+    },
+    {
+      "commit": "Enable GrokAgent learning and ShadowIntegrations cleanup",
       "status": "done"
     }
   ],

--- a/packages/agents/GrokAgent.test.ts
+++ b/packages/agents/GrokAgent.test.ts
@@ -12,4 +12,10 @@ describe('GrokAgent', () => {
     agent.setPatternLibrary(['foo']);
     expect(agent.analyze('foo bar')).toBe('Matched 1: foo');
   });
+
+  it('learns patterns from text', () => {
+    const agent = new GrokAgent();
+    agent.learn('alpha beta');
+    expect(agent.analyze('gamma alpha')).toBe('Matched 1: alpha');
+  });
 });

--- a/packages/agents/GrokAgent.ts
+++ b/packages/agents/GrokAgent.ts
@@ -5,6 +5,16 @@ export class GrokAgent {
     this.patterns = patterns;
   }
 
+  /**
+   * Learns patterns from provided text by extracting unique words
+   * and merging them into the internal pattern library.
+   */
+  learn(text: string) {
+    const words = text.split(/\s+/).filter(Boolean);
+    const unique = Array.from(new Set(words));
+    this.patterns = Array.from(new Set([...this.patterns, ...unique]));
+  }
+
   analyze(text: string): string {
     const words = text.split(/\s+/).filter(Boolean);
     const matches = words.filter(w => this.patterns.includes(w));

--- a/packages/integration/ShadowIntegrations.test.ts
+++ b/packages/integration/ShadowIntegrations.test.ts
@@ -7,5 +7,7 @@ describe('ShadowIntegrations', () => {
     sis.register('secret', 'data', 1);
     expect(sis.list()).toContain('secret');
     expect(sis.retrieve('secret', 1)).toBe('data');
+    sis.unregister('secret');
+    expect(sis.list()).not.toContain('secret');
   });
 });

--- a/packages/integration/ShadowIntegrations.ts
+++ b/packages/integration/ShadowIntegrations.ts
@@ -8,6 +8,10 @@ export class ShadowIntegrations {
     this.flows.set(name, encoded);
   }
 
+  unregister(name: string) {
+    this.flows.delete(name);
+  }
+
   retrieve(name: string, key = 42): string | undefined {
     const encoded = this.flows.get(name);
     if (!encoded) return undefined;


### PR DESCRIPTION
## Summary
- teach `GrokAgent` to learn patterns from text
- allow `ShadowIntegrations` flows to be removed
- record progress for learning features in advanced to-do files

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run packages/agents/GrokAgent.test.ts`
- `npx vitest run packages/integration/ShadowIntegrations.test.ts` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689128f9f1d88322a6747e4d147552f3