### PR TITLE
feat(ui): add conversation stats to dashboard

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,14 +1,13 @@
 {
-  "lastCommit": "Validate plugin manifest and Aeon transition docs",
+  "lastCommit": "Integrate conversation stats into MandalaDashboard",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added plugin manifest schema validation and expanded Aeon transition guidelines; next: integrate stats into dashboards.",
+  "notes": "Added plugin manifest schema validation and expanded Aeon transition guidelines; next: validate implicit todo extraction results.",
   "pendingTasks": [
-    "Validate implicit todo extraction results",
-    "Integrate conversation stats into dashboards"
+    "Validate implicit todo extraction results"
   ],
   "progress": [
     {
@@ -865,6 +864,10 @@
     },
     {
       "commit": "Validate plugin manifest and Aeon transition docs",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate conversation stats into MandalaDashboard",
       "status": "done"
     }
   ],

--- a/packages/unifiedmandala-ui/components/ConversationStats.test.tsx
+++ b/packages/unifiedmandala-ui/components/ConversationStats.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ConversationStats from './ConversationStats';
+
+test('displays conversation and message counts', () => {
+  render(<ConversationStats conversationCount={3} messageCount={10} />);
+  expect(screen.getByText('Total Conversations:')).toBeInTheDocument();
+  expect(screen.getByText('3')).toBeInTheDocument();
+  expect(screen.getByText('Total Messages:')).toBeInTheDocument();
+  expect(screen.getByText('10')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/ConversationStats.tsx
+++ b/packages/unifiedmandala-ui/components/ConversationStats.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export interface ConversationStatsProps {
+  conversationCount: number;
+  messageCount: number;
+}
+
+const ConversationStats: React.FC<ConversationStatsProps> = ({ conversationCount, messageCount }) => (
+  <div aria-label="Conversation Stats">
+    <p>Total Conversations: <span>{conversationCount}</span></p>
+    <p>Total Messages: <span>{messageCount}</span></p>
+  </div>
+);
+
+export default ConversationStats;

--- a/packages/unifiedmandala-ui/components/MandalaDashboard.test.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaDashboard.test.tsx
@@ -3,13 +3,17 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import MandalaDashboard, { ModuleStatus } from './MandalaDashboard';
 
-test('renders module names and statuses', () => {
+test('renders module names, statuses and conversation stats', () => {
   const modules: ModuleStatus[] = [
     { name: 'core', status: 'synced' },
     { name: 'ui', status: 'pending' },
   ];
-  render(<MandalaDashboard modules={modules} />);
+  const stats = { conversationCount: 2, messageCount: 5 };
+  render(<MandalaDashboard modules={modules} conversationStats={stats} />);
   expect(screen.getByText('core:')).toBeInTheDocument();
   expect(screen.getByText('ui:')).toBeInTheDocument();
   expect(screen.getAllByTestId('sync-status')).toHaveLength(2);
+  expect(screen.getByLabelText('Conversation Stats')).toBeInTheDocument();
+  expect(screen.getByText('Total Conversations:')).toBeInTheDocument();
+  expect(screen.getByText('Total Messages:')).toBeInTheDocument();
 });

--- a/packages/unifiedmandala-ui/components/MandalaDashboard.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaDashboard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import SyncStatus from './SyncStatus';
+import ConversationStats, { ConversationStatsProps } from './ConversationStats';
 
 export interface ModuleStatus {
   name: string;
@@ -8,9 +9,10 @@ export interface ModuleStatus {
 
 interface MandalaDashboardProps {
   modules: ModuleStatus[];
+  conversationStats?: ConversationStatsProps;
 }
 
-const MandalaDashboard: React.FC<MandalaDashboardProps> = ({ modules }) => (
+const MandalaDashboard: React.FC<MandalaDashboardProps> = ({ modules, conversationStats }) => (
   <div aria-label="Mandala Dashboard">
     <h3>Module Synchronisation</h3>
     <ul>
@@ -20,6 +22,12 @@ const MandalaDashboard: React.FC<MandalaDashboardProps> = ({ modules }) => (
         </li>
       ))}
     </ul>
+    {conversationStats && (
+      <ConversationStats
+        conversationCount={conversationStats.conversationCount}
+        messageCount={conversationStats.messageCount}
+      />
+    )}
   </div>
 );
 


### PR DESCRIPTION
## Summary
- Display aggregated conversation metrics via new `ConversationStats` component
- Extend `MandalaDashboard` to surface conversation totals alongside module sync status
- Track progress in `advancedprogress.json` for conversation stats integration

## Testing
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx jest packages/unifiedmandala-ui/components/MandalaDashboard.test.tsx packages/unifiedmandala-ui/components/ConversationStats.test.tsx`
- `pnpm test` *(fails: JavaScript heap out of memory)*
- `pnpm test:agents` *(fails: multiple suites missing test globals)*

------
https://chatgpt.com/codex/tasks/task_e_689134b95f6c832298ebbb9dc49fbe09