### PR TITLE
docs: expand CREP export documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 ## 🚀 Features
 
 - [**CREP-Systematik**](docs/crep/overview.md) – Coherence, Resonance, Emergence, Poetics
+- [**CREP-Exportstruktur**](docs/CREPDocExport.md) – Aufbau der exportierten CREP-Daten
 - [**Sigillin-Logik**](docs/sigils/SIGILLIN_GENESIS.md) – Heimkehr-Trigger, Symbolphasen, SigillinMap
 - [**Symbolzeit-Modulator**](packages/shared-utils/symbolzeitModulator.ts) – morgen, tag, abend, nacht
 - [**MandalaNetworkView**](packages/unifiedmandala-ui/components/MandalaNetworkView.tsx) – Visualisierung aller Sigillin-Knoten und CREP-Felder

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Integrate conversation stats into MandalaDashboard",
+  "lastCommit": "Expand CREP export documentation",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added plugin manifest schema validation and expanded Aeon transition guidelines; next: validate implicit todo extraction results.",
+  "notes": "Expanded CREP export documentation; next: validate implicit todo extraction results.",
   "pendingTasks": [
     "Validate implicit todo extraction results"
   ],
@@ -576,6 +576,10 @@
     },
     {
       "commit": "Add KEDA and HPA scaling configuration",
+      "status": "done"
+    },
+    {
+      "commit": "Expand CREP export documentation",
       "status": "done"
     }
   ],

--- a/docs/CREPDocExport.md
+++ b/docs/CREPDocExport.md
@@ -1,3 +1,35 @@
 # CREPDocExport
 
 Dieses Dokument beschreibt die Exportstruktur der CREP-Daten. Die CREP-Engine erzeugt JSON-Dateien, die alle Einträge nach Symbolzeit sortiert enthalten. Jeder Export besteht aus einer Liste von Objekten mit `timestamp`, `symbolzeit` und `crepValue`.
+
+## Dateiformat
+
+Die Exportdatei ist eine JSON‑Liste. Jedes Element repräsentiert einen Messpunkt der CREP‑Werte und besitzt folgende Felder:
+
+| Feld       | Typ     | Beschreibung                                |
+|------------|---------|---------------------------------------------|
+| `timestamp`| string  | ISO‑Datum des Messzeitpunkts               |
+| `symbolzeit` | string | Symbolische Zeitangabe (z. B. `morgen`) |
+| `crepValue` | object | Objekt mit `C`, `R`, `E` und `P` Komponenten |
+
+## Beispiel
+
+```json
+[
+  {
+    "timestamp": "2025-01-01T12:00:00Z",
+    "symbolzeit": "tag",
+    "crepValue": { "C": 0.8, "R": 0.6, "E": 0.7, "P": 0.9 }
+  }
+]
+```
+
+## Erstellung
+
+Ein Export kann über das CLI‑Skript `packages/cli-tools/export-doc.js` generiert werden:
+
+```bash
+node packages/cli-tools/export-doc.js
+```
+
+Die Ausgabe wird als `CREPDocExport.md` im Projektstamm abgelegt und lässt sich anschließend in weitere Formate überführen.


### PR DESCRIPTION
## Summary
- document CREP export format and provide CLI usage instructions
- link CREP export doc in README
- record progress for CREP export documentation

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68913bc583f483229c08a45b51190d95