### PR TITLE
feat: extend agent CI with plugin build and policy linter

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -584,7 +584,8 @@
     "commit": "Extend GitHub Actions for extras",
     "path": "ci/agent.yml",
     "task": "Add ML plugin build and policy linter steps",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Write documentation and examples for extras",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -414,6 +414,7 @@
   path: ci/agent.yml
   task: Add ML plugin build and policy linter steps
   test: ""
+  status: done
 - commit: Write documentation and examples for extras
   path: docs/go-agent
   task: Add ml-prioritization and policy guide docs

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Expand CREP export documentation",
+  "lastCommit": "Extend GitHub Actions for extras",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Expanded CREP export documentation; next: validate implicit todo extraction results.",
+  "notes": "Added ML plugin build and policy linter steps to agent workflow; next: validate implicit todo extraction results.",
   "pendingTasks": [
     "Validate implicit todo extraction results"
   ],
@@ -872,6 +872,10 @@
     },
     {
       "commit": "Integrate conversation stats into MandalaDashboard",
+      "status": "done"
+    },
+    {
+      "commit": "Extend GitHub Actions for extras",
       "status": "done"
     }
   ],

--- a/ci/agent.yml
+++ b/ci/agent.yml
@@ -16,3 +16,11 @@ jobs:
           go test ./services/vector-indexer
       - name: Package Lambda@Edge
         run: ./scripts/package-lambda-edge.sh
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+      - run: pnpm install
+      - name: Build ML plugins
+        run: npx ts-node scripts/generate-plugin-manifest.ts
+      - name: Lint AI policy
+        run: node scripts/check-ai-policy.js


### PR DESCRIPTION
## Summary
- build ML plugin manifest and lint AI policy in Agent workflow
- log completion of CI enhancement in advanced ToDo and progress trackers

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68913fa1d8f08322b6a26a2ed1024de9