### PR TITLE
meta:implement-features – add implicit todo validator

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -22,6 +22,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - Über `scripts/generate-next-sigil.js` wird nach jedem Zyklus ein neues Sigil
   mit aktuellem `update_time` erzeugt.
 Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js` und aktualisiere `advancedToDo.json` sowie `advancedprogress.json`.
+Validiere extrahierte Einträge mit `node scripts/validate-implicit-todos.js` um fehlende Felder oder Duplikate zu finden.
 - Gesprächsstatistiken (inkl. Zeitspanne) aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
 - QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`

--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ Teil 5 enthält Aufgaben zur Sigil-Historie.
 Teil 7 listet Aufgaben zu poetischen Sigill- und Mandala-Modulen.
 Nutze `node scripts/parse-advanced-conversations.js` um Gesprächs-TODOs aus dem Datensatz zu filtern.
 Neu erzeugte Einträge landen in `advancedToDo.json` und `advancedToDo.yaml` und werden in `advancedprogress.json` dokumentiert.
+Prüfe fehlende Felder oder doppelte Tasks mit `node scripts/validate-implicit-todos.js`.
 Nutze `node scripts/update-advanced-from-newconvos.js` um die ToDo-Dateien aus `newadvancedconversations.json` zu aktualisieren.
 
 - **Module**: unter `packages/` gegliedert in Agents, Core und mehr

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,13 +1,13 @@
 {
-  "lastCommit": "Extend GitHub Actions for extras",
+  "lastCommit": "Add implicit todo validation script",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added ML plugin build and policy linter steps to agent workflow; next: validate implicit todo extraction results.",
+  "notes": "Created script to validate advancedToDo entries; next: integrate into CI pipeline.",
   "pendingTasks": [
-    "Validate implicit todo extraction results"
+    "Integrate validation script into CI pipeline"
   ],
   "progress": [
     {
@@ -580,6 +580,10 @@
     },
     {
       "commit": "Expand CREP export documentation",
+      "status": "done"
+    },
+    {
+      "commit": "Add implicit todo validation script",
       "status": "done"
     }
   ],

--- a/scripts/validate-implicit-todos.js
+++ b/scripts/validate-implicit-todos.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const path = require('path');
+const YAML = require('yaml');
+
+const yamlPath = process.argv[2] || path.join(__dirname, '../advancedToDo.yaml');
+const jsonPath = process.argv[3] || path.join(__dirname, '../advancedToDo.json');
+
+function loadTodos(file, parser) {
+  try {
+    const content = fs.readFileSync(file, 'utf8');
+    return parser(content);
+  } catch (err) {
+    console.error(`Unable to read ${file}:`, err.message);
+    process.exitCode = 1;
+    return [];
+  }
+}
+
+function validateList(list, source) {
+  const errors = [];
+  const seen = new Set();
+  list.forEach((item, idx) => {
+    ['commit', 'path', 'task', 'test'].forEach(key => {
+      if (!item[key] || typeof item[key] !== 'string' || !item[key].trim()) {
+        errors.push(`${source}[${idx}] missing ${key}`);
+      }
+    });
+    const id = item.commit || item.task;
+    if (seen.has(id)) {
+      errors.push(`${source}[${idx}] duplicate entry ${id}`);
+    }
+    seen.add(id);
+  });
+  return { errors, seen };
+}
+
+const yamlTodos = loadTodos(yamlPath, YAML.parse);
+const jsonTodos = loadTodos(jsonPath, JSON.parse);
+
+const yamlCheck = validateList(yamlTodos, 'yaml');
+const jsonCheck = validateList(jsonTodos, 'json');
+
+const errors = [...yamlCheck.errors, ...jsonCheck.errors];
+
+if (yamlTodos.length !== jsonTodos.length) {
+  errors.push(`mismatched lengths yaml(${yamlTodos.length}) vs json(${jsonTodos.length})`);
+}
+
+for (const id of jsonCheck.seen) {
+  if (!yamlCheck.seen.has(id)) {
+    errors.push(`missing in yaml: ${id}`);
+  }
+}
+for (const id of yamlCheck.seen) {
+  if (!jsonCheck.seen.has(id)) {
+    errors.push(`missing in json: ${id}`);
+  }
+}
+
+if (errors.length) {
+  console.error('Validation errors:\n' + errors.join('\n'));
+  process.exitCode = 1;
+} else {
+  console.log('All advancedToDo entries look valid');
+}


### PR DESCRIPTION
## Summary
- document validation flow for advanced todos
- add script to check advanced todo entries for completeness and duplicates
- track validator progress in advancedprogress.json

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `node scripts/validate-implicit-todos.js`
- `node_modules/.bin/tsc -p tsconfig.json --pretty false --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6891443beac88322b2abb25805abf717