### PR TITLE
ci: integrate implicit todo validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: '18'
       - run: pnpm install
       - run: pnpm run update:code-todos
+      - run: pnpm run validate:todos
       - run: pnpm audit --audit-level=moderate
       - run: pnpm --filter ./packages/crep-engine run lint test build
       - run: pnpm --filter ./packages/unifiedmandala-ui run lint test build

--- a/Handbuch.md
+++ b/Handbuch.md
@@ -22,7 +22,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - Über `scripts/generate-next-sigil.js` wird nach jedem Zyklus ein neues Sigil
   mit aktuellem `update_time` erzeugt.
 Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js` und aktualisiere `advancedToDo.json` sowie `advancedprogress.json`.
-Validiere extrahierte Einträge mit `node scripts/validate-implicit-todos.js` um fehlende Felder oder Duplikate zu finden.
+Validiere extrahierte Einträge mit `pnpm run validate:todos` (CI integriert) um fehlende Felder oder Duplikate zu finden.
 - Gesprächsstatistiken (inkl. Zeitspanne) aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
 - QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`

--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ Teil 5 enthält Aufgaben zur Sigil-Historie.
 Teil 7 listet Aufgaben zu poetischen Sigill- und Mandala-Modulen.
 Nutze `node scripts/parse-advanced-conversations.js` um Gesprächs-TODOs aus dem Datensatz zu filtern.
 Neu erzeugte Einträge landen in `advancedToDo.json` und `advancedToDo.yaml` und werden in `advancedprogress.json` dokumentiert.
-Prüfe fehlende Felder oder doppelte Tasks mit `node scripts/validate-implicit-todos.js`.
+Prüfe fehlende Felder oder doppelte Tasks mit `pnpm run validate:todos` (läuft auch in der CI).
 Nutze `node scripts/update-advanced-from-newconvos.js` um die ToDo-Dateien aus `newadvancedconversations.json` zu aktualisieren.
 
 - **Module**: unter `packages/` gegliedert in Agents, Core und mehr

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,14 +1,12 @@
 {
-  "lastCommit": "Add implicit todo validation script",
+  "lastCommit": "Integrate implicit todo validation into CI",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Created script to validate advancedToDo entries; next: integrate into CI pipeline.",
-  "pendingTasks": [
-    "Integrate validation script into CI pipeline"
-  ],
+  "notes": "Validation script integrated into CI pipeline.",
+  "pendingTasks": [],
   "progress": [
     {
       "commit": "Add Sigillin Fractal Visualizer component",
@@ -584,6 +582,10 @@
     },
     {
       "commit": "Add implicit todo validation script",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate implicit todo validation into CI",
       "status": "done"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "update:newadvanced-todo": "node scripts/update-newadvanced-todo.js",
     "update:fractal-todo": "node scripts/update-fractal-todo.js",
     "update:todo-sigil": "node scripts/update-todo-sigil.js",
+    "validate:todos": "node scripts/validate-implicit-todos.js",
     "export:crep-docs": "node scripts/export-crep-docs.js",
     "symbolzeit:run": "node scripts/symbolzeit-runner.js",
     "generate:next-sigil": "node scripts/generate-next-sigil.js",


### PR DESCRIPTION
## Summary
- run implicit todo validation during CI builds
- document new validation script
- track progress for todo validation integration

## Testing
- `pnpm install`
- `poetry install --with test`
- `pnpm run validate:todos` *(fails: missing fields and duplicates)*
- `npx pyright`
- `pnpm exec tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689147fd60f0832286c74d55ffd89996