### PR TITLE
chore: add advanced todo validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ Verwende `./scripts/aeon.sh <command>` für alle CLI-Aufrufe.
 | `node scripts/update-advanced-todo.js` | Aktualisiert Advanced-ToDo-Liste |
 | `node scripts/update-advancedprogress.js` | Dokumentiert Fortschritt |
 | `node scripts/sync-todo-progress.js` | Aktualisiert ToDo- & Progress-Dateien |
+| `node scripts/validate-advancedtodo.js` | Prüft Konsistenz zwischen YAML und JSON |
 | `node scripts/update-kontext.js` | Passt Kontext-Datei an (nutzt conversations oder newadvancedconversations) |
 | `node scripts/generate-readmes.ts` | Erstellt Modul-READMEs |
 | `node scripts/extract-snippets.js` | Extrahiert Code-Snippets |

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Integrate implicit todo validation into CI",
+  "lastCommit": "Add advancedToDo consistency validator script",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Validation script integrated into CI pipeline.",
+  "notes": "Added script validating advancedToDo YAML/JSON alignment.",
   "pendingTasks": [],
   "progress": [
     {
@@ -882,6 +882,10 @@
     },
     {
       "commit": "Extend GitHub Actions for extras",
+      "status": "done"
+    },
+    {
+      "commit": "Add advancedToDo consistency validator script",
       "status": "done"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "update:fractal-todo": "node scripts/update-fractal-todo.js",
     "update:todo-sigil": "node scripts/update-todo-sigil.js",
     "validate:todos": "node scripts/validate-implicit-todos.js",
+    "validate:advancedtodo": "node scripts/validate-advancedtodo.js",
     "export:crep-docs": "node scripts/export-crep-docs.js",
     "symbolzeit:run": "node scripts/symbolzeit-runner.js",
     "generate:next-sigil": "node scripts/generate-next-sigil.js",

--- a/scripts/validate-advancedtodo.js
+++ b/scripts/validate-advancedtodo.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+function loadYaml(file) {
+  try {
+    return yaml.load(fs.readFileSync(file, 'utf8')) || [];
+  } catch (err) {
+    console.error(`Failed to read ${file}:`, err.message);
+    return [];
+  }
+}
+
+function loadJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8')) || [];
+  } catch (err) {
+    console.error(`Failed to read ${file}:`, err.message);
+    return [];
+  }
+}
+
+function commitSet(entries) {
+  return new Set(
+    entries
+      .filter(e => e && typeof e.commit === 'string')
+      .map(e => e.commit.trim())
+      .filter(Boolean)
+  );
+}
+
+const root = path.join(__dirname, '..');
+const yamlPath = path.join(root, 'advancedToDo.yaml');
+const jsonPath = path.join(root, 'advancedToDo.json');
+
+const yamlEntries = loadYaml(yamlPath);
+const jsonEntries = loadJson(jsonPath);
+
+const yamlCommits = commitSet(yamlEntries);
+const jsonCommits = commitSet(jsonEntries);
+
+const missingInYaml = [...jsonCommits].filter(c => !yamlCommits.has(c));
+const missingInJson = [...yamlCommits].filter(c => !jsonCommits.has(c));
+
+function sample(arr) {
+  const max = 20;
+  return arr
+    .slice(0, max)
+    .map(c => (c.length > 80 ? `${c.slice(0, 77)}...` : c))
+    .concat(arr.length > max ? ['…'] : []);
+}
+
+if (missingInYaml.length || missingInJson.length) {
+  console.error('advancedToDo mismatch detected');
+  if (missingInYaml.length) {
+    console.error('  Commits missing in YAML:', sample(missingInYaml));
+  }
+  if (missingInJson.length) {
+    console.error('  Commits missing in JSON:', sample(missingInJson));
+  }
+  process.exit(1);
+}
+
+console.log('advancedToDo files are consistent.');


### PR DESCRIPTION
## Summary
- add script validating consistency between advancedToDo.yaml and .json
- expose validator via npm script and docs
- record progress in advancedprogress

## Testing
- `node scripts/validate-advancedtodo.js` *(fails: advancedToDo mismatch detected)*
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68914cf5bd60832289ec96c244e4de08