### PR TITLE
feat: add validator for new advanced conversations

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -24,6 +24,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js` und aktualisiere `advancedToDo.json` sowie `advancedprogress.json`.
 Validiere extrahierte Einträge mit `pnpm run validate:todos` (CI integriert) um fehlende Felder oder Duplikate zu finden.
 - Gesprächsstatistiken (inkl. Zeitspanne) aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
+- Strukturvalidierung für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
 - QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`
 - KEDA/HPA Skalierung unter `deployment/keda` für NATS Queue-Length

--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ Verwende `./scripts/aeon.sh <command>` für alle CLI-Aufrufe.
 | `node scripts/sync-todo-progress.js` | Aktualisiert ToDo- & Progress-Dateien |
 | `node scripts/validate-advancedtodo.js` | Prüft Konsistenz zwischen YAML und JSON |
 | `node scripts/update-kontext.js` | Passt Kontext-Datei an (nutzt conversations oder newadvancedconversations) |
+| `ts-node scripts/validate-newadvanced-conversations.ts` | Prüft Struktur von `newadvancedconversations.json` |
 | `node scripts/generate-readmes.ts` | Erstellt Modul-READMEs |
 | `node scripts/extract-snippets.js` | Extrahiert Code-Snippets |
 | `node scripts/extract_new_ai_fragments.js` | Extrahiert neue KI-Fragmente |

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Add advancedToDo consistency validator script",
+  "lastCommit": "Add newadvancedconversations validator",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added script validating advancedToDo YAML/JSON alignment.",
+  "notes": "Added validator for newadvancedconversations dataset.",
   "pendingTasks": [],
   "progress": [
     {
@@ -886,6 +886,10 @@
     },
     {
       "commit": "Add advancedToDo consistency validator script",
+      "status": "done"
+    },
+    {
+      "commit": "Add newadvancedconversations validator",
       "status": "done"
     }
   ],

--- a/scripts/__tests__/validate-newadvanced-conversations.test.ts
+++ b/scripts/__tests__/validate-newadvanced-conversations.test.ts
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+import { test, expect } from 'vitest';
+import { validateNewAdvancedConversations } from '../validate-newadvanced-conversations';
+
+test('detects duplicates and missing fields', () => {
+  const tmp = fs.mkdtempSync(path.join(__dirname, 'val-'));
+  const file = path.join(tmp, 'conv.json');
+  fs.writeFileSync(
+    file,
+    JSON.stringify([
+      { id: '1', title: 'A', mapping: {} },
+      { id: '1', mapping: {} },
+      { title: 'C', mapping: {} }
+    ])
+  );
+  const res = validateNewAdvancedConversations(file);
+  expect(res.conversationCount).toBe(3);
+  expect(res.duplicateIds).toEqual(['1']);
+  expect(res.missingFields.length).toBe(2);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env ts-node
+import fs from 'fs';
+import path from 'path';
+
+export interface ValidationResult {
+  conversationCount: number;
+  duplicateIds: string[];
+  missingFields: { index: number; fields: string[] }[];
+}
+
+export function validateNewAdvancedConversations(filePath: string): ValidationResult {
+  const raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const seen = new Set<string>();
+  const duplicateIds: string[] = [];
+  const missingFields: { index: number; fields: string[] }[] = [];
+
+  raw.forEach((conv: any, idx: number) => {
+    const missing: string[] = [];
+    if (!conv.id) missing.push('id');
+    if (!conv.title) missing.push('title');
+    if (typeof conv.mapping !== 'object') missing.push('mapping');
+    if (missing.length) missingFields.push({ index: idx, fields: missing });
+    if (conv.id) {
+      if (seen.has(conv.id)) duplicateIds.push(conv.id);
+      else seen.add(conv.id);
+    }
+  });
+
+  return { conversationCount: raw.length, duplicateIds, missingFields };
+}
+
+if (require.main === module) {
+  const file = process.argv[2] || path.join(__dirname, '../docs/sigils/newadvancedconversations.json');
+  const result = validateNewAdvancedConversations(file);
+  if (result.duplicateIds.length || result.missingFields.length) {
+    console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
+    process.exit(1);
+  }
+  console.log(`Validated ${result.conversationCount} conversations.`);
+}


### PR DESCRIPTION
## Summary
- add TypeScript validator ensuring `docs/sigils/newadvancedconversations.json` has unique IDs and required fields
- document validator in README and Handbuch
- record fractal run in `advancedprogress.json`

## Testing
- `npx pyright --stats`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/__tests__/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68915796115c8322b26ad8e54268d3e0