### PR TITLE
feat: track todo markers in conversation analyzer

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Add Sigillin example validator",
+  "lastCommit": "Count TODO markers in conversation analyzer",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added validation script for sigillin.examples",
+  "notes": "Extended analyzer to count TODO markers",
   "pendingTasks": [],
   "progress": [
     {
@@ -894,6 +894,10 @@
     },
     {
       "commit": "Add newadvancedconversations validator",
+      "status": "done"
+    },
+    {
+      "commit": "Count TODO markers in conversation analyzer",
       "status": "done"
     }
   ],

--- a/scripts/analyze-newadvanced-conversations.test.ts
+++ b/scripts/analyze-newadvanced-conversations.test.ts
@@ -12,5 +12,6 @@ describe('analyzeNewAdvancedConversations', () => {
     expect(stats.averageMessagesPerConversation).toBe(1);
     expect(stats.timeRange.start).toBe(1234567890);
     expect(stats.timeRange.end).toBe(1234567890);
+    expect(stats.todoCount).toBe(1);
   });
 });

--- a/scripts/analyze-newadvanced-conversations.ts
+++ b/scripts/analyze-newadvanced-conversations.ts
@@ -8,6 +8,7 @@ export interface ConversationStats {
   authorCounts: Record<string, number>;
   averageMessagesPerConversation: number;
   timeRange: { start: number | null; end: number | null };
+  todoCount: number;
 }
 
 export function analyzeNewAdvancedConversations(filePath: string): ConversationStats {
@@ -16,6 +17,7 @@ export function analyzeNewAdvancedConversations(filePath: string): ConversationS
   const authorCounts: Record<string, number> = {};
   let minTime: number | null = null;
   let maxTime: number | null = null;
+  let todoCount = 0;
   raw.forEach((session: any) => {
     const nodes = Object.values(session.mapping || {});
     nodes.forEach((node: any) => {
@@ -29,6 +31,10 @@ export function analyzeNewAdvancedConversations(filePath: string): ConversationS
           minTime = minTime === null ? ct : Math.min(minTime, ct);
           maxTime = maxTime === null ? ct : Math.max(maxTime, ct);
         }
+        const parts: string[] = msg.content?.parts || [];
+        const text = parts.join(' ');
+        const matches = text.match(/TODO/gi);
+        if (matches) todoCount += matches.length;
       }
     });
   });
@@ -38,6 +44,7 @@ export function analyzeNewAdvancedConversations(filePath: string): ConversationS
     authorCounts,
     averageMessagesPerConversation: raw.length ? messageCount / raw.length : 0,
     timeRange: { start: minTime, end: maxTime },
+    todoCount,
   };
 }
 

--- a/tests/fixtures/newadvanced-sample.json
+++ b/tests/fixtures/newadvanced-sample.json
@@ -7,7 +7,7 @@
         "message": {
           "author": { "role": "user" },
           "create_time": 1234567890,
-          "content": { "content_type": "text", "parts": ["hello"] }
+          "content": { "content_type": "text", "parts": ["TODO: hello"] }
         }
       }
     }


### PR DESCRIPTION
## Summary
- count TODO markers in `analyze-newadvanced-conversations` stats output
- cover todo counting with fixture and vitest
- log progress for fractal run

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test:agents` *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6891681ee3ac8322bf8148d1a3dcb007