### PR TITLE
feat: add per-conversation todo counter

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8226,5 +8226,12 @@
     "task": "Include implicit conversation cues when updating advancedToDo",
     "test": "packages/shared-utils/advancedTodoUpdater.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add per-conversation TODO counter",
+    "path": "packages/shared-utils/conversationAnalyzer.ts",
+    "task": "Provide TODO counts per conversation",
+    "test": "packages/shared-utils/conversationAnalyzer.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -9013,3 +9013,8 @@
   task: Include implicit conversation cues when updating advancedToDo
   test: packages/shared-utils/advancedTodoUpdater.test.ts
   status: done
+- commit: Add per-conversation TODO counter
+  path: packages/shared-utils/conversationAnalyzer.ts
+  task: Provide TODO counts per conversation
+  test: packages/shared-utils/conversationAnalyzer.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Count TODO markers in conversation analyzer",
+  "lastCommit": "Add per-conversation TODO counter",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Extended analyzer to count TODO markers",
+  "notes": "Expose per-conversation TODO marker counts",
   "pendingTasks": [],
   "progress": [
     {
@@ -898,6 +898,10 @@
     },
     {
       "commit": "Count TODO markers in conversation analyzer",
+      "status": "done"
+    },
+    {
+      "commit": "Add per-conversation TODO counter",
       "status": "done"
     }
   ],

--- a/packages/shared-utils/conversationAnalyzer.test.ts
+++ b/packages/shared-utils/conversationAnalyzer.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { analyzeConversations, extractTodosFromConversations, extractImplicitTodosFromConversations, loadConversations } from './conversationAnalyzer';
+import { analyzeConversations, extractTodosFromConversations, extractImplicitTodosFromConversations, loadConversations, countTodosByConversation } from './conversationAnalyzer';
 
 describe('conversationAnalyzer', () => {
   const sample = path.join(__dirname, 'sample-conv.json');
@@ -27,6 +27,11 @@ describe('conversationAnalyzer', () => {
   it('extracts TODOs', () => {
     const todos = extractTodosFromConversations(sample);
     expect(todos).toEqual(['teste']);
+  });
+
+  it('counts TODO markers per conversation', () => {
+    const counts = countTodosByConversation(sample);
+    expect(counts['a']).toBe(1);
   });
 
   it('extracts implicit todos', () => {

--- a/packages/shared-utils/conversationAnalyzer.ts
+++ b/packages/shared-utils/conversationAnalyzer.ts
@@ -104,3 +104,25 @@ export function extractImplicitTodosFromConversations(filePath: string): string[
   }
   return Array.from(new Set(todos));
 }
+
+export function countTodosByConversation(filePath: string): Record<string, number> {
+  const convs = loadConversations(filePath);
+  const regex = /TODO[:]?\s*(.*)/i;
+  const counts: Record<string, number> = {};
+  for (const conv of convs) {
+    let count = 0;
+    for (const node of Object.values(conv.mapping)) {
+      const msg = node.message;
+      if (!msg) continue;
+      const parts = msg.content?.parts || [];
+      for (const part of parts) {
+        if (typeof part !== 'string') continue;
+        for (const line of part.split(/\n+/)) {
+          if (regex.test(line)) count++;
+        }
+      }
+    }
+    counts[conv.id] = count;
+  }
+  return counts;
+}


### PR DESCRIPTION
## Summary
- add `countTodosByConversation` to analyze TODO markers per chat
- verify counts with new unit test
- document feature in advanced ToDo and progress tracking

## Testing
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx vitest packages/shared-utils/conversationAnalyzer.test.ts` *(no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68918762125c83228a483498527d912a