### PR TITLE
feat: add particle force kernel

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2677,7 +2677,8 @@
     "commit": "feat: add ParticleForce module",
     "path": "packages/universum-simulationen/modules/particle_force.py",
     "task": "Kernel for stable particles and basic forces",
-    "test": "packages/universum-simulationen/__tests__/particle_force.test.py"
+    "test": "packages/universum-simulationen/__tests__/particle_force_test.py",
+    "status": "done"
   },
   {
     "commit": "feat: add FusionEvolution module",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4379,7 +4379,8 @@
 - commit: "feat: add ParticleForce module"
   path: packages/universum-simulationen/modules/particle_force.py
   task: Kernel for stable particles and basic forces
-  test: packages/universum-simulationen/__tests__/particle_force.test.py
+  test: packages/universum-simulationen/__tests__/particle_force_test.py
+  status: done
 - commit: "feat: add FusionEvolution module"
   path: packages/universum-simulationen/modules/fusion_evolution.py
   task: Compute fusion processes and heavier elements

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Add per-conversation TODO counter",
+  "lastCommit": "feat: add ParticleForce module",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Expose per-conversation TODO marker counts",
+  "notes": "Added basic particle force kernel for simulations",
   "pendingTasks": [],
   "progress": [
     {
@@ -902,6 +902,10 @@
     },
     {
       "commit": "Add per-conversation TODO counter",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add ParticleForce module",
       "status": "done"
     }
   ],

--- a/packages/universum-simulationen/__tests__/particle_force_test.py
+++ b/packages/universum-simulationen/__tests__/particle_force_test.py
@@ -1,0 +1,36 @@
+import math
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "modules" / "particle_force.py"
+spec = importlib.util.spec_from_file_location("particle_force", MODULE_PATH)
+pf = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules[spec.name] = pf
+spec.loader.exec_module(pf)
+
+Particle = pf.Particle
+compute_force = pf.compute_force
+G = pf.G
+K = pf.K
+
+
+def test_compute_force_basic():
+    p1 = Particle(mass=1.0, charge=1.0)
+    p2 = Particle(mass=2.0, charge=-1.0)
+    forces = compute_force(p1, p2, distance=1.0)
+
+    assert math.isclose(forces["gravity"], G * 2.0, rel_tol=1e-9)
+    assert math.isclose(forces["electric"], -K, rel_tol=1e-9)
+
+
+def test_invalid_distance():
+    p1 = Particle(1.0, 0.0)
+    p2 = Particle(1.0, 0.0)
+    try:
+        compute_force(p1, p2, distance=0)
+    except ValueError:
+        assert True
+    else:
+        assert False

--- a/packages/universum-simulationen/modules/particle_force.py
+++ b/packages/universum-simulationen/modules/particle_force.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Particle force kernel for universum-simulationen package.
+
+This module provides a small utility to compute basic forces between two
+particles.  It currently supports gravitational and electrostatic (Coulomb)
+forces.  The goal of this module is to serve as a minimal physics kernel
+that other simulations can import.
+"""
+
+from dataclasses import dataclass
+from typing import Dict
+
+# Gravitational constant (m^3 kg^-1 s^-2)
+G = 6.674e-11
+# Coulomb constant (N m^2 C^-2)
+K = 8.988e9
+
+
+@dataclass
+class Particle:
+    """Simple particle representation with mass and electric charge."""
+
+    mass: float  # in kilograms
+    charge: float  # in Coulombs
+
+
+def compute_force(p1: Particle, p2: Particle, distance: float) -> Dict[str, float]:
+    """Compute forces between two particles.
+
+    Args:
+        p1: First particle.
+        p2: Second particle.
+        distance: Distance between particles in meters. Must be > 0.
+
+    Returns:
+        A dictionary with ``gravity`` and ``electric`` force magnitudes in
+        Newtons.  The electric value preserves the sign (attraction vs.
+        repulsion).
+    """
+
+    if distance <= 0:
+        raise ValueError("distance must be positive")
+
+    gravity = G * p1.mass * p2.mass / (distance ** 2)
+    electric = K * p1.charge * p2.charge / (distance ** 2)
+    return {"gravity": gravity, "electric": electric}


### PR DESCRIPTION
## Summary
- add basic ParticleForce kernel and tests
- mark ParticleForce task complete in advancedToDo
- log progress for fractal run

## Testing
- `npx pyright packages/universum-simulationen/modules/particle_force.py packages/universum-simulationen/__tests__/particle_force_test.py`
- `npx tsc -p tsconfig.json --noEmit`
- `pytest packages/universum-simulationen/__tests__/particle_force_test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891c4f3aa1c83229656d827983b3aa6