### PR TITLE
feat: summarize newadvancedconversations

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,12 +1,14 @@
 {
-  "lastCommit": "feat: add ParticleForce module",
+  "lastCommit": "feat: summarize newadvancedconversations",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added basic particle force kernel for simulations",
-  "pendingTasks": [],
+  "notes": "Generated summary from newadvancedconversations.json; next: fragment extraction",
+  "pendingTasks": [
+    "Split newadvancedconversations into fragments and link to TODOs"
+  ],
   "progress": [
     {
       "commit": "Add Sigillin Fractal Visualizer component",
@@ -590,6 +592,10 @@
     },
     {
       "commit": "Add Sigillin example validator",
+      "status": "done"
+    },
+    {
+      "commit": "Summarize newadvancedconversations dataset",
       "status": "done"
     }
   ],

--- a/docs/newadvanced-summary.md
+++ b/docs/newadvanced-summary.md
@@ -1,0 +1,11 @@
+# New Advanced Conversations Stats
+
+- Conversations: 258
+- Messages: 27863
+- Authors:
+  - system: 2151
+  - user: 7479
+  - tool: 4776
+  - assistant: 13457
+- TODOs: 2083
+- Time range: 1677604304.583708 - 1749551173338

--- a/scripts/analyze-newadvanced-conversations.ts
+++ b/scripts/analyze-newadvanced-conversations.ts
@@ -49,9 +49,31 @@ export function analyzeNewAdvancedConversations(filePath: string): ConversationS
 }
 
 if (require.main === module) {
-  const file = process.argv[2] || path.join(__dirname, '../docs/sigils/newadvancedconversations.json');
+  const fileArgIndex = process.argv.findIndex((a: string) => !a.startsWith('--'));
+  const file =
+    fileArgIndex > 1
+      ? process.argv[fileArgIndex]
+      : path.join(__dirname, '../docs/sigils/newadvancedconversations.json');
+  const summaryIndex = process.argv.indexOf('--summary');
+  const summaryPath = summaryIndex >= 0 ? process.argv[summaryIndex + 1] : null;
   const stats = analyzeNewAdvancedConversations(file);
   console.log(`Conversations: ${stats.conversationCount}`);
   console.log(`Messages: ${stats.messageCount}`);
   console.log('Authors:', stats.authorCounts);
+  if (summaryPath) {
+    const lines = [
+      '# New Advanced Conversations Stats',
+      '',
+      `- Conversations: ${stats.conversationCount}`,
+      `- Messages: ${stats.messageCount}`,
+      '- Authors:',
+      ...Object.entries(stats.authorCounts).map(
+        ([role, count]) => `  - ${role}: ${count}`
+      ),
+      `- TODOs: ${stats.todoCount}`,
+      `- Time range: ${stats.timeRange.start ?? 'n/a'} - ${stats.timeRange.end ?? 'n/a'}`,
+    ];
+    fs.writeFileSync(summaryPath, lines.join('\n') + '\n');
+    console.log(`Summary written to ${summaryPath}`);
+  }
 }


### PR DESCRIPTION
## Summary
- extend analyzer script with optional summary output for new advanced conversation data
- generate initial summary documenting conversation counts, authors and TODO totals
- record fractal-run status and next steps in advancedprogress

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6891d1278ed48322b079731eb7b29453