### PR TITLE
feat: list titles in newadvanced analyzer

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -23,7 +23,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
   mit aktuellem `update_time` erzeugt.
 Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js` und aktualisiere `advancedToDo.json` sowie `advancedprogress.json`.
 Validiere extrahierte Einträge mit `pnpm run validate:todos` (CI integriert) um fehlende Felder oder Duplikate zu finden.
-- Gesprächsstatistiken (inkl. Zeitspanne) aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
+- Gesprächsstatistiken (inkl. Titel & Zeitspanne) aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
 - Strukturvalidierung für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
 - QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
   synchronisiere ToDo-Dateien vor großen Commits mit
   `scripts/sync-todo-progress.js`.
 - Freundschaftssystem-Konzept siehe [docs/friendship-system.md](docs/friendship-system.md)
-- Gesprächsstatistiken (inkl. Zeitspanne) aus neuen Chat-Logs: `ts-node scripts/analyze-newadvanced-conversations.ts`
+- Gesprächsstatistiken (inkl. Titel & Zeitspanne) aus neuen Chat-Logs: `ts-node scripts/analyze-newadvanced-conversations.ts`
 
 ## 🚀 Features
 

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,13 +1,13 @@
 {
-  "lastCommit": "feat: summarize newadvancedconversations",
+  "lastCommit": "feat: add conversation titles to analyzer",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Generated summary from newadvancedconversations.json; next: fragment extraction",
+  "notes": "Analyzer now lists conversation titles; next: extract tasks for specific conversations",
   "pendingTasks": [
-    "Split newadvancedconversations into fragments and link to TODOs"
+    "Extract tasks from Programm testen Feedback and Sigillin Entwicklungszusammenfassung"
   ],
   "progress": [
     {
@@ -596,6 +596,10 @@
     },
     {
       "commit": "Summarize newadvancedconversations dataset",
+      "status": "done"
+    },
+    {
+      "commit": "Add conversation title reporting to analyzer",
       "status": "done"
     }
   ],

--- a/scripts/analyze-newadvanced-conversations.test.ts
+++ b/scripts/analyze-newadvanced-conversations.test.ts
@@ -13,5 +13,6 @@ describe('analyzeNewAdvancedConversations', () => {
     expect(stats.timeRange.start).toBe(1234567890);
     expect(stats.timeRange.end).toBe(1234567890);
     expect(stats.todoCount).toBe(1);
+    expect(stats.titles).toEqual(['Sample']);
   });
 });

--- a/scripts/analyze-newadvanced-conversations.ts
+++ b/scripts/analyze-newadvanced-conversations.ts
@@ -9,6 +9,7 @@ export interface ConversationStats {
   averageMessagesPerConversation: number;
   timeRange: { start: number | null; end: number | null };
   todoCount: number;
+  titles: string[];
 }
 
 export function analyzeNewAdvancedConversations(filePath: string): ConversationStats {
@@ -18,7 +19,9 @@ export function analyzeNewAdvancedConversations(filePath: string): ConversationS
   let minTime: number | null = null;
   let maxTime: number | null = null;
   let todoCount = 0;
+  const titles: string[] = [];
   raw.forEach((session: any) => {
+    titles.push(session.title || 'Untitled');
     const nodes = Object.values(session.mapping || {});
     nodes.forEach((node: any) => {
       const msg = node.message;
@@ -45,6 +48,7 @@ export function analyzeNewAdvancedConversations(filePath: string): ConversationS
     averageMessagesPerConversation: raw.length ? messageCount / raw.length : 0,
     timeRange: { start: minTime, end: maxTime },
     todoCount,
+    titles,
   };
 }
 
@@ -60,6 +64,7 @@ if (require.main === module) {
   console.log(`Conversations: ${stats.conversationCount}`);
   console.log(`Messages: ${stats.messageCount}`);
   console.log('Authors:', stats.authorCounts);
+  console.log('Titles:', stats.titles);
   if (summaryPath) {
     const lines = [
       '# New Advanced Conversations Stats',
@@ -70,6 +75,8 @@ if (require.main === module) {
       ...Object.entries(stats.authorCounts).map(
         ([role, count]) => `  - ${role}: ${count}`
       ),
+      '- Titles:',
+      ...stats.titles.map((t) => `  - ${t}`),
       `- TODOs: ${stats.todoCount}`,
       `- Time range: ${stats.timeRange.start ?? 'n/a'} - ${stats.timeRange.end ?? 'n/a'}`,
     ];


### PR DESCRIPTION
## Summary
- include conversation titles in `analyze-newadvanced-conversations` output
- document title extraction in README and Handbuch
- log progress for conversation title feature

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test` *(fails: Ineffective mark-compacts near heap limit)*
- `pnpm test:agents scripts/analyze-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6891d8b7b15883229bb69007886f1296