### PR TITLE
feat: award sigils in C-Tutor progress workflow

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -933,7 +933,8 @@
     "commit": "Implement C-Tutor progress workflow",
     "path": "packages/tutorials/C-Tutor",
     "task": "Track user progress and award Sigil per milestone",
-    "test": "packages/tutorials/__tests__/C-Tutor.test.ts"
+    "test": "packages/tutorials/__tests__/C-Tutor.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add JavaHamster AI Flow",
@@ -1175,7 +1176,8 @@
     "commit": "Implement GhostShell session store",
     "path": "services/ghost-shell/session-store.ts",
     "task": "Track WebSocket message history per client",
-    "test": "services/ghost-shell/session-store.test.ts"
+    "test": "services/ghost-shell/session-store.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add GhostShell cluster manager",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -662,6 +662,7 @@
   path: packages/tutorials/C-Tutor
   task: Track user progress and award Sigil per milestone
   test: packages/tutorials/__tests__/C-Tutor.test.ts
+  status: done
 - commit: Add JavaHamster AI Flow
   path: packages/tutorials/JavaHamsterAI
   task: Interactive hamster coding with AI coach and Sigil rewards
@@ -853,6 +854,7 @@
   path: services/ghost-shell/session-store.ts
   task: Track WebSocket message history per client
   test: services/ghost-shell/session-store.test.ts
+  status: done
 - commit: Add GhostShell cluster manager
   path: services/ghost-shell/cluster.ts
   task: Start Node.js cluster of GhostShellAgent workers using `cluster` API

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,13 +1,14 @@
 {
-  "lastCommit": "feat: extract todos by conversation title",
+  "lastCommit": "feat: award sigils in C-Tutor progress",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added helper to extract TODOs from conversations by title; tasks from Programm testen Feedback and Sigillin Entwicklungszusammenfassung captured",
+  "notes": "Implemented CTutor sigil awarding; GhostShell session store marked done",
   "pendingTasks": [
-    "Integrate extracted tasks into advancedToDo manifest"
+    "Integrate extracted tasks into advancedToDo manifest",
+    "Implement JavaHamster AI Flow"
   ],
   "progress": [
     {
@@ -419,10 +420,6 @@
       "status": "done"
     },
     {
-      "commit": "Implement C-Tutor progress workflow",
-      "status": "done"
-    },
-    {
       "commit": "Add JavaHamster AI Flow",
       "status": "done"
     },
@@ -600,6 +597,10 @@
     },
     {
       "commit": "Add conversation title reporting to analyzer",
+      "status": "done"
+    },
+    {
+      "commit": "Implement C-Tutor progress workflow",
       "status": "done"
     }
   ],

--- a/packages/tutorials/C-Tutor/index.ts
+++ b/packages/tutorials/C-Tutor/index.ts
@@ -5,15 +5,29 @@ export interface Milestone {
 
 export class CTutorProgress {
   private milestones: Milestone[];
-  constructor(milestones: string[] = []) {
+  private awarded: string[] = [];
+  private awardCallback?: (name: string) => void;
+
+  constructor(milestones: string[] = [], awardCallback?: (name: string) => void) {
     this.milestones = milestones.map((m) => ({ name: m, completed: false }));
+    this.awardCallback = awardCallback;
   }
+
   complete(name: string) {
     const m = this.milestones.find((m) => m.name === name);
-    if (m) m.completed = true;
+    if (m && !m.completed) {
+      m.completed = true;
+      this.awarded.push(name);
+      this.awardCallback?.(name);
+    }
   }
+
   getProgress() {
     const completed = this.milestones.filter((m) => m.completed).length;
-    return completed / this.milestones.length;
+    return this.milestones.length === 0 ? 0 : completed / this.milestones.length;
+  }
+
+  getAwardedSigils() {
+    return [...this.awarded];
   }
 }

--- a/packages/tutorials/__tests__/C-Tutor.test.ts
+++ b/packages/tutorials/__tests__/C-Tutor.test.ts
@@ -9,4 +9,12 @@ describe('CTutorProgress', () => {
     tutor.complete('b');
     expect(tutor.getProgress()).toBe(1);
   });
+
+  it('awards a sigil per milestone', () => {
+    const awarded: string[] = [];
+    const tutor = new CTutorProgress(['a'], (name) => awarded.push(name));
+    tutor.complete('a');
+    expect(awarded).toEqual(['a']);
+    expect(tutor.getAwardedSigils()).toEqual(['a']);
+  });
 });


### PR DESCRIPTION
## Summary
- award sigils when C-Tutor milestones are completed
- mark GhostShell session store and C-Tutor tasks as done in advancedToDo manifests
- log progress for C-Tutor sigil awarding

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false`
- `npx jest packages/tutorials/__tests__/C-Tutor.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6891f02910388322ba310e992b6a0ece