### PR TITLE
feat: validate duplicate conversation titles

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8236,5 +8236,12 @@
     "task": "Provide TODO counts per conversation",
     "test": "packages/shared-utils/conversationAnalyzer.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Validate duplicate conversation titles",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Extend validator to check for duplicate conversation titles",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1,3 +1,8 @@
+- commit: Validate duplicate conversation titles
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Extend validator to check for duplicate conversation titles
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done
 - commit: Add CREPTooltip component
   path: packages/unifiedmandala-ui/components/CREPTooltip.tsx
   task: Small info overlay for CREP values

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: award sigils in C-Tutor progress",
+  "lastCommit": "feat: validate duplicate conversation titles",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented CTutor sigil awarding; GhostShell session store marked done",
+  "notes": "Added duplicate title check for new advanced conversations. Next: integrate extracted tasks into advancedToDo manifest and implement JavaHamster AI Flow.",
   "pendingTasks": [
     "Integrate extracted tasks into advancedToDo manifest",
     "Implement JavaHamster AI Flow"
@@ -601,6 +601,10 @@
     },
     {
       "commit": "Implement C-Tutor progress workflow",
+      "status": "done"
+    },
+    {
+      "commit": "Validate duplicate conversation titles",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { validateNewAdvancedConversations } from './validate-newadvanced-conversations';
+
+describe('validateNewAdvancedConversations', () => {
+  it('flags duplicate titles', () => {
+    const file = path.join(__dirname, '../tests/fixtures/newadvanced-duplicate-titles.json');
+    const res = validateNewAdvancedConversations(file);
+    expect(res.duplicateTitles).toEqual(['Foo']);
+  });
+});

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -5,13 +5,16 @@ import path from 'path';
 export interface ValidationResult {
   conversationCount: number;
   duplicateIds: string[];
+  duplicateTitles: string[];
   missingFields: { index: number; fields: string[] }[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
   const raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  const seen = new Set<string>();
+  const seenIds = new Set<string>();
+  const seenTitles = new Set<string>();
   const duplicateIds: string[] = [];
+  const duplicateTitles: string[] = [];
   const missingFields: { index: number; fields: string[] }[] = [];
 
   raw.forEach((conv: any, idx: number) => {
@@ -21,18 +24,22 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     if (typeof conv.mapping !== 'object') missing.push('mapping');
     if (missing.length) missingFields.push({ index: idx, fields: missing });
     if (conv.id) {
-      if (seen.has(conv.id)) duplicateIds.push(conv.id);
-      else seen.add(conv.id);
+      if (seenIds.has(conv.id)) duplicateIds.push(conv.id);
+      else seenIds.add(conv.id);
+    }
+    if (conv.title) {
+      if (seenTitles.has(conv.title)) duplicateTitles.push(conv.title);
+      else seenTitles.add(conv.title);
     }
   });
 
-  return { conversationCount: raw.length, duplicateIds, missingFields };
+  return { conversationCount: raw.length, duplicateIds, duplicateTitles, missingFields };
 }
 
 if (require.main === module) {
   const file = process.argv[2] || path.join(__dirname, '../docs/sigils/newadvancedconversations.json');
   const result = validateNewAdvancedConversations(file);
-  if (result.duplicateIds.length || result.missingFields.length) {
+  if (result.duplicateIds.length || result.duplicateTitles.length || result.missingFields.length) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);
   }

--- a/tests/fixtures/newadvanced-duplicate-titles.json
+++ b/tests/fixtures/newadvanced-duplicate-titles.json
@@ -1,0 +1,4 @@
+[
+  { "id": "conv1", "title": "Foo", "mapping": {} },
+  { "id": "conv2", "title": "Foo", "mapping": {} }
+]


### PR DESCRIPTION
## Summary
- extend newadvanced conversation validator to detect duplicate titles
- add tests and fixture for duplicate title validation
- log validator enhancement in advanced ToDo and progress manifests

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6891f6042d90832286577073a9781f90