### PR TITLE
feat: validate message timestamp order

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -24,7 +24,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js` und aktualisiere `advancedToDo.json` sowie `advancedprogress.json`.
 Validiere extrahierte Einträge mit `pnpm run validate:todos` (CI integriert) um fehlende Felder oder Duplikate zu finden.
 - Gesprächsstatistiken (inkl. Titel & Zeitspanne) aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
-- Strukturvalidierung für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
+- Struktur- und Zeitvalidierung für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
 - QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`
 - KEDA/HPA Skalierung unter `deployment/keda` für NATS Queue-Length

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ Verwende `./scripts/aeon.sh <command>` für alle CLI-Aufrufe.
 | `node scripts/sync-todo-progress.js` | Aktualisiert ToDo- & Progress-Dateien |
 | `node scripts/validate-advancedtodo.js` | Prüft Konsistenz zwischen YAML und JSON |
 | `node scripts/update-kontext.js` | Passt Kontext-Datei an (nutzt conversations oder newadvancedconversations) |
-| `ts-node scripts/validate-newadvanced-conversations.ts` | Prüft Struktur von `newadvancedconversations.json` |
+| `ts-node scripts/validate-newadvanced-conversations.ts` | Prüft Struktur und Zeitreihen von `newadvancedconversations.json` |
 | `ts-node scripts/validate-sigillin-examples.ts` | Validiert Sigillin-Beispieldateien |
 | `node scripts/generate-readmes.ts` | Erstellt Modul-READMEs |
 | `node scripts/extract-snippets.js` | Extrahiert Code-Snippets |

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: validate duplicate conversation titles",
+  "lastCommit": "feat: validate message timestamp order",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added duplicate title check for new advanced conversations. Next: integrate extracted tasks into advancedToDo manifest and implement JavaHamster AI Flow.",
+  "notes": "Added duplicate title check for new advanced conversations. Implemented timestamp order validation. Next: integrate extracted tasks into advancedToDo manifest and implement JavaHamster AI Flow.",
   "pendingTasks": [
     "Integrate extracted tasks into advancedToDo manifest",
     "Implement JavaHamster AI Flow"
@@ -925,6 +925,10 @@
     },
     {
       "commit": "feat: extract todos by conversation title",
+      "status": "done"
+    },
+    {
+      "commit": "feat: validate message timestamp order",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -8,4 +8,13 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.duplicateTitles).toEqual(['Foo']);
   });
+
+  it('detects out-of-order message timestamps', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-out-of-order.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.outOfOrderConversations).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -7,6 +7,7 @@ export interface ValidationResult {
   duplicateIds: string[];
   duplicateTitles: string[];
   missingFields: { index: number; fields: string[] }[];
+  outOfOrderConversations: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -16,6 +17,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const duplicateIds: string[] = [];
   const duplicateTitles: string[] = [];
   const missingFields: { index: number; fields: string[] }[] = [];
+  const outOfOrder: number[] = [];
 
   raw.forEach((conv: any, idx: number) => {
     const missing: string[] = [];
@@ -31,15 +33,36 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       if (seenTitles.has(conv.title)) duplicateTitles.push(conv.title);
       else seenTitles.add(conv.title);
     }
+
+    const times = Object.values(conv.mapping || {})
+      .map((n: any) => n?.message?.create_time)
+      .filter((t: any): t is number => typeof t === 'number');
+    for (let i = 1; i < times.length; i++) {
+      if (times[i] < times[i - 1]) {
+        outOfOrder.push(idx);
+        break;
+      }
+    }
   });
 
-  return { conversationCount: raw.length, duplicateIds, duplicateTitles, missingFields };
+  return {
+    conversationCount: raw.length,
+    duplicateIds,
+    duplicateTitles,
+    missingFields,
+    outOfOrderConversations: outOfOrder,
+  };
 }
 
 if (require.main === module) {
   const file = process.argv[2] || path.join(__dirname, '../docs/sigils/newadvancedconversations.json');
   const result = validateNewAdvancedConversations(file);
-  if (result.duplicateIds.length || result.duplicateTitles.length || result.missingFields.length) {
+  if (
+    result.duplicateIds.length ||
+    result.duplicateTitles.length ||
+    result.missingFields.length ||
+    result.outOfOrderConversations.length
+  ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);
   }

--- a/tests/fixtures/newadvanced-out-of-order.json
+++ b/tests/fixtures/newadvanced-out-of-order.json
@@ -1,0 +1,23 @@
+[
+  {
+    "title": "OutOfOrder",
+    "mapping": {
+      "a": {
+        "id": "a",
+        "message": {
+          "author": { "role": "user" },
+          "create_time": 2,
+          "content": { "content_type": "text", "parts": ["hi"] }
+        }
+      },
+      "b": {
+        "id": "b",
+        "message": {
+          "author": { "role": "user" },
+          "create_time": 1,
+          "content": { "content_type": "text", "parts": ["hi"] }
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- extend `validate-newadvanced-conversations` to flag conversations with out-of-order timestamps
- document conversation validator in README and Handbuch
- record progress for timestamp validation

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68920dd6497c8322b4995b025787f26e