### PR TITLE
feat: extract training data from conversations

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,14 +1,15 @@
 {
-  "lastCommit": "feat: trigger webhooks in HookTriggererAgent",
+  "lastCommit": "feat: extract training data from conversations",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added duplicate title check for new advanced conversations. Implemented timestamp order validation. Implemented webhook triggering in HookTriggererAgent. Next: integrate extracted tasks into advancedToDo manifest and implement JavaHamster AI Flow.",
+  "notes": "Added training data extraction script for new advanced conversations. Implemented webhook triggering earlier. Next: run extractor and integrate tasks into advancedToDo manifest; continue with JavaHamster AI Flow.",
   "pendingTasks": [
     "Integrate extracted tasks into advancedToDo manifest",
     "Implement JavaHamster AI Flow",
+    "Run scripts/extract-training-data.ts to fragment new advanced conversations",
     {
       "commit": "- ToDo-Dateien vor größeren Commits mit `scripts/sync-todo-progress.js` abgleichen",
       "status": "planned"

--- a/scripts/__tests__/extract-training-data.test.ts
+++ b/scripts/__tests__/extract-training-data.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { promises as fs, constants as fsConstants } from 'fs';
+import path from 'path';
+import os from 'os';
+import yaml from 'js-yaml';
+import { extractTrainingData } from '../extract-training-data';
+
+async function exists(p: string) {
+  try {
+    await fs.access(p, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('extractTrainingData', () => {
+  it('writes conversation fragments and manifest', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'extract-'));
+    const src = path.join(tmp, 'source.json');
+    const out = path.join(tmp, 'out');
+    const manifest = path.join(tmp, 'manifest.yaml');
+
+    const sample = [
+      {
+        timestamp: '2025-01-01T00:00:00Z',
+        title: 'Test Conversation',
+        messages: [
+          { role: 'user', content: 'Hello' },
+          { role: 'assistant', content: 'Hi' },
+        ],
+      },
+    ];
+    await fs.writeFile(src, JSON.stringify(sample));
+
+    await extractTrainingData(src, out, manifest);
+
+    const slug = '2025-01-01-test-conversation';
+    expect(await exists(path.join(out, slug, 'conversation.json'))).toBe(true);
+    expect(await exists(path.join(out, slug, 'msg_0001.yaml'))).toBe(true);
+
+    const manifestContent = yaml.load(await fs.readFile(manifest, 'utf8')) as any;
+    expect(manifestContent.conversations[0].id).toBe(slug);
+  });
+});

--- a/scripts/extract-training-data.ts
+++ b/scripts/extract-training-data.ts
@@ -1,0 +1,99 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+function slugifyTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export async function extractTrainingData(
+  src = path.resolve('docs/sigils/newadvancedconversations.json'),
+  outRoot = path.resolve('GenesisAeonZIPMEM/newadvancedconversations'),
+  manifestPath = path.resolve('GenesisAeonZIPMEM/ZIPMEM_manifest.yaml')
+) {
+  let raw = '';
+  try {
+    raw = await fs.readFile(src, 'utf8');
+  } catch (e) {
+    console.error('Fehler beim Lesen oder Parsen der Source JSON:', e);
+    process.exit(1);
+  }
+  let convos: any[] = [];
+  try {
+    convos = JSON.parse(raw);
+    if (!Array.isArray(convos)) throw new Error('Expected JSON array');
+  } catch (e) {
+    console.error('Fehler beim Lesen oder Parsen der Source JSON:', e);
+    process.exit(1);
+  }
+
+  let manifest: any = { conversations: [] };
+  try {
+    const manifestRaw = await fs.readFile(manifestPath, 'utf8');
+    manifest = (yaml.load(manifestRaw) as any) || manifest;
+  } catch {
+    // ignore if manifest doesn't exist
+  }
+
+  for (const convo of convos) {
+    const date = (convo.timestamp || convo.date || new Date().toISOString()).slice(0, 10);
+    const title = convo.title || convo.id || 'conversation';
+    const slug = `${date}-${slugifyTitle(title)}`;
+    const folder = path.join(outRoot, slug);
+    await fs.mkdir(folder, { recursive: true });
+
+    await fs.writeFile(path.join(folder, 'conversation.json'), JSON.stringify(convo, null, 2));
+    await fs.writeFile(path.join(folder, 'conversation.yaml'), yaml.dump(convo, { lineWidth: 120 }));
+
+    const messages = convo.messages || convo.log || [];
+    for (let i = 0; i < messages.length; i++) {
+      const msg = messages[i];
+      const idx = String(i + 1).padStart(4, '0');
+      const frag = {
+        conversation: slug,
+        index: i + 1,
+        role: msg.role || msg.sender || 'unknown',
+        content: msg.content || msg.text || '',
+        time: msg.timestamp || msg.time || null,
+      };
+      await fs.writeFile(
+        path.join(folder, `msg_${idx}.yaml`),
+        yaml.dump(frag, { lineWidth: 120 })
+      );
+    }
+
+    const summaryMd = `# Summary for ${slug}\n\n*TODO: Generate conversation summary here.*\n`;
+    await fs.writeFile(path.join(folder, 'summary.md'), summaryMd);
+
+    const participants = Array.from(
+      new Set((messages || []).map((m: any) => m.role || m.sender).filter(Boolean))
+    );
+    const meta = { id: slug, title, date, participants, tags: convo.tags || [] };
+    await fs.writeFile(path.join(folder, 'meta.yaml'), yaml.dump(meta));
+
+    if (!manifest.conversations.find((c: any) => c.id === slug)) {
+      manifest.conversations.push({
+        id: slug,
+        title,
+        date,
+        summary: '',
+        tags: meta.tags,
+      });
+    }
+  }
+
+  await fs.mkdir(path.dirname(manifestPath), { recursive: true });
+  await fs.writeFile(manifestPath, yaml.dump(manifest, { lineWidth: 120 }));
+
+  console.log('✅ Training data extraction complete.');
+}
+
+if (require.main === module) {
+  extractTrainingData().catch((err) => {
+    console.error('Unexpected error:', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add script to fragment docs/sigils/newadvancedconversations.json into ZIPMEM training data and manifest
- cover extractor with unit test
- record fractal progress for extraction step

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test:agents scripts/__tests__/extract-training-data.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68923783ac688322a490008c6fcbef54