### PR TITLE
feat: validate conversation timestamps

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: extract training data from conversations",
+  "lastCommit": "feat: validate conversation timestamps",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added training data extraction script for new advanced conversations. Implemented webhook triggering earlier. Next: run extractor and integrate tasks into advancedToDo manifest; continue with JavaHamster AI Flow.",
+  "notes": "Added timestamp validation for new advanced conversations. Next: refine extraction pipeline.",
   "pendingTasks": [
     "Integrate extracted tasks into advancedToDo manifest",
     "Implement JavaHamster AI Flow",
@@ -309,7 +309,8 @@
     {
       "commit": "Create todo_parser Go component",
       "status": "open"
-    }
+    },
+    "Refine extraction pipeline for new advanced conversations"
   ],
   "progress": [
     {

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -17,4 +17,13 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.outOfOrderConversations).toEqual([0]);
   });
+
+  it('flags conversations where update_time precedes create_time', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-times.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.invalidTimestamps).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -8,6 +8,7 @@ export interface ValidationResult {
   duplicateTitles: string[];
   missingFields: { index: number; fields: string[] }[];
   outOfOrderConversations: number[];
+  invalidTimestamps: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -18,12 +19,22 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const duplicateTitles: string[] = [];
   const missingFields: { index: number; fields: string[] }[] = [];
   const outOfOrder: number[] = [];
+  const invalidTimestamps: number[] = [];
 
   raw.forEach((conv: any, idx: number) => {
     const missing: string[] = [];
     if (!conv.id) missing.push('id');
     if (!conv.title) missing.push('title');
     if (typeof conv.mapping !== 'object') missing.push('mapping');
+    if (typeof conv.create_time !== 'number') missing.push('create_time');
+    if (typeof conv.update_time !== 'number') missing.push('update_time');
+    if (
+      typeof conv.create_time === 'number' &&
+      typeof conv.update_time === 'number' &&
+      conv.update_time < conv.create_time
+    ) {
+      invalidTimestamps.push(idx);
+    }
     if (missing.length) missingFields.push({ index: idx, fields: missing });
     if (conv.id) {
       if (seenIds.has(conv.id)) duplicateIds.push(conv.id);
@@ -51,6 +62,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     duplicateTitles,
     missingFields,
     outOfOrderConversations: outOfOrder,
+    invalidTimestamps,
   };
 }
 
@@ -61,7 +73,8 @@ if (require.main === module) {
     result.duplicateIds.length ||
     result.duplicateTitles.length ||
     result.missingFields.length ||
-    result.outOfOrderConversations.length
+    result.outOfOrderConversations.length ||
+    result.invalidTimestamps.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-invalid-times.json
+++ b/tests/fixtures/newadvanced-invalid-times.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "test-convo",
+    "title": "Invalid times",
+    "create_time": 200,
+    "update_time": 100,
+    "mapping": {}
+  }
+]


### PR DESCRIPTION
## Summary
- validate `create_time` and `update_time` in `newadvancedconversations.json`
- test update times to ensure timestamps are ordered
- log progress to continue refining extraction pipeline

## Testing
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689246e67b008322816fec20e1878c36