### PR TITLE
feat: validate conversation roles

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8250,5 +8250,12 @@
     "task": "Add webhook POST trigger based on task.url",
     "test": "packages/agents/__tests__/HookTriggererAgent.spec.ts",
     "status": "done"
+  },
+  {
+    "commit": "Validate conversation roles",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure conversation messages use allowed roles",
+    "test": "scripts/__tests__/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -9031,3 +9031,9 @@
   task: Add webhook POST trigger based on task.url
   test: packages/agents/__tests__/HookTriggererAgent.spec.ts
   status: done
+
+- commit: Validate conversation roles
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure conversation messages use allowed roles
+  test: scripts/__tests__/validate-newadvanced-conversations.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: validate conversation timestamps",
+  "lastCommit": "feat: validate conversation roles",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added timestamp validation for new advanced conversations. Next: refine extraction pipeline.",
+  "notes": "Added role validation for conversations. Next: refine extraction pipeline.",
   "pendingTasks": [
     "Integrate extracted tasks into advancedToDo manifest",
     "Implement JavaHamster AI Flow",

--- a/scripts/__tests__/validate-newadvanced-conversations.test.ts
+++ b/scripts/__tests__/validate-newadvanced-conversations.test.ts
@@ -3,20 +3,39 @@ import path from 'path';
 import { test, expect } from 'vitest';
 import { validateNewAdvancedConversations } from '../validate-newadvanced-conversations';
 
-test('detects duplicates and missing fields', () => {
+test('detects duplicates, missing fields and invalid roles', () => {
   const tmp = fs.mkdtempSync(path.join(__dirname, 'val-'));
   const file = path.join(tmp, 'conv.json');
   fs.writeFileSync(
     file,
     JSON.stringify([
-      { id: '1', title: 'A', mapping: {} },
-      { id: '1', mapping: {} },
-      { title: 'C', mapping: {} }
+      { id: '1', title: 'A', mapping: {}, create_time: 1, update_time: 2 },
+      { id: '1', mapping: {}, create_time: 1, update_time: 2 },
+      { title: 'C', mapping: {}, create_time: 1, update_time: 2 },
+      {
+        id: '3',
+        title: 'Valid mapping but invalid role',
+        mapping: {
+          node: {
+            id: 'node',
+            parent: null,
+            children: [],
+            message: {
+              id: 'node',
+              author: { role: 'hacker' },
+              create_time: 1
+            }
+          }
+        },
+        create_time: 1,
+        update_time: 2
+      }
     ])
   );
   const res = validateNewAdvancedConversations(file);
-  expect(res.conversationCount).toBe(3);
+  expect(res.conversationCount).toBe(4);
   expect(res.duplicateIds).toEqual(['1']);
   expect(res.missingFields.length).toBe(2);
+  expect(res.conversationsWithInvalidRoles).toEqual([3]);
   fs.rmSync(tmp, { recursive: true, force: true });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -9,6 +9,7 @@ export interface ValidationResult {
   missingFields: { index: number; fields: string[] }[];
   outOfOrderConversations: number[];
   invalidTimestamps: number[];
+  conversationsWithInvalidRoles: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -20,6 +21,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const missingFields: { index: number; fields: string[] }[] = [];
   const outOfOrder: number[] = [];
   const invalidTimestamps: number[] = [];
+  const invalidRoles: number[] = [];
 
   raw.forEach((conv: any, idx: number) => {
     const missing: string[] = [];
@@ -54,6 +56,13 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
         break;
       }
     }
+
+    const roles = Object.values(conv.mapping || {})
+      .map((n: any) => n?.message?.author?.role)
+      .filter((r: any): r is string => typeof r === 'string');
+    if (roles.some((r) => !['system', 'user', 'assistant'].includes(r))) {
+      invalidRoles.push(idx);
+    }
   });
 
   return {
@@ -63,6 +72,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     missingFields,
     outOfOrderConversations: outOfOrder,
     invalidTimestamps,
+    conversationsWithInvalidRoles: invalidRoles,
   };
 }
 


### PR DESCRIPTION
## Summary
- validate roles in `newadvancedconversations.json` against known sender types
- cover invalid conversation roles in validator unit tests
- log new validator step in advanced progress tracking

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/__tests__/validate-newadvanced-conversations.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68924c7fa5a083229e3698f5914a6540