### PR TITLE
feat: skip empty conversations in training data extraction

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: validate conversation roles",
+  "lastCommit": "feat: skip empty conversations in training data extraction",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added role validation for conversations. Next: refine extraction pipeline.",
+  "notes": "Updated extract-training-data to skip empty conversations. Next: run extraction on full dataset and integrate summaries.",
   "pendingTasks": [
     "Integrate extracted tasks into advancedToDo manifest",
     "Implement JavaHamster AI Flow",

--- a/scripts/__tests__/extract-training-data.test.ts
+++ b/scripts/__tests__/extract-training-data.test.ts
@@ -30,16 +30,24 @@ describe('extractTrainingData', () => {
           { role: 'assistant', content: 'Hi' },
         ],
       },
+      {
+        timestamp: '2025-01-02T00:00:00Z',
+        title: 'Empty Conversation',
+        messages: [],
+      },
     ];
     await fs.writeFile(src, JSON.stringify(sample));
 
     await extractTrainingData(src, out, manifest);
 
     const slug = '2025-01-01-test-conversation';
+    const emptySlug = '2025-01-02-empty-conversation';
     expect(await exists(path.join(out, slug, 'conversation.json'))).toBe(true);
     expect(await exists(path.join(out, slug, 'msg_0001.yaml'))).toBe(true);
+    expect(await exists(path.join(out, emptySlug))).toBe(false);
 
     const manifestContent = yaml.load(await fs.readFile(manifest, 'utf8')) as any;
+    expect(manifestContent.conversations).toHaveLength(1);
     expect(manifestContent.conversations[0].id).toBe(slug);
   });
 });

--- a/scripts/extract-training-data.ts
+++ b/scripts/extract-training-data.ts
@@ -43,12 +43,18 @@ export async function extractTrainingData(
     const title = convo.title || convo.id || 'conversation';
     const slug = `${date}-${slugifyTitle(title)}`;
     const folder = path.join(outRoot, slug);
+
+    const messages = convo.messages || convo.log || [];
+    if (messages.length === 0) {
+      console.warn(`Skipping conversation '${title}' with no messages`);
+      continue;
+    }
+
     await fs.mkdir(folder, { recursive: true });
 
     await fs.writeFile(path.join(folder, 'conversation.json'), JSON.stringify(convo, null, 2));
     await fs.writeFile(path.join(folder, 'conversation.yaml'), yaml.dump(convo, { lineWidth: 120 }));
 
-    const messages = convo.messages || convo.log || [];
     for (let i = 0; i < messages.length; i++) {
       const msg = messages[i];
       const idx = String(i + 1).padStart(4, '0');
@@ -69,7 +75,7 @@ export async function extractTrainingData(
     await fs.writeFile(path.join(folder, 'summary.md'), summaryMd);
 
     const participants = Array.from(
-      new Set((messages || []).map((m: any) => m.role || m.sender).filter(Boolean))
+      new Set(messages.map((m: any) => m.role || m.sender).filter(Boolean))
     );
     const meta = { id: slug, title, date, participants, tags: convo.tags || [] };
     await fs.writeFile(path.join(folder, 'meta.yaml'), yaml.dump(meta));


### PR DESCRIPTION
## Summary
- skip conversations without messages when extracting training data
- test empty conversations are ignored and not added to manifest
- record progress for new training data extraction feature

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/__tests__/extract-training-data.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6892515a27948322b4f722cfc4c47371