### PR TITLE
test: cover SocialGood workflow trigger

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -28,6 +28,7 @@ Validiere extrahierte Einträge mit `pnpm run validate:todos` (CI integriert) um
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
 - QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`
 - KEDA/HPA Skalierung unter `deployment/keda` für NATS Queue-Length
+- Sozialaktionen anstoßen: `node scripts/trigger-socialgood-workflow.js` (parst ToDos und startet SocialGood-Matching)
 
 > **TL;DR**
 > - Installation: `./scripts/setup-unifiedmandala.sh`

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
   `scripts/sync-todo-progress.js`.
 - Freundschaftssystem-Konzept siehe [docs/friendship-system.md](docs/friendship-system.md)
 - Gesprächsstatistiken (inkl. Titel & Zeitspanne) aus neuen Chat-Logs: `ts-node scripts/analyze-newadvanced-conversations.ts`
+- Sozialaktionen anstoßen: `node scripts/trigger-socialgood-workflow.js` (parst ToDos und startet SocialGood-Matching)
 
 ## 🚀 Features
 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1030,7 +1030,8 @@
     "commit": "Add parsing & SocialGood workflow trigger",
     "path": "scripts",
     "task": "Provide command or UI to start Parsing and SocialGood-Matching",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Generate memory-job config templates",

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: skip empty conversations in training data extraction",
+  "lastCommit": "test: cover SocialGood workflow trigger",
   "fractalStep": "fractal-run",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Updated extract-training-data to skip empty conversations. Next: run extraction on full dataset and integrate summaries.",
+  "notes": "Reviewed sigil docs and SocialGood workflow; next integrate UI trigger.",
   "pendingTasks": [
     "Integrate extracted tasks into advancedToDo manifest",
     "Implement JavaHamster AI Flow",
@@ -310,7 +310,8 @@
       "commit": "Create todo_parser Go component",
       "status": "open"
     },
-    "Refine extraction pipeline for new advanced conversations"
+    "Refine extraction pipeline for new advanced conversations",
+    "Connect trigger-socialgood-workflow.js to UI and process full conversation dataset"
   ],
   "progress": [
     {

--- a/scripts/__tests__/trigger-socialgood-workflow.test.ts
+++ b/scripts/__tests__/trigger-socialgood-workflow.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect, vi } from 'vitest';
+
+describe('trigger-socialgood-workflow script', () => {
+  it('calls parsing and socialgood endpoints', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({});
+    // @ts-ignore
+    global.fetch = fetchMock;
+    // @ts-ignore
+    await import('../trigger-socialgood-workflow.js');
+    expect(fetchMock).toHaveBeenNthCalledWith(1, 'http://localhost:3000/usecases/todo/parse');
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://localhost:3000/socialgood/match');
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest coverage for trigger-socialgood-workflow script
- document SocialGood workflow trigger in Handbuch and README
- mark SocialGood workflow trigger todo as done and track next steps

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/__tests__/trigger-socialgood-workflow.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689258a9c7188322902528885f8bdcef