### PR TITLE
feat: filter analyze new advanced conversations by title

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: memory promotion and parsing-socialgood runner",
-  "fractalStep": "fractal-run",
+  "lastCommit": "feat: filter analyze new advanced conversations by title",
+  "fractalStep": "fractal-run/analyze-filter",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added MemoryManager promotion and workflow script; next integrate fragment and code hooks.",
+  "notes": "Added title filtering to analyze-newadvanced-conversations script; next extract training data and integrate tasks.",
   "pendingTasks": [
     "Integrate extracted tasks into advancedToDo manifest",
     "Implement JavaHamster AI Flow",

--- a/scripts/analyze-newadvanced-conversations.test.ts
+++ b/scripts/analyze-newadvanced-conversations.test.ts
@@ -15,4 +15,17 @@ describe('analyzeNewAdvancedConversations', () => {
     expect(stats.todoCount).toBe(1);
     expect(stats.titles).toEqual(['Sample']);
   });
+
+  it('filters by specified titles', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-multi.json'
+    );
+    const stats = analyzeNewAdvancedConversations(file, ['Second']);
+    expect(stats.conversationCount).toBe(1);
+    expect(stats.messageCount).toBe(1);
+    expect(stats.authorCounts.assistant).toBe(1);
+    expect(stats.titles).toEqual(['Second']);
+    expect(stats.todoCount).toBe(0);
+  });
 });

--- a/scripts/analyze-newadvanced-conversations.ts
+++ b/scripts/analyze-newadvanced-conversations.ts
@@ -12,16 +12,22 @@ export interface ConversationStats {
   titles: string[];
 }
 
-export function analyzeNewAdvancedConversations(filePath: string): ConversationStats {
+export function analyzeNewAdvancedConversations(
+  filePath: string,
+  filterTitles?: string[]
+): ConversationStats {
   const raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const sessions = Array.isArray(filterTitles)
+    ? raw.filter((s: any) => filterTitles.includes(s.title))
+    : raw;
   let messageCount = 0;
   const authorCounts: Record<string, number> = {};
   let minTime: number | null = null;
   let maxTime: number | null = null;
   let todoCount = 0;
-  const titles: string[] = [];
-  raw.forEach((session: any) => {
-    titles.push(session.title || 'Untitled');
+  const collectedTitles: string[] = [];
+  sessions.forEach((session: any) => {
+    collectedTitles.push(session.title || 'Untitled');
     const nodes = Object.values(session.mapping || {});
     nodes.forEach((node: any) => {
       const msg = node.message;
@@ -42,13 +48,15 @@ export function analyzeNewAdvancedConversations(filePath: string): ConversationS
     });
   });
   return {
-    conversationCount: raw.length,
+    conversationCount: sessions.length,
     messageCount,
     authorCounts,
-    averageMessagesPerConversation: raw.length ? messageCount / raw.length : 0,
+    averageMessagesPerConversation: sessions.length
+      ? messageCount / sessions.length
+      : 0,
     timeRange: { start: minTime, end: maxTime },
     todoCount,
-    titles,
+    titles: collectedTitles,
   };
 }
 
@@ -60,7 +68,14 @@ if (require.main === module) {
       : path.join(__dirname, '../docs/sigils/newadvancedconversations.json');
   const summaryIndex = process.argv.indexOf('--summary');
   const summaryPath = summaryIndex >= 0 ? process.argv[summaryIndex + 1] : null;
-  const stats = analyzeNewAdvancedConversations(file);
+  const titlesArgIndex = process.argv.indexOf('--titles');
+  const titleList =
+    titlesArgIndex >= 0
+      ? process.argv[titlesArgIndex + 1]
+          .split(',')
+          .map((t: string) => t.trim())
+      : undefined;
+  const stats = analyzeNewAdvancedConversations(file, titleList);
   console.log(`Conversations: ${stats.conversationCount}`);
   console.log(`Messages: ${stats.messageCount}`);
   console.log('Authors:', stats.authorCounts);

--- a/tests/fixtures/newadvanced-multi.json
+++ b/tests/fixtures/newadvanced-multi.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "1",
+    "title": "First",
+    "mapping": {
+      "n1": {
+        "id": "n1",
+        "message": {
+          "author": { "role": "user" },
+          "create_time": 1000,
+          "content": { "parts": ["TODO: first task"] }
+        }
+      }
+    },
+    "create_time": 1000,
+    "update_time": 1001
+  },
+  {
+    "id": "2",
+    "title": "Second",
+    "mapping": {
+      "n1": {
+        "id": "n1",
+        "message": {
+          "author": { "role": "assistant" },
+          "create_time": 2000,
+          "content": { "parts": ["no tasks here"] }
+        }
+      }
+    },
+    "create_time": 2000,
+    "update_time": 2001
+  }
+]


### PR DESCRIPTION
## Summary
- allow `scripts/analyze-newadvanced-conversations.ts` to filter statistics by conversation title and expose `--titles` CLI option
- test title filtering with a multi-conversation fixture
- track progress of analyzer enhancement in `advancedprogress.json`

## Testing
- `pnpm vitest run scripts/analyze-newadvanced-conversations.test.ts`
- `npx tsc -p tsconfig.json`
- `npx pyright`


------
https://chatgpt.com/codex/tasks/task_e_68926a721c008322b54f700e8cf0e32b