### PR TITLE
feat: validate root node in new advanced conversations

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -24,7 +24,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js` und aktualisiere `advancedToDo.json` sowie `advancedprogress.json`.
 Validiere extrahierte Einträge mit `pnpm run validate:todos` (CI integriert) um fehlende Felder oder Duplikate zu finden.
 - Gesprächsstatistiken (inkl. Titel & Zeitspanne) aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
-- Struktur- und Zeitvalidierung für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
+- Struktur-, Zeit- und Root-Knoten-Validierung für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
 - QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`
 - KEDA/HPA Skalierung unter `deployment/keda` für NATS Queue-Length

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ Verwende `./scripts/aeon.sh <command>` für alle CLI-Aufrufe.
 | `node scripts/sync-todo-progress.js` | Aktualisiert ToDo- & Progress-Dateien |
 | `node scripts/validate-advancedtodo.js` | Prüft Konsistenz zwischen YAML und JSON |
 | `node scripts/update-kontext.js` | Passt Kontext-Datei an (nutzt conversations oder newadvancedconversations) |
-| `ts-node scripts/validate-newadvanced-conversations.ts` | Prüft Struktur und Zeitreihen von `newadvancedconversations.json` |
+| `ts-node scripts/validate-newadvanced-conversations.ts` | Prüft Struktur, Zeitreihen und Root-Knoten von `newadvancedconversations.json` |
 | `ts-node scripts/validate-sigillin-examples.ts` | Validiert Sigillin-Beispieldateien |
 | `node scripts/generate-readmes.ts` | Erstellt Modul-READMEs |
 | `node scripts/extract-snippets.js` | Extrahiert Code-Snippets |

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add SymbolMapper agent",
-  "fractalStep": "fractal-run/symbolmapper",
+  "lastCommit": "feat: validate root node in newadvanced conversations",
+  "fractalStep": "fractal-run/validate-newadvanced-root",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented SymbolMapper agent for glyph mapping; next integrate into SealCore and process remaining conversation tasks.",
+  "notes": "Added root-node validation for newadvanced conversations; next integrate training data extraction and remaining conversation tasks.",
   "pendingTasks": [
     "Integrate extracted tasks into advancedToDo manifest",
     "Implement JavaHamster AI Flow",

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -26,4 +26,13 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.invalidTimestamps).toEqual([0]);
   });
+
+  it('flags conversations missing root node', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-missing-root.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsMissingRoot).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -10,6 +10,7 @@ export interface ValidationResult {
   outOfOrderConversations: number[];
   invalidTimestamps: number[];
   conversationsWithInvalidRoles: number[];
+  conversationsMissingRoot: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -22,6 +23,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const outOfOrder: number[] = [];
   const invalidTimestamps: number[] = [];
   const invalidRoles: number[] = [];
+  const missingRoot: number[] = [];
 
   raw.forEach((conv: any, idx: number) => {
     const missing: string[] = [];
@@ -63,6 +65,11 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     if (roles.some((r) => !['system', 'user', 'assistant'].includes(r))) {
       invalidRoles.push(idx);
     }
+
+    const root = conv.mapping?.['client-created-root'];
+    if (!root || root.parent !== null) {
+      missingRoot.push(idx);
+    }
   });
 
   return {
@@ -73,6 +80,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     outOfOrderConversations: outOfOrder,
     invalidTimestamps,
     conversationsWithInvalidRoles: invalidRoles,
+    conversationsMissingRoot: missingRoot,
   };
 }
 
@@ -84,7 +92,8 @@ if (require.main === module) {
     result.duplicateTitles.length ||
     result.missingFields.length ||
     result.outOfOrderConversations.length ||
-    result.invalidTimestamps.length
+    result.invalidTimestamps.length ||
+    result.conversationsMissingRoot.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-missing-root.json
+++ b/tests/fixtures/newadvanced-missing-root.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "conv1",
+    "title": "Missing root",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "some-node": {
+        "id": "some-node",
+        "message": {"author": {"role": "user"}, "create_time": 1},
+        "parent": null,
+        "children": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- validate presence of `client-created-root` in `newadvancedconversations.json`
- document root node check in Handbuch and README
- note progress for fractal run in `advancedprogress.json`

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689282d221c08322b3ee88d91c38d273