### PR TITLE
feat: enforce case-insensitive conversation titles

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8254,6 +8254,13 @@
     "status": "done"
   },
   {
+    "commit": "Enforce case-insensitive conversation titles",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Treat conversation titles as case-insensitive when checking duplicates",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
+  },
+  {
     "commit": "Implement HookTriggererAgent webhook",
     "path": "packages/agents/HookTriggererAgent.ts",
     "task": "Add webhook POST trigger based on task.url",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -8,6 +8,11 @@
   task: Extend validator to check for duplicate conversation titles
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Enforce case-insensitive conversation titles
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Treat conversation titles as case-insensitive when checking duplicates
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done
 - commit: Add CREPTooltip component
   path: packages/unifiedmandala-ui/components/CREPTooltip.tsx
   task: Small info overlay for CREP values

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: extract todos by conversation title",
-  "fractalStep": "fractal-run/parse-newadvanced-titles",
+  "lastCommit": "feat: enforce case-insensitive conversation titles",
+  "fractalStep": "fractal-run/validate-case-insensitive-titles",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added dynamic title parsing for new advanced conversations and refreshed ToDo manifests; next run training data extraction and JavaHamster AI flow.",
+  "notes": "Added case-insensitive duplicate title validation; next run training data extraction and JavaHamster AI flow.",
   "pendingTasks": [
     "Run scripts/extract-training-data.ts to fragment new advanced conversations",
     "Implement JavaHamster AI Flow"
@@ -937,6 +937,11 @@
     },
     {
       "commit": "feat: validate message timestamp order",
+      "status": "done"
+    }
+    ,
+    {
+      "commit": "feat: enforce case-insensitive conversation titles",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -9,6 +9,15 @@ describe('validateNewAdvancedConversations', () => {
     expect(res.duplicateTitles).toEqual(['Foo']);
   });
 
+  it('flags duplicate titles case-insensitively', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-duplicate-titles-case.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.duplicateTitles).toEqual(['foo']);
+  });
+
   it('detects out-of-order message timestamps', () => {
     const file = path.join(
       __dirname,

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -45,8 +45,9 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       else seenIds.add(conv.id);
     }
     if (conv.title) {
-      if (seenTitles.has(conv.title)) duplicateTitles.push(conv.title);
-      else seenTitles.add(conv.title);
+      const key = conv.title.toLowerCase();
+      if (seenTitles.has(key)) duplicateTitles.push(conv.title);
+      else seenTitles.add(key);
     }
 
     const times = Object.values(conv.mapping || {})

--- a/tests/fixtures/newadvanced-duplicate-titles-case.json
+++ b/tests/fixtures/newadvanced-duplicate-titles-case.json
@@ -1,0 +1,4 @@
+[
+  { "id": "c1", "title": "Foo", "mapping": {} },
+  { "id": "c2", "title": "foo", "mapping": {} }
+]


### PR DESCRIPTION
## Summary
- ensure new advanced conversation validator treats titles case-insensitively
- test duplicate title detection with new fixture and case-insensitive check
- record progress for case-insensitive conversation title validation

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json --listFiles | tail -n 20`
- `npx vitest scripts/validate-newadvanced-conversations.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68931b0106d88322992e6ea118c7657c