### PR TITLE
docs: add go-agent extras docs

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -332,6 +332,7 @@ packages/
   ├── TonePlayground.ts        # Experimentelle Tone.js-Steuerung
   ├── go-bridge             # Go-Client für REST, gRPC und NATS (inkl. GPTBridge)
   ├── go-agent              # Autonomer Go-Daemon für Tasks
+  │   └── docs/go-agent          # ML-Priorisierung und Policy Guide
   │   ├── pkg/policy        # Policy Enforcement Stubs
   │   ├── pkg/handler       # Task handlers (CoordinationHandler)
   │   └── pkg/hooks         # Event Hook Publisher

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**TuringOrchestrator**](packages/testing/TuringOrchestrator.ts) – run minimal Turing tests
 - [**TuringTestSuite**](packages/testing/TuringTestSuite.ts) – automated conversation Turing tests
 - [**CodeAgent**](go-agent/pkg/codeagent) – scaffold for language-aware automation with CLI support
+- [**Go Agent Extras Docs**](docs/go-agent) – ML-Prioritization and policy guidance
 - [**Climate Module**](packages/unifiedmandala-climate/index.ts) – blueprint for climate data
 - [**Keilschrift Module**](packages/aeon-labs/keilschrift/index.ts) – cuneiform utilities
 - [**ZivilisationsSandbox**](packages/pantheon/ZivilisationsSandbox/index.ts) – simulate ancient builds

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -605,7 +605,8 @@
     "commit": "Write documentation and examples for extras",
     "path": "docs/go-agent",
     "task": "Add ml-prioritization and policy guide docs",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Add append only chat writer",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -439,6 +439,7 @@
   path: docs/go-agent
   task: Add ml-prioritization and policy guide docs
   test: ""
+  status: done
 - commit: Add append only chat writer
   path: services/chat-writer/writer.go
   task: Store messages.json logs and optional eventHook

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: validate parent references in conversations",
-  "fractalStep": "fractal-run/validate-parent-references",
+  "lastCommit": "docs: add go-agent extras docs",
+  "fractalStep": "fractal-run/go-agent-docs",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added parent reference validation; next run training data extraction and JavaHamster AI flow.",
+  "notes": "Added ML prioritization and policy guide docs with example; next run training data extraction and JavaHamster AI flow.",
   "pendingTasks": [
     "Run scripts/extract-training-data.ts to fragment new advanced conversations",
     "Implement JavaHamster AI Flow"
@@ -208,7 +208,7 @@
       "status": "done"
     },
     {
-      "commit": "meta:update-progress \u2013 mark memory governance done",
+      "commit": "meta:update-progress – mark memory governance done",
       "status": "done"
     },
     {
@@ -480,7 +480,7 @@
       "status": "done"
     },
     {
-      "commit": "Chat-Log Parser f\u00fcr Aufgaben",
+      "commit": "Chat-Log Parser für Aufgaben",
       "status": "done"
     },
     {
@@ -612,11 +612,15 @@
       "status": "done"
     },
     {
-      "commit": "Der *SymbolMapper*-Agent \u00fcbersetzt numerische und textuelle Muster in definierte Symbol-Glyphen\u301015\u2020L53-L61\u3011. Er schlie\u00dft die L\u00fccke zwischen quantitativen Werten (z.\u202fB. statistische Ergebnisse, Scores) und der symbolischen **Sigillin-Sprache** des Systems. Manifest-Spezifikation: Der SymbolMapper v1 hat Methoden `map_numeric_to_symbol` und `map_text_to_glyph`\u301015\u2020L55-L63\u3011. Im Python-Skeleton (`agents/symbolmapper/main.py`) implementieren wir z.\u202fB. eine Liste vordefinierter Glyphen (im Manifest-Beispiel: \u25cb, \u2206, \u03c8, \u2605\u301015\u2020L67-L73\u3011) und die Abbildungsfunktionen analog zum YAML-Snippet: ein Durchschnittswert wird auf einen Index im Glyphen-Array gemappt\u301015\u2020L67-L75\u3011, Texte werden auf Basis von Schl\u00fcsselbegriffen einem Symbol zugeordnet (Bsp: enth\u00e4lt der Text \"Erweckung\", dann \u2605 als Glyph)\u301015\u2020L69-L73\u3011. Integration: Dieser Agent kann von anderen Modulen genutzt werden, die rohe Daten symbolisch darstellen wollen \u2013 z.\u202fB. der CREPBridge k\u00f6nnte SymbolMapper fragen, welcher Glyph einem bestimmten Score entspricht (um dann einen Sigil zu generieren). Auch f\u00fcr Graphen/Charts in der UI k\u00f6nnte SymbolMapper herangezogen werden, um interessante Datenpunkte mit Symbolen zu markieren. Orchestrator: wahrscheinlich auf Abruf, nicht dauernd laufend \u2013 d.h. Module rufen ihn als Library auf (alternativ EventBus-Request/Reply-Pattern). UI: Keine direkte, aber z.\u202fB. im Sigil-Portfolio des Nutzers k\u00f6nnten diese Glyphen vorkommen. Test & Deploy: Test, ob gegebene Werte die richtigen Symbole liefern (z.\u202fB. Eingabe [0.1, 0.9] ergibt einen Index im g\u00fcltigen Bereich und ein Symbol aus der Liste\u301015\u2020L137-L142\u3011). Deployment: Sicherstellen, dass NumPy verf\u00fcgbar ist (im Manifest als Dependency angegeben\u301015\u2020L61-L69\u3011) und dass das System die Unicode-Symbole unterst\u00fctzt (Fonts in UI etc.).",
+      "commit": "Der *SymbolMapper*-Agent übersetzt numerische und textuelle Muster in definierte Symbol-Glyphen【15†L53-L61】. Er schließt die Lücke zwischen quantitativen Werten (z. B. statistische Ergebnisse, Scores) und der symbolischen **Sigillin-Sprache** des Systems. Manifest-Spezifikation: Der SymbolMapper v1 hat Methoden `map_numeric_to_symbol` und `map_text_to_glyph`【15†L55-L63】. Im Python-Skeleton (`agents/symbolmapper/main.py`) implementieren wir z. B. eine Liste vordefinierter Glyphen (im Manifest-Beispiel: ○, ∆, ψ, ★【15†L67-L73】) und die Abbildungsfunktionen analog zum YAML-Snippet: ein Durchschnittswert wird auf einen Index im Glyphen-Array gemappt【15†L67-L75】, Texte werden auf Basis von Schlüsselbegriffen einem Symbol zugeordnet (Bsp: enthält der Text \"Erweckung\", dann ★ als Glyph)【15†L69-L73】. Integration: Dieser Agent kann von anderen Modulen genutzt werden, die rohe Daten symbolisch darstellen wollen – z. B. der CREPBridge könnte SymbolMapper fragen, welcher Glyph einem bestimmten Score entspricht (um dann einen Sigil zu generieren). Auch für Graphen/Charts in der UI könnte SymbolMapper herangezogen werden, um interessante Datenpunkte mit Symbolen zu markieren. Orchestrator: wahrscheinlich auf Abruf, nicht dauernd laufend – d.h. Module rufen ihn als Library auf (alternativ EventBus-Request/Reply-Pattern). UI: Keine direkte, aber z. B. im Sigil-Portfolio des Nutzers könnten diese Glyphen vorkommen. Test & Deploy: Test, ob gegebene Werte die richtigen Symbole liefern (z. B. Eingabe [0.1, 0.9] ergibt einen Index im gültigen Bereich und ein Symbol aus der Liste【15†L137-L142】). Deployment: Sicherstellen, dass NumPy verfügbar ist (im Manifest als Dependency angegeben【15†L61-L69】) und dass das System die Unicode-Symbole unterstützt (Fonts in UI etc.).",
       "status": "done"
     },
     {
       "commit": "feat: validate parent references in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Add go-agent extras docs",
       "status": "done"
     }
   ],
@@ -641,67 +645,67 @@
   "featureLog": [
     {
       "featureId": "open-ethik-dashboard",
-      "commit": "meta:implement-features \u2013 open-ethik-dashboard",
+      "commit": "meta:implement-features – open-ethik-dashboard",
       "status": "done"
     },
     {
       "featureId": "implicit-todos",
-      "commit": "meta:extract-features \u2013 implicit todo extraction",
+      "commit": "meta:extract-features – implicit todo extraction",
       "status": "done"
     },
     {
       "featureId": "zivilisations-sandboxen",
-      "commit": "meta:extract-features \u2013 Zivilisations-Sandboxen",
+      "commit": "meta:extract-features – Zivilisations-Sandboxen",
       "status": "done"
     },
     {
       "featureId": "climate-integration",
-      "commit": "meta:extract-features \u2013 climate integration",
+      "commit": "meta:extract-features – climate integration",
       "status": "done"
     },
     {
       "featureId": "keilschrift",
-      "commit": "meta:extract-features \u2013 keilschrift",
+      "commit": "meta:extract-features – keilschrift",
       "status": "done"
     },
     {
       "featureId": "grok-agent",
-      "commit": "meta:implement-features \u2013 grok agent skeleton",
+      "commit": "meta:implement-features – grok agent skeleton",
       "status": "done"
     },
     {
       "featureId": "shadow-integration",
-      "commit": "meta:extract-features \u2013 shadow integration",
+      "commit": "meta:extract-features – shadow integration",
       "status": "done"
     },
     {
       "featureId": "self-reflection",
-      "commit": "meta:extract-features \u2013 self reflection",
+      "commit": "meta:extract-features – self reflection",
       "status": "done"
     },
     {
       "featureId": "memory-governance",
-      "commit": "meta:extract-features \u2013 memory governance",
+      "commit": "meta:extract-features – memory governance",
       "status": "done"
     },
     {
       "featureId": "turing-tests",
-      "commit": "meta:extract-features \u2013 turing tests",
+      "commit": "meta:extract-features – turing tests",
       "status": "done"
     },
     {
       "featureId": "schwerewellen",
-      "commit": "meta:extract-features \u2013 schwerewellen",
+      "commit": "meta:extract-features – schwerewellen",
       "status": "done"
     },
     {
       "featureId": "anthropic-multiversum",
-      "commit": "meta:extract-features \u2013 anthropic multiversum",
+      "commit": "meta:extract-features – anthropic multiversum",
       "status": "done"
     },
     {
       "featureId": "memory-governance",
-      "commit": "meta:implement-features \u2013 memory governance service",
+      "commit": "meta:implement-features – memory governance service",
       "status": "done"
     },
     {

--- a/docs/go-agent/ml-prioritization.md
+++ b/docs/go-agent/ml-prioritization.md
@@ -1,0 +1,24 @@
+# ML-Prioritization for Go Agent
+
+Der Go Agent kann Aufgaben anhand von ML-basierten Scores priorisieren. Dieses Dokument beschreibt den Ablauf.
+
+## Workflow
+1. **Feature Extraction** – Eingehende Aufgaben werden analysiert und in numerische Feature-Vektoren umgewandelt.
+2. **Modellbewertung** – Ein leichtgewichtiges Modell (z.B. logistisches Regressionsmodell) berechnet einen Prioritätsscore zwischen 0 und 1.
+3. **Scheduler** – Der Scheduler sortiert Aufgaben nach Score und Gewichtung.
+
+## Konfiguration
+```yaml
+# examples/go-agent/prioritization-example.yaml
+job: "analyze-sigil"
+features:
+  size: 120
+  urgency: 0.8
+model: logistic-regression
+```
+
+## Hinweise
+- Modelle liegen unter `go-agent/pkg/ml/`.
+- Scores können optional mit CREP-Werten kombiniert werden.
+- Fallback auf statische Prioritäten, falls das Modell keine Vorhersage liefert.
+

--- a/docs/go-agent/policy-guide.md
+++ b/docs/go-agent/policy-guide.md
@@ -1,0 +1,26 @@
+# Policy Guide for Go Agent
+
+Diese Anleitung beschreibt, wie der Go Agent Policies prüft und anwendet.
+
+## Policy Definition
+Policies werden als YAML-Dateien unter `config/policies/` abgelegt.
+
+```yaml
+# config/policies/sample-policy.yaml
+id: basic-example
+rules:
+  - type: rate-limit
+    limit: 100
+  - type: allow-tags
+    tags: ["sigil", "analysis"]
+```
+
+## Enforcement
+1. Der Agent lädt beim Start alle aktiven Policies.
+2. Eingehende Jobs werden gegen die Regeln geprüft.
+3. Verstöße werden protokolliert und der Job verworfen.
+
+## Empfehlungen
+- Policies versionieren und in CI testen.
+- Kombiniere Policy-Prüfungen mit ML-Priorisierung für robuste Workflows.
+

--- a/examples/go-agent/README.md
+++ b/examples/go-agent/README.md
@@ -1,0 +1,7 @@
+# Go Agent Examples
+
+Dieses Verzeichnis enthält Beispielaufträge für den Go Agent.
+
+- `prioritization-example.yaml` – zeigt, wie ML-Priorisierung und Policy-Tags kombiniert werden.
+
+Weitere Beispiele folgen in zukünftigen Fraktalruns.

--- a/examples/go-agent/prioritization-example.yaml
+++ b/examples/go-agent/prioritization-example.yaml
@@ -1,0 +1,8 @@
+job: analyze-sigil
+description: Sample job with ML-based prioritization and policy tags
+features:
+  size: 120
+  urgency: 0.8
+policy:
+  tags: [sigil, analysis]
+  maxRuntime: 300


### PR DESCRIPTION
## Summary
- document ML-based task prioritization and policy enforcement for Go Agent
- provide sample job configuration and reference docs in README and Handbuch
- mark related advancedToDo entries done and update progress tracker

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6893383947948322989f4ae2a64d8506