### PR TITLE
feat: validate node id consistency

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,14 +1,15 @@
 {
-  "lastCommit": "docs: add go-agent extras docs",
-  "fractalStep": "fractal-run/go-agent-docs",
+  "lastCommit": "feat: validate node id consistency",
+  "fractalStep": "fractal-run/newadvanced-validation",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added ML prioritization and policy guide docs with example; next run training data extraction and JavaHamster AI flow.",
+  "notes": "Added mismatched node id check to conversation validator; next run training data extraction and JavaHamster AI flow.",
   "pendingTasks": [
     "Run scripts/extract-training-data.ts to fragment new advanced conversations",
-    "Implement JavaHamster AI Flow"
+    "Implement JavaHamster AI Flow",
+    "Add cyclic parent reference detection for conversations"
   ],
   "progress": [
     {
@@ -949,6 +950,10 @@
     },
     {
       "commit": "feat: enforce case-insensitive conversation titles",
+      "status": "done"
+    },
+    {
+      "commit": "feat: validate node id consistency",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -53,4 +53,13 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithMissingParents).toEqual([0]);
   });
+
+  it('flags nodes with mismatched ids', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-mismatched-node-ids.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithMismatchedNodeIds).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -12,6 +12,7 @@ export interface ValidationResult {
   conversationsWithInvalidRoles: number[];
   conversationsMissingRoot: number[];
   conversationsWithMissingParents: number[];
+  conversationsWithMismatchedNodeIds: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -26,6 +27,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const invalidRoles: number[] = [];
   const missingRoot: number[] = [];
   const missingParents: number[] = [];
+  const mismatchedNodeIds: number[] = [];
 
   raw.forEach((conv: any, idx: number) => {
     const missing: string[] = [];
@@ -69,7 +71,11 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       invalidRoles.push(idx);
     }
 
-    for (const node of Object.values(conv.mapping || {}) as any[]) {
+    for (const [key, node] of Object.entries(conv.mapping || {}) as [string, any][]) {
+      if (node.id && node.id !== key) {
+        mismatchedNodeIds.push(idx);
+        break;
+      }
       if (node.parent && !conv.mapping[node.parent]) {
         missingParents.push(idx);
         break;
@@ -92,6 +98,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithInvalidRoles: invalidRoles,
     conversationsMissingRoot: missingRoot,
     conversationsWithMissingParents: missingParents,
+    conversationsWithMismatchedNodeIds: mismatchedNodeIds,
   };
 }
 
@@ -105,7 +112,8 @@ if (require.main === module) {
     result.outOfOrderConversations.length ||
     result.invalidTimestamps.length ||
     result.conversationsMissingRoot.length ||
-    result.conversationsWithMissingParents.length
+    result.conversationsWithMissingParents.length ||
+    result.conversationsWithMismatchedNodeIds.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-mismatched-node-ids.json
+++ b/tests/fixtures/newadvanced-mismatched-node-ids.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "conv1",
+    "title": "Mismatched node",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["node1"]
+      },
+      "node1": {
+        "id": "node2",
+        "message": {"author": {"role": "user"}, "create_time": 1},
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- validate that mapping keys match internal node IDs in newadvanced conversation validator
- add fixture and test for mismatched node IDs
- log progress in advancedprogress.json

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68934036175083228c05047ae9a3e098