### PR TITLE
feat: detect cyclic parent reference loops

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11179,5 +11179,12 @@
     "path": "",
     "task": "das Schritt für Schritt durchgehen",
     "test": ""
+  },
+  {
+    "commit": "Add cyclic parent reference detection",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Detect cyclic parent reference loops in conversations",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3,6 +3,11 @@
   task: Ensure all nodes reference existing parents
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Add cyclic parent reference detection
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Detect and report cyclic parent references in conversation mappings
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done
 - commit: Add SymbolMapper agent
   path: agents/symbolmapper/main.py
   task: Map numeric and textual inputs to glyphs

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,15 +1,14 @@
 {
-  "lastCommit": "feat: validate node id consistency",
+  "lastCommit": "feat: detect cyclic parent reference loops",
   "fractalStep": "fractal-run/newadvanced-validation",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added mismatched node id check to conversation validator; next run training data extraction and JavaHamster AI flow.",
+  "notes": "Added cycle detection to conversation validator; next run training data extraction and implement JavaHamster AI flow.",
   "pendingTasks": [
     "Run scripts/extract-training-data.ts to fragment new advanced conversations",
-    "Implement JavaHamster AI Flow",
-    "Add cyclic parent reference detection for conversations"
+    "Implement JavaHamster AI Flow"
   ],
   "progress": [
     {
@@ -622,6 +621,10 @@
     },
     {
       "commit": "Add go-agent extras docs",
+      "status": "done"
+    },
+    {
+      "commit": "Add cyclic parent reference detection for conversations",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -62,4 +62,13 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithMismatchedNodeIds).toEqual([0]);
   });
+
+  it('detects cyclic parent references', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-parent-cycle.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithParentCycles).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -13,6 +13,7 @@ export interface ValidationResult {
   conversationsMissingRoot: number[];
   conversationsWithMissingParents: number[];
   conversationsWithMismatchedNodeIds: number[];
+  conversationsWithParentCycles: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -28,6 +29,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const missingRoot: number[] = [];
   const missingParents: number[] = [];
   const mismatchedNodeIds: number[] = [];
+  const parentCycles: number[] = [];
 
   raw.forEach((conv: any, idx: number) => {
     const missing: string[] = [];
@@ -80,6 +82,21 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
         missingParents.push(idx);
         break;
       }
+
+      // Detect cyclic parent references
+      const visited = new Set<string>([key]);
+      let current = node.parent;
+      while (current) {
+        if (visited.has(current)) {
+          parentCycles.push(idx);
+          current = null;
+          break;
+        }
+        visited.add(current);
+        const parentNode = conv.mapping[current];
+        current = parentNode ? parentNode.parent : null;
+      }
+      if (parentCycles.includes(idx)) break;
     }
 
     const root = conv.mapping?.['client-created-root'];
@@ -99,6 +116,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsMissingRoot: missingRoot,
     conversationsWithMissingParents: missingParents,
     conversationsWithMismatchedNodeIds: mismatchedNodeIds,
+    conversationsWithParentCycles: parentCycles,
   };
 }
 
@@ -113,7 +131,8 @@ if (require.main === module) {
     result.invalidTimestamps.length ||
     result.conversationsMissingRoot.length ||
     result.conversationsWithMissingParents.length ||
-    result.conversationsWithMismatchedNodeIds.length
+    result.conversationsWithMismatchedNodeIds.length ||
+    result.conversationsWithParentCycles.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-parent-cycle.json
+++ b/tests/fixtures/newadvanced-parent-cycle.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "1",
+    "title": "Parent Cycle",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["A"]
+      },
+      "A": {
+        "id": "A",
+        "message": {"author": {"role": "user"}, "create_time": 1},
+        "parent": "B",
+        "children": []
+      },
+      "B": {
+        "id": "B",
+        "message": {"author": {"role": "assistant"}, "create_time": 2},
+        "parent": "A",
+        "children": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- detect cyclic parent references in newadvanced conversations
- expand validator tests with cycle fixture
- log fractal progress for conversation validator

## Testing
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`
- `npx tsc -p tsconfig.json`
- `npx pyright`

------
https://chatgpt.com/codex/tasks/task_e_68934a9a35248322a56c7f8f72d2a65f