### PR TITLE
feat: validate child references in conversations

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -24,7 +24,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js` und aktualisiere `advancedToDo.json` sowie `advancedprogress.json`.
 Validiere extrahierte Einträge mit `pnpm run validate:todos` (CI integriert) um fehlende Felder oder Duplikate zu finden.
 - Gesprächsstatistiken (inkl. Titel & Zeitspanne) aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
-- Struktur-, Zeit-, Root-Knoten- und Elternreferenz-Validierung für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
+- Struktur-, Zeit-, Root-Knoten-, Eltern- und Kindreferenz-Validierung für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
 - QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`
 - KEDA/HPA Skalierung unter `deployment/keda` für NATS Queue-Length

--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ Verwende `./scripts/aeon.sh <command>` für alle CLI-Aufrufe.
 | `node scripts/sync-todo-progress.js` | Aktualisiert ToDo- & Progress-Dateien |
 | `node scripts/validate-advancedtodo.js` | Prüft Konsistenz zwischen YAML und JSON |
 | `node scripts/update-kontext.js` | Passt Kontext-Datei an (nutzt conversations oder newadvancedconversations) |
-| `ts-node scripts/validate-newadvanced-conversations.ts` | Prüft Struktur, Zeitreihen, Root-Knoten und Elternverweise von `newadvancedconversations.json` |
+| `ts-node scripts/validate-newadvanced-conversations.ts` | Prüft Struktur, Zeitreihen, Root-Knoten sowie Eltern- und Kindverweise von `newadvancedconversations.json` |
 | `ts-node scripts/validate-sigillin-examples.ts` | Validiert Sigillin-Beispieldateien |
 | `node scripts/generate-readmes.ts` | Erstellt Modul-READMEs |
 | `node scripts/extract-snippets.js` | Extrahiert Code-Snippets |

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11186,5 +11186,12 @@
     "task": "Detect cyclic parent reference loops in conversations",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add child reference validation",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure children reference existing nodes and proper parents",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11253,3 +11253,8 @@
   path: ""
   task: das Schritt für Schritt durchgehen
   test: ""
+- commit: Add child reference validation
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure children reference existing nodes and proper parents
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: detect cyclic parent reference loops",
+  "lastCommit": "feat: validate child node references",
   "fractalStep": "fractal-run/newadvanced-validation",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added cycle detection to conversation validator; next run training data extraction and implement JavaHamster AI flow.",
+  "notes": "Added child reference validation to conversation validator; next run training data extraction and implement JavaHamster AI flow.",
   "pendingTasks": [
     "Run scripts/extract-training-data.ts to fragment new advanced conversations",
     "Implement JavaHamster AI Flow"
@@ -957,6 +957,10 @@
     },
     {
       "commit": "feat: validate node id consistency",
+      "status": "done"
+    },
+    {
+      "commit": "feat: validate child node references",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -71,4 +71,13 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithParentCycles).toEqual([0]);
   });
+
+  it('flags nodes referencing missing children', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-missing-child.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidChildRefs).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -14,6 +14,7 @@ export interface ValidationResult {
   conversationsWithMissingParents: number[];
   conversationsWithMismatchedNodeIds: number[];
   conversationsWithParentCycles: number[];
+  conversationsWithInvalidChildRefs: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -30,6 +31,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const missingParents: number[] = [];
   const mismatchedNodeIds: number[] = [];
   const parentCycles: number[] = [];
+  const invalidChildren: number[] = [];
 
   raw.forEach((conv: any, idx: number) => {
     const missing: string[] = [];
@@ -97,6 +99,20 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
         current = parentNode ? parentNode.parent : null;
       }
       if (parentCycles.includes(idx)) break;
+
+      if (Array.isArray(node.children)) {
+        let childInvalid = false;
+        for (const childId of node.children) {
+          const child = conv.mapping[childId];
+          if (!child || child.parent !== key) {
+            childInvalid = true;
+            break;
+          }
+        }
+        if (childInvalid) {
+          invalidChildren.push(idx);
+        }
+      }
     }
 
     const root = conv.mapping?.['client-created-root'];
@@ -117,6 +133,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithMissingParents: missingParents,
     conversationsWithMismatchedNodeIds: mismatchedNodeIds,
     conversationsWithParentCycles: parentCycles,
+    conversationsWithInvalidChildRefs: invalidChildren,
   };
 }
 
@@ -132,7 +149,8 @@ if (require.main === module) {
     result.conversationsMissingRoot.length ||
     result.conversationsWithMissingParents.length ||
     result.conversationsWithMismatchedNodeIds.length ||
-    result.conversationsWithParentCycles.length
+    result.conversationsWithParentCycles.length ||
+    result.conversationsWithInvalidChildRefs.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-missing-child.json
+++ b/tests/fixtures/newadvanced-missing-child.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "1",
+    "title": "Missing child",
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["ghost"]
+      }
+    },
+    "create_time": 1,
+    "update_time": 2
+  }
+]


### PR DESCRIPTION
## Summary
- validate child node references in `newadvancedconversations.json`
- document validator updates in handbook and readme
- track feature in advanced todo and progress files

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test:agents scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68934f87e3788322a74dba63d1e55594