### PR TITLE
feat: detect unreachable conversation nodes

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11193,5 +11193,12 @@
     "task": "Ensure children reference existing nodes and proper parents",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add unreachable node validation",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure all nodes are reachable from root",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11258,3 +11258,8 @@
   task: Ensure children reference existing nodes and proper parents
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Add unreachable node validation
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure all nodes are reachable from root
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: validate child node references",
+  "lastCommit": "feat: detect unreachable conversation nodes",
   "fractalStep": "fractal-run/newadvanced-validation",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added child reference validation to conversation validator; next run training data extraction and implement JavaHamster AI flow.",
+  "notes": "Added unreachable node validation to conversation validator; next run training data extraction and implement JavaHamster AI flow.",
   "pendingTasks": [
     "Run scripts/extract-training-data.ts to fragment new advanced conversations",
     "Implement JavaHamster AI Flow"
@@ -625,6 +625,10 @@
     },
     {
       "commit": "Add cyclic parent reference detection for conversations",
+      "status": "done"
+    },
+    {
+      "commit": "feat: detect unreachable conversation nodes",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -80,4 +80,13 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithInvalidChildRefs).toEqual([0]);
   });
+
+  it('flags unreachable nodes', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-unreachable-node.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithUnreachableNodes).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -15,6 +15,7 @@ export interface ValidationResult {
   conversationsWithMismatchedNodeIds: number[];
   conversationsWithParentCycles: number[];
   conversationsWithInvalidChildRefs: number[];
+  conversationsWithUnreachableNodes: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -32,6 +33,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const mismatchedNodeIds: number[] = [];
   const parentCycles: number[] = [];
   const invalidChildren: number[] = [];
+  const unreachableNodes: number[] = [];
 
   raw.forEach((conv: any, idx: number) => {
     const missing: string[] = [];
@@ -118,6 +120,23 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     const root = conv.mapping?.['client-created-root'];
     if (!root || root.parent !== null) {
       missingRoot.push(idx);
+    } else {
+      const visited = new Set<string>();
+      const stack = ['client-created-root'];
+      while (stack.length) {
+        const id = stack.pop()!;
+        if (visited.has(id)) continue;
+        visited.add(id);
+        const node = conv.mapping[id];
+        if (Array.isArray(node?.children)) {
+          for (const childId of node.children) {
+            stack.push(childId);
+          }
+        }
+      }
+      if (visited.size !== Object.keys(conv.mapping || {}).length) {
+        unreachableNodes.push(idx);
+      }
     }
   });
 
@@ -134,6 +153,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithMismatchedNodeIds: mismatchedNodeIds,
     conversationsWithParentCycles: parentCycles,
     conversationsWithInvalidChildRefs: invalidChildren,
+    conversationsWithUnreachableNodes: unreachableNodes,
   };
 }
 
@@ -150,7 +170,8 @@ if (require.main === module) {
     result.conversationsWithMissingParents.length ||
     result.conversationsWithMismatchedNodeIds.length ||
     result.conversationsWithParentCycles.length ||
-    result.conversationsWithInvalidChildRefs.length
+    result.conversationsWithInvalidChildRefs.length ||
+    result.conversationsWithUnreachableNodes.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-unreachable-node.json
+++ b/tests/fixtures/newadvanced-unreachable-node.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "1",
+    "title": "Unreachable node",
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["a"]
+      },
+      "a": {
+        "id": "a",
+        "message": null,
+        "parent": "client-created-root",
+        "children": []
+      },
+      "b": {
+        "id": "b",
+        "message": null,
+        "parent": "client-created-root",
+        "children": []
+      }
+    },
+    "create_time": 1,
+    "update_time": 2
+  }
+]


### PR DESCRIPTION
## Summary
- ensure new advanced conversation validator flags nodes unreachable from root
- add test and fixture for unreachable node detection
- log progress in advanced task trackers

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689357077a848322a3c87af109aecf22