### PR TITLE
feat: validate empty message content in new conversations

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -24,7 +24,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js` und aktualisiere `advancedToDo.json` sowie `advancedprogress.json`.
 Validiere extrahierte Einträge mit `pnpm run validate:todos` (CI integriert) um fehlende Felder oder Duplikate zu finden.
 - Gesprächsstatistiken (inkl. Titel & Zeitspanne) aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
-- Struktur-, Zeit-, Root-Knoten-, Eltern- und Kindreferenz-Validierung für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
+- Struktur-, Zeit-, Root-Knoten-, Eltern- und Kindreferenz-Validierung sowie leere Nachrichteninhalte für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
 - QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`
 - KEDA/HPA Skalierung unter `deployment/keda` für NATS Queue-Length

--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ Verwende `./scripts/aeon.sh <command>` für alle CLI-Aufrufe.
 | `node scripts/sync-todo-progress.js` | Aktualisiert ToDo- & Progress-Dateien |
 | `node scripts/validate-advancedtodo.js` | Prüft Konsistenz zwischen YAML und JSON |
 | `node scripts/update-kontext.js` | Passt Kontext-Datei an (nutzt conversations oder newadvancedconversations) |
-| `ts-node scripts/validate-newadvanced-conversations.ts` | Prüft Struktur, Zeitreihen, Root-Knoten sowie Eltern- und Kindverweise von `newadvancedconversations.json` |
+| `ts-node scripts/validate-newadvanced-conversations.ts` | Prüft Struktur, Zeitreihen, Root-Knoten, Eltern- und Kindverweise sowie leere Nachrichteninhalte von `newadvancedconversations.json` |
 | `ts-node scripts/validate-sigillin-examples.ts` | Validiert Sigillin-Beispieldateien |
 | `node scripts/generate-readmes.ts` | Erstellt Modul-READMEs |
 | `node scripts/extract-snippets.js` | Extrahiert Code-Snippets |

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: detect unreachable conversation nodes",
+  "lastCommit": "feat: validate empty message content",
   "fractalStep": "fractal-run/newadvanced-validation",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added unreachable node validation to conversation validator; next run training data extraction and implement JavaHamster AI flow.",
+  "notes": "Added validation for empty message content; next run training data extraction and implement JavaHamster AI flow.",
   "pendingTasks": [
     "Run scripts/extract-training-data.ts to fragment new advanced conversations",
     "Implement JavaHamster AI Flow"
@@ -965,6 +965,10 @@
     },
     {
       "commit": "feat: validate child node references",
+      "status": "done"
+    },
+    {
+      "commit": "feat: validate empty message content",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -89,4 +89,13 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithUnreachableNodes).toEqual([0]);
   });
+
+  it('flags conversations with empty message content', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-empty-message.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithEmptyMessages).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -16,6 +16,7 @@ export interface ValidationResult {
   conversationsWithParentCycles: number[];
   conversationsWithInvalidChildRefs: number[];
   conversationsWithUnreachableNodes: number[];
+  conversationsWithEmptyMessages: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -34,6 +35,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const parentCycles: number[] = [];
   const invalidChildren: number[] = [];
   const unreachableNodes: number[] = [];
+  const emptyMessages: number[] = [];
 
   raw.forEach((conv: any, idx: number) => {
     const missing: string[] = [];
@@ -60,7 +62,8 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       else seenTitles.add(key);
     }
 
-    const times = Object.values(conv.mapping || {})
+    const nodes = Object.values(conv.mapping || {});
+    const times = nodes
       .map((n: any) => n?.message?.create_time)
       .filter((t: any): t is number => typeof t === 'number');
     for (let i = 1; i < times.length; i++) {
@@ -70,7 +73,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       }
     }
 
-    const roles = Object.values(conv.mapping || {})
+    const roles = nodes
       .map((n: any) => n?.message?.author?.role)
       .filter((r: any): r is string => typeof r === 'string');
     if (roles.some((r) => !['system', 'user', 'assistant'].includes(r))) {
@@ -117,6 +120,15 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       }
     }
 
+    if (
+      nodes.some((n: any) => {
+        const parts = n?.message?.content?.parts;
+        return !parts || parts.length === 0 || parts.every((p: any) => typeof p === 'string' && p.trim() === '');
+      })
+    ) {
+      emptyMessages.push(idx);
+    }
+
     const root = conv.mapping?.['client-created-root'];
     if (!root || root.parent !== null) {
       missingRoot.push(idx);
@@ -154,6 +166,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithParentCycles: parentCycles,
     conversationsWithInvalidChildRefs: invalidChildren,
     conversationsWithUnreachableNodes: unreachableNodes,
+    conversationsWithEmptyMessages: emptyMessages,
   };
 }
 
@@ -171,7 +184,8 @@ if (require.main === module) {
     result.conversationsWithMismatchedNodeIds.length ||
     result.conversationsWithParentCycles.length ||
     result.conversationsWithInvalidChildRefs.length ||
-    result.conversationsWithUnreachableNodes.length
+    result.conversationsWithUnreachableNodes.length ||
+    result.conversationsWithEmptyMessages.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-empty-message.json
+++ b/tests/fixtures/newadvanced-empty-message.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "c1",
+    "title": "Empty",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["n1"]
+      },
+      "n1": {
+        "id": "n1",
+        "message": {
+          "author": { "role": "user" },
+          "content": { "parts": [""] }
+        },
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- extend new advanced conversation validator to catch empty message content
- cover empty message detection with fixture and README/Handbuch notes
- log progress for fractal run

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689360d7d5788322894d2c2a8c83eba7