### PR TITLE
feat: validate missing node messages

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: validate empty message content",
+  "lastCommit": "feat: validate missing node messages",
   "fractalStep": "fractal-run/newadvanced-validation",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added validation for empty message content; next run training data extraction and implement JavaHamster AI flow.",
+  "notes": "Added validation for missing node messages; next run training data extraction and implement JavaHamster AI flow.",
   "pendingTasks": [
     "Run scripts/extract-training-data.ts to fragment new advanced conversations",
     "Implement JavaHamster AI Flow"
@@ -969,6 +969,10 @@
     },
     {
       "commit": "feat: validate empty message content",
+      "status": "done"
+    },
+    {
+      "commit": "feat: validate missing node messages",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -98,4 +98,13 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithEmptyMessages).toEqual([0]);
   });
+
+  it('flags nodes missing message objects', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-missing-message.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithMissingMessages).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -17,6 +17,7 @@ export interface ValidationResult {
   conversationsWithInvalidChildRefs: number[];
   conversationsWithUnreachableNodes: number[];
   conversationsWithEmptyMessages: number[];
+  conversationsWithMissingMessages: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -36,6 +37,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const invalidChildren: number[] = [];
   const unreachableNodes: number[] = [];
   const emptyMessages: number[] = [];
+  const missingMessages: number[] = [];
 
   raw.forEach((conv: any, idx: number) => {
     const missing: string[] = [];
@@ -81,6 +83,10 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     }
 
     for (const [key, node] of Object.entries(conv.mapping || {}) as [string, any][]) {
+      if (key !== 'client-created-root' && !node.message) {
+        missingMessages.push(idx);
+        break;
+      }
       if (node.id && node.id !== key) {
         mismatchedNodeIds.push(idx);
         break;
@@ -167,6 +173,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithInvalidChildRefs: invalidChildren,
     conversationsWithUnreachableNodes: unreachableNodes,
     conversationsWithEmptyMessages: emptyMessages,
+    conversationsWithMissingMessages: missingMessages,
   };
 }
 
@@ -185,7 +192,8 @@ if (require.main === module) {
     result.conversationsWithParentCycles.length ||
     result.conversationsWithInvalidChildRefs.length ||
     result.conversationsWithUnreachableNodes.length ||
-    result.conversationsWithEmptyMessages.length
+    result.conversationsWithEmptyMessages.length ||
+    result.conversationsWithMissingMessages.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-missing-message.json
+++ b/tests/fixtures/newadvanced-missing-message.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "c1",
+    "title": "Missing",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["n1"]
+      },
+      "n1": {
+        "id": "n1",
+        "message": null,
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- track missing message entries in conversation validator
- test missing node messages case
- record progress for new validation

## Testing
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`
- `npx tsc -p tsconfig.json`
- `npx pyright`


------
https://chatgpt.com/codex/tasks/task_e_6893745f222c83228002acaae769bc81