### PR TITLE
feat: validate parent child linkage

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11200,5 +11200,12 @@
     "task": "Ensure all nodes are reachable from root",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add parent-child link validation",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure each node is listed in its parent's children array",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11263,3 +11263,8 @@
   task: Ensure all nodes are reachable from root
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Add parent-child link validation
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure each node is listed in its parent's children array
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: validate missing node messages",
+  "lastCommit": "feat: validate parent-child linkage",
   "fractalStep": "fractal-run/newadvanced-validation",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added validation for missing node messages; next run training data extraction and implement JavaHamster AI flow.",
+  "notes": "Added validation for parent-child linkage; next run training data extraction and implement JavaHamster AI flow.",
   "pendingTasks": [
     "Run scripts/extract-training-data.ts to fragment new advanced conversations",
     "Implement JavaHamster AI Flow"
@@ -973,6 +973,10 @@
     },
     {
       "commit": "feat: validate missing node messages",
+      "status": "done"
+    },
+    {
+      "commit": "feat: validate parent-child linkage",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -107,4 +107,13 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithMissingMessages).toEqual([0]);
   });
+
+  it('flags nodes whose parents do not list them as children', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-unlinked-child.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithUnlistedChildren).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -15,6 +15,7 @@ export interface ValidationResult {
   conversationsWithMismatchedNodeIds: number[];
   conversationsWithParentCycles: number[];
   conversationsWithInvalidChildRefs: number[];
+  conversationsWithUnlistedChildren: number[];
   conversationsWithUnreachableNodes: number[];
   conversationsWithEmptyMessages: number[];
   conversationsWithMissingMessages: number[];
@@ -35,6 +36,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const mismatchedNodeIds: number[] = [];
   const parentCycles: number[] = [];
   const invalidChildren: number[] = [];
+  const unlistedChildren: number[] = [];
   const unreachableNodes: number[] = [];
   const emptyMessages: number[] = [];
   const missingMessages: number[] = [];
@@ -111,6 +113,18 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       }
       if (parentCycles.includes(idx)) break;
 
+      if (node.parent) {
+        const parent = conv.mapping[node.parent];
+        if (
+          parent &&
+          Array.isArray(parent.children) &&
+          !parent.children.includes(key)
+        ) {
+          unlistedChildren.push(idx);
+          break;
+        }
+      }
+
       if (Array.isArray(node.children)) {
         let childInvalid = false;
         for (const childId of node.children) {
@@ -171,6 +185,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithMismatchedNodeIds: mismatchedNodeIds,
     conversationsWithParentCycles: parentCycles,
     conversationsWithInvalidChildRefs: invalidChildren,
+    conversationsWithUnlistedChildren: unlistedChildren,
     conversationsWithUnreachableNodes: unreachableNodes,
     conversationsWithEmptyMessages: emptyMessages,
     conversationsWithMissingMessages: missingMessages,
@@ -191,6 +206,7 @@ if (require.main === module) {
     result.conversationsWithMismatchedNodeIds.length ||
     result.conversationsWithParentCycles.length ||
     result.conversationsWithInvalidChildRefs.length ||
+    result.conversationsWithUnlistedChildren.length ||
     result.conversationsWithUnreachableNodes.length ||
     result.conversationsWithEmptyMessages.length ||
     result.conversationsWithMissingMessages.length

--- a/tests/fixtures/newadvanced-unlinked-child.json
+++ b/tests/fixtures/newadvanced-unlinked-child.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "1",
+    "title": "Unlinked child",
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["a"]
+      },
+      "a": {
+        "id": "a",
+        "message": {
+          "id": "m1",
+          "author": { "role": "user" },
+          "content": { "parts": ["hi"] },
+          "create_time": 1
+        },
+        "parent": "client-created-root",
+        "children": []
+      },
+      "b": {
+        "id": "b",
+        "message": {
+          "id": "m2",
+          "author": { "role": "assistant" },
+          "content": { "parts": ["hello"] },
+          "create_time": 2
+        },
+        "parent": "a",
+        "children": []
+      }
+    },
+    "create_time": 1,
+    "update_time": 3
+  }
+]


### PR DESCRIPTION
## Summary
- validate that each node is referenced by its parent's children list
- test parent-child linkage validation
- log progress for parent-child validation

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx vitest scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689378db01c083228d0c6d039e0f423d