### PR TITLE
feat: detect duplicate child references in conversation validator

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11207,5 +11207,12 @@
     "task": "Ensure each node is listed in its parent's children array",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add duplicate child reference validation",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Detect duplicate IDs within children arrays",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11268,3 +11268,8 @@
   task: Ensure each node is listed in its parent's children array
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Add duplicate child reference validation
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Detect duplicate IDs within children arrays
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: validate parent-child linkage",
+  "lastCommit": "feat: detect duplicate child references",
   "fractalStep": "fractal-run/newadvanced-validation",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added validation for parent-child linkage; next run training data extraction and implement JavaHamster AI flow.",
+  "notes": "Added duplicate child reference detection; next run training data extraction and implement JavaHamster AI flow.",
   "pendingTasks": [
     "Run scripts/extract-training-data.ts to fragment new advanced conversations",
     "Implement JavaHamster AI Flow"
@@ -977,6 +977,10 @@
     },
     {
       "commit": "feat: validate parent-child linkage",
+      "status": "done"
+    },
+    {
+      "commit": "feat: detect duplicate child references",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -116,4 +116,13 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithUnlistedChildren).toEqual([0]);
   });
+
+  it('flags duplicate child references', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-duplicate-children.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithDuplicateChildIds).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -19,6 +19,7 @@ export interface ValidationResult {
   conversationsWithUnreachableNodes: number[];
   conversationsWithEmptyMessages: number[];
   conversationsWithMissingMessages: number[];
+  conversationsWithDuplicateChildIds: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -40,6 +41,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const unreachableNodes: number[] = [];
   const emptyMessages: number[] = [];
   const missingMessages: number[] = [];
+  const duplicateChildIds: number[] = [];
 
   raw.forEach((conv: any, idx: number) => {
     const missing: string[] = [];
@@ -127,7 +129,14 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
 
       if (Array.isArray(node.children)) {
         let childInvalid = false;
+        let duplicateChild = false;
+        const seenChildren = new Set<string>();
         for (const childId of node.children) {
+          if (seenChildren.has(childId)) {
+            duplicateChild = true;
+            break;
+          }
+          seenChildren.add(childId);
           const child = conv.mapping[childId];
           if (!child || child.parent !== key) {
             childInvalid = true;
@@ -136,6 +145,9 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
         }
         if (childInvalid) {
           invalidChildren.push(idx);
+        }
+        if (duplicateChild) {
+          duplicateChildIds.push(idx);
         }
       }
     }
@@ -189,6 +201,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithUnreachableNodes: unreachableNodes,
     conversationsWithEmptyMessages: emptyMessages,
     conversationsWithMissingMessages: missingMessages,
+    conversationsWithDuplicateChildIds: duplicateChildIds,
   };
 }
 
@@ -209,7 +222,8 @@ if (require.main === module) {
     result.conversationsWithUnlistedChildren.length ||
     result.conversationsWithUnreachableNodes.length ||
     result.conversationsWithEmptyMessages.length ||
-    result.conversationsWithMissingMessages.length
+    result.conversationsWithMissingMessages.length ||
+    result.conversationsWithDuplicateChildIds.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-duplicate-children.json
+++ b/tests/fixtures/newadvanced-duplicate-children.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "conv1",
+    "title": "Duplicate Children",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["a"]
+      },
+      "a": {
+        "id": "a",
+        "parent": "client-created-root",
+        "children": ["b", "b"],
+        "message": {
+          "id": "a",
+          "author": { "role": "user" },
+          "content": { "parts": ["hello"] },
+          "create_time": 1
+        }
+      },
+      "b": {
+        "id": "b",
+        "parent": "a",
+        "children": [],
+        "message": {
+          "id": "b",
+          "author": { "role": "assistant" },
+          "content": { "parts": ["hi"] },
+          "create_time": 2
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- validate that conversation nodes do not list the same child twice
- cover duplicate-child scenario in tests and fixtures
- log progress for the new validation step

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689394628a688322a79ced0aefe87ba3