### PR TITLE
feat: validate message timestamps

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -24,7 +24,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js` und aktualisiere `advancedToDo.json` sowie `advancedprogress.json`.
 Validiere extrahierte Einträge mit `pnpm run validate:todos` (CI integriert) um fehlende Felder oder Duplikate zu finden.
 - Gesprächsstatistiken (inkl. Titel & Zeitspanne) aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
-- Struktur-, Zeit-, Root-Knoten-, Eltern- und Kindreferenz-Validierung sowie leere Nachrichteninhalte für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
+- Struktur-, Zeit-, Root-Knoten-, Eltern- und Kindreferenz-Validierung, leere Nachrichteninhalte sowie Nachrichtenzeitstempel für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
 - QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`
 - KEDA/HPA Skalierung unter `deployment/keda` für NATS Queue-Length

--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ Verwende `./scripts/aeon.sh <command>` für alle CLI-Aufrufe.
 | `node scripts/sync-todo-progress.js` | Aktualisiert ToDo- & Progress-Dateien |
 | `node scripts/validate-advancedtodo.js` | Prüft Konsistenz zwischen YAML und JSON |
 | `node scripts/update-kontext.js` | Passt Kontext-Datei an (nutzt conversations oder newadvancedconversations) |
-| `ts-node scripts/validate-newadvanced-conversations.ts` | Prüft Struktur, Zeitreihen, Root-Knoten, Eltern- und Kindverweise sowie leere Nachrichteninhalte von `newadvancedconversations.json` |
+| `ts-node scripts/validate-newadvanced-conversations.ts` | Prüft Struktur, Zeitreihen, Root-Knoten, Eltern- und Kindverweise, leere Nachrichteninhalte sowie fehlende/ungültige Nachrichtenzeitstempel von `newadvancedconversations.json` |
 | `ts-node scripts/validate-sigillin-examples.ts` | Validiert Sigillin-Beispieldateien |
 | `node scripts/generate-readmes.ts` | Erstellt Modul-READMEs |
 | `node scripts/extract-snippets.js` | Extrahiert Code-Snippets |

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14,6 +14,13 @@
     "status": "done"
   },
   {
+    "commit": "Validate message timestamps in conversations",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure each node message has create_time and update_time with update_time >= create_time",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
+  },
+  {
     "commit": "Add SymbolMapper agent",
     "path": "agents/symbolmapper/main.py",
     "task": "Map numeric and textual inputs to glyphs",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11278,3 +11278,8 @@
   task: Detect duplicate IDs within children arrays
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Validate message timestamps in conversations
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure each node message has create_time and update_time with update_time >= create_time
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: validate message id presence",
+  "lastCommit": "feat: validate message timestamps",
   "fractalStep": "fractal-run/newadvanced-validation",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added message ID validation; next run training data extraction and implement JavaHamster AI flow.",
+  "notes": "Added message timestamp validation; next run training data extraction and implement JavaHamster AI flow.",
   "pendingTasks": [
     "Run scripts/extract-training-data.ts to fragment new advanced conversations",
     "Implement JavaHamster AI Flow"
@@ -985,6 +985,10 @@
     },
     {
       "commit": "feat: validate message id presence",
+      "status": "done"
+    },
+    {
+      "commit": "feat: validate message timestamps",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -134,4 +134,22 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithDuplicateChildIds).toEqual([0]);
   });
+
+  it('flags nodes missing message timestamps', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-missing-message-timestamp.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithMessagesMissingTimestamps).toEqual([0]);
+  });
+
+  it('flags nodes with invalid message timestamps', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-message-times.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidMessageTimestamps).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -21,6 +21,8 @@ export interface ValidationResult {
   conversationsWithMissingMessages: number[];
   conversationsWithDuplicateChildIds: number[];
   conversationsWithMissingMessageIds: number[];
+  conversationsWithMessagesMissingTimestamps: number[];
+  conversationsWithInvalidMessageTimestamps: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -44,6 +46,8 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const missingMessages: number[] = [];
   const duplicateChildIds: number[] = [];
   const missingMessageIds: number[] = [];
+  const messagesMissingTimestamps: number[] = [];
+  const invalidMessageTimestamps: number[] = [];
 
   raw.forEach((conv: any, idx: number) => {
     const missing: string[] = [];
@@ -156,6 +160,20 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
           duplicateChildIds.push(idx);
         }
       }
+      if (key !== 'client-created-root' && node.message) {
+        const m = node.message;
+        if (
+          typeof m.create_time !== 'number' ||
+          typeof m.update_time !== 'number'
+        ) {
+          messagesMissingTimestamps.push(idx);
+          break;
+        }
+        if (m.update_time < m.create_time) {
+          invalidMessageTimestamps.push(idx);
+          break;
+        }
+      }
     }
 
     if (
@@ -209,6 +227,8 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithMissingMessages: missingMessages,
     conversationsWithDuplicateChildIds: duplicateChildIds,
     conversationsWithMissingMessageIds: missingMessageIds,
+    conversationsWithMessagesMissingTimestamps: messagesMissingTimestamps,
+    conversationsWithInvalidMessageTimestamps: invalidMessageTimestamps,
   };
 }
 

--- a/tests/fixtures/newadvanced-invalid-message-times.json
+++ b/tests/fixtures/newadvanced-invalid-message-times.json
@@ -1,0 +1,28 @@
+[
+  {
+    "title": "Invalid message times",
+    "id": "conv-invalid-msg-times",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["n1"]
+      },
+      "n1": {
+        "id": "n1",
+        "message": {
+          "id": "n1",
+          "author": {"role": "user"},
+          "create_time": 5,
+          "update_time": 4,
+          "content": {"parts": ["hi"]}
+        },
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]

--- a/tests/fixtures/newadvanced-missing-message-timestamp.json
+++ b/tests/fixtures/newadvanced-missing-message-timestamp.json
@@ -1,0 +1,26 @@
+[
+  {
+    "title": "Missing message timestamp",
+    "id": "conv-missing-time",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["n1"]
+      },
+      "n1": {
+        "id": "n1",
+        "message": {
+          "id": "n1",
+          "author": {"role": "user"},
+          "content": {"parts": ["hi"]}
+        },
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]

--- a/tests/fixtures/newadvanced-unlinked-child.json
+++ b/tests/fixtures/newadvanced-unlinked-child.json
@@ -15,7 +15,8 @@
           "id": "m1",
           "author": { "role": "user" },
           "content": { "parts": ["hi"] },
-          "create_time": 1
+          "create_time": 1,
+          "update_time": 1
         },
         "parent": "client-created-root",
         "children": []


### PR DESCRIPTION
## Summary
- extend newadvanced conversation validator with message timestamp checks
- cover missing and invalid timestamps in tests and fixtures
- document validator improvements in README and Handbuch; track progress in advanced files

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6893a68c2fb88322b3ee5299d12a8432