### PR TITLE
feat: expand JavaHamsterFlow

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -969,7 +969,8 @@
     "commit": "Add JavaHamster AI Flow",
     "path": "packages/tutorials/JavaHamsterAI",
     "task": "Interactive hamster coding with AI coach and Sigil rewards",
-    "test": "packages/tutorials/__tests__/JavaHamsterAI.test.ts"
+    "test": "packages/tutorials/__tests__/JavaHamsterAI.test.ts",
+    "status": "done"
   },
   {
     "commit": "Document learning modules",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -698,6 +698,7 @@
   path: packages/tutorials/JavaHamsterAI
   task: Interactive hamster coding with AI coach and Sigil rewards
   test: packages/tutorials/__tests__/JavaHamsterAI.test.ts
+  status: done
 - commit: Document learning modules
   path: docs/learning-modules.md
   task: Describe workflows from advancedconversations_snippet.json

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,14 +1,13 @@
 {
-  "lastCommit": "feat: validate message timestamps",
+  "lastCommit": "feat: expand JavaHamsterFlow",
   "fractalStep": "fractal-run/newadvanced-validation",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added message timestamp validation; next run training data extraction and implement JavaHamster AI flow.",
+  "notes": "Expanded JavaHamsterFlow with coaching hints and sigil rewards; next run training data extraction.",
   "pendingTasks": [
-    "Run scripts/extract-training-data.ts to fragment new advanced conversations",
-    "Implement JavaHamster AI Flow"
+    "Run scripts/extract-training-data.ts to fragment new advanced conversations"
   ],
   "progress": [
     {
@@ -989,6 +988,10 @@
     },
     {
       "commit": "feat: validate message timestamps",
+      "status": "done"
+    },
+    {
+      "commit": "feat: expand JavaHamsterFlow",
       "status": "done"
     }
   ],

--- a/packages/tutorials/JavaHamsterAI/index.ts
+++ b/packages/tutorials/JavaHamsterAI/index.ts
@@ -1,18 +1,54 @@
 export interface Level {
   id: string;
   solved: boolean;
+  hint?: string;
 }
 
+/**
+ * JavaHamsterFlow simulates a small learning game where each level can provide
+ * a coaching hint and awards a sigil once all levels are solved. The class is
+ * intentionally lightweight so it can be used in unit tests without any GPT
+ * calls while still reflecting the high level idea of an "AI coach".
+ */
 export class JavaHamsterFlow {
   private levels: Level[];
-  constructor(levels: string[] = []) {
-    this.levels = levels.map((l) => ({ id: l, solved: false }));
+  private sigil: string | null = null;
+
+  constructor(levels: { id: string; hint?: string }[] = []) {
+    this.levels = levels.map((l) => ({ id: l.id, solved: false, hint: l.hint }));
   }
+
   solve(id: string) {
     const level = this.levels.find((l) => l.id === id);
     if (level) level.solved = true;
   }
+
+  /**
+   * Returns a hint for the requested level. If no hint was provided, a default
+   * motivational message is returned to emulate an AI coach response.
+   */
+  coach(id: string): string {
+    const level = this.levels.find((l) => l.id === id);
+    return level?.hint ?? 'Keep going, little hamster!';
+  }
+
   rewardReady() {
     return this.levels.every((l) => l.solved);
+  }
+
+  /**
+   * Awards a simple sigil string once all levels are solved. Subsequent calls
+   * return the same sigil value.
+   */
+  awardSigil(): string | null {
+    if (this.rewardReady()) {
+      if (!this.sigil) {
+        // Basic sigil pattern composed from solved level ids
+        const pattern = this.levels.map((l) => l.id).join('-');
+        this.sigil = `sigil-${pattern}`;
+      }
+      return this.sigil;
+    }
+    return null;
   }
 }

--- a/packages/tutorials/__tests__/JavaHamsterAI.test.ts
+++ b/packages/tutorials/__tests__/JavaHamsterAI.test.ts
@@ -1,12 +1,27 @@
 import { JavaHamsterFlow } from '../JavaHamsterAI';
 
 describe('JavaHamsterFlow', () => {
-  it('rewards after solving all levels', () => {
-    const flow = new JavaHamsterFlow(['l1', 'l2']);
-    expect(flow.rewardReady()).toBe(false);
+  it('coaches and awards sigil after all levels solved', () => {
+    const flow = new JavaHamsterFlow([
+      { id: 'l1', hint: 'Use move();' },
+      { id: 'l2', hint: 'Try turnLeft();' },
+    ]);
+
+    // Coach provides hints
+    expect(flow.coach('l1')).toBe('Use move();');
+    expect(flow.awardSigil()).toBeNull();
+
+    // Solve levels sequentially
     flow.solve('l1');
     expect(flow.rewardReady()).toBe(false);
     flow.solve('l2');
+
+    // After solving all levels a sigil is awarded
     expect(flow.rewardReady()).toBe(true);
+    const sigil = flow.awardSigil();
+    expect(sigil).toMatch(/sigil-l1-l2/);
+
+    // Subsequent calls return the same sigil
+    expect(flow.awardSigil()).toBe(sigil);
   });
 });


### PR DESCRIPTION
## Summary
- add coaching hints and sigil rewards to `JavaHamsterFlow`
- document completed JavaHamster AI Flow task in ToDo trackers
- log JavaHamsterFlow expansion in advanced progress file

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/tutorials/__tests__/JavaHamsterAI.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6893b02fccc88322a4f7372d8f643c5a