### PR TITLE
feat: add GhostShell NGINX proxy

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -420,6 +420,8 @@ npm run dev   # oder: yarn dev
 Nutze `scripts/protodeploy.sh up` für einen lokalen Docker-Start.
 Die Compose-Datei findet sich unter `infrastructure/protodeploy/docker-compose.yml`.
 
+Für den GhostShellAgent steht eine NGINX-Reverse-Proxy-Config unter `config/nginx/ghostshell.conf` bereit.
+
 
 ## QA-Workflow
 Führe `pnpm run qa` aus, um Linting und Tests zu starten. Das Skript `scripts/qa-test-runner.ts` erstellt im Projektstamm die Datei `qa-report.log`.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
  - [**FourierAPI**](packages/analysis/FourierAPI.ts) – exposes metrics via REST (`/metrics`, `/analyze`)
  - [**SelfReflectionAgent**](docs/agents/SelfReflectionAgent.md) – system introspection helper with memory governance checks
 - [**CosmicTheoryAgent introspection log**](packages/agents/CosmicTheoryAgent.ts#L1) – captures Fourier metrics
+- **GhostShellAgent NGINX proxy** – reverse proxy configuration for clustered GhostShell deployments (`config/nginx/ghostshell.conf`)
 - [**GrokAgent**](packages/agents/GrokAgent.ts) – simple pattern analyzer
 - [**SymbolMapper**](agents/symbolmapper/main.py) – maps numeric and textual patterns to Sigillin glyphs
 - [**ShadowIntegration**](packages/integration/ShadowIntegration.ts) – experimental data bridge

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1202,7 +1202,8 @@
     "commit": "Add GhostShell NGINX config",
     "path": "config/nginx/ghostshell.conf",
     "task": "Provide NGINX reverse proxy for clustered GhostShellAgent",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "Implement GhostShell session store",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -884,6 +884,7 @@
   path: config/nginx/ghostshell.conf
   task: Provide NGINX reverse proxy for clustered GhostShellAgent
   test: ""
+  status: done
 - commit: Implement GhostShell session store
   path: services/ghost-shell/session-store.ts
   task: Track WebSocket message history per client

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,13 +1,14 @@
 {
-  "lastCommit": "feat: expand JavaHamsterFlow",
-  "fractalStep": "fractal-run/newadvanced-validation",
+  "lastCommit": "feat: add GhostShell NGINX config",
+  "fractalStep": "fractal-run/ghostshell-nginx",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Expanded JavaHamsterFlow with coaching hints and sigil rewards; next run training data extraction.",
+  "notes": "Added GhostShell reverse proxy; next step deploy at edge",
   "pendingTasks": [
-    "Run scripts/extract-training-data.ts to fragment new advanced conversations"
+    "Run scripts/extract-training-data.ts to fragment new advanced conversations",
+    "Deploy GhostShellAgent as Lambda@Edge"
   ],
   "progress": [
     {
@@ -628,6 +629,10 @@
     },
     {
       "commit": "feat: detect unreachable conversation nodes",
+      "status": "done"
+    },
+    {
+      "commit": "Add GhostShell NGINX config",
       "status": "done"
     }
   ],

--- a/config/nginx/ghostshell.conf
+++ b/config/nginx/ghostshell.conf
@@ -1,14 +1,16 @@
 upstream ghostshell {
-    server 127.0.0.1:${PORT_BASE:-3000};
-    server 127.0.0.1:${PORT_NEXT:-3001};
+  server ghostshell:8080;
 }
+
 server {
-    listen 80;
-    location / {
-        proxy_pass http://ghostshell;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
-    }
+  listen 80;
+  server_name _;
+
+  location / {
+    proxy_pass http://ghostshell;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+  }
 }


### PR DESCRIPTION
## Summary
- provide NGINX reverse proxy config for clustered GhostShellAgent
- document GhostShell proxy in README and Handbuch
- mark GhostShell NGINX task as done and log progress state

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright` *(fails: venvPath /workspace/unified-mandala/.venv is not a valid directory)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6893c6850bd08322a5d1068b9dc42ede