### PR TITLE
feat: validate conversation content parts

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add GhostShell NGINX config",
-  "fractalStep": "fractal-run/ghostshell-nginx",
+  "lastCommit": "feat: validate conversation content parts",
+  "fractalStep": "fractal-run/validate-content-parts",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added GhostShell reverse proxy; next step deploy at edge",
+  "notes": "Validated non-string message parts and strengthened timestamp checks",
   "pendingTasks": [
     "Run scripts/extract-training-data.ts to fragment new advanced conversations",
     "Deploy GhostShellAgent as Lambda@Edge"
@@ -997,6 +997,10 @@
     },
     {
       "commit": "feat: expand JavaHamsterFlow",
+      "status": "done"
+    },
+    {
+      "commit": "feat: validate conversation content parts",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -152,4 +152,13 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithInvalidMessageTimestamps).toEqual([0]);
   });
+
+  it('flags non-string message parts', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-part-types.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidContentParts).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -23,6 +23,7 @@ export interface ValidationResult {
   conversationsWithMissingMessageIds: number[];
   conversationsWithMessagesMissingTimestamps: number[];
   conversationsWithInvalidMessageTimestamps: number[];
+  conversationsWithInvalidContentParts: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -48,6 +49,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const missingMessageIds: number[] = [];
   const messagesMissingTimestamps: number[] = [];
   const invalidMessageTimestamps: number[] = [];
+  const invalidContentParts: number[] = [];
 
   raw.forEach((conv: any, idx: number) => {
     const missing: string[] = [];
@@ -185,6 +187,15 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       emptyMessages.push(idx);
     }
 
+    if (
+      nodes.some((n: any) => {
+        const parts = n?.message?.content?.parts;
+        return Array.isArray(parts) && parts.some((p: any) => typeof p !== 'string');
+      })
+    ) {
+      invalidContentParts.push(idx);
+    }
+
     const root = conv.mapping?.['client-created-root'];
     if (!root || root.parent !== null) {
       missingRoot.push(idx);
@@ -229,6 +240,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithMissingMessageIds: missingMessageIds,
     conversationsWithMessagesMissingTimestamps: messagesMissingTimestamps,
     conversationsWithInvalidMessageTimestamps: invalidMessageTimestamps,
+    conversationsWithInvalidContentParts: invalidContentParts,
   };
 }
 
@@ -251,7 +263,10 @@ if (require.main === module) {
     result.conversationsWithEmptyMessages.length ||
     result.conversationsWithMissingMessages.length ||
     result.conversationsWithDuplicateChildIds.length ||
-    result.conversationsWithMissingMessageIds.length
+    result.conversationsWithMissingMessageIds.length ||
+    result.conversationsWithMessagesMissingTimestamps.length ||
+    result.conversationsWithInvalidMessageTimestamps.length ||
+    result.conversationsWithInvalidContentParts.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-invalid-part-types.json
+++ b/tests/fixtures/newadvanced-invalid-part-types.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "1",
+    "title": "Invalid parts",
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["a"]
+      },
+      "a": {
+        "id": "a",
+        "message": {
+          "id": "m1",
+          "author": {"role": "user"},
+          "content": {"parts": ["valid", {"foo": "bar"}]},
+          "create_time": 1,
+          "update_time": 1
+        },
+        "parent": "client-created-root",
+        "children": []
+      }
+    },
+    "create_time": 1,
+    "update_time": 1
+  }
+]


### PR DESCRIPTION
## Summary
- expand conversation validator to flag non-string content parts and to fail when timestamp issues occur
- add fixture and tests for invalid content parts
- log progress for validator enhancement

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test:agents scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6893cf8cacd88322b47851c99a48dd82