### PR TITLE
feat: detect orphan nodes in conversations

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11230,5 +11230,19 @@
     "task": "Detect duplicate IDs within children arrays",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Validate message timestamps in conversations",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure each node message has create_time and update_time with update_time >= create_time",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
+  },
+  {
+    "commit": "Detect orphan nodes in conversations",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Flag nodes without parent aside from root",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11285,3 +11285,8 @@
   task: Ensure each node message has create_time and update_time with update_time >= create_time
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Detect orphan nodes in conversations
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Flag nodes without parent aside from root
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: validate conversation content parts",
-  "fractalStep": "fractal-run/validate-content-parts",
+  "lastCommit": "feat: detect orphan nodes in conversations",
+  "fractalStep": "fractal-run/validate-orphan-nodes",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Validated non-string message parts and strengthened timestamp checks",
+  "notes": "Added orphan node detection to conversation validator",
   "pendingTasks": [
     "Run scripts/extract-training-data.ts to fragment new advanced conversations",
     "Deploy GhostShellAgent as Lambda@Edge"
@@ -1001,6 +1001,10 @@
     },
     {
       "commit": "feat: validate conversation content parts",
+      "status": "done"
+    },
+    {
+      "commit": "feat: detect orphan nodes in conversations",
       "status": "done"
     }
   ],

--- a/scripts/__tests__/validate-newadvanced-conversations.test.ts
+++ b/scripts/__tests__/validate-newadvanced-conversations.test.ts
@@ -16,14 +16,22 @@ test('detects duplicates, missing fields and invalid roles', () => {
         id: '3',
         title: 'Valid mapping but invalid role',
         mapping: {
+          'client-created-root': {
+            id: 'client-created-root',
+            parent: null,
+            children: ['node'],
+            message: null
+          },
           node: {
             id: 'node',
-            parent: null,
+            parent: 'client-created-root',
             children: [],
             message: {
               id: 'node',
               author: { role: 'hacker' },
-              create_time: 1
+              create_time: 1,
+              update_time: 1,
+              content: { content_type: 'text', parts: ['hi'] }
             }
           }
         },
@@ -48,13 +56,41 @@ test('detects duplicates, missing fields and invalid roles', () => {
         create_time: 1,
         update_time: 2
       }
+      ,
+      {
+        id: '5',
+        title: 'Orphan node',
+        mapping: {
+          'client-created-root': {
+            id: 'client-created-root',
+            parent: null,
+            children: [],
+            message: null
+          },
+          node: {
+            id: 'node',
+            parent: null,
+            children: [],
+            message: {
+              id: 'node',
+              author: { role: 'user' },
+              create_time: 1,
+              update_time: 1,
+              content: { content_type: 'text', parts: ['hi'] }
+            }
+          }
+        },
+        create_time: 1,
+        update_time: 2
+      }
     ])
   );
   const res = validateNewAdvancedConversations(file);
-  expect(res.conversationCount).toBe(5);
+  expect(res.conversationCount).toBe(6);
   expect(res.duplicateIds).toEqual(['1']);
   expect(res.missingFields.length).toBe(2);
   expect(res.conversationsWithInvalidRoles).toEqual([3]);
   expect(res.conversationsWithMissingParents).toEqual([4]);
+  expect(res.conversationsWithOrphanNodes).toEqual([5]);
   fs.rmSync(tmp, { recursive: true, force: true });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -16,6 +16,7 @@ export interface ValidationResult {
   conversationsWithParentCycles: number[];
   conversationsWithInvalidChildRefs: number[];
   conversationsWithUnlistedChildren: number[];
+  conversationsWithOrphanNodes: number[];
   conversationsWithUnreachableNodes: number[];
   conversationsWithEmptyMessages: number[];
   conversationsWithMissingMessages: number[];
@@ -42,6 +43,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const parentCycles: number[] = [];
   const invalidChildren: number[] = [];
   const unlistedChildren: number[] = [];
+  const orphanNodes: number[] = [];
   const unreachableNodes: number[] = [];
   const emptyMessages: number[] = [];
   const missingMessages: number[] = [];
@@ -109,6 +111,10 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       }
       if (node.parent && !conv.mapping[node.parent]) {
         missingParents.push(idx);
+        break;
+      }
+      if ((node.parent === null || node.parent === undefined) && key !== 'client-created-root') {
+        orphanNodes.push(idx);
         break;
       }
 
@@ -233,6 +239,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithParentCycles: parentCycles,
     conversationsWithInvalidChildRefs: invalidChildren,
     conversationsWithUnlistedChildren: unlistedChildren,
+    conversationsWithOrphanNodes: orphanNodes,
     conversationsWithUnreachableNodes: unreachableNodes,
     conversationsWithEmptyMessages: emptyMessages,
     conversationsWithMissingMessages: missingMessages,
@@ -259,6 +266,7 @@ if (require.main === module) {
     result.conversationsWithParentCycles.length ||
     result.conversationsWithInvalidChildRefs.length ||
     result.conversationsWithUnlistedChildren.length ||
+    result.conversationsWithOrphanNodes.length ||
     result.conversationsWithUnreachableNodes.length ||
     result.conversationsWithEmptyMessages.length ||
     result.conversationsWithMissingMessages.length ||


### PR DESCRIPTION
## Summary
- extend newadvanced conversation validator with orphan-node detection
- cover orphan scenarios in validator tests
- record validator upgrade in advanced todo and progress logs

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/__tests__/validate-newadvanced-conversations.test.ts`
- `npx ts-node scripts/validate-newadvanced-conversations.ts docs/sigils/newadvancedconversations.json`

------
https://chatgpt.com/codex/tasks/task_e_6893d77442148322a1b617c91af53e5a