### PR TITLE
feat: detect self-referential child nodes

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -21,6 +21,13 @@
     "status": "done"
   },
   {
+    "commit": "Detect self-referential child nodes",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Flag nodes that list themselves as children",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
+  },
+  {
     "commit": "Add SymbolMapper agent",
     "path": "agents/symbolmapper/main.py",
     "task": "Map numeric and textual inputs to glyphs",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11290,3 +11290,8 @@
   task: Flag nodes without parent aside from root
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Detect self-referential child nodes
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Flag nodes that list themselves as children
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: detect orphan nodes in conversations",
-  "fractalStep": "fractal-run/validate-orphan-nodes",
+  "lastCommit": "feat: detect self-referential child nodes",
+  "fractalStep": "fractal-run/self-referential-child-validation",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added orphan node detection to conversation validator",
+  "notes": "Added self-referential child detection to conversation validator",
   "pendingTasks": [
     "Run scripts/extract-training-data.ts to fragment new advanced conversations",
     "Deploy GhostShellAgent as Lambda@Edge"
@@ -1005,6 +1005,10 @@
     },
     {
       "commit": "feat: detect orphan nodes in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "feat: detect self-referential child nodes",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -135,6 +135,15 @@ describe('validateNewAdvancedConversations', () => {
     expect(res.conversationsWithDuplicateChildIds).toEqual([0]);
   });
 
+  it('flags self-referential child nodes', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-self-referential-child.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithSelfReferencingChildren).toEqual([0]);
+  });
+
   it('flags nodes missing message timestamps', () => {
     const file = path.join(
       __dirname,

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -25,6 +25,7 @@ export interface ValidationResult {
   conversationsWithMessagesMissingTimestamps: number[];
   conversationsWithInvalidMessageTimestamps: number[];
   conversationsWithInvalidContentParts: number[];
+  conversationsWithSelfReferencingChildren: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -52,6 +53,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const messagesMissingTimestamps: number[] = [];
   const invalidMessageTimestamps: number[] = [];
   const invalidContentParts: number[] = [];
+  const selfReferencingChildren: number[] = [];
 
   raw.forEach((conv: any, idx: number) => {
     const missing: string[] = [];
@@ -148,6 +150,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       if (Array.isArray(node.children)) {
         let childInvalid = false;
         let duplicateChild = false;
+        let selfReference = false;
         const seenChildren = new Set<string>();
         for (const childId of node.children) {
           if (seenChildren.has(childId)) {
@@ -155,6 +158,10 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
             break;
           }
           seenChildren.add(childId);
+          if (childId === key) {
+            selfReference = true;
+            break;
+          }
           const child = conv.mapping[childId];
           if (!child || child.parent !== key) {
             childInvalid = true;
@@ -166,6 +173,9 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
         }
         if (duplicateChild) {
           duplicateChildIds.push(idx);
+        }
+        if (selfReference) {
+          selfReferencingChildren.push(idx);
         }
       }
       if (key !== 'client-created-root' && node.message) {
@@ -248,6 +258,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithMessagesMissingTimestamps: messagesMissingTimestamps,
     conversationsWithInvalidMessageTimestamps: invalidMessageTimestamps,
     conversationsWithInvalidContentParts: invalidContentParts,
+    conversationsWithSelfReferencingChildren: selfReferencingChildren,
   };
 }
 
@@ -274,7 +285,8 @@ if (require.main === module) {
     result.conversationsWithMissingMessageIds.length ||
     result.conversationsWithMessagesMissingTimestamps.length ||
     result.conversationsWithInvalidMessageTimestamps.length ||
-    result.conversationsWithInvalidContentParts.length
+    result.conversationsWithInvalidContentParts.length ||
+    result.conversationsWithSelfReferencingChildren.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-self-referential-child.json
+++ b/tests/fixtures/newadvanced-self-referential-child.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "1",
+    "title": "Self child",
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["1"]
+      },
+      "1": {
+        "id": "1",
+        "parent": "client-created-root",
+        "children": ["1"],
+        "message": {
+          "id": "m1",
+          "author": { "role": "user" },
+          "create_time": 1,
+          "update_time": 1,
+          "content": { "parts": ["hello"] }
+        }
+      }
+    },
+    "create_time": 1,
+    "update_time": 1
+  }
+]


### PR DESCRIPTION
## Summary
- extend conversation validator to detect self-referential child links
- cover new validation with unit tests and fixture
- record progress and TODO entries for the new check

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6893dd518c9483228e42e44949167476