### PR TITLE
feat: normalize conversation titles

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: detect self-referential child nodes",
-  "fractalStep": "fractal-run/self-referential-child-validation",
+  "lastCommit": "feat: normalize conversation titles",
+  "fractalStep": "fractal-run/title-whitespace-validation",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added self-referential child detection to conversation validator",
+  "notes": "Normalized conversation titles and added whitespace validation",
   "pendingTasks": [
     "Run scripts/extract-training-data.ts to fragment new advanced conversations",
     "Deploy GhostShellAgent as Lambda@Edge"
@@ -1009,6 +1009,10 @@
     },
     {
       "commit": "feat: detect self-referential child nodes",
+      "status": "done"
+    },
+    {
+      "commit": "feat: normalize conversation titles",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -4,9 +4,12 @@ import { validateNewAdvancedConversations } from './validate-newadvanced-convers
 
 describe('validateNewAdvancedConversations', () => {
   it('flags duplicate titles', () => {
-    const file = path.join(__dirname, '../tests/fixtures/newadvanced-duplicate-titles.json');
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-duplicate-titles.json'
+    );
     const res = validateNewAdvancedConversations(file);
-    expect(res.duplicateTitles).toEqual(['Foo']);
+    expect(res.duplicateTitles).toEqual(['foo']);
   });
 
   it('flags duplicate titles case-insensitively', () => {
@@ -16,6 +19,16 @@ describe('validateNewAdvancedConversations', () => {
     );
     const res = validateNewAdvancedConversations(file);
     expect(res.duplicateTitles).toEqual(['foo']);
+  });
+
+  it('flags titles with extra whitespace and normalizes for duplicates', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-title-whitespace.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.duplicateTitles).toEqual(['foo']);
+    expect(res.conversationsWithTitleWhitespace).toEqual([1]);
   });
 
   it('detects out-of-order message timestamps', () => {

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -6,6 +6,7 @@ export interface ValidationResult {
   conversationCount: number;
   duplicateIds: string[];
   duplicateTitles: string[];
+  conversationsWithTitleWhitespace: number[];
   missingFields: { index: number; fields: string[] }[];
   outOfOrderConversations: number[];
   invalidTimestamps: number[];
@@ -34,6 +35,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const seenTitles = new Set<string>();
   const duplicateIds: string[] = [];
   const duplicateTitles: string[] = [];
+  const titlesWithWhitespace: number[] = [];
   const missingFields: { index: number; fields: string[] }[] = [];
   const outOfOrder: number[] = [];
   const invalidTimestamps: number[] = [];
@@ -74,10 +76,13 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       if (seenIds.has(conv.id)) duplicateIds.push(conv.id);
       else seenIds.add(conv.id);
     }
-    if (conv.title) {
-      const key = conv.title.toLowerCase();
-      if (seenTitles.has(key)) duplicateTitles.push(conv.title);
-      else seenTitles.add(key);
+    if (typeof conv.title === 'string') {
+      const normalized = conv.title.trim().replace(/\s+/g, ' ').toLowerCase();
+      if (conv.title.trim() !== conv.title || /\s{2,}/.test(conv.title)) {
+        titlesWithWhitespace.push(idx);
+      }
+      if (seenTitles.has(normalized)) duplicateTitles.push(normalized);
+      else seenTitles.add(normalized);
     }
 
     const nodes = Object.values(conv.mapping || {});
@@ -239,6 +244,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationCount: raw.length,
     duplicateIds,
     duplicateTitles,
+    conversationsWithTitleWhitespace: titlesWithWhitespace,
     missingFields,
     outOfOrderConversations: outOfOrder,
     invalidTimestamps,
@@ -268,6 +274,7 @@ if (require.main === module) {
   if (
     result.duplicateIds.length ||
     result.duplicateTitles.length ||
+    result.conversationsWithTitleWhitespace.length ||
     result.missingFields.length ||
     result.outOfOrderConversations.length ||
     result.invalidTimestamps.length ||

--- a/tests/fixtures/newadvanced-title-whitespace.json
+++ b/tests/fixtures/newadvanced-title-whitespace.json
@@ -1,0 +1,4 @@
+[
+  { "id": "c1", "title": "Foo", "mapping": {} },
+  { "id": "c2", "title": " Foo ", "mapping": {} }
+]


### PR DESCRIPTION
## Summary
- normalize conversation titles when validating new advanced conversations
- flag titles containing leading, trailing, or repeated whitespace
- track fractal run progress for the new validation step

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6894b3b29b608322be0561d594075f77