### PR TITLE
feat: enhance AgentCoordinator thresholds

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -168,6 +168,7 @@ console.log(sigil.id); // hello
 - `AeonKIResonanzAnalyzer` – Analysiert Resonanzmuster in Gesprächen.
 - `KIBewusstseinResonanzMonitor` – Überwacht Bewusstseins- und Resonanzmetriken.
 - `StrategicAgentCoordinator` – synchronisiert die Agentenliste und schreibt `strategy-overview.json` ([docs/agents/StrategicAgentCoordinator.md](docs/agents/StrategicAgentCoordinator.md))
+- `AgentCoordinator` – steuert Agenten abhängig von CREP und Symbolzeit ([packages/agents/AgentCoordinator.ts](packages/agents/AgentCoordinator.ts))
 - `VisionContextIntegrator` – verteilt die Vision aus `AgentStrategy.md` an alle Agenten ([docs/agents/VisionContextIntegrator.md](docs/agents/VisionContextIntegrator.md))
 - `QualityAssuranceAgent` – führt Lint- und Test-Suites aus ([docs/agents/QualityAssuranceAgent.md](docs/agents/QualityAssuranceAgent.md))
 ### collab-editor

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - [**Friendship System**](docs/friendship-system.md) – Konzept
 - [**Agent-Registry**](agents.yaml) – zentrale Übersicht aller Agents
 - [**StrategicAgentCoordinator**](docs/agents/StrategicAgentCoordinator.md) – synchronisiert AGENTS.md
+- [**AgentCoordinator**](packages/agents/AgentCoordinator.ts) – orchestriert Agents nach CREP und Symbolzeit
 - [**VisionContextIntegrator**](docs/agents/VisionContextIntegrator.md) – verteilt Vision-Kontext an alle Agenten
 - [**QualityAssuranceAgent**](docs/agents/QualityAssuranceAgent.md) – führt Lint- und Test-Suites aus
 - [**SigilStory**](docs/CommunityOnboarding.md) – Mandala-Lern-Lebenslauf für C-Tutor & JavaHamster

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1369,7 +1369,8 @@
     "commit": "Add AgentCoordinator orchestrator",
     "path": "packages/agents/AgentCoordinator.ts",
     "task": "Dynamically manage agents based on CREP and Symbolzeit",
-    "test": "packages/agents/AgentCoordinator.test.ts"
+    "test": "packages/agents/AgentCoordinator.test.ts",
+    "status": "done"
   },
   {
     "commit": "Implement EmergencePredictorAgent",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -999,6 +999,7 @@
   path: packages/agents/AgentCoordinator.ts
   task: Dynamically manage agents based on CREP and Symbolzeit
   test: packages/agents/AgentCoordinator.test.ts
+  status: done
 - commit: Implement EmergencePredictorAgent
   path: packages/agents/EmergencePredictorAgent.ts
   task: Predict emergent states from historic data

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1014,6 +1014,10 @@
     {
       "commit": "feat: normalize conversation titles",
       "status": "done"
+    },
+    {
+      "commit": "feat: enhance AgentCoordinator thresholds",
+      "status": "done"
     }
   ],
   "metacommitTags": [

--- a/packages/agents/AgentCoordinator.test.ts
+++ b/packages/agents/AgentCoordinator.test.ts
@@ -9,3 +9,113 @@ test('runs agents in priority order when crep high', async () => {
   await coord.coordinate(10, 0.8);
   expect(calls).toEqual(['b', 'a']);
 });
+
+test('agents with no thresholds always run', async () => {
+  const run = vi.fn();
+  const a: CoordinatedAgent = {
+    id: 'a',
+    run: async () => {
+      run();
+    },
+  };
+  const coord = new AgentCoordinator([a]);
+  await coord.coordinate(5, 0); // low CREP and arbitrary symbolzeit
+  expect(run).toHaveBeenCalled();
+});
+
+test('skips agents when individual thresholds not met', async () => {
+  const calls: string[] = [];
+  const byCrep: CoordinatedAgent = {
+    id: 'crep',
+    minCrep: 0.7,
+    run: async () => {
+      calls.push('crep');
+    },
+  };
+  const bySymbol: CoordinatedAgent = {
+    id: 'symbol',
+    symbolzeitInterval: 3,
+    run: async () => {
+      calls.push('symbol');
+    },
+  };
+  const coord = new AgentCoordinator([byCrep, bySymbol]);
+  await coord.coordinate(2, 0.6); // CREP below 0.7 and symbolzeit not multiple of 3
+  expect(calls).toEqual([]);
+});
+
+test('agent with both thresholds runs only when both satisfied', async () => {
+  const spy = vi.fn();
+  const agent: CoordinatedAgent = {
+    id: 'a',
+    minCrep: 0.5,
+    symbolzeitInterval: 2,
+    run: async (s, c) => {
+      spy(s, c);
+    },
+  };
+  const coord = new AgentCoordinator([agent]);
+  await coord.coordinate(2, 0.4); // symbolzeit ok, CREP too low
+  await coord.coordinate(3, 0.6); // CREP ok, symbolzeit not divisible by 2
+  await coord.coordinate(4, 0.6); // both satisfied
+  expect(spy).toHaveBeenCalledTimes(1);
+});
+
+test('symbolzeitInterval of 1 always passes when CREP gate satisfied', async () => {
+  const spy = vi.fn();
+  const agent: CoordinatedAgent = {
+    id: 'a',
+    minCrep: 0.5,
+    symbolzeitInterval: 1,
+    run: async (s, c) => {
+      spy(s, c);
+    },
+  };
+  const coord = new AgentCoordinator([agent]);
+  await coord.coordinate(5, 0.4); // CREP too low
+  await coord.coordinate(7, 0.6); // CREP satisfied, interval always passes
+  expect(spy).toHaveBeenCalledTimes(1);
+});
+
+test('handles negative and zero threshold values', async () => {
+  const calls: string[] = [];
+  const negMin: CoordinatedAgent = {
+    id: 'negMin',
+    minCrep: -1,
+    run: async () => {
+      calls.push('negMin');
+    },
+  };
+  const zeroMin: CoordinatedAgent = {
+    id: 'zeroMin',
+    minCrep: 0,
+    run: async () => {
+      calls.push('zeroMin');
+    },
+  };
+  const zeroInterval: CoordinatedAgent = {
+    id: 'zeroInterval',
+    symbolzeitInterval: 0,
+    run: async () => {
+      calls.push('zeroInterval');
+    },
+  };
+  const negInterval: CoordinatedAgent = {
+    id: 'negInterval',
+    symbolzeitInterval: -2,
+    run: async () => {
+      calls.push('negInterval');
+    },
+  };
+  const coord = new AgentCoordinator([
+    negMin,
+    zeroMin,
+    zeroInterval,
+    negInterval,
+  ]);
+  await coord.coordinate(4, 0.2);
+  expect(calls).toContain('negMin');
+  expect(calls).toContain('zeroMin');
+  expect(calls).not.toContain('zeroInterval');
+  expect(calls).not.toContain('negInterval');
+});

--- a/packages/agents/AgentCoordinator.ts
+++ b/packages/agents/AgentCoordinator.ts
@@ -1,6 +1,10 @@
 export interface CoordinatedAgent {
   id: string;
   priority?: number;
+  /** Minimum CREP required to run this agent */
+  minCrep?: number;
+  /** Execute only when symbolzeit is divisible by this number */
+  symbolzeitInterval?: number;
   run: (symbolzeit: number, crep: number) => Promise<void>;
 }
 
@@ -12,9 +16,15 @@ export class AgentCoordinator {
   }
 
   async coordinate(symbolzeit: number, crep: number) {
-    const sorted = [...this.agents].sort((a,b)=>(b.priority||0)-(a.priority||0));
+    const sorted = [...this.agents].sort(
+      (a, b) => (b.priority || 0) - (a.priority || 0)
+    );
     for (const a of sorted) {
-      if (crep >= 0.5) {
+      const meetsCrep = a.minCrep === undefined || crep >= a.minCrep;
+      const meetsSymbolzeit =
+        a.symbolzeitInterval === undefined ||
+        (a.symbolzeitInterval > 0 && symbolzeit % a.symbolzeitInterval === 0);
+      if (meetsCrep && meetsSymbolzeit) {
         await a.run(symbolzeit, crep);
       }
     }


### PR DESCRIPTION
## Summary
- ignore non-positive `symbolzeitInterval` values during coordination
- add extensive test coverage for AgentCoordinator threshold scenarios

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run packages/agents/AgentCoordinator.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6894e299db4c8322947ad660f7686037