### PR TITLE
feat: validate id format and message id uniqueness

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11252,5 +11252,12 @@
     "task": "Flag nodes without parent aside from root",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Validate ID formats and duplicate message IDs",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure IDs follow UUID format and message IDs are unique",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11296,3 +11296,8 @@
   task: Flag nodes that list themselves as children
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Validate ID formats and duplicate message IDs
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure IDs follow UUID format and message IDs are unique
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1018,6 +1018,10 @@
     {
       "commit": "feat: enhance AgentCoordinator thresholds",
       "status": "done"
+    },
+    {
+      "commit": "Validate ID formats and duplicate message IDs",
+      "status": "done"
     }
   ],
   "metacommitTags": [

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -183,4 +183,22 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithInvalidContentParts).toEqual([0]);
   });
+
+  it('flags invalid id formats', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-id-format.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidIds).toEqual([0]);
+  });
+
+  it('flags duplicate message ids', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-duplicate-message-id.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithDuplicateMessageIds).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -27,6 +27,8 @@ export interface ValidationResult {
   conversationsWithInvalidMessageTimestamps: number[];
   conversationsWithInvalidContentParts: number[];
   conversationsWithSelfReferencingChildren: number[];
+  conversationsWithInvalidIds: number[];
+  conversationsWithDuplicateMessageIds: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -56,8 +58,13 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const invalidMessageTimestamps: number[] = [];
   const invalidContentParts: number[] = [];
   const selfReferencingChildren: number[] = [];
+  const invalidIds: number[] = [];
+  const duplicateMessageIds: number[] = [];
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
   raw.forEach((conv: any, idx: number) => {
+    const seenMessageIds = new Set<string>();
+    let invalidIdRecorded = false;
     const missing: string[] = [];
     if (!conv.id) missing.push('id');
     if (!conv.title) missing.push('title');
@@ -73,6 +80,10 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     }
     if (missing.length) missingFields.push({ index: idx, fields: missing });
     if (conv.id) {
+      if (!uuidPattern.test(conv.id)) {
+        invalidIds.push(idx);
+        invalidIdRecorded = true;
+      }
       if (seenIds.has(conv.id)) duplicateIds.push(conv.id);
       else seenIds.add(conv.id);
     }
@@ -104,6 +115,10 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     }
 
     for (const [key, node] of Object.entries(conv.mapping || {}) as [string, any][]) {
+      if (key !== 'client-created-root' && !uuidPattern.test(key) && !invalidIdRecorded) {
+        invalidIds.push(idx);
+        invalidIdRecorded = true;
+      }
       if (key !== 'client-created-root' && !node.message) {
         missingMessages.push(idx);
         break;
@@ -115,6 +130,25 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       if (node.id && node.id !== key) {
         mismatchedNodeIds.push(idx);
         break;
+      }
+      if (node.id && !uuidPattern.test(node.id) && key !== 'client-created-root' && !invalidIdRecorded) {
+        invalidIds.push(idx);
+        invalidIdRecorded = true;
+      }
+      if (node.message && typeof node.message.id === 'string' && !uuidPattern.test(node.message.id) && !invalidIdRecorded) {
+        invalidIds.push(idx);
+        invalidIdRecorded = true;
+      }
+      if (
+        node.message &&
+        typeof node.message.id === 'string' &&
+        seenMessageIds.has(node.message.id)
+      ) {
+        duplicateMessageIds.push(idx);
+        break;
+      }
+      if (node.message && typeof node.message.id === 'string') {
+        seenMessageIds.add(node.message.id);
       }
       if (node.parent && !conv.mapping[node.parent]) {
         missingParents.push(idx);
@@ -265,6 +299,8 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithInvalidMessageTimestamps: invalidMessageTimestamps,
     conversationsWithInvalidContentParts: invalidContentParts,
     conversationsWithSelfReferencingChildren: selfReferencingChildren,
+    conversationsWithInvalidIds: invalidIds,
+    conversationsWithDuplicateMessageIds: duplicateMessageIds,
   };
 }
 
@@ -293,7 +329,9 @@ if (require.main === module) {
     result.conversationsWithMessagesMissingTimestamps.length ||
     result.conversationsWithInvalidMessageTimestamps.length ||
     result.conversationsWithInvalidContentParts.length ||
-    result.conversationsWithSelfReferencingChildren.length
+    result.conversationsWithSelfReferencingChildren.length ||
+    result.conversationsWithInvalidIds.length ||
+    result.conversationsWithDuplicateMessageIds.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-duplicate-message-id.json
+++ b/tests/fixtures/newadvanced-duplicate-message-id.json
@@ -1,0 +1,43 @@
+[
+  {
+    "id": "123e4567-e89b-12d3-a456-426614174000",
+    "title": "Duplicate message IDs",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": [
+          "11111111-1111-1111-1111-111111111111",
+          "22222222-2222-2222-2222-222222222222"
+        ]
+      },
+      "11111111-1111-1111-1111-111111111111": {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "parent": "client-created-root",
+        "children": [],
+        "message": {
+          "id": "99999999-9999-9999-9999-999999999999",
+          "author": {"role": "user"},
+          "create_time": 1,
+          "update_time": 1,
+          "content": {"content_type": "text", "parts": ["Hi"]}
+        }
+      },
+      "22222222-2222-2222-2222-222222222222": {
+        "id": "22222222-2222-2222-2222-222222222222",
+        "parent": "client-created-root",
+        "children": [],
+        "message": {
+          "id": "99999999-9999-9999-9999-999999999999",
+          "author": {"role": "assistant"},
+          "create_time": 2,
+          "update_time": 2,
+          "content": {"content_type": "text", "parts": ["Response"]}
+        }
+      }
+    }
+  }
+]

--- a/tests/fixtures/newadvanced-invalid-id-format.json
+++ b/tests/fixtures/newadvanced-invalid-id-format.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "invalid",
+    "title": "Invalid ID format",
+    "create_time": 1,
+    "update_time": 1,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["bad-node"]
+      },
+      "bad-node": {
+        "id": "bad-node",
+        "parent": "client-created-root",
+        "children": [],
+        "message": {
+          "id": "not-a-uuid",
+          "author": {"role": "user"},
+          "create_time": 1,
+          "update_time": 1,
+          "content": {"content_type": "text", "parts": ["Hello"]}
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- check conversation, node, and message IDs for UUID format
- detect duplicate message IDs in conversation data
- document completion in advanced TODO and progress trackers

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json --diagnostics`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6894ec5fd6dc83228d7e515f8b318895