### PR TITLE
feat: validate current node and conversation id

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -24,7 +24,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js` und aktualisiere `advancedToDo.json` sowie `advancedprogress.json`.
 Validiere extrahierte Einträge mit `pnpm run validate:todos` (CI integriert) um fehlende Felder oder Duplikate zu finden.
 - Gesprächsstatistiken (inkl. Titel & Zeitspanne) aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
-- Struktur-, Zeit-, Root-Knoten-, Eltern- und Kindreferenz-Validierung, leere Nachrichteninhalte sowie Nachrichtenzeitstempel für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
+- Struktur-, Zeit-, Root-Knoten-, Eltern- und Kindreferenz-Validierung, leere Nachrichteninhalte, Nachrichtenzeitstempel sowie Prüfung von `current_node` und `conversation_id` für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
 - QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`
 - KEDA/HPA Skalierung unter `deployment/keda` für NATS Queue-Length

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ Verwende `./scripts/aeon.sh <command>` für alle CLI-Aufrufe.
 | `node scripts/sync-todo-progress.js` | Aktualisiert ToDo- & Progress-Dateien |
 | `node scripts/validate-advancedtodo.js` | Prüft Konsistenz zwischen YAML und JSON |
 | `node scripts/update-kontext.js` | Passt Kontext-Datei an (nutzt conversations oder newadvancedconversations) |
-| `ts-node scripts/validate-newadvanced-conversations.ts` | Prüft Struktur, Zeitreihen, Root-Knoten, Eltern- und Kindverweise, leere Nachrichteninhalte sowie fehlende/ungültige Nachrichtenzeitstempel von `newadvancedconversations.json` |
+| `ts-node scripts/validate-newadvanced-conversations.ts` | Prüft Struktur, Zeitreihen, Root-Knoten, Eltern- und Kindverweise, aktuelle Knoten (`current_node`), Konversations-IDs sowie leere oder fehlende/ungültige Nachrichtenzeitstempel von `newadvancedconversations.json` |
 | `ts-node scripts/validate-sigillin-examples.ts` | Validiert Sigillin-Beispieldateien |
 | `node scripts/generate-readmes.ts` | Erstellt Modul-READMEs |
 | `node scripts/extract-snippets.js` | Extrahiert Code-Snippets |

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11259,5 +11259,12 @@
     "task": "Ensure IDs follow UUID format and message IDs are unique",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Validate current_node and conversation_id consistency",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure current_node exists and conversation_id matches id",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11301,3 +11301,8 @@
   task: Ensure IDs follow UUID format and message IDs are unique
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Validate current_node and conversation_id consistency
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure current_node exists and conversation_id matches id
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1022,6 +1022,10 @@
     {
       "commit": "Validate ID formats and duplicate message IDs",
       "status": "done"
+    },
+    {
+      "commit": "Validate current_node and conversation_id consistency",
+      "status": "done"
     }
   ],
   "metacommitTags": [

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -201,4 +201,22 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithDuplicateMessageIds).toEqual([0]);
   });
+
+  it('flags invalid current_node references', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-current-node.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidCurrentNode).toEqual([0]);
+  });
+
+  it('flags mismatched conversation_id', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-mismatched-conversation-id.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithMismatchedConversationIds).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -29,6 +29,8 @@ export interface ValidationResult {
   conversationsWithSelfReferencingChildren: number[];
   conversationsWithInvalidIds: number[];
   conversationsWithDuplicateMessageIds: number[];
+  conversationsWithInvalidCurrentNode: number[];
+  conversationsWithMismatchedConversationIds: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -60,6 +62,8 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const selfReferencingChildren: number[] = [];
   const invalidIds: number[] = [];
   const duplicateMessageIds: number[] = [];
+  const invalidCurrentNodes: number[] = [];
+  const mismatchedConversationIds: number[] = [];
   const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
   raw.forEach((conv: any, idx: number) => {
@@ -71,6 +75,8 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     if (typeof conv.mapping !== 'object') missing.push('mapping');
     if (typeof conv.create_time !== 'number') missing.push('create_time');
     if (typeof conv.update_time !== 'number') missing.push('update_time');
+    if (typeof conv.conversation_id !== 'string') missing.push('conversation_id');
+    if (typeof conv.current_node !== 'string') missing.push('current_node');
     if (
       typeof conv.create_time === 'number' &&
       typeof conv.update_time === 'number' &&
@@ -86,6 +92,21 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       }
       if (seenIds.has(conv.id)) duplicateIds.push(conv.id);
       else seenIds.add(conv.id);
+    }
+    if (
+      typeof conv.conversation_id === 'string' &&
+      conv.id &&
+      conv.conversation_id !== conv.id
+    ) {
+      mismatchedConversationIds.push(idx);
+    }
+    if (
+      typeof conv.conversation_id === 'string' &&
+      !uuidPattern.test(conv.conversation_id) &&
+      !invalidIdRecorded
+    ) {
+      invalidIds.push(idx);
+      invalidIdRecorded = true;
     }
     if (typeof conv.title === 'string') {
       const normalized = conv.title.trim().replace(/\s+/g, ' ').toLowerCase();
@@ -271,6 +292,12 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       if (visited.size !== Object.keys(conv.mapping || {}).length) {
         unreachableNodes.push(idx);
       }
+      if (
+        typeof conv.current_node === 'string' &&
+        !conv.mapping[conv.current_node]
+      ) {
+        invalidCurrentNodes.push(idx);
+      }
     }
   });
 
@@ -301,6 +328,8 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithSelfReferencingChildren: selfReferencingChildren,
     conversationsWithInvalidIds: invalidIds,
     conversationsWithDuplicateMessageIds: duplicateMessageIds,
+    conversationsWithInvalidCurrentNode: invalidCurrentNodes,
+    conversationsWithMismatchedConversationIds: mismatchedConversationIds,
   };
 }
 
@@ -331,7 +360,9 @@ if (require.main === module) {
     result.conversationsWithInvalidContentParts.length ||
     result.conversationsWithSelfReferencingChildren.length ||
     result.conversationsWithInvalidIds.length ||
-    result.conversationsWithDuplicateMessageIds.length
+    result.conversationsWithDuplicateMessageIds.length ||
+    result.conversationsWithInvalidCurrentNode.length ||
+    result.conversationsWithMismatchedConversationIds.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-invalid-current-node.json
+++ b/tests/fixtures/newadvanced-invalid-current-node.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "conversation_id": "00000000-0000-0000-0000-000000000001",
+    "title": "Invalid current node",
+    "create_time": 1,
+    "update_time": 2,
+    "current_node": "11111111-1111-1111-1111-111111111111",
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": {
+          "id": "22222222-2222-2222-2222-222222222222",
+          "author": { "role": "user" },
+          "create_time": 1,
+          "update_time": 1,
+          "content": { "parts": ["hi"] }
+        },
+        "parent": null,
+        "children": []
+      }
+    }
+  }
+]

--- a/tests/fixtures/newadvanced-mismatched-conversation-id.json
+++ b/tests/fixtures/newadvanced-mismatched-conversation-id.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000002",
+    "conversation_id": "00000000-0000-0000-0000-000000000003",
+    "title": "Mismatched conversation id",
+    "create_time": 1,
+    "update_time": 2,
+    "current_node": "client-created-root",
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": {
+          "id": "33333333-3333-3333-3333-333333333333",
+          "author": { "role": "user" },
+          "create_time": 1,
+          "update_time": 1,
+          "content": { "parts": ["hi"] }
+        },
+        "parent": null,
+        "children": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- extend newadvanced conversation validator to ensure `current_node` references existing nodes and `conversation_id` matches `id`
- document validator updates and track progress in ToDo files
- add targeted tests and fixtures

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json --noEmit`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6894f30f97a88322ad6ca9d714d03ca0