### PR TITLE
feat: validate author roles in conversations

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -24,7 +24,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js` und aktualisiere `advancedToDo.json` sowie `advancedprogress.json`.
 Validiere extrahierte Einträge mit `pnpm run validate:todos` (CI integriert) um fehlende Felder oder Duplikate zu finden.
 - Gesprächsstatistiken (inkl. Titel & Zeitspanne) aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
-- Struktur-, Zeit-, Root-Knoten-, Eltern- und Kindreferenz-Validierung, leere Nachrichteninhalte, Nachrichtenzeitstempel, Titel (Whitespaces und Steuerzeichen) sowie Prüfung von `current_node` und `conversation_id` für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
+- Struktur-, Zeit-, Root-Knoten-, Eltern- und Kindreferenz-Validierung, leere Nachrichteninhalte, Nachrichtenzeitstempel, Titel (Whitespaces und Steuerzeichen), Autorenrollen sowie Prüfung von `current_node` und `conversation_id` für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
 - QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`
 - KEDA/HPA Skalierung unter `deployment/keda` für NATS Queue-Length

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ Verwende `./scripts/aeon.sh <command>` für alle CLI-Aufrufe.
 | `node scripts/sync-todo-progress.js` | Aktualisiert ToDo- & Progress-Dateien |
 | `node scripts/validate-advancedtodo.js` | Prüft Konsistenz zwischen YAML und JSON |
 | `node scripts/update-kontext.js` | Passt Kontext-Datei an (nutzt conversations oder newadvancedconversations) |
-| `ts-node scripts/validate-newadvanced-conversations.ts` | Prüft Struktur, Zeitreihen, Root-Knoten, Eltern- und Kindverweise, aktuelle Knoten (`current_node`), Konversations-IDs, Titel (Whitespaces und Steuerzeichen) sowie leere oder fehlende/ungültige Nachrichtenzeitstempel von `newadvancedconversations.json` |
+| `ts-node scripts/validate-newadvanced-conversations.ts` | Prüft Struktur, Zeitreihen, Root-Knoten, Eltern- und Kindverweise, aktuelle Knoten (`current_node`), Konversations-IDs, Titel (Whitespaces und Steuerzeichen), Autorenrollen sowie leere oder fehlende/ungültige Nachrichtenzeitstempel von `newadvancedconversations.json` |
 | `ts-node scripts/validate-sigillin-examples.ts` | Validiert Sigillin-Beispieldateien |
 | `node scripts/generate-readmes.ts` | Erstellt Modul-READMEs |
 | `node scripts/extract-snippets.js` | Extrahiert Code-Snippets |

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11274,5 +11274,12 @@
     "task": "Flag titles containing control characters",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Validate message author roles",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure each node message has an author role and valid role value",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11311,3 +11311,8 @@
   task: Flag titles containing control characters
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Validate message author roles
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure each node message has an author role and valid role value
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1030,6 +1030,10 @@
     {
       "commit": "Validate conversation title characters",
       "status": "done"
+    },
+    {
+      "commit": "Validate presence and validity of message author roles",
+      "status": "done"
     }
   ],
   "metacommitTags": [

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -40,6 +40,24 @@ describe('validateNewAdvancedConversations', () => {
     expect(res.conversationsWithInvalidTitleChars).toEqual([0]);
   });
 
+  it('flags nodes with invalid author roles', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-role.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidRoles).toEqual([0]);
+  });
+
+  it('flags nodes missing author roles', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-missing-role.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithMissingRoles).toEqual([0]);
+  });
+
   it('detects out-of-order message timestamps', () => {
     const file = path.join(
       __dirname,

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -32,6 +32,7 @@ export interface ValidationResult {
   conversationsWithDuplicateMessageIds: number[];
   conversationsWithInvalidCurrentNode: number[];
   conversationsWithMismatchedConversationIds: number[];
+  conversationsWithMissingRoles: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -46,6 +47,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const outOfOrder: number[] = [];
   const invalidTimestamps: number[] = [];
   const invalidRoles: number[] = [];
+  const missingRoles: number[] = [];
   const missingRoot: number[] = [];
   const missingParents: number[] = [];
   const mismatchedNodeIds: number[] = [];
@@ -133,11 +135,16 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       }
     }
 
-    const roles = nodes
-      .map((n: any) => n?.message?.author?.role)
-      .filter((r: any): r is string => typeof r === 'string');
-    if (roles.some((r) => !['system', 'user', 'assistant'].includes(r))) {
-      invalidRoles.push(idx);
+    for (const node of nodes) {
+      const role = node?.message?.author?.role;
+      if (typeof role !== 'string') {
+        missingRoles.push(idx);
+        break;
+      }
+      if (!['system', 'user', 'assistant'].includes(role)) {
+        invalidRoles.push(idx);
+        break;
+      }
     }
 
     for (const [key, node] of Object.entries(conv.mapping || {}) as [string, any][]) {
@@ -336,6 +343,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithDuplicateMessageIds: duplicateMessageIds,
     conversationsWithInvalidCurrentNode: invalidCurrentNodes,
     conversationsWithMismatchedConversationIds: mismatchedConversationIds,
+    conversationsWithMissingRoles: missingRoles,
   };
 }
 
@@ -369,7 +377,8 @@ if (require.main === module) {
     result.conversationsWithInvalidIds.length ||
     result.conversationsWithDuplicateMessageIds.length ||
     result.conversationsWithInvalidCurrentNode.length ||
-    result.conversationsWithMismatchedConversationIds.length
+    result.conversationsWithMismatchedConversationIds.length ||
+    result.conversationsWithMissingRoles.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-invalid-role.json
+++ b/tests/fixtures/newadvanced-invalid-role.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000002",
+    "conversation_id": "00000000-0000-0000-0000-000000000002",
+    "title": "Invalid role",
+    "create_time": 1,
+    "update_time": 2,
+    "current_node": "client-created-root",
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": {
+          "id": "22222222-2222-2222-2222-222222222222",
+          "author": { "role": "invalid" },
+          "create_time": 1,
+          "update_time": 1,
+          "content": { "parts": ["hi"] }
+        },
+        "parent": null,
+        "children": []
+      }
+    }
+  }
+]

--- a/tests/fixtures/newadvanced-missing-role.json
+++ b/tests/fixtures/newadvanced-missing-role.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "conversation_id": "00000000-0000-0000-0000-000000000001",
+    "title": "Missing role",
+    "create_time": 1,
+    "update_time": 2,
+    "current_node": "client-created-root",
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": {
+          "id": "11111111-1111-1111-1111-111111111111",
+          "create_time": 1,
+          "update_time": 1,
+          "content": { "parts": ["hi"] }
+        },
+        "parent": null,
+        "children": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- validate presence and validity of message author roles in new advanced conversations
- add tests and fixtures for invalid or missing roles
- document validator capability and update progress tracking

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6895012a090c8322805c54d2adcbadfe