### PR TITLE
feat: add Nullfeld simulation modules

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "feat: validate conversation title chars",
-  "fractalStep": "fractal-run/title-char-validation",
+  "lastCommit": "feat: add NullfeldSimulation and visualization modules",
+  "fractalStep": "fractal-run/nullfeld-modules",
   "openBranches": [
     "work"
   ],
@@ -634,6 +634,14 @@
     {
       "commit": "Add GhostShell NGINX config",
       "status": "done"
+    },
+    {
+      "commit": "Add NullfeldSimulation and visualization modules",
+      "status": "done"
+    },
+    {
+      "commit": "Fraktalrun: continue with NullfeldWellenModul",
+      "status": "open"
     }
   ],
   "completed": [

--- a/packages/universum-simulationen/NullfeldSimulation.test.ts
+++ b/packages/universum-simulationen/NullfeldSimulation.test.ts
@@ -1,0 +1,14 @@
+import { gravitationalForce, membraneCurvature, energyConversion, NullfeldParameters } from './NullfeldSimulation';
+
+test('computes gravitational force', () => {
+  const params: NullfeldParameters = { mass1: 1, mass2: 2, distance: 3, membraneEnergy: 0 };
+  expect(gravitationalForce(params)).toBeCloseTo(6.674e-11 * 2 / 9);
+});
+
+test('computes membrane curvature', () => {
+  expect(membraneCurvature(10)).toBe(1);
+});
+
+test('converts energy', () => {
+  expect(energyConversion(100)).toBe(42);
+});

--- a/packages/universum-simulationen/NullfeldSimulation.ts
+++ b/packages/universum-simulationen/NullfeldSimulation.ts
@@ -1,0 +1,21 @@
+export interface NullfeldParameters {
+  mass1: number;
+  mass2: number;
+  distance: number;
+  membraneEnergy: number;
+}
+
+export function gravitationalForce({ mass1, mass2, distance }: NullfeldParameters): number {
+  const G = 6.674e-11;
+  return (G * mass1 * mass2) / (distance * distance);
+}
+
+export function membraneCurvature(energy: number): number {
+  const k = 0.1;
+  return k * energy;
+}
+
+export function energyConversion(energy: number): number {
+  const efficiency = 0.42;
+  return energy * efficiency;
+}

--- a/packages/universum-simulationen/NullfeldVisualization.test.ts
+++ b/packages/universum-simulationen/NullfeldVisualization.test.ts
@@ -1,0 +1,13 @@
+import { generateCurvatureMap, generateGalaxyMap, simulateDarkMatterDistribution } from './NullfeldVisualization';
+
+test('inverts curvature values', () => {
+  expect(generateCurvatureMap([1, -2])).toEqual([-1, 2]);
+});
+
+test('creates galaxy map identifiers', () => {
+  expect(generateGalaxyMap(2)).toEqual(['Galaxy-0', 'Galaxy-1']);
+});
+
+test('estimates dark matter distribution', () => {
+  expect(simulateDarkMatterDistribution(100)).toBeCloseTo(27);
+});

--- a/packages/universum-simulationen/NullfeldVisualization.ts
+++ b/packages/universum-simulationen/NullfeldVisualization.ts
@@ -1,0 +1,12 @@
+export function generateCurvatureMap(curvatures: number[]): number[] {
+  return curvatures.map(c => c * -1);
+}
+
+export function generateGalaxyMap(count: number): string[] {
+  return Array.from({ length: count }, (_, i) => `Galaxy-${i}`);
+}
+
+export function simulateDarkMatterDistribution(mass: number): number {
+  const darkMatterFraction = 0.27;
+  return mass * darkMatterFraction;
+}

--- a/packages/universum-simulationen/index.ts
+++ b/packages/universum-simulationen/index.ts
@@ -4,3 +4,5 @@ export * from './InteractiveNarrativeEngine';
 export * from './SimHostCore';
 export * from './SoundResonanceModule';
 export * from './PyramidNodeSimulation';
+export * from './NullfeldSimulation';
+export * from './NullfeldVisualization';


### PR DESCRIPTION
## Summary
- add NullfeldSimulation module modeling gravity, membrane curvature and energy
- add NullfeldVisualization helpers for curvature maps, galaxy maps and dark matter distribution
- track progress for Nullfeld modules

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: venvPath .venv is not a valid directory)*
- `npx tsc -p tsconfig.json`
- `npx vitest run packages/universum-simulationen/NullfeldSimulation.test.ts packages/universum-simulationen/NullfeldVisualization.test.ts` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689506f34d488322943739f7bed137b2