### PR TITLE
feat: enhance Sigillin integrity validation

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1448,7 +1448,8 @@
     "commit": "Add SigillinIntegrityChecker",
     "path": "packages/genesis-sigillin-core/SigillinIntegrityChecker.ts",
     "task": "Verify Sigillin data for integrity",
-    "test": "packages/genesis-sigillin-core/SigillinIntegrityChecker.test.ts"
+    "test": "packages/genesis-sigillin-core/SigillinIntegrityChecker.test.ts",
+    "status": "done"
   },
   {
     "commit": "Create RealTimeCollaborationChat",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1052,6 +1052,7 @@
   path: packages/genesis-sigillin-core/SigillinIntegrityChecker.ts
   task: Verify Sigillin data for integrity
   test: packages/genesis-sigillin-core/SigillinIntegrityChecker.test.ts
+  status: done
 - commit: Create RealTimeCollaborationChat
   path: packages/collab-editor/RealTimeCollaborationChat.ts
   task: Provide integrated chat during collaborative editing

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1042,6 +1042,10 @@
     {
       "commit": "Validate presence and validity of message author roles",
       "status": "done"
+    },
+    {
+      "commit": "Enhance Sigillin integrity validation",
+      "status": "done"
     }
   ],
   "metacommitTags": [

--- a/packages/genesis-sigillin-core/SigillinIntegrityChecker.test.ts
+++ b/packages/genesis-sigillin-core/SigillinIntegrityChecker.test.ts
@@ -1,6 +1,21 @@
 import { checkIntegrity } from './SigillinIntegrityChecker';
+import { Sigillin } from './types';
 
-test('checks for sigil keyword', () => {
-  expect(checkIntegrity('mysigil')).toBe(true);
-  expect(checkIntegrity('other')).toBe(false);
+const base: Sigillin = {
+  schema_version: '1.0',
+  id: 'abc',
+  type: 'fallback-anchor',
+  status: 'draft',
+  creator: 'tester',
+  created_at: '2025-01-01',
+};
+
+test('accepts valid sigillin objects', () => {
+  expect(checkIntegrity(base)).toBe(true);
+});
+
+test('rejects missing fields and invalid enums', () => {
+  expect(checkIntegrity({ ...base, id: '' })).toBe(false);
+  expect(checkIntegrity({ ...base, type: 'unknown' as any })).toBe(false);
+  expect(checkIntegrity(undefined)).toBe(false);
 });

--- a/packages/genesis-sigillin-core/SigillinIntegrityChecker.ts
+++ b/packages/genesis-sigillin-core/SigillinIntegrityChecker.ts
@@ -1,3 +1,32 @@
-export function checkIntegrity(sig: string): boolean {
-  return sig.includes('sigil');
+import { Sigillin } from './types';
+
+const VALID_TYPES: Sigillin['type'][] = [
+  'fallback-anchor',
+  'poetic-root',
+  'crep-trigger',
+  'session-memory',
+  'ethik-node',
+];
+
+const VALID_STATUS: Sigillin['status'][] = ['draft', 'reviewed', 'published'];
+
+export function checkIntegrity(sig: Partial<Sigillin> | null | undefined): boolean {
+  if (!sig || typeof sig !== 'object') return false;
+  const required: (keyof Sigillin)[] = [
+    'schema_version',
+    'id',
+    'type',
+    'status',
+    'creator',
+    'created_at',
+  ];
+  for (const field of required) {
+    const value = (sig as any)[field];
+    if (typeof value !== 'string' || value.trim() === '') {
+      return false;
+    }
+  }
+  if (!VALID_TYPES.includes(sig.type as Sigillin['type'])) return false;
+  if (!VALID_STATUS.includes(sig.status as Sigillin['status'])) return false;
+  return true;
 }

--- a/packages/genesis-sigillin-core/index.ts
+++ b/packages/genesis-sigillin-core/index.ts
@@ -5,3 +5,4 @@ export * from './SigillinSuggestionEngine';
 export * from './SigillinSyncManager';
 export * from './SigilFormulaEngine';
 export * from './FractalSigilGenerator';
+export * from './SigillinIntegrityChecker';


### PR DESCRIPTION
## Summary
- strengthen SigillinIntegrityChecker with required field and enum checks
- expose SigillinIntegrityChecker via package index
- track completion in advanced ToDo and progress files

## Testing
- `npx jest packages/genesis-sigillin-core/SigillinIntegrityChecker.test.ts`
- `node scripts/validate-advancedtodo.js` *(fails: advancedToDo mismatch detected)*
- `npx tsc -p tsconfig.json` *(fails: Property 'message' does not exist on type '{}')*
- `npx pyright`
- `npx ts-node scripts/validate-newadvanced-conversations.ts docs/sigils/newadvancedconversations.json` *(fails: Property 'message' does not exist on type '{}')*


------
https://chatgpt.com/codex/tasks/task_e_689510d1e8908322a424ae681342cfa9