### PR TITLE
feat: split newadvanced conversations

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -4916,9 +4916,9 @@
   },
   {
     "commit": "Split newadvancedconversations into fragments",
-    "path": "scripts/newadvancedconvo_splitter.ts",
+    "path": "scripts/split-newadvanced-conversations.ts",
     "task": "Split newadvancedconversations.json into numbered YAML/JSON fragments",
-    "test": "scripts/__tests__/newadvancedconvo_splitter.test.ts",
+    "test": "scripts/split-newadvanced-conversations.test.ts",
     "status": "done"
   },
   {
@@ -11267,8 +11267,7 @@
     "task": "Ensure current_node exists and conversation_id matches id",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
-  }
-  ,
+  },
   {
     "commit": "Validate conversation title characters",
     "path": "scripts/validate-newadvanced-conversations.ts",

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -642,6 +642,10 @@
     {
       "commit": "Fraktalrun: continue with NullfeldWellenModul",
       "status": "open"
+    },
+    {
+      "commit": "Add conversation splitter for newadvancedconversations",
+      "status": "done"
     }
   ],
   "completed": [

--- a/scripts/split-newadvanced-conversations.test.ts
+++ b/scripts/split-newadvanced-conversations.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { splitNewAdvancedConversations } from './split-newadvanced-conversations';
+
+describe('splitNewAdvancedConversations', () => {
+  it('splits conversations into separate files', () => {
+    const src = path.join(__dirname, '../tests/fixtures/newadvanced-multi.json');
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'split-convo-'));
+    const files = splitNewAdvancedConversations(src, outDir);
+    expect(files.length).toBe(2);
+    const first = JSON.parse(fs.readFileSync(files[0], 'utf8'));
+    expect(first.title).toBe('First');
+  });
+});

--- a/scripts/split-newadvanced-conversations.ts
+++ b/scripts/split-newadvanced-conversations.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env ts-node
+import fs from 'fs';
+import path from 'path';
+
+export function splitNewAdvancedConversations(
+  srcPath: string,
+  outDir: string
+): string[] {
+  const data = JSON.parse(fs.readFileSync(srcPath, 'utf8'));
+  if (!Array.isArray(data)) {
+    throw new Error('Expected an array of conversations');
+  }
+  if (!fs.existsSync(outDir)) {
+    fs.mkdirSync(outDir, { recursive: true });
+  }
+  return data.map((conv: any, idx: number) => {
+    const file = path.join(outDir, `conversation-${idx + 1}.json`);
+    fs.writeFileSync(file, JSON.stringify(conv, null, 2));
+    return file;
+  });
+}
+
+if (require.main === module) {
+  const src =
+    process.argv[2] ||
+    path.join(__dirname, '../docs/sigils/newadvancedconversations.json');
+  const out =
+    process.argv[3] ||
+    path.join(__dirname, '../docs/sigils/newadvancedconversations_fragments');
+  const files = splitNewAdvancedConversations(src, out);
+  console.log(`Wrote ${files.length} fragments to ${out}`);
+}

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -124,7 +124,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       else seenTitles.add(normalized);
     }
 
-    const nodes = Object.values(conv.mapping || {});
+    const nodes: any[] = Object.values(conv.mapping || {});
     const times = nodes
       .map((n: any) => n?.message?.create_time)
       .filter((t: any): t is number => typeof t === 'number');


### PR DESCRIPTION
## Summary
- add script to split `newadvancedconversations.json` into individual fragments
- mark splitter task as complete in advanced todo and progress tracking
- fix type in validator for stricter compilation

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/split-newadvanced-conversations.test.ts`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68951740a4ec83229c4d66c6123ab025