### PR TITLE
feat: validate conversation timestamp bounds

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11281,5 +11281,12 @@
     "task": "Ensure each node message has an author role and valid role value",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Validate conversation message timestamp bounds",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure conversation timestamps encompass all message timestamps",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11284,7 +11284,8 @@
   status: done
 - commit: Validate message timestamps in conversations
   path: scripts/validate-newadvanced-conversations.ts
-  task: Ensure each node message has create_time and update_time with update_time >= create_time
+  task: Ensure each node message has create_time and update_time with update_time
+    >= create_time
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
 - commit: Detect orphan nodes in conversations
@@ -11315,5 +11316,10 @@
 - commit: Validate message author roles
   path: scripts/validate-newadvanced-conversations.ts
   task: Ensure each node message has an author role and valid role value
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done
+- commit: Validate conversation message timestamp bounds
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure conversation timestamps encompass all message timestamps
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,15 +1,12 @@
 {
-  "lastCommit": "feat: add NullfeldSimulation and visualization modules",
-  "fractalStep": "fractal-run/nullfeld-modules",
+  "lastCommit": "Merge pull request #1069 from GenesisAeon/h0ydyc-codex/implement-features-from-advancedtodo.yaml-and-json",
+  "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
   "notes": "Normalized conversation titles, added whitespace and control-char validation",
-  "pendingTasks": [
-    "Run scripts/extract-training-data.ts to fragment new advanced conversations",
-    "Deploy GhostShellAgent as Lambda@Edge"
-  ],
+  "pendingTasks": [],
   "progress": [
     {
       "commit": "Add Sigillin Fractal Visualizer component",
@@ -1049,6 +1046,10 @@
     },
     {
       "commit": "Enhance Sigillin integrity validation",
+      "status": "done"
+    },
+    {
+      "commit": "Validate conversation message timestamp bounds",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -58,6 +58,15 @@ describe('validateNewAdvancedConversations', () => {
     expect(res.conversationsWithMissingRoles).toEqual([0]);
   });
 
+  it('flags conversations with message timestamps outside conversation range', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-message-time-out-of-range.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithMessageTimeOutOfRange).toEqual([0]);
+  });
+
   it('detects out-of-order message timestamps', () => {
     const file = path.join(
       __dirname,

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -32,6 +32,7 @@ export interface ValidationResult {
   conversationsWithDuplicateMessageIds: number[];
   conversationsWithInvalidCurrentNode: number[];
   conversationsWithMismatchedConversationIds: number[];
+  conversationsWithMessageTimeOutOfRange: number[];
   conversationsWithMissingRoles: number[];
 }
 
@@ -68,6 +69,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const duplicateMessageIds: number[] = [];
   const invalidCurrentNodes: number[] = [];
   const mismatchedConversationIds: number[] = [];
+  const messageTimeOutOfRange: number[] = [];
   const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
   raw.forEach((conv: any, idx: number) => {
@@ -311,6 +313,23 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
         invalidCurrentNodes.push(idx);
       }
     }
+
+    const msgTimes = nodes.flatMap((n: any) => {
+      const m = n?.message;
+      return typeof m?.create_time === 'number' && typeof m?.update_time === 'number'
+        ? [m.create_time, m.update_time]
+        : [];
+    });
+    if (msgTimes.length) {
+      const earliest = Math.min(...msgTimes);
+      const latest = Math.max(...msgTimes);
+      if (
+        (typeof conv.create_time === 'number' && conv.create_time > earliest) ||
+        (typeof conv.update_time === 'number' && conv.update_time < latest)
+      ) {
+        messageTimeOutOfRange.push(idx);
+      }
+    }
   });
 
   return {
@@ -343,6 +362,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithDuplicateMessageIds: duplicateMessageIds,
     conversationsWithInvalidCurrentNode: invalidCurrentNodes,
     conversationsWithMismatchedConversationIds: mismatchedConversationIds,
+    conversationsWithMessageTimeOutOfRange: messageTimeOutOfRange,
     conversationsWithMissingRoles: missingRoles,
   };
 }
@@ -378,6 +398,7 @@ if (require.main === module) {
     result.conversationsWithDuplicateMessageIds.length ||
     result.conversationsWithInvalidCurrentNode.length ||
     result.conversationsWithMismatchedConversationIds.length ||
+    result.conversationsWithMessageTimeOutOfRange.length ||
     result.conversationsWithMissingRoles.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));

--- a/tests/fixtures/newadvanced-message-time-out-of-range.json
+++ b/tests/fixtures/newadvanced-message-time-out-of-range.json
@@ -1,0 +1,45 @@
+[
+  {
+    "id": "11111111-1111-1111-1111-111111111111",
+    "conversation_id": "11111111-1111-1111-1111-111111111111",
+    "title": "Message time out of range",
+    "create_time": 100,
+    "update_time": 200,
+    "current_node": "client-created-root",
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": [
+          "22222222-2222-2222-2222-222222222222",
+          "33333333-3333-3333-3333-333333333333"
+        ]
+      },
+      "22222222-2222-2222-2222-222222222222": {
+        "id": "22222222-2222-2222-2222-222222222222",
+        "message": {
+          "id": "22222222-2222-2222-2222-222222222222",
+          "author": { "role": "user" },
+          "create_time": 90,
+          "update_time": 150,
+          "content": { "parts": ["early"] }
+        },
+        "parent": "client-created-root",
+        "children": []
+      },
+      "33333333-3333-3333-3333-333333333333": {
+        "id": "33333333-3333-3333-3333-333333333333",
+        "message": {
+          "id": "33333333-3333-3333-3333-333333333333",
+          "author": { "role": "assistant" },
+          "create_time": 160,
+          "update_time": 250,
+          "content": { "parts": ["late"] }
+        },
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- validate that conversation create/update times encompass all message timestamps
- test coverage for out-of-range message timestamps
- sync advanced ToDo and progress records

## Testing
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68951bb8cb1083228aa1505d5c7b04f7