### PR TITLE
Add validation for plugin and URL fields

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1055,6 +1055,10 @@
     {
       "commit": "Validate conversation message timestamp bounds",
       "status": "done"
+    },
+    {
+      "commit": "Validate plugin and URL fields in conversations",
+      "status": "done"
     }
   ],
   "metacommitTags": [

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -264,4 +264,16 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithMismatchedConversationIds).toEqual([0]);
   });
+
+  it('flags invalid plugin and URL fields', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-extras.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidPluginIds).toEqual([0]);
+    expect(res.conversationsWithInvalidDisabledToolIds).toEqual([0]);
+    expect(res.conversationsWithInvalidBlockedUrls).toEqual([0]);
+    expect(res.conversationsWithInvalidSafeUrls).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -35,6 +35,10 @@ export interface ValidationResult {
   conversationsWithMismatchedConversationIds: number[];
   conversationsWithMessageTimeOutOfRange: number[];
   conversationsWithMissingRoles: number[];
+  conversationsWithInvalidPluginIds: number[];
+  conversationsWithInvalidDisabledToolIds: number[];
+  conversationsWithInvalidBlockedUrls: number[];
+  conversationsWithInvalidSafeUrls: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -72,6 +76,10 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const invalidCurrentNodes: number[] = [];
   const mismatchedConversationIds: number[] = [];
   const messageTimeOutOfRange: number[] = [];
+  const invalidPluginIds: number[] = [];
+  const invalidDisabledToolIds: number[] = [];
+  const invalidBlockedUrls: number[] = [];
+  const invalidSafeUrls: number[] = [];
   const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
   raw.forEach((conv: any, idx: number) => {
@@ -107,6 +115,38 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       conv.conversation_id !== conv.id
     ) {
       mismatchedConversationIds.push(idx);
+    }
+    if (conv.plugin_ids !== undefined && conv.plugin_ids !== null) {
+      if (
+        !Array.isArray(conv.plugin_ids) ||
+        conv.plugin_ids.some((p: any) => typeof p !== 'string')
+      ) {
+        invalidPluginIds.push(idx);
+      }
+    }
+    if (conv.disabled_tool_ids !== undefined && conv.disabled_tool_ids !== null) {
+      if (
+        !Array.isArray(conv.disabled_tool_ids) ||
+        conv.disabled_tool_ids.some((p: any) => typeof p !== 'string')
+      ) {
+        invalidDisabledToolIds.push(idx);
+      }
+    }
+    if (conv.blocked_urls !== undefined) {
+      if (
+        !Array.isArray(conv.blocked_urls) ||
+        conv.blocked_urls.some((u: any) => typeof u !== 'string')
+      ) {
+        invalidBlockedUrls.push(idx);
+      }
+    }
+    if (conv.safe_urls !== undefined) {
+      if (
+        !Array.isArray(conv.safe_urls) ||
+        conv.safe_urls.some((u: any) => typeof u !== 'string')
+      ) {
+        invalidSafeUrls.push(idx);
+      }
     }
     if (
       typeof conv.conversation_id === 'string' &&
@@ -370,6 +410,10 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithMismatchedConversationIds: mismatchedConversationIds,
     conversationsWithMessageTimeOutOfRange: messageTimeOutOfRange,
     conversationsWithMissingRoles: missingRoles,
+    conversationsWithInvalidPluginIds: invalidPluginIds,
+    conversationsWithInvalidDisabledToolIds: invalidDisabledToolIds,
+    conversationsWithInvalidBlockedUrls: invalidBlockedUrls,
+    conversationsWithInvalidSafeUrls: invalidSafeUrls,
   };
 }
 
@@ -406,7 +450,11 @@ if (require.main === module) {
     result.conversationsWithInvalidCurrentNode.length ||
     result.conversationsWithMismatchedConversationIds.length ||
     result.conversationsWithMessageTimeOutOfRange.length ||
-    result.conversationsWithMissingRoles.length
+    result.conversationsWithMissingRoles.length ||
+    result.conversationsWithInvalidPluginIds.length ||
+    result.conversationsWithInvalidDisabledToolIds.length ||
+    result.conversationsWithInvalidBlockedUrls.length ||
+    result.conversationsWithInvalidSafeUrls.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-invalid-extras.json
+++ b/tests/fixtures/newadvanced-invalid-extras.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "11111111-1111-4111-8111-111111111111",
+    "conversation_id": "11111111-1111-4111-8111-111111111111",
+    "title": "Invalid extras",
+    "current_node": "client-created-root",
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "parent": null,
+        "children": [],
+        "message": null
+      }
+    },
+    "create_time": 1,
+    "update_time": 1,
+    "plugin_ids": [123],
+    "disabled_tool_ids": ["ok", 42],
+    "blocked_urls": [null],
+    "safe_urls": ["https://example.com", 5]
+  }
+]


### PR DESCRIPTION
## Summary
- extend conversation validator to ensure plugin and URL arrays only contain strings
- cover new cases with fixture-based tests
- log progress for plugin/URL field validation

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689528d67c0c8322a6bc2b8a10d84f81