### PR TITLE
chore: record training data extraction todos

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1,5 +1,19 @@
 [
   {
+    "commit": "Add summary generator to training data extraction",
+    "path": "scripts/extract-training-data.ts",
+    "task": "Replace placeholder with generated conversation summaries",
+    "test": "scripts/__tests__/extract-training-data.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Integrate CREP SelfReflection filter into training data extractor",
+    "path": "scripts/extract-training-data.ts",
+    "task": "Filter extracted data through SelfReflectionAgent based on CREP scores",
+    "test": "scripts/__tests__/extract-training-data.test.ts",
+    "status": "todo"
+  },
+  {
     "commit": "Validate parent references in conversations",
     "path": "scripts/validate-newadvanced-conversations.ts",
     "task": "Ensure all nodes reference existing parents",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1,3 +1,13 @@
+- commit: Add summary generator to training data extraction
+  path: scripts/extract-training-data.ts
+  task: Replace placeholder with generated conversation summaries
+  test: scripts/__tests__/extract-training-data.test.ts
+  status: todo
+- commit: Integrate CREP SelfReflection filter into training data extractor
+  path: scripts/extract-training-data.ts
+  task: Filter extracted data through SelfReflectionAgent based on CREP scores
+  test: scripts/__tests__/extract-training-data.test.ts
+  status: todo
 - commit: Validate parent references in conversations
   path: scripts/validate-newadvanced-conversations.ts
   task: Ensure all nodes reference existing parents

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,13 +1,20 @@
 {
-  "lastCommit": "Merge pull request #1069 from GenesisAeon/h0ydyc-codex/implement-features-from-advancedtodo.yaml-and-json",
-  "fractalStep": "implementiert",
+  "lastCommit": "Add extract-training-data enhancement ToDos",
+  "fractalStep": "todo-added",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Normalized conversation titles, added whitespace and control-char validation",
-  "pendingTasks": [],
+  "notes": "Added ToDos for summary generation and CREP filtering in extract-training-data script",
+  "pendingTasks": [
+    "Implement summary generation in scripts/extract-training-data.ts",
+    "Integrate CREP SelfReflection filter in scripts/extract-training-data.ts"
+  ],
   "progress": [
+    {
+      "commit": "Add extract-training-data enhancement ToDos",
+      "status": "pending"
+    },
     {
       "commit": "Add Sigillin Fractal Visualizer component",
       "status": "done"


### PR DESCRIPTION
## Summary
- track pending summary generation for training data extraction
- note CREP-based quality filter todo for training data
- update fractal progress with new tasks and notes

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689538d6ba8483228b2d3f6901ce7b2c