### PR TITLE
Add message weight validation task

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-06, in der Zeit des Abend.
+Am 2025-08-08, in der Zeit des Morgen.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11309,5 +11309,12 @@
     "task": "Flag titles exceeding 100 characters",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Validate message weight bounds in conversations",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure message weight values are between 0 and 1",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "todo"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11338,3 +11338,8 @@
   task: Flag titles exceeding 100 characters
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Validate message weight bounds in conversations
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure message weight values are between 0 and 1
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: todo

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,14 +1,24 @@
 {
-  "lastCommit": "Add extract-training-data enhancement ToDos",
-  "fractalStep": "todo-added",
+  "lastCommit": "Add message weight validation TODO",
+  "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
   "notes": "Added ToDos for summary generation and CREP filtering in extract-training-data script",
   "pendingTasks": [
-    "Implement summary generation in scripts/extract-training-data.ts",
-    "Integrate CREP SelfReflection filter in scripts/extract-training-data.ts"
+    {
+      "commit": "Add summary generator to training data extraction",
+      "status": "todo"
+    },
+    {
+      "commit": "Integrate CREP SelfReflection filter into training data extractor",
+      "status": "todo"
+    },
+    {
+      "commit": "Validate message weight bounds in conversations",
+      "status": "todo"
+    }
   ],
   "progress": [
     {
@@ -654,6 +664,10 @@
     {
       "commit": "Validate conversation title length",
       "status": "done"
+    },
+    {
+      "commit": "Plan message weight validation for conversations",
+      "status": "todo"
     }
   ],
   "completed": [
@@ -1066,6 +1080,10 @@
     {
       "commit": "Validate plugin and URL fields in conversations",
       "status": "done"
+    },
+    {
+      "commit": "Plan message weight validation for conversations",
+      "status": "todo"
     }
   ],
   "metacommitTags": [


### PR DESCRIPTION
## Summary
- track need for message weight bounds validation in conversation dataset
- reference the new validation in YAML and mark progress entry

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689541782fa883229e5da8e025169d49