### PR TITLE
feat: validate message weight bounds

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11315,6 +11315,6 @@
     "path": "scripts/validate-newadvanced-conversations.ts",
     "task": "Ensure message weight values are between 0 and 1",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
-    "status": "todo"
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11342,4 +11342,4 @@
   path: scripts/validate-newadvanced-conversations.ts
   task: Ensure message weight values are between 0 and 1
   test: scripts/validate-newadvanced-conversations.test.ts
-  status: todo
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Add message weight validation TODO",
+  "lastCommit": "feat: validate message weight bounds",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -13,10 +13,6 @@
     },
     {
       "commit": "Integrate CREP SelfReflection filter into training data extractor",
-      "status": "todo"
-    },
-    {
-      "commit": "Validate message weight bounds in conversations",
       "status": "todo"
     }
   ],
@@ -667,7 +663,7 @@
     },
     {
       "commit": "Plan message weight validation for conversations",
-      "status": "todo"
+      "status": "done"
     }
   ],
   "completed": [
@@ -1083,7 +1079,7 @@
     },
     {
       "commit": "Plan message weight validation for conversations",
-      "status": "todo"
+      "status": "done"
     }
   ],
   "metacommitTags": [

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -276,4 +276,13 @@ describe('validateNewAdvancedConversations', () => {
     expect(res.conversationsWithInvalidBlockedUrls).toEqual([0]);
     expect(res.conversationsWithInvalidSafeUrls).toEqual([0]);
   });
+
+  it('flags messages with weight outside 0-1', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-message-weight.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidMessageWeights).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -27,6 +27,7 @@ export interface ValidationResult {
   conversationsWithMissingMessageIds: number[];
   conversationsWithMessagesMissingTimestamps: number[];
   conversationsWithInvalidMessageTimestamps: number[];
+  conversationsWithInvalidMessageWeights: number[];
   conversationsWithInvalidContentParts: number[];
   conversationsWithSelfReferencingChildren: number[];
   conversationsWithInvalidIds: number[];
@@ -69,6 +70,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const missingMessageIds: number[] = [];
   const messagesMissingTimestamps: number[] = [];
   const invalidMessageTimestamps: number[] = [];
+  const invalidMessageWeights: number[] = [];
   const invalidContentParts: number[] = [];
   const selfReferencingChildren: number[] = [];
   const invalidIds: number[] = [];
@@ -299,18 +301,25 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       }
       if (key !== 'client-created-root' && node.message) {
         const m = node.message;
-        if (
-          typeof m.create_time !== 'number' ||
-          typeof m.update_time !== 'number'
-        ) {
-          messagesMissingTimestamps.push(idx);
-          break;
-        }
-        if (m.update_time < m.create_time) {
-          invalidMessageTimestamps.push(idx);
-          break;
-        }
+      if (
+        typeof m.create_time !== 'number' ||
+        typeof m.update_time !== 'number'
+      ) {
+        messagesMissingTimestamps.push(idx);
+        break;
       }
+      if (m.update_time < m.create_time) {
+        invalidMessageTimestamps.push(idx);
+        break;
+      }
+      if (
+        m.weight !== undefined &&
+        (typeof m.weight !== 'number' || m.weight < 0 || m.weight > 1)
+      ) {
+        invalidMessageWeights.push(idx);
+        break;
+      }
+    }
     }
 
     if (
@@ -402,6 +411,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithMissingMessageIds: missingMessageIds,
     conversationsWithMessagesMissingTimestamps: messagesMissingTimestamps,
     conversationsWithInvalidMessageTimestamps: invalidMessageTimestamps,
+    conversationsWithInvalidMessageWeights: invalidMessageWeights,
     conversationsWithInvalidContentParts: invalidContentParts,
     conversationsWithSelfReferencingChildren: selfReferencingChildren,
     conversationsWithInvalidIds: invalidIds,
@@ -443,6 +453,7 @@ if (require.main === module) {
     result.conversationsWithMissingMessageIds.length ||
     result.conversationsWithMessagesMissingTimestamps.length ||
     result.conversationsWithInvalidMessageTimestamps.length ||
+    result.conversationsWithInvalidMessageWeights.length ||
     result.conversationsWithInvalidContentParts.length ||
     result.conversationsWithSelfReferencingChildren.length ||
     result.conversationsWithInvalidIds.length ||

--- a/tests/fixtures/newadvanced-invalid-message-weight.json
+++ b/tests/fixtures/newadvanced-invalid-message-weight.json
@@ -1,0 +1,29 @@
+[
+  {
+    "title": "Invalid message weight",
+    "id": "conv-invalid-weight",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["n1"]
+      },
+      "n1": {
+        "id": "n1",
+        "message": {
+          "id": "n1",
+          "author": {"role": "user"},
+          "create_time": 1,
+          "update_time": 1,
+          "content": {"parts": ["hi"]},
+          "weight": 1.5
+        },
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- ensure conversation message weights remain between 0 and 1
- add fixture and test for invalid message weights
- mark message weight validation task as complete in advanced ToDo and progress files

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68958dda43d08322bb8a9171737e8409