### PR TITLE
feat: generate training data summaries

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1,11 +1,11 @@
 [
   {
-    "commit": "Add summary generator to training data extraction",
-    "path": "scripts/extract-training-data.ts",
-    "task": "Replace placeholder with generated conversation summaries",
-    "test": "scripts/__tests__/extract-training-data.test.ts",
-    "status": "todo"
-  },
+  "commit": "Add summary generator to training data extraction",
+  "path": "scripts/extract-training-data.ts",
+  "task": "Replace placeholder with generated conversation summaries",
+  "test": "scripts/__tests__/extract-training-data.test.ts",
+  "status": "done"
+},
   {
     "commit": "Integrate CREP SelfReflection filter into training data extractor",
     "path": "scripts/extract-training-data.ts",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -2,7 +2,7 @@
   path: scripts/extract-training-data.ts
   task: Replace placeholder with generated conversation summaries
   test: scripts/__tests__/extract-training-data.test.ts
-  status: todo
+  status: done
 - commit: Integrate CREP SelfReflection filter into training data extractor
   path: scripts/extract-training-data.ts
   task: Filter extracted data through SelfReflectionAgent based on CREP scores

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,15 +1,15 @@
 {
-  "lastCommit": "feat: validate message weight bounds",
+  "lastCommit": "feat: add conversation summary generation",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added ToDos for summary generation and CREP filtering in extract-training-data script",
+  "notes": "Implemented summary generation; CREP filter remains pending",
   "pendingTasks": [
     {
       "commit": "Add summary generator to training data extraction",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Integrate CREP SelfReflection filter into training data extractor",
@@ -20,6 +20,10 @@
     {
       "commit": "Add extract-training-data enhancement ToDos",
       "status": "pending"
+    },
+    {
+      "commit": "Add summary generator to training data extraction",
+      "status": "done"
     },
     {
       "commit": "Add Sigillin Fractal Visualizer component",

--- a/scripts/__tests__/extract-training-data.test.ts
+++ b/scripts/__tests__/extract-training-data.test.ts
@@ -49,5 +49,10 @@ describe('extractTrainingData', () => {
     const manifestContent = yaml.load(await fs.readFile(manifest, 'utf8')) as any;
     expect(manifestContent.conversations).toHaveLength(1);
     expect(manifestContent.conversations[0].id).toBe(slug);
+    expect(manifestContent.conversations[0].summary).toContain('Hello');
+
+    const summaryFile = await fs.readFile(path.join(out, slug, 'summary.md'), 'utf8');
+    expect(summaryFile).toContain('Hello');
+    expect(summaryFile).not.toContain('TODO');
   });
 });

--- a/scripts/extract-training-data.ts
+++ b/scripts/extract-training-data.ts
@@ -9,6 +9,15 @@ function slugifyTitle(title: string): string {
     .replace(/^-+|-+$/g, '');
 }
 
+function summarizeMessages(messages: any[]): string {
+  const contents = messages
+    .map((m: any) => (m.content || m.text || '').toString().trim())
+    .filter(Boolean);
+  if (contents.length === 0) return 'No summary available.';
+  const summary = contents.slice(0, 2).join(' ').replace(/\s+/g, ' ');
+  return summary.length > 200 ? summary.slice(0, 197) + '...' : summary;
+}
+
 export async function extractTrainingData(
   src = path.resolve('docs/sigils/newadvancedconversations.json'),
   outRoot = path.resolve('GenesisAeonZIPMEM/newadvancedconversations'),
@@ -71,7 +80,8 @@ export async function extractTrainingData(
       );
     }
 
-    const summaryMd = `# Summary for ${slug}\n\n*TODO: Generate conversation summary here.*\n`;
+    const summaryText = summarizeMessages(messages);
+    const summaryMd = `# Summary for ${slug}\n\n${summaryText}\n`;
     await fs.writeFile(path.join(folder, 'summary.md'), summaryMd);
 
     const participants = Array.from(
@@ -85,7 +95,7 @@ export async function extractTrainingData(
         id: slug,
         title,
         date,
-        summary: '',
+        summary: summaryText,
         tags: meta.tags,
       });
     }


### PR DESCRIPTION
## Summary
- generate simple summaries for conversations in training data extraction and store them in manifest
- test training data extractor for summary content and placeholder removal
- mark summary-generation task as completed in progress and ToDo trackers

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/__tests__/extract-training-data.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6895d005cf7083228f77b5691a2b11e5