### PR TITLE
chore: add agents schema and review validation todos

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1,11 +1,11 @@
 [
   {
-  "commit": "Add summary generator to training data extraction",
-  "path": "scripts/extract-training-data.ts",
-  "task": "Replace placeholder with generated conversation summaries",
-  "test": "scripts/__tests__/extract-training-data.test.ts",
-  "status": "done"
-},
+    "commit": "Add summary generator to training data extraction",
+    "path": "scripts/extract-training-data.ts",
+    "task": "Replace placeholder with generated conversation summaries",
+    "test": "scripts/__tests__/extract-training-data.test.ts",
+    "status": "done"
+  },
   {
     "commit": "Integrate CREP SelfReflection filter into training data extractor",
     "path": "scripts/extract-training-data.ts",
@@ -11316,5 +11316,19 @@
     "task": "Ensure message weight values are between 0 and 1",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add AGENTS manifest schema validation",
+    "path": "scripts/validate-agents-schema.ts",
+    "task": "Validate AGENTS.md entries against JSON/YAML schema for consistency",
+    "test": "scripts/validate-agents-schema.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Implement ReviewAgent for manual fragment validation",
+    "path": "packages/agents/ReviewAgent.ts",
+    "task": "Sample conversation fragments for human validation",
+    "test": "packages/agents/__tests__/ReviewAgent.test.ts",
+    "status": "todo"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11343,3 +11343,14 @@
   task: Ensure message weight values are between 0 and 1
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Add AGENTS manifest schema validation
+  path: scripts/validate-agents-schema.ts
+  task: Validate AGENTS.md entries against JSON/YAML schema for consistency
+  test: scripts/validate-agents-schema.test.ts
+  status: todo
+- commit: Implement ReviewAgent for manual fragment validation
+  path: packages/agents/ReviewAgent.ts
+  task: Sample conversation fragments for human validation
+  test: packages/agents/__tests__/ReviewAgent.test.ts
+  status: todo
+

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add conversation summary generation",
+  "lastCommit": "Merge pull request #1076 from GenesisAeon/wxgp76-codex/implement-features-from-advancedtodo.yaml",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -8,11 +8,15 @@
   "notes": "Implemented summary generation; CREP filter remains pending",
   "pendingTasks": [
     {
-      "commit": "Add summary generator to training data extraction",
-      "status": "done"
+      "commit": "Integrate CREP SelfReflection filter into training data extractor",
+      "status": "todo"
     },
     {
-      "commit": "Integrate CREP SelfReflection filter into training data extractor",
+      "commit": "Add AGENTS manifest schema validation",
+      "status": "todo"
+    },
+    {
+      "commit": "Implement ReviewAgent for manual fragment validation",
       "status": "todo"
     }
   ],
@@ -668,6 +672,14 @@
     {
       "commit": "Plan message weight validation for conversations",
       "status": "done"
+    },
+    {
+      "commit": "Planned AGENTS manifest schema validation",
+      "status": "pending"
+    },
+    {
+      "commit": "Planned ReviewAgent for manual fragment validation",
+      "status": "pending"
     }
   ],
   "completed": [


### PR DESCRIPTION
## Summary
- track AGENTS manifest schema validation task
- note ReviewAgent for manual fragment validation
- record new tasks in progress log

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6895da5033a883229a58d7a04f49f72d