### PR TITLE
feat: validate AGENTS manifest schema

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11322,7 +11322,7 @@
     "path": "scripts/validate-agents-schema.ts",
     "task": "Validate AGENTS.md entries against JSON/YAML schema for consistency",
     "test": "scripts/validate-agents-schema.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Implement ReviewAgent for manual fragment validation",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11347,7 +11347,7 @@
   path: scripts/validate-agents-schema.ts
   task: Validate AGENTS.md entries against JSON/YAML schema for consistency
   test: scripts/validate-agents-schema.test.ts
-  status: todo
+  status: done
 - commit: Implement ReviewAgent for manual fragment validation
   path: packages/agents/ReviewAgent.ts
   task: Sample conversation fragments for human validation

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,18 +1,14 @@
 {
-  "lastCommit": "Merge pull request #1076 from GenesisAeon/wxgp76-codex/implement-features-from-advancedtodo.yaml",
-  "fractalStep": "implementiert",
+  "lastCommit": "Add AGENTS manifest schema validation",
+  "fractalStep": "weiter",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented summary generation; CREP filter remains pending",
+  "notes": "AGENTS manifest schema validation complete; ReviewAgent still pending",
   "pendingTasks": [
     {
       "commit": "Integrate CREP SelfReflection filter into training data extractor",
-      "status": "todo"
-    },
-    {
-      "commit": "Add AGENTS manifest schema validation",
       "status": "todo"
     },
     {
@@ -674,8 +670,8 @@
       "status": "done"
     },
     {
-      "commit": "Planned AGENTS manifest schema validation",
-      "status": "pending"
+      "commit": "Add AGENTS manifest schema validation",
+      "status": "done"
     },
     {
       "commit": "Planned ReviewAgent for manual fragment validation",

--- a/scripts/validate-agents-schema.test.ts
+++ b/scripts/validate-agents-schema.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { validateAgentsSchema } from './validate-agents-schema';
+
+describe('validateAgentsSchema', () => {
+  it('detects missing fields', () => {
+    const file = path.join(__dirname, '../tests/fixtures/agents-invalid.md');
+    const res = validateAgentsSchema(file);
+    expect(res.missingStart).toEqual(['NoStartAgent']);
+    expect(res.missingRoles).toEqual(['NoRolesAgent']);
+    expect(res.missingDocs).toEqual(['NoDocsAgent']);
+  });
+
+  it('passes on valid AGENTS.md', () => {
+    const file = path.join(__dirname, '../AGENTS.md');
+    const res = validateAgentsSchema(file);
+    expect(res.missingStart).toEqual([]);
+    expect(res.missingRoles).toEqual([]);
+    expect(res.missingDocs).toEqual([]);
+  });
+});

--- a/scripts/validate-agents-schema.ts
+++ b/scripts/validate-agents-schema.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env ts-node
+import fs from 'fs';
+import path from 'path';
+
+export interface AgentValidationResult {
+  agentCount: number;
+  missingStart: string[];
+  missingRoles: string[];
+  missingDocs: string[];
+}
+
+export function validateAgentsSchema(filePath: string): AgentValidationResult {
+  const text = fs.readFileSync(filePath, 'utf8');
+  const lines = text.split(/\r?\n/);
+  const sections: { name: string; type: string; lines: string[] }[] = [];
+  let current: { name: string; type: string; lines: string[] } | null = null;
+
+  for (const line of lines) {
+    const match = line.match(/^##.*?(ExportAgent|Agent): (.+)$/);
+    if (match) {
+      if (current) sections.push(current);
+      current = { name: match[2].trim(), type: match[1], lines: [] };
+    } else if (current) {
+      current.lines.push(line);
+    }
+  }
+  if (current) sections.push(current);
+
+  const missingStart: string[] = [];
+  const missingRoles: string[] = [];
+  const missingDocs: string[] = [];
+
+  const startRegex = /- \*\*(Startmodul|Startmodule|Startinput|Start)\*\*:/i;
+  const rolesRegex = /roles_allowed\s*:/i;
+  const docsRegex = /Dokumentation\s*:/i;
+
+  for (const sec of sections) {
+    const content = sec.lines.join('\n');
+    if (sec.type !== 'ExportAgent' && !startRegex.test(content)) missingStart.push(sec.name);
+    if (!rolesRegex.test(content)) missingRoles.push(sec.name);
+    if (!docsRegex.test(content)) missingDocs.push(sec.name);
+  }
+
+  return {
+    agentCount: sections.length,
+    missingStart,
+    missingRoles,
+    missingDocs,
+  };
+}
+
+if (require.main === module) {
+  const target = process.argv[2] || path.join(__dirname, '..', 'AGENTS.md');
+  const res = validateAgentsSchema(target);
+  if (res.missingStart.length || res.missingRoles.length || res.missingDocs.length) {
+    if (res.missingStart.length)
+      console.error('Agents missing start module/input:', res.missingStart);
+    if (res.missingRoles.length)
+      console.error('Agents missing roles_allowed:', res.missingRoles);
+    if (res.missingDocs.length)
+      console.error('Agents missing documentation:', res.missingDocs);
+    process.exit(1);
+  }
+  console.log(`Validated ${res.agentCount} agents successfully.`);
+}

--- a/tests/fixtures/agents-invalid.md
+++ b/tests/fixtures/agents-invalid.md
@@ -1,0 +1,12 @@
+## Agent: NoStartAgent
+- **Module**: none
+roles_allowed: [dev]
+Dokumentation: docs/agents/NoStartAgent.md
+
+## Agent: NoRolesAgent
+- **Startmodul**: foo.ts
+Dokumentation: docs/agents/NoRolesAgent.md
+
+## Agent: NoDocsAgent
+- **Startmodul**: bar.ts
+roles_allowed: [admin]


### PR DESCRIPTION
## Summary
- add schema validator for AGENTS.md entries
- ensure advanced ToDo tracking marks validation feature complete
- record progress update in advancedprogress.json

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/validate-agents-schema.test.ts`
- `npx ts-node scripts/validate-agents-schema.ts AGENTS.md`
- `node scripts/validate-advancedtodo.js` *(fails: advancedToDo mismatch detected)*

------
https://chatgpt.com/codex/tasks/task_e_6895df1719bc83229bca1186651a7f12