### PR TITLE
docs: add channel and recipient validation todos

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11337,5 +11337,19 @@
     "task": "Ensure node messages use allowed status values",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "todo"
+  },
+  {
+    "commit": "Validate message channel values in conversations",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure node messages use allowed channel values",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Validate message recipient values in conversations",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure node messages use allowed recipient values",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "todo"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -9888,3 +9888,13 @@
   task: Ensure node messages use allowed status values
   test: scripts/validate-newadvanced-conversations.test.ts
   status: todo
+- commit: Validate message channel values in conversations
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure node messages use allowed channel values
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: todo
+- commit: Validate message recipient values in conversations
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure node messages use allowed recipient values
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: todo

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Integrate CREP SelfReflection filter into training data extractor",
+  "lastCommit": "Add channel and recipient validation ToDos",
   "fractalStep": "weiter",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Integrated SelfReflection CREP filter; ReviewAgent and message status validation pending",
+  "notes": "Added ToDos for message channel and recipient validation; ReviewAgent and message status validation pending",
   "pendingTasks": [
     {
       "commit": "Implement ReviewAgent for manual fragment validation",
@@ -13,6 +13,14 @@
     },
     {
       "commit": "Validate message status values in conversations",
+      "status": "todo"
+    },
+    {
+      "commit": "Validate message channel values in conversations",
+      "status": "todo"
+    },
+    {
+      "commit": "Validate message recipient values in conversations",
       "status": "todo"
     }
   ],
@@ -680,6 +688,10 @@
     {
       "commit": "Integrate CREP SelfReflection filter into training data extractor",
       "status": "done"
+    },
+    {
+      "commit": "Plan message channel and recipient validation for conversations",
+      "status": "pending"
     }
   ],
   "completed": [
@@ -1096,6 +1108,10 @@
     {
       "commit": "Plan message weight validation for conversations",
       "status": "done"
+    },
+    {
+      "commit": "Plan message channel and recipient validation for conversations",
+      "status": "pending"
     }
   ],
   "metacommitTags": [


### PR DESCRIPTION
## Summary
- track upcoming validation for `channel` fields in `newadvanced-conversations`
- add TODOs for recipient value checks
- record progress and pending tasks for these validations

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6896337a08048322803daf433f308e2d