### PR TITLE
Validate message status, channel, and recipient values

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11336,20 +11336,20 @@
     "path": "scripts/validate-newadvanced-conversations.ts",
     "task": "Ensure node messages use allowed status values",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Validate message channel values in conversations",
     "path": "scripts/validate-newadvanced-conversations.ts",
     "task": "Ensure node messages use allowed channel values",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Validate message recipient values in conversations",
     "path": "scripts/validate-newadvanced-conversations.ts",
     "task": "Ensure node messages use allowed recipient values",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
-    "status": "todo"
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -9887,14 +9887,14 @@
   path: scripts/validate-newadvanced-conversations.ts
   task: Ensure node messages use allowed status values
   test: scripts/validate-newadvanced-conversations.test.ts
-  status: todo
+  status: done
 - commit: Validate message channel values in conversations
   path: scripts/validate-newadvanced-conversations.ts
   task: Ensure node messages use allowed channel values
   test: scripts/validate-newadvanced-conversations.test.ts
-  status: todo
+  status: done
 - commit: Validate message recipient values in conversations
   path: scripts/validate-newadvanced-conversations.ts
   task: Ensure node messages use allowed recipient values
   test: scripts/validate-newadvanced-conversations.test.ts
-  status: todo
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,26 +1,14 @@
 {
-  "lastCommit": "Add channel and recipient validation ToDos",
+  "lastCommit": "Validate message status, channel, and recipient values",
   "fractalStep": "weiter",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added ToDos for message channel and recipient validation; ReviewAgent and message status validation pending",
+  "notes": "Implemented message status, channel, and recipient validations; ReviewAgent pending",
   "pendingTasks": [
     {
       "commit": "Implement ReviewAgent for manual fragment validation",
-      "status": "todo"
-    },
-    {
-      "commit": "Validate message status values in conversations",
-      "status": "todo"
-    },
-    {
-      "commit": "Validate message channel values in conversations",
-      "status": "todo"
-    },
-    {
-      "commit": "Validate message recipient values in conversations",
       "status": "todo"
     }
   ],
@@ -691,7 +679,7 @@
     },
     {
       "commit": "Plan message channel and recipient validation for conversations",
-      "status": "pending"
+      "status": "done"
     }
   ],
   "completed": [
@@ -1111,7 +1099,19 @@
     },
     {
       "commit": "Plan message channel and recipient validation for conversations",
-      "status": "pending"
+      "status": "done"
+    },
+    {
+      "commit": "Validate message status values in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Validate message channel values in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Validate message recipient values in conversations",
+      "status": "done"
     }
   ],
   "metacommitTags": [

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -285,4 +285,31 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithInvalidMessageWeights).toEqual([0]);
   });
+
+  it('flags messages with invalid status values', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-message-status.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidMessageStatuses).toEqual([0]);
+  });
+
+  it('flags messages with invalid channel values', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-message-channel.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidMessageChannels).toEqual([0]);
+  });
+
+  it('flags messages with invalid recipient values', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-message-recipient.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidMessageRecipients).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -40,6 +40,9 @@ export interface ValidationResult {
   conversationsWithInvalidDisabledToolIds: number[];
   conversationsWithInvalidBlockedUrls: number[];
   conversationsWithInvalidSafeUrls: number[];
+  conversationsWithInvalidMessageStatuses: number[];
+  conversationsWithInvalidMessageChannels: number[];
+  conversationsWithInvalidMessageRecipients: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -82,7 +85,49 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const invalidDisabledToolIds: number[] = [];
   const invalidBlockedUrls: number[] = [];
   const invalidSafeUrls: number[] = [];
+  const invalidMessageStatuses: number[] = [];
+  const invalidMessageChannels: number[] = [];
+  const invalidMessageRecipients: number[] = [];
   const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  const allowedStatuses = [
+    'cancelled',
+    'done',
+    'failed_with_in_kernel_exception',
+    'finished',
+    'finished_partial_completion',
+    'finished_successfully',
+    'in_progress',
+    'requested',
+    'running',
+    'success',
+  ];
+  const allowedChannels = ['commentary', 'final'];
+  const allowedRecipients = [
+    'all',
+    'assistant',
+    'bio',
+    'browser.open',
+    'browser.search',
+    'canmore.comment_textdoc',
+    'canmore.create_textdoc',
+    'canmore.update_textdoc',
+    'computer.do',
+    'computer.get',
+    'computer.initialize',
+    'computer.sync_file',
+    'container.exec',
+    'dalle.text2im',
+    'de1d73e.create',
+    'de1d73e.update',
+    'file_search.msearch',
+    'python',
+    'research_kickoff_tool.start_research_task',
+    't2uay3k.sj1i4kz',
+    'web',
+    'web.open_url',
+    'web.run',
+    'web.search',
+  ];
 
   raw.forEach((conv: any, idx: number) => {
     const seenMessageIds = new Set<string>();
@@ -319,6 +364,28 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
         invalidMessageWeights.push(idx);
         break;
       }
+      if (
+        m.status !== undefined &&
+        (typeof m.status !== 'string' || !allowedStatuses.includes(m.status))
+      ) {
+        invalidMessageStatuses.push(idx);
+        break;
+      }
+      if (
+        m.channel !== undefined &&
+        m.channel !== null &&
+        !allowedChannels.includes(m.channel)
+      ) {
+        invalidMessageChannels.push(idx);
+        break;
+      }
+      if (
+        m.recipient !== undefined &&
+        (typeof m.recipient !== 'string' || !allowedRecipients.includes(m.recipient))
+      ) {
+        invalidMessageRecipients.push(idx);
+        break;
+      }
     }
     }
 
@@ -424,6 +491,9 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithInvalidDisabledToolIds: invalidDisabledToolIds,
     conversationsWithInvalidBlockedUrls: invalidBlockedUrls,
     conversationsWithInvalidSafeUrls: invalidSafeUrls,
+    conversationsWithInvalidMessageStatuses: invalidMessageStatuses,
+    conversationsWithInvalidMessageChannels: invalidMessageChannels,
+    conversationsWithInvalidMessageRecipients: invalidMessageRecipients,
   };
 }
 
@@ -465,7 +535,10 @@ if (require.main === module) {
     result.conversationsWithInvalidPluginIds.length ||
     result.conversationsWithInvalidDisabledToolIds.length ||
     result.conversationsWithInvalidBlockedUrls.length ||
-    result.conversationsWithInvalidSafeUrls.length
+    result.conversationsWithInvalidSafeUrls.length ||
+    result.conversationsWithInvalidMessageStatuses.length ||
+    result.conversationsWithInvalidMessageChannels.length ||
+    result.conversationsWithInvalidMessageRecipients.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-invalid-message-channel.json
+++ b/tests/fixtures/newadvanced-invalid-message-channel.json
@@ -1,0 +1,32 @@
+[
+  {
+    "title": "Invalid message channel",
+    "id": "conv-invalid-channel",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["n1"]
+      },
+      "n1": {
+        "id": "n1",
+        "message": {
+          "id": "n1",
+          "author": {"role": "user"},
+          "create_time": 1,
+          "update_time": 1,
+          "content": {"parts": ["hi"]},
+          "status": "finished_successfully",
+          "recipient": "all",
+          "channel": "invalid_channel",
+          "weight": 0.5
+        },
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]

--- a/tests/fixtures/newadvanced-invalid-message-recipient.json
+++ b/tests/fixtures/newadvanced-invalid-message-recipient.json
@@ -1,0 +1,32 @@
+[
+  {
+    "title": "Invalid message recipient",
+    "id": "conv-invalid-recipient",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["n1"]
+      },
+      "n1": {
+        "id": "n1",
+        "message": {
+          "id": "n1",
+          "author": {"role": "user"},
+          "create_time": 1,
+          "update_time": 1,
+          "content": {"parts": ["hi"]},
+          "status": "finished_successfully",
+          "recipient": "invalid_recipient",
+          "channel": "final",
+          "weight": 0.5
+        },
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]

--- a/tests/fixtures/newadvanced-invalid-message-status.json
+++ b/tests/fixtures/newadvanced-invalid-message-status.json
@@ -1,0 +1,32 @@
+[
+  {
+    "title": "Invalid message status",
+    "id": "conv-invalid-status",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["n1"]
+      },
+      "n1": {
+        "id": "n1",
+        "message": {
+          "id": "n1",
+          "author": {"role": "user"},
+          "create_time": 1,
+          "update_time": 1,
+          "content": {"parts": ["hi"]},
+          "status": "invalid_status",
+          "recipient": "all",
+          "channel": null,
+          "weight": 0.5
+        },
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- extend conversation validator with checks for allowed message statuses, channels, and recipients
- cover new validations with targeted fixtures and unit tests
- mark related ToDo entries and progress tracking as complete

## Testing
- `npx vitest scripts/validate-newadvanced-conversations.test.ts`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68963b0c6c808322808fb0313beb5911