### PR TITLE
feat: add ReviewAgent for conversation fragment sampling

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11329,6 +11329,13 @@
     "path": "packages/agents/ReviewAgent.ts",
     "task": "Sample conversation fragments for human validation",
     "test": "packages/agents/__tests__/ReviewAgent.test.ts",
+    "status": "done"
+  },
+  {
+    "commit": "Add cyclic reference validation for conversations",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Detect cycles in conversation graph to ensure tree structure",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "todo"
   },
   {

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -9882,6 +9882,11 @@
   path: packages/agents/ReviewAgent.ts
   task: Sample conversation fragments for human validation
   test: packages/agents/__tests__/ReviewAgent.test.ts
+  status: done
+- commit: Add cyclic reference validation for conversations
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Detect cycles in conversation graph to ensure tree structure
+  test: scripts/validate-newadvanced-conversations.test.ts
   status: todo
 - commit: Validate message status values in conversations
   path: scripts/validate-newadvanced-conversations.ts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,14 +1,14 @@
 {
-  "lastCommit": "Validate message status, channel, and recipient values",
+  "lastCommit": "Implement ReviewAgent for manual fragment validation",
   "fractalStep": "weiter",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented message status, channel, and recipient validations; ReviewAgent pending",
+  "notes": "Implemented message status, channel, and recipient validations; planned cyclic reference validation",
   "pendingTasks": [
     {
-      "commit": "Implement ReviewAgent for manual fragment validation",
+      "commit": "Add cyclic reference validation for conversations",
       "status": "todo"
     }
   ],
@@ -671,7 +671,11 @@
     },
     {
       "commit": "Planned ReviewAgent for manual fragment validation",
-      "status": "pending"
+      "status": "done"
+    },
+    {
+      "commit": "Implement ReviewAgent for manual fragment validation",
+      "status": "done"
     },
     {
       "commit": "Integrate CREP SelfReflection filter into training data extractor",
@@ -680,6 +684,10 @@
     {
       "commit": "Plan message channel and recipient validation for conversations",
       "status": "done"
+    },
+    {
+      "commit": "Plan cyclic reference validation for conversations",
+      "status": "pending"
     }
   ],
   "completed": [

--- a/packages/agents/ReviewAgent.ts
+++ b/packages/agents/ReviewAgent.ts
@@ -1,0 +1,28 @@
+import { Agent, Task } from '../core/interfaces';
+
+/**
+ * ReviewAgent samples conversation fragments for manual validation.
+ * It logs the first available message content from the provided conversation
+ * structure so that humans can review extracted fragments easily.
+ */
+export class ReviewAgent implements Agent {
+  id = 'ReviewAgent';
+  layer = 'analysis';
+
+  handle(task: Task): void {
+    const conv = (task as any).conversation;
+    if (!conv || typeof conv !== 'object' || !conv.mapping) {
+      console.log('📝 ReviewAgent → no conversation provided');
+      return;
+    }
+    const nodes = Object.values(conv.mapping).filter(
+      (n: any) => n && n.message && n.message.content
+    );
+    const fragment = nodes[0] as any;
+    if (fragment) {
+      console.log(`📝 ReviewAgent → review fragment: ${fragment.message.content}`);
+    } else {
+      console.log('📝 ReviewAgent → no fragments found');
+    }
+  }
+}

--- a/packages/agents/__tests__/ReviewAgent.test.ts
+++ b/packages/agents/__tests__/ReviewAgent.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ReviewAgent } from '../ReviewAgent';
+
+describe('ReviewAgent', () => {
+  it('logs first conversation fragment for review', () => {
+    const agent = new ReviewAgent();
+    const conversation = {
+      mapping: {
+        root: { id: 'root', message: null, parent: null, children: ['a'] },
+        a: {
+          id: 'a',
+          message: { content: 'Hello world' },
+          parent: 'root',
+          children: []
+        }
+      }
+    };
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    agent.handle({ id: 't1', description: 'review', conversation } as any);
+    expect(spy).toHaveBeenCalledWith(
+      '📝 ReviewAgent → review fragment: Hello world'
+    );
+    spy.mockRestore();
+  });
+});

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -54,3 +54,4 @@ export * from './ArchivAeon';
 export * from './mistral-api-agent';
 export * from './mistral-code-agent';
 export * from './QuantumTheoryAgent';
+export * from './ReviewAgent';


### PR DESCRIPTION
## Summary
- implement ReviewAgent to log conversation fragments for manual review
- track progress and new cyclic-reference validation task in advanced todo files

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest packages/agents/__tests__/ReviewAgent.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689644220a14832288909b7bc2969189