### PR TITLE
feat: validate cyclic conversation references

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11336,7 +11336,7 @@
     "path": "scripts/validate-newadvanced-conversations.ts",
     "task": "Detect cycles in conversation graph to ensure tree structure",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Validate message status values in conversations",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -9887,7 +9887,7 @@
   path: scripts/validate-newadvanced-conversations.ts
   task: Detect cycles in conversation graph to ensure tree structure
   test: scripts/validate-newadvanced-conversations.test.ts
-  status: todo
+  status: done
 - commit: Validate message status values in conversations
   path: scripts/validate-newadvanced-conversations.ts
   task: Ensure node messages use allowed status values

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,17 +1,12 @@
 {
-  "lastCommit": "Implement ReviewAgent for manual fragment validation",
+  "lastCommit": "Add cyclic reference validation for conversations",
   "fractalStep": "weiter",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented message status, channel, and recipient validations; planned cyclic reference validation",
-  "pendingTasks": [
-    {
-      "commit": "Add cyclic reference validation for conversations",
-      "status": "todo"
-    }
-  ],
+  "notes": "Implemented cyclic reference validation for conversations",
+  "pendingTasks": [],
   "progress": [
     {
       "commit": "Add extract-training-data enhancement ToDos",
@@ -1119,6 +1114,10 @@
     },
     {
       "commit": "Validate message recipient values in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Add cyclic reference validation for conversations",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -312,4 +312,13 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithInvalidMessageRecipients).toEqual([0]);
   });
+
+  it('flags cyclic child references', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-cyclic-reference.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithCyclicReferences).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -17,6 +17,7 @@ export interface ValidationResult {
   conversationsWithMissingParents: number[];
   conversationsWithMismatchedNodeIds: number[];
   conversationsWithParentCycles: number[];
+  conversationsWithCyclicReferences: number[];
   conversationsWithInvalidChildRefs: number[];
   conversationsWithUnlistedChildren: number[];
   conversationsWithOrphanNodes: number[];
@@ -63,6 +64,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const missingParents: number[] = [];
   const mismatchedNodeIds: number[] = [];
   const parentCycles: number[] = [];
+  const cyclicReferences: number[] = [];
   const invalidChildren: number[] = [];
   const unlistedChildren: number[] = [];
   const orphanNodes: number[] = [];
@@ -407,6 +409,30 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       invalidContentParts.push(idx);
     }
 
+    // Detect cycles in child references using DFS
+    const globalVisited = new Set<string>();
+    const stackSet = new Set<string>();
+    const detectCycle = (id: string): boolean => {
+      if (stackSet.has(id)) return true;
+      if (globalVisited.has(id)) return false;
+      globalVisited.add(id);
+      stackSet.add(id);
+      const node = conv.mapping[id];
+      if (Array.isArray(node?.children)) {
+        for (const childId of node.children) {
+          if (detectCycle(childId)) return true;
+        }
+      }
+      stackSet.delete(id);
+      return false;
+    };
+    for (const id of Object.keys(conv.mapping || {})) {
+      if (detectCycle(id)) {
+        cyclicReferences.push(idx);
+        break;
+      }
+    }
+
     const root = conv.mapping?.['client-created-root'];
     if (!root || root.parent !== null) {
       missingRoot.push(idx);
@@ -468,6 +494,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithMissingParents: missingParents,
     conversationsWithMismatchedNodeIds: mismatchedNodeIds,
     conversationsWithParentCycles: parentCycles,
+    conversationsWithCyclicReferences: cyclicReferences,
     conversationsWithInvalidChildRefs: invalidChildren,
     conversationsWithUnlistedChildren: unlistedChildren,
     conversationsWithOrphanNodes: orphanNodes,
@@ -513,6 +540,7 @@ if (require.main === module) {
     result.conversationsWithMissingParents.length ||
     result.conversationsWithMismatchedNodeIds.length ||
     result.conversationsWithParentCycles.length ||
+    result.conversationsWithCyclicReferences.length ||
     result.conversationsWithInvalidChildRefs.length ||
     result.conversationsWithUnlistedChildren.length ||
     result.conversationsWithOrphanNodes.length ||

--- a/tests/fixtures/newadvanced-cyclic-reference.json
+++ b/tests/fixtures/newadvanced-cyclic-reference.json
@@ -1,0 +1,40 @@
+[
+  {
+    "id": "1",
+    "title": "Cycle",
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["a"]
+      },
+      "a": {
+        "id": "a",
+        "parent": "client-created-root",
+        "children": ["b"],
+        "message": {
+          "id": "m1",
+          "author": { "role": "user" },
+          "create_time": 1,
+          "update_time": 1,
+          "content": { "parts": ["hello"] }
+        }
+      },
+      "b": {
+        "id": "b",
+        "parent": "a",
+        "children": ["client-created-root"],
+        "message": {
+          "id": "m2",
+          "author": { "role": "assistant" },
+          "create_time": 1,
+          "update_time": 1,
+          "content": { "parts": ["hi"] }
+        }
+      }
+    },
+    "create_time": 1,
+    "update_time": 1
+  }
+]


### PR DESCRIPTION
## Summary
- detect cyclic child references in conversation graphs
- add regression test for cyclic conversation structures
- record completion of cyclic validation task in advanced todo and progress files

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest scripts/validate-newadvanced-conversations.test.ts --run`
- `npx ts-node scripts/validate-newadvanced-conversations.ts docs/sigils/newadvancedconversations.json`

------
https://chatgpt.com/codex/tasks/task_e_689649483c288322b5f0c69f0d3ea34e