### PR TITLE
chore: plan conversation validation for root and timestamps

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11358,5 +11358,26 @@
     "task": "Ensure node messages use allowed recipient values",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Validate root node presence in conversations",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure each conversation mapping defines exactly one root node",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Validate conversation timestamp ordering",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Check that create_time and update_time are numeric and update_time >= create_time",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Validate conversation message weight values",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure node message weight is within 0-1 range",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "todo"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -9903,3 +9903,18 @@
   task: Ensure node messages use allowed recipient values
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Validate root node presence in conversations
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure each conversation mapping defines exactly one root node
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: todo
+- commit: Validate conversation timestamp ordering
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Check that create_time and update_time are numeric and update_time >= create_time
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: todo
+- commit: Validate conversation message weight values
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure node message weight is within 0-1 range
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: todo

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,12 +1,16 @@
 {
-  "lastCommit": "Add cyclic reference validation for conversations",
+  "lastCommit": "Plan conversation validation for root node, timestamps, and weights",
   "fractalStep": "weiter",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented cyclic reference validation for conversations",
-  "pendingTasks": [],
+  "notes": "Outlined ToDos for root node presence, timestamp ordering, and message weight range",
+  "pendingTasks": [
+    "Implement root node presence validation",
+    "Implement conversation timestamp ordering validation",
+    "Implement message weight range validation"
+  ],
   "progress": [
     {
       "commit": "Add extract-training-data enhancement ToDos",
@@ -682,6 +686,18 @@
     },
     {
       "commit": "Plan cyclic reference validation for conversations",
+      "status": "pending"
+    },
+    {
+      "commit": "Plan root node presence validation",
+      "status": "pending"
+    },
+    {
+      "commit": "Plan conversation timestamp ordering validation",
+      "status": "pending"
+    },
+    {
+      "commit": "Plan message weight range validation",
       "status": "pending"
     }
   ],


### PR DESCRIPTION
## Summary
- add TODOs for conversation root node presence
- add TODOs for conversation timestamp ordering
- add TODOs for message weight validation and record progress

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689656201b7883229d7ae933a07e72bc