### PR TITLE
validate template and model slug

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11400,5 +11400,12 @@
     "task": "Ensure end_turn is boolean when defined",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Validate conversation template and model slug",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure conversation_template_id matches UUID format and default_model_slug is non-empty",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11404,3 +11404,8 @@
   task: Ensure end_turn is boolean when defined
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Validate conversation template and model slug
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure conversation_template_id matches UUID format and default_model_slug is non-empty
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Validate message content_type and end_turn values",
+  "lastCommit": "Validate conversation template and model slug",
   "fractalStep": "weiter",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added validations for message content_type and end_turn; further metadata checks may follow",
+  "notes": "Added validation for conversation_template_id and default_model_slug; continue reviewing metadata fields",
   "pendingTasks": [],
   "progress": [
     {
@@ -695,6 +695,10 @@
     {
       "commit": "Plan message weight range validation",
       "status": "pending"
+    },
+    {
+      "commit": "Validate conversation template and model slug",
+      "status": "done"
     }
   ],
   "completed": [

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -348,4 +348,22 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithMissingAttachments).toEqual([0]);
   });
+
+  it('flags invalid conversation_template_id values', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-template-id.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidTemplateId).toEqual([0]);
+  });
+
+  it('flags invalid default_model_slug values', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-model-slug.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidDefaultModelSlug).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -47,6 +47,8 @@ export interface ValidationResult {
   conversationsWithMissingAttachments: number[];
   conversationsWithInvalidContentTypes: number[];
   conversationsWithInvalidEndTurn: number[];
+  conversationsWithInvalidTemplateId: number[];
+  conversationsWithInvalidDefaultModelSlug: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -82,6 +84,8 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const invalidContentParts: number[] = [];
   const invalidContentTypes: number[] = [];
   const invalidEndTurn: number[] = [];
+  const invalidTemplateIds: number[] = [];
+  const invalidDefaultModelSlugs: number[] = [];
   const selfReferencingChildren: number[] = [];
   const invalidIds: number[] = [];
   const duplicateMessageIds: number[] = [];
@@ -212,6 +216,28 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
         conv.safe_urls.some((u: any) => typeof u !== 'string')
       ) {
         invalidSafeUrls.push(idx);
+      }
+    }
+    if (
+      conv.conversation_template_id !== undefined &&
+      conv.conversation_template_id !== null
+    ) {
+      if (
+        typeof conv.conversation_template_id !== 'string' ||
+        !uuidPattern.test(conv.conversation_template_id)
+      ) {
+        invalidTemplateIds.push(idx);
+      }
+    }
+    if (
+      conv.default_model_slug !== undefined &&
+      conv.default_model_slug !== null
+    ) {
+      if (
+        typeof conv.default_model_slug !== 'string' ||
+        !conv.default_model_slug.trim()
+      ) {
+        invalidDefaultModelSlugs.push(idx);
       }
     }
     if (
@@ -574,6 +600,8 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithMissingAttachments: missingAttachments,
     conversationsWithInvalidContentTypes: invalidContentTypes,
     conversationsWithInvalidEndTurn: invalidEndTurn,
+    conversationsWithInvalidTemplateId: invalidTemplateIds,
+    conversationsWithInvalidDefaultModelSlug: invalidDefaultModelSlugs,
   };
 }
 
@@ -622,7 +650,9 @@ if (require.main === module) {
     result.conversationsWithInvalidMessageRecipients.length ||
     result.conversationsWithInvalidContentTypes.length ||
     result.conversationsWithInvalidEndTurn.length ||
-    result.conversationsWithMissingAttachments.length
+    result.conversationsWithMissingAttachments.length ||
+    result.conversationsWithInvalidTemplateId.length ||
+    result.conversationsWithInvalidDefaultModelSlug.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-invalid-model-slug.json
+++ b/tests/fixtures/newadvanced-invalid-model-slug.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "conversation_id": "00000000-0000-0000-0000-000000000001",
+    "title": "Invalid default model slug",
+    "create_time": 1,
+    "update_time": 2,
+    "current_node": "client-created-root",
+    "default_model_slug": "",
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": {
+          "id": "22222222-2222-2222-2222-222222222222",
+          "author": { "role": "user" },
+          "create_time": 1,
+          "update_time": 1,
+          "content": { "parts": ["hi"] }
+        },
+        "parent": null,
+        "children": []
+      }
+    }
+  }
+]

--- a/tests/fixtures/newadvanced-invalid-template-id.json
+++ b/tests/fixtures/newadvanced-invalid-template-id.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "conversation_id": "00000000-0000-0000-0000-000000000001",
+    "title": "Invalid template id",
+    "create_time": 1,
+    "update_time": 2,
+    "current_node": "client-created-root",
+    "conversation_template_id": "not-a-uuid",
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": {
+          "id": "22222222-2222-2222-2222-222222222222",
+          "author": { "role": "user" },
+          "create_time": 1,
+          "update_time": 1,
+          "content": { "parts": ["hi"] }
+        },
+        "parent": null,
+        "children": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- extend conversation validator to flag invalid `conversation_template_id` and empty `default_model_slug`
- cover new validation paths with dedicated fixtures and tests
- log progress and to-dos for template and model slug verification

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright -p pyrightconfig.json` *(no output)*
- `npx tsc -p tsconfig.json` *(no output)*
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6896efcbc2e0832295ffdd4309c1fed9