### PR TITLE
chore: plan async_status and voice validation

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11407,5 +11407,12 @@
     "task": "Ensure conversation_template_id matches UUID format and default_model_slug is non-empty",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Validate conversation async_status and voice fields",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure async_status uses allowed values and voice is non-empty when defined",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "planned"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11409,3 +11409,8 @@
   task: Ensure conversation_template_id matches UUID format and default_model_slug is non-empty
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Validate conversation async_status and voice fields
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure async_status uses allowed values and voice is non-empty when defined
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: planned

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1147,6 +1147,10 @@
     {
       "commit": "Validate message end_turn values in conversations",
       "status": "done"
+    },
+    {
+      "commit": "Plan validation for async_status and voice fields in conversations",
+      "status": "planned"
     }
   ],
   "metacommitTags": [


### PR DESCRIPTION
## Summary
- track a new validation task for `async_status` and `voice` fields in conversations
- record planned work in advanced progress log

## Testing
- `npx pyright` *(fails: workspace enumeration taking too long)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6896f5834b7c8322910047c54c3d9e15