### PR TITLE
feat: validate async status and voice

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11413,6 +11413,13 @@
     "path": "scripts/validate-newadvanced-conversations.ts",
     "task": "Ensure async_status uses allowed values and voice is non-empty when defined",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
+  },
+  {
+    "commit": "Validate conversation memory_scope values",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure memory_scope uses allowed values",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "planned"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11413,4 +11413,9 @@
   path: scripts/validate-newadvanced-conversations.ts
   task: Ensure async_status uses allowed values and voice is non-empty when defined
   test: scripts/validate-newadvanced-conversations.test.ts
+  status: done
+- commit: Validate conversation memory_scope values
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure memory_scope uses allowed values
+  test: scripts/validate-newadvanced-conversations.test.ts
   status: planned

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1150,6 +1150,10 @@
     },
     {
       "commit": "Plan validation for async_status and voice fields in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Plan validation for memory_scope field in conversations",
       "status": "planned"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -366,4 +366,22 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithInvalidDefaultModelSlug).toEqual([0]);
   });
+
+  it('flags invalid async_status values', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-async-status.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidAsyncStatus).toEqual([0]);
+  });
+
+  it('flags empty voice fields', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-voice.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidVoice).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -49,6 +49,8 @@ export interface ValidationResult {
   conversationsWithInvalidEndTurn: number[];
   conversationsWithInvalidTemplateId: number[];
   conversationsWithInvalidDefaultModelSlug: number[];
+  conversationsWithInvalidAsyncStatus: number[];
+  conversationsWithInvalidVoice: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -100,6 +102,8 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const invalidMessageChannels: number[] = [];
   const invalidMessageRecipients: number[] = [];
   const missingAttachments: number[] = [];
+  const invalidAsyncStatus: number[] = [];
+  const invalidVoice: number[] = [];
   const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   const allowedStatuses = [
     'cancelled',
@@ -151,6 +155,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     'tether_browsing_display',
     'tether_quote',
   ];
+  const allowedAsyncStatuses = ['not_started', 'in_progress', 'completed', 'failed'];
 
   raw.forEach((conv: any, idx: number) => {
     const seenMessageIds = new Set<string>();
@@ -171,6 +176,21 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       invalidTimestamps.push(idx);
     }
     if (missing.length) missingFields.push({ index: idx, fields: missing });
+
+    if (
+      conv.async_status !== undefined &&
+      conv.async_status !== null &&
+      !allowedAsyncStatuses.includes(conv.async_status)
+    ) {
+      invalidAsyncStatus.push(idx);
+    }
+
+    if (
+      'voice' in conv &&
+      (typeof conv.voice !== 'string' || conv.voice.trim() === '')
+    ) {
+      invalidVoice.push(idx);
+    }
     if (conv.id) {
       if (!uuidPattern.test(conv.id)) {
         invalidIds.push(idx);
@@ -602,6 +622,8 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithInvalidEndTurn: invalidEndTurn,
     conversationsWithInvalidTemplateId: invalidTemplateIds,
     conversationsWithInvalidDefaultModelSlug: invalidDefaultModelSlugs,
+    conversationsWithInvalidAsyncStatus: invalidAsyncStatus,
+    conversationsWithInvalidVoice: invalidVoice,
   };
 }
 
@@ -652,7 +674,9 @@ if (require.main === module) {
     result.conversationsWithInvalidEndTurn.length ||
     result.conversationsWithMissingAttachments.length ||
     result.conversationsWithInvalidTemplateId.length ||
-    result.conversationsWithInvalidDefaultModelSlug.length
+    result.conversationsWithInvalidDefaultModelSlug.length ||
+    result.conversationsWithInvalidAsyncStatus.length ||
+    result.conversationsWithInvalidVoice.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-invalid-async-status.json
+++ b/tests/fixtures/newadvanced-invalid-async-status.json
@@ -1,0 +1,32 @@
+[
+  {
+    "title": "Invalid async status",
+    "id": "conv-invalid-async",
+    "async_status": "invalid_status",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["n1"]
+      },
+      "n1": {
+        "id": "n1",
+        "message": {
+          "id": "n1",
+          "author": {"role": "user"},
+          "create_time": 1,
+          "update_time": 1,
+          "content": {"parts": ["hi"]},
+          "recipient": "all",
+          "channel": null,
+          "weight": 0.5
+        },
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]

--- a/tests/fixtures/newadvanced-invalid-voice.json
+++ b/tests/fixtures/newadvanced-invalid-voice.json
@@ -1,0 +1,32 @@
+[
+  {
+    "title": "Invalid voice",
+    "id": "conv-invalid-voice",
+    "voice": "",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["n1"]
+      },
+      "n1": {
+        "id": "n1",
+        "message": {
+          "id": "n1",
+          "author": {"role": "user"},
+          "create_time": 1,
+          "update_time": 1,
+          "content": {"parts": ["hi"]},
+          "recipient": "all",
+          "channel": null,
+          "weight": 0.5
+        },
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- validate async_status values and non-empty voice fields in conversation data
- cover async_status and voice rules with dedicated test fixtures
- update advanced todo and progress tracking, planning memory_scope validation next

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689700c2b2308322b81158d962fa72c2