### PR TITLE
Validate conversation memory_scope values

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11420,6 +11420,6 @@
     "path": "scripts/validate-newadvanced-conversations.ts",
     "task": "Ensure memory_scope uses allowed values",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
-    "status": "planned"
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11418,4 +11418,4 @@
   path: scripts/validate-newadvanced-conversations.ts
   task: Ensure memory_scope uses allowed values
   test: scripts/validate-newadvanced-conversations.test.ts
-  status: planned
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1154,6 +1154,10 @@
     },
     {
       "commit": "Plan validation for memory_scope field in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Review docs/sigils for additional spec insights",
       "status": "planned"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -384,4 +384,13 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithInvalidVoice).toEqual([0]);
   });
+
+  it('flags invalid memory_scope values', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-memory-scope.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidMemoryScope).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -51,6 +51,7 @@ export interface ValidationResult {
   conversationsWithInvalidDefaultModelSlug: number[];
   conversationsWithInvalidAsyncStatus: number[];
   conversationsWithInvalidVoice: number[];
+  conversationsWithInvalidMemoryScope: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -104,6 +105,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const missingAttachments: number[] = [];
   const invalidAsyncStatus: number[] = [];
   const invalidVoice: number[] = [];
+  const invalidMemoryScope: number[] = [];
   const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   const allowedStatuses = [
     'cancelled',
@@ -156,6 +158,13 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     'tether_quote',
   ];
   const allowedAsyncStatuses = ['not_started', 'in_progress', 'completed', 'failed'];
+  const allowedMemoryScopes = [
+    'none',
+    'project_enabled',
+    'project_disabled',
+    'global_enabled',
+    'global_disabled',
+  ];
 
   raw.forEach((conv: any, idx: number) => {
     const seenMessageIds = new Set<string>();
@@ -190,6 +199,13 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       (typeof conv.voice !== 'string' || conv.voice.trim() === '')
     ) {
       invalidVoice.push(idx);
+    }
+    if (
+      conv.memory_scope !== undefined &&
+      conv.memory_scope !== null &&
+      !allowedMemoryScopes.includes(conv.memory_scope)
+    ) {
+      invalidMemoryScope.push(idx);
     }
     if (conv.id) {
       if (!uuidPattern.test(conv.id)) {
@@ -624,6 +640,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithInvalidDefaultModelSlug: invalidDefaultModelSlugs,
     conversationsWithInvalidAsyncStatus: invalidAsyncStatus,
     conversationsWithInvalidVoice: invalidVoice,
+    conversationsWithInvalidMemoryScope: invalidMemoryScope,
   };
 }
 
@@ -676,7 +693,8 @@ if (require.main === module) {
     result.conversationsWithInvalidTemplateId.length ||
     result.conversationsWithInvalidDefaultModelSlug.length ||
     result.conversationsWithInvalidAsyncStatus.length ||
-    result.conversationsWithInvalidVoice.length
+    result.conversationsWithInvalidVoice.length ||
+    result.conversationsWithInvalidMemoryScope.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-invalid-memory-scope.json
+++ b/tests/fixtures/newadvanced-invalid-memory-scope.json
@@ -1,0 +1,32 @@
+[
+  {
+    "title": "Invalid memory scope",
+    "id": "conv-invalid-memory",
+    "memory_scope": "invalid_scope",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["n1"]
+      },
+      "n1": {
+        "id": "n1",
+        "message": {
+          "id": "n1",
+          "author": {"role": "user"},
+          "create_time": 1,
+          "update_time": 1,
+          "content": {"parts": ["hi"]},
+          "recipient": "all",
+          "channel": null,
+          "weight": 0.5
+        },
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- validate `memory_scope` field in `validate-newadvanced-conversations` script with allowed scopes
- add unit test and fixture for invalid `memory_scope`
- mark corresponding advanced TODOs and progress entries as done

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689713eaaa208322ab8dffe4e2b118dc