### PR TITLE
chore: add conversation metadata validation todos

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11421,5 +11421,26 @@
     "task": "Ensure memory_scope uses allowed values",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Plan validation for conversation boolean flags",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure is_archived, is_starred, and is_do_not_remember are boolean when defined",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "planned"
+  },
+  {
+    "commit": "Plan validation for gizmo metadata fields",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Check gizmo_id follows g-<hash> pattern and gizmo_type is a non-empty string",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "planned"
+  },
+  {
+    "commit": "Plan validation for conversation_origin and sugar_item_id",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure conversation_origin and sugar_item_id are strings when present",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "planned"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11419,3 +11419,18 @@
   task: Ensure memory_scope uses allowed values
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Plan validation for conversation boolean flags
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure is_archived, is_starred, and is_do_not_remember are boolean when defined
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: planned
+- commit: Plan validation for gizmo metadata fields
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Check gizmo_id follows g-<hash> pattern and gizmo_type is a non-empty string
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: planned
+- commit: Plan validation for conversation_origin and sugar_item_id
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure conversation_origin and sugar_item_id are strings when present
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: planned

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Validate conversation template and model slug",
+  "lastCommit": "Add conversation metadata validation ToDos",
   "fractalStep": "weiter",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added validation for conversation_template_id and default_model_slug; continue reviewing metadata fields",
+  "notes": "Added ToDo items for boolean flags, gizmo metadata, and origin fields; continue exploring conversation metadata.",
   "pendingTasks": [],
   "progress": [
     {
@@ -698,6 +698,10 @@
     },
     {
       "commit": "Validate conversation template and model slug",
+      "status": "done"
+    },
+    {
+      "commit": "Add conversation metadata validation ToDos",
       "status": "done"
     }
   ],


### PR DESCRIPTION
## Summary
- note planned validation for conversation boolean flags
- note planned validation for gizmo metadata fields
- note planned validation for conversation_origin and sugar_item_id

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68971e076d808322b46b937a55182d48