### PR TITLE
feat: validate conversation metadata fields

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11427,20 +11427,20 @@
     "path": "scripts/validate-newadvanced-conversations.ts",
     "task": "Ensure is_archived, is_starred, and is_do_not_remember are boolean when defined",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
-    "status": "planned"
+    "status": "done"
   },
   {
     "commit": "Plan validation for gizmo metadata fields",
     "path": "scripts/validate-newadvanced-conversations.ts",
     "task": "Check gizmo_id follows g-<hash> pattern and gizmo_type is a non-empty string",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
-    "status": "planned"
+    "status": "done"
   },
   {
     "commit": "Plan validation for conversation_origin and sugar_item_id",
     "path": "scripts/validate-newadvanced-conversations.ts",
     "task": "Ensure conversation_origin and sugar_item_id are strings when present",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
-    "status": "planned"
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11423,14 +11423,14 @@
   path: scripts/validate-newadvanced-conversations.ts
   task: Ensure is_archived, is_starred, and is_do_not_remember are boolean when defined
   test: scripts/validate-newadvanced-conversations.test.ts
-  status: planned
+  status: done
 - commit: Plan validation for gizmo metadata fields
   path: scripts/validate-newadvanced-conversations.ts
   task: Check gizmo_id follows g-<hash> pattern and gizmo_type is a non-empty string
   test: scripts/validate-newadvanced-conversations.test.ts
-  status: planned
+  status: done
 - commit: Plan validation for conversation_origin and sugar_item_id
   path: scripts/validate-newadvanced-conversations.ts
   task: Ensure conversation_origin and sugar_item_id are strings when present
   test: scripts/validate-newadvanced-conversations.test.ts
-  status: planned
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Add conversation metadata validation ToDos",
+  "lastCommit": "Validate conversation metadata fields",
   "fractalStep": "weiter",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added ToDo items for boolean flags, gizmo metadata, and origin fields; continue exploring conversation metadata.",
+  "notes": "Validated boolean flags, gizmo metadata, and origin fields; continue exploring conversation metadata and review docs/sigils.",
   "pendingTasks": [],
   "progress": [
     {
@@ -1158,6 +1158,10 @@
     },
     {
       "commit": "Plan validation for memory_scope field in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Validate conversation boolean flags, gizmo metadata, and origin fields",
       "status": "done"
     },
     {

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -393,4 +393,31 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithInvalidMemoryScope).toEqual([0]);
   });
+
+  it('flags invalid boolean flags', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-boolean-flags.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidBooleanFlags).toEqual([0]);
+  });
+
+  it('flags invalid gizmo metadata fields', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-gizmo-metadata.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidGizmoMetadata).toEqual([0]);
+  });
+
+  it('flags invalid origin fields', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-origin-fields.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidOriginFields).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -52,6 +52,9 @@ export interface ValidationResult {
   conversationsWithInvalidAsyncStatus: number[];
   conversationsWithInvalidVoice: number[];
   conversationsWithInvalidMemoryScope: number[];
+  conversationsWithInvalidBooleanFlags: number[];
+  conversationsWithInvalidGizmoMetadata: number[];
+  conversationsWithInvalidOriginFields: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -106,6 +109,9 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const invalidAsyncStatus: number[] = [];
   const invalidVoice: number[] = [];
   const invalidMemoryScope: number[] = [];
+  const invalidBooleanFlags: number[] = [];
+  const invalidGizmoMetadata: number[] = [];
+  const invalidOriginFields: number[] = [];
   const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   const allowedStatuses = [
     'cancelled',
@@ -206,6 +212,42 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       !allowedMemoryScopes.includes(conv.memory_scope)
     ) {
       invalidMemoryScope.push(idx);
+    }
+
+    if (
+      (conv.is_archived !== undefined &&
+        conv.is_archived !== null &&
+        typeof conv.is_archived !== 'boolean') ||
+      (conv.is_starred !== undefined &&
+        conv.is_starred !== null &&
+        typeof conv.is_starred !== 'boolean') ||
+      (conv.is_do_not_remember !== undefined &&
+        conv.is_do_not_remember !== null &&
+        typeof conv.is_do_not_remember !== 'boolean')
+    ) {
+      invalidBooleanFlags.push(idx);
+    }
+
+    if (
+      (conv.gizmo_id !== undefined &&
+        conv.gizmo_id !== null &&
+        (typeof conv.gizmo_id !== 'string' || !/^g-[a-f0-9]{32}$/.test(conv.gizmo_id))) ||
+      (conv.gizmo_type !== undefined &&
+        conv.gizmo_type !== null &&
+        (typeof conv.gizmo_type !== 'string' || conv.gizmo_type.trim() === ''))
+    ) {
+      invalidGizmoMetadata.push(idx);
+    }
+
+    if (
+      (conv.conversation_origin !== undefined &&
+        conv.conversation_origin !== null &&
+        typeof conv.conversation_origin !== 'string') ||
+      (conv.sugar_item_id !== undefined &&
+        conv.sugar_item_id !== null &&
+        typeof conv.sugar_item_id !== 'string')
+    ) {
+      invalidOriginFields.push(idx);
     }
     if (conv.id) {
       if (!uuidPattern.test(conv.id)) {
@@ -641,6 +683,9 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithInvalidAsyncStatus: invalidAsyncStatus,
     conversationsWithInvalidVoice: invalidVoice,
     conversationsWithInvalidMemoryScope: invalidMemoryScope,
+    conversationsWithInvalidBooleanFlags: invalidBooleanFlags,
+    conversationsWithInvalidGizmoMetadata: invalidGizmoMetadata,
+    conversationsWithInvalidOriginFields: invalidOriginFields,
   };
 }
 
@@ -694,7 +739,10 @@ if (require.main === module) {
     result.conversationsWithInvalidDefaultModelSlug.length ||
     result.conversationsWithInvalidAsyncStatus.length ||
     result.conversationsWithInvalidVoice.length ||
-    result.conversationsWithInvalidMemoryScope.length
+    result.conversationsWithInvalidMemoryScope.length ||
+    result.conversationsWithInvalidBooleanFlags.length ||
+    result.conversationsWithInvalidGizmoMetadata.length ||
+    result.conversationsWithInvalidOriginFields.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-invalid-boolean-flags.json
+++ b/tests/fixtures/newadvanced-invalid-boolean-flags.json
@@ -1,0 +1,31 @@
+[
+  {
+    "title": "Invalid boolean flags",
+    "id": "conv-invalid-bools",
+    "is_archived": "no",
+    "is_starred": 1,
+    "is_do_not_remember": "false",
+    "create_time": 1,
+    "update_time": 1,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["n1"]
+      },
+      "n1": {
+        "id": "n1",
+        "message": {
+          "id": "n1",
+          "author": {"role": "user"},
+          "create_time": 1,
+          "update_time": 1,
+          "content": {"parts": ["hi"]}
+        },
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]

--- a/tests/fixtures/newadvanced-invalid-gizmo-metadata.json
+++ b/tests/fixtures/newadvanced-invalid-gizmo-metadata.json
@@ -1,0 +1,30 @@
+[
+  {
+    "title": "Invalid gizmo metadata",
+    "id": "conv-invalid-gizmo",
+    "gizmo_id": "bad-format",
+    "gizmo_type": "",
+    "create_time": 1,
+    "update_time": 1,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["n1"]
+      },
+      "n1": {
+        "id": "n1",
+        "message": {
+          "id": "n1",
+          "author": {"role": "user"},
+          "create_time": 1,
+          "update_time": 1,
+          "content": {"parts": ["hi"]}
+        },
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]

--- a/tests/fixtures/newadvanced-invalid-origin-fields.json
+++ b/tests/fixtures/newadvanced-invalid-origin-fields.json
@@ -1,0 +1,30 @@
+[
+  {
+    "title": "Invalid origin fields",
+    "id": "conv-invalid-origin",
+    "conversation_origin": 42,
+    "sugar_item_id": false,
+    "create_time": 1,
+    "update_time": 1,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["n1"]
+      },
+      "n1": {
+        "id": "n1",
+        "message": {
+          "id": "n1",
+          "author": {"role": "user"},
+          "create_time": 1,
+          "update_time": 1,
+          "content": {"parts": ["hi"]}
+        },
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- validate optional conversation flags and metadata in new advanced conversations
- test boolean, gizmo and origin validations with dedicated fixtures
- update advanced ToDo and progress tracking

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68972248e1e883228da1891c5363ccfc