### PR TITLE
feat: validate attachment metadata in conversations

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11442,5 +11442,12 @@
     "task": "Ensure conversation_origin and sugar_item_id are strings when present",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Validate attachment metadata in conversations",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure attachments include valid mimeType and fileSizeTokens",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11434,3 +11434,8 @@
   task: Ensure conversation_origin and sugar_item_id are strings when present
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Validate attachment metadata in conversations
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure attachments include valid mimeType and fileSizeTokens
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -703,6 +703,10 @@
     {
       "commit": "Add conversation metadata validation ToDos",
       "status": "done"
+    },
+    {
+      "commit": "Validate attachment metadata in conversations",
+      "status": "done"
     }
   ],
   "completed": [
@@ -1166,7 +1170,11 @@
     },
     {
       "commit": "Review docs/sigils for additional spec insights",
-      "status": "planned"
+      "status": "done"
+    },
+    {
+      "commit": "Validate attachment metadata in conversations",
+      "status": "done"
     }
   ],
   "metacommitTags": [

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -349,6 +349,15 @@ describe('validateNewAdvancedConversations', () => {
     expect(res.conversationsWithMissingAttachments).toEqual([0]);
   });
 
+  it('flags attachments with invalid metadata', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-attachment-metadata.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidAttachmentMetadata).toEqual([0]);
+  });
+
   it('flags invalid conversation_template_id values', () => {
     const file = path.join(
       __dirname,

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -45,6 +45,7 @@ export interface ValidationResult {
   conversationsWithInvalidMessageChannels: number[];
   conversationsWithInvalidMessageRecipients: number[];
   conversationsWithMissingAttachments: number[];
+  conversationsWithInvalidAttachmentMetadata: number[];
   conversationsWithInvalidContentTypes: number[];
   conversationsWithInvalidEndTurn: number[];
   conversationsWithInvalidTemplateId: number[];
@@ -106,6 +107,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const invalidMessageChannels: number[] = [];
   const invalidMessageRecipients: number[] = [];
   const missingAttachments: number[] = [];
+  const invalidAttachmentMetadata: number[] = [];
   const invalidAsyncStatus: number[] = [];
   const invalidVoice: number[] = [];
   const invalidMemoryScope: number[] = [];
@@ -171,6 +173,12 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     'global_enabled',
     'global_disabled',
   ];
+  const mimeByExt: Record<string, string> = {
+    '.md': 'text/markdown',
+    '.json': 'application/json',
+    '.yaml': 'application/x-yaml',
+    '.yml': 'application/x-yaml',
+  };
 
   raw.forEach((conv: any, idx: number) => {
     const seenMessageIds = new Set<string>();
@@ -365,6 +373,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     }
 
     let attachmentMissing = false;
+    let attachmentInvalid = false;
     for (const node of nodes) {
       const atts = node?.message?.metadata?.attachments;
       if (Array.isArray(atts)) {
@@ -375,13 +384,31 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
               attachmentMissing = true;
               break;
             }
+            const ext = path.extname(att.name).toLowerCase();
+            const expected = mimeByExt[ext];
+            if (
+              typeof att.id !== 'string' ||
+              typeof att.mimeType !== 'string' ||
+              typeof att.fileSizeTokens !== 'number' ||
+              att.fileSizeTokens <= 0 ||
+              (expected && att.mimeType !== expected)
+            ) {
+              attachmentInvalid = true;
+              break;
+            }
+          } else {
+            attachmentInvalid = true;
+            break;
           }
         }
       }
-      if (attachmentMissing) break;
+      if (attachmentMissing || attachmentInvalid) break;
     }
     if (attachmentMissing) {
       missingAttachments.push(idx);
+    }
+    if (attachmentInvalid) {
+      invalidAttachmentMetadata.push(idx);
     }
 
     for (const [key, node] of Object.entries(conv.mapping || {}) as [string, any][]) {
@@ -676,6 +703,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithInvalidMessageChannels: invalidMessageChannels,
     conversationsWithInvalidMessageRecipients: invalidMessageRecipients,
     conversationsWithMissingAttachments: missingAttachments,
+    conversationsWithInvalidAttachmentMetadata: invalidAttachmentMetadata,
     conversationsWithInvalidContentTypes: invalidContentTypes,
     conversationsWithInvalidEndTurn: invalidEndTurn,
     conversationsWithInvalidTemplateId: invalidTemplateIds,
@@ -732,6 +760,7 @@ if (require.main === module) {
     result.conversationsWithInvalidMessageStatuses.length ||
     result.conversationsWithInvalidMessageChannels.length ||
     result.conversationsWithInvalidMessageRecipients.length ||
+    result.conversationsWithInvalidAttachmentMetadata.length ||
     result.conversationsWithInvalidContentTypes.length ||
     result.conversationsWithInvalidEndTurn.length ||
     result.conversationsWithMissingAttachments.length ||

--- a/tests/fixtures/newadvanced-invalid-attachment-metadata.json
+++ b/tests/fixtures/newadvanced-invalid-attachment-metadata.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "00000000-0000-0000-0000-0000000000ab",
+    "conversation_id": "00000000-0000-0000-0000-0000000000ab",
+    "title": "Invalid attachment metadata",
+    "create_time": 1,
+    "update_time": 2,
+    "current_node": "client-created-root",
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": {
+          "id": "22222222-2222-2222-2222-222222222223",
+          "author": { "role": "user" },
+          "create_time": 1,
+          "update_time": 1,
+          "content": { "content_type": "text", "parts": ["hi"] },
+          "metadata": {
+            "attachments": [
+              {
+                "id": "file-1",
+                "name": "SIGILLIN_GENESIS.md",
+                "mimeType": "application/json",
+                "fileSizeTokens": 0
+              }
+            ]
+          }
+        },
+        "parent": null,
+        "children": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- validate attachment metadata fields like `mimeType` and `fileSizeTokens`
- test invalid attachment metadata case
- track new validation in advanced ToDo and progress files

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest scripts/validate-newadvanced-conversations.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68972e189a2c8322a7f54e14a7b3c01b