### PR TITLE
Validate message metadata flags in conversations

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-08, in der Zeit des Morgen.
+Am 2025-08-09, in der Zeit des Tag.
 
-Symbolphase: Initiation (Fokus: C)
+Symbolphase: Aktivierung (Fokus: R)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11449,5 +11449,12 @@
     "task": "Ensure attachments include valid mimeType and fileSizeTokens",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Validate message metadata flags in conversations",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure message metadata is an object and is_visually_hidden_from_conversation is boolean when present",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11406,7 +11406,8 @@
   status: done
 - commit: Validate conversation template and model slug
   path: scripts/validate-newadvanced-conversations.ts
-  task: Ensure conversation_template_id matches UUID format and default_model_slug is non-empty
+  task: Ensure conversation_template_id matches UUID format and default_model_slug
+    is non-empty
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
 - commit: Validate conversation async_status and voice fields
@@ -11421,7 +11422,8 @@
   status: done
 - commit: Plan validation for conversation boolean flags
   path: scripts/validate-newadvanced-conversations.ts
-  task: Ensure is_archived, is_starred, and is_do_not_remember are boolean when defined
+  task: Ensure is_archived, is_starred, and is_do_not_remember are boolean when
+    defined
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
 - commit: Plan validation for gizmo metadata fields
@@ -11437,5 +11439,11 @@
 - commit: Validate attachment metadata in conversations
   path: scripts/validate-newadvanced-conversations.ts
   task: Ensure attachments include valid mimeType and fileSizeTokens
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done
+- commit: Validate message metadata flags in conversations
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure message metadata is an object and
+    is_visually_hidden_from_conversation is boolean when present
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,12 +1,14 @@
 {
-  "lastCommit": "Validate conversation metadata fields",
+  "lastCommit": "Validate message metadata flags in conversations",
   "fractalStep": "weiter",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Validated boolean flags, gizmo metadata, and origin fields; continue exploring conversation metadata and review docs/sigils.",
-  "pendingTasks": [],
+  "notes": "Added validation for message metadata flags; continue exploring metadata structure in conversations.",
+  "pendingTasks": [
+    "Expand message metadata schema checks"
+  ],
   "progress": [
     {
       "commit": "Add extract-training-data enhancement ToDos",
@@ -706,6 +708,10 @@
     },
     {
       "commit": "Validate attachment metadata in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Validate message metadata flags in conversations",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -358,6 +358,15 @@ describe('validateNewAdvancedConversations', () => {
     expect(res.conversationsWithInvalidAttachmentMetadata).toEqual([0]);
   });
 
+  it('flags invalid message metadata', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-message-metadata.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidMessageMetadata).toEqual([0]);
+  });
+
   it('flags invalid conversation_template_id values', () => {
     const file = path.join(
       __dirname,

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -56,6 +56,7 @@ export interface ValidationResult {
   conversationsWithInvalidBooleanFlags: number[];
   conversationsWithInvalidGizmoMetadata: number[];
   conversationsWithInvalidOriginFields: number[];
+  conversationsWithInvalidMessageMetadata: number[];
 }
 
 export function validateNewAdvancedConversations(filePath: string): ValidationResult {
@@ -108,6 +109,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const invalidMessageRecipients: number[] = [];
   const missingAttachments: number[] = [];
   const invalidAttachmentMetadata: number[] = [];
+  const invalidMessageMetadata: number[] = [];
   const invalidAsyncStatus: number[] = [];
   const invalidVoice: number[] = [];
   const invalidMemoryScope: number[] = [];
@@ -409,6 +411,30 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     }
     if (attachmentInvalid) {
       invalidAttachmentMetadata.push(idx);
+    }
+
+    let invalidMetadata = false;
+    for (const node of nodes) {
+      const meta = node?.message?.metadata;
+      if (meta !== undefined) {
+        if (typeof meta !== 'object' || Array.isArray(meta)) {
+          invalidMetadata = true;
+          break;
+        }
+        if (
+          Object.prototype.hasOwnProperty.call(
+            meta,
+            'is_visually_hidden_from_conversation'
+          ) &&
+          typeof meta.is_visually_hidden_from_conversation !== 'boolean'
+        ) {
+          invalidMetadata = true;
+          break;
+        }
+      }
+    }
+    if (invalidMetadata) {
+      invalidMessageMetadata.push(idx);
     }
 
     for (const [key, node] of Object.entries(conv.mapping || {}) as [string, any][]) {
@@ -714,6 +740,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithInvalidBooleanFlags: invalidBooleanFlags,
     conversationsWithInvalidGizmoMetadata: invalidGizmoMetadata,
     conversationsWithInvalidOriginFields: invalidOriginFields,
+    conversationsWithInvalidMessageMetadata: invalidMessageMetadata,
   };
 }
 
@@ -771,7 +798,8 @@ if (require.main === module) {
     result.conversationsWithInvalidMemoryScope.length ||
     result.conversationsWithInvalidBooleanFlags.length ||
     result.conversationsWithInvalidGizmoMetadata.length ||
-    result.conversationsWithInvalidOriginFields.length
+    result.conversationsWithInvalidOriginFields.length ||
+    result.conversationsWithInvalidMessageMetadata.length
   ) {
     console.error('Validation issues found:\n', JSON.stringify(result, null, 2));
     process.exit(1);

--- a/tests/fixtures/newadvanced-invalid-message-metadata.json
+++ b/tests/fixtures/newadvanced-invalid-message-metadata.json
@@ -1,0 +1,33 @@
+[
+  {
+    "title": "Invalid message metadata",
+    "id": "conv-invalid-message-metadata",
+    "create_time": 1,
+    "update_time": 2,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["n1"]
+      },
+      "n1": {
+        "id": "n1",
+        "message": {
+          "id": "n1",
+          "author": {"role": "user"},
+          "create_time": 1,
+          "update_time": 1,
+          "content": {"parts": ["hi"]},
+          "status": "finished",
+          "recipient": "all",
+          "channel": null,
+          "weight": 0.5,
+          "metadata": {"is_visually_hidden_from_conversation": "true"}
+        },
+        "parent": "client-created-root",
+        "children": []
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- enforce boolean `is_visually_hidden_from_conversation` metadata in conversation messages
- cover the new metadata check with fixture-based tests
- track metadata validation in advanced progress and ToDo files

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68973f71a104832294787cac6b062af7