### PR TITLE
feat: validate conversation author names

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11456,5 +11456,12 @@
     "task": "Ensure message metadata is an object and is_visually_hidden_from_conversation is boolean when present",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Validate message author names",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure author.name is a non-empty string when defined",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11447,3 +11447,8 @@
     is_visually_hidden_from_conversation is boolean when present
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Validate message author names
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure author.name is a non-empty string when defined
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,14 +1,12 @@
 {
-  "lastCommit": "Validate message metadata flags in conversations",
-  "fractalStep": "weiter",
+  "lastCommit": "test: add invalid author name fixture",
+  "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
   "notes": "Added validation for message metadata flags; continue exploring metadata structure in conversations.",
-  "pendingTasks": [
-    "Expand message metadata schema checks"
-  ],
+  "pendingTasks": [],
   "progress": [
     {
       "commit": "Add extract-training-data enhancement ToDos",
@@ -1180,6 +1178,10 @@
     },
     {
       "commit": "Validate attachment metadata in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Validate message author names",
       "status": "done"
     }
   ],

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -67,6 +67,15 @@ describe('validateNewAdvancedConversations', () => {
     expect(res.conversationsWithMissingRoles).toEqual([0]);
   });
 
+  it('flags nodes with invalid author names', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-author-name.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidAuthorNames).toEqual([0]);
+  });
+
   it('flags conversations with message timestamps outside conversation range', () => {
     const file = path.join(
       __dirname,

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -44,6 +44,7 @@ export interface ValidationResult {
   conversationsWithInvalidMessageStatuses: number[];
   conversationsWithInvalidMessageChannels: number[];
   conversationsWithInvalidMessageRecipients: number[];
+  conversationsWithInvalidAuthorNames: number[];
   conversationsWithMissingAttachments: number[];
   conversationsWithInvalidAttachmentMetadata: number[];
   conversationsWithInvalidContentTypes: number[];
@@ -107,6 +108,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const invalidMessageStatuses: number[] = [];
   const invalidMessageChannels: number[] = [];
   const invalidMessageRecipients: number[] = [];
+  const invalidAuthorNames: number[] = [];
   const missingAttachments: number[] = [];
   const invalidAttachmentMetadata: number[] = [];
   const invalidMessageMetadata: number[] = [];
@@ -372,6 +374,18 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
         invalidRoles.push(idx);
         break;
       }
+    }
+
+    let invalidAuthorName = false;
+    for (const node of nodes) {
+      const name = node?.message?.author?.name;
+      if (name !== undefined && name !== null && (typeof name !== 'string' || name.trim() === '')) {
+        invalidAuthorName = true;
+        break;
+      }
+    }
+    if (invalidAuthorName) {
+      invalidAuthorNames.push(idx);
     }
 
     let attachmentMissing = false;
@@ -728,6 +742,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithInvalidMessageStatuses: invalidMessageStatuses,
     conversationsWithInvalidMessageChannels: invalidMessageChannels,
     conversationsWithInvalidMessageRecipients: invalidMessageRecipients,
+    conversationsWithInvalidAuthorNames: invalidAuthorNames,
     conversationsWithMissingAttachments: missingAttachments,
     conversationsWithInvalidAttachmentMetadata: invalidAttachmentMetadata,
     conversationsWithInvalidContentTypes: invalidContentTypes,
@@ -787,6 +802,7 @@ if (require.main === module) {
     result.conversationsWithInvalidMessageStatuses.length ||
     result.conversationsWithInvalidMessageChannels.length ||
     result.conversationsWithInvalidMessageRecipients.length ||
+    result.conversationsWithInvalidAuthorNames.length ||
     result.conversationsWithInvalidAttachmentMetadata.length ||
     result.conversationsWithInvalidContentTypes.length ||
     result.conversationsWithInvalidEndTurn.length ||

--- a/tests/fixtures/newadvanced-invalid-author-name.json
+++ b/tests/fixtures/newadvanced-invalid-author-name.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000003",
+    "conversation_id": "00000000-0000-0000-0000-000000000003",
+    "title": "Invalid author name",
+    "create_time": 1,
+    "update_time": 2,
+    "current_node": "client-created-root",
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": {
+          "id": "33333333-3333-3333-3333-333333333333",
+          "author": { "role": "user", "name": "" },
+          "create_time": 1,
+          "update_time": 1,
+          "content": { "parts": ["hi"] }
+        },
+        "parent": null,
+        "children": []
+      }
+    }
+  }
+]
+


### PR DESCRIPTION
## Summary
- check `author.name` fields in newadvanced conversations
- test invalid author names and record progress

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689746d10ea08322af425487d07f2c90