### PR TITLE
chore: add conversation moderation and url tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11463,5 +11463,19 @@
     "task": "Ensure author.name is a non-empty string when defined",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Validate moderation results in conversations",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Ensure moderation_results entries include category and flagged fields",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "todo"
+  },
+  {
+    "commit": "Validate blocked and safe URLs in conversations",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Verify blocked_urls and safe_urls contain valid URLs",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "todo"
   }
-]
+ ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11452,3 +11452,13 @@
   task: Ensure author.name is a non-empty string when defined
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Validate moderation results in conversations
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Ensure moderation_results entries include category and flagged fields
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: todo
+- commit: Validate blocked and safe URLs in conversations
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Verify blocked_urls and safe_urls contain valid URLs
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: todo

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1183,6 +1183,10 @@
     {
       "commit": "Validate message author names",
       "status": "done"
+    },
+    {
+      "commit": "Plan moderation and URL validation tasks",
+      "status": "todo"
     }
   ],
   "metacommitTags": [


### PR DESCRIPTION
## Summary
- track pending validation tasks for conversation moderation results
- track TODO for blocked and safe URL validation
- log progress entry for future moderation and URL checks

## Testing
- `npx pyright` (fails: venvPath /workspace/unified-mandala/.venv is not a valid directory)
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68975017c6108322b3485042a515ee07