### PR TITLE
Add NewsBot flow summary tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11666,5 +11666,26 @@
     "task": "Add finetune and review service containers",
     "test": "",
     "status": "todo"
+  },
+  {
+    "commit": "Document NewsBot live cycle flow",
+    "path": "docs/newsbot/flows.md",
+    "status": "todo",
+    "task": "Describe NewsFetch -> ScriptGen -> TTS -> Avatar -> Stream",
+    "test": ""
+  },
+  {
+    "commit": "Document NewsBot training flow",
+    "path": "docs/newsbot/flows.md",
+    "status": "todo",
+    "task": "Explain /training/collect and /finetune leading to new model",
+    "test": ""
+  },
+  {
+    "commit": "Document NewsBot draft and publish flow",
+    "path": "docs/newsbot/flows.md",
+    "status": "todo",
+    "task": "Detail ReviewAgent -> manual gate -> LiveStore -> Stream",
+    "test": ""
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11597,3 +11597,18 @@
   task: Add finetune and review service containers
   test: ''
   status: todo
+- commit: Document NewsBot live cycle flow
+  path: docs/newsbot/flows.md
+  task: Describe NewsFetch -> ScriptGen -> TTS -> Avatar -> Stream
+  test: ''
+  status: todo
+- commit: Document NewsBot training flow
+  path: docs/newsbot/flows.md
+  task: Explain /training/collect and /finetune leading to new model
+  test: ''
+  status: todo
+- commit: Document NewsBot draft and publish flow
+  path: docs/newsbot/flows.md
+  task: Detail ReviewAgent -> manual gate -> LiveStore -> Stream
+  test: ''
+  status: todo


### PR DESCRIPTION
## Summary
- add ToDos for documenting NewsBot live cycle, training, and draft/publish flows

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json --listFiles`

------
https://chatgpt.com/codex/tasks/task_e_6897e2aae4248322ad614e17064f56c8