### PR TITLE
chore: add singularity simulator todos

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12086,5 +12086,47 @@
     "task": "Display ethically grounded refusal messages",
     "test": "packages/unifiedmandala-ui/components/RefusalNotice.test.tsx",
     "status": "todo"
+  },
+  {
+    "commit": "Add Singularity Simulator plugin manifest",
+    "path": "plugins/singularity-simulator.yaml",
+    "task": "Register SingularitySimulatorAgent plugin with growth parameters",
+    "test": "",
+    "status": "todo"
+  },
+  {
+    "commit": "Implement SingularitySimulatorAgent",
+    "path": "agents/singularity_simulator/main.py",
+    "task": "Serve /simulate endpoint for intelligence growth projection",
+    "test": "agents/singularity_simulator/main.test.py",
+    "status": "todo"
+  },
+  {
+    "commit": "Map singularity simulator pipeline",
+    "path": "pipeline_config.yaml",
+    "task": "Map simulate_singularity to singularity-simulator with CREP threshold",
+    "test": "",
+    "status": "todo"
+  },
+  {
+    "commit": "Extend docker-compose with singularity simulator service",
+    "path": "docker-compose.yml",
+    "task": "Add singularity_simulator service with build and ports",
+    "test": "",
+    "status": "todo"
+  },
+  {
+    "commit": "Create SingularitySimulatorPanel component",
+    "path": "packages/unifiedmandala-ui/components/SingularitySimulatorPanel.tsx",
+    "task": "Interactive UI to run Singularity simulation and chart results",
+    "test": "packages/unifiedmandala-ui/components/SingularitySimulatorPanel.test.tsx",
+    "status": "todo"
+  },
+  {
+    "commit": "Define Singularity-Simulator sigillin",
+    "path": "docs/sigillin.examples/singularity-simulator.sigil.yaml",
+    "task": "Poetic sigillin for Singularity Simulator trigger",
+    "test": "scripts/validate-sigillin-examples.ts",
+    "status": "todo"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11900,3 +11900,33 @@
   task: Display ethically grounded refusal messages
   test: "packages/unifiedmandala-ui/components/RefusalNotice.test.tsx"
   status: todo
+- commit: Add Singularity Simulator plugin manifest
+  path: plugins/singularity-simulator.yaml
+  task: Register SingularitySimulatorAgent plugin with growth parameters
+  test: ""
+  status: todo
+- commit: Implement SingularitySimulatorAgent
+  path: agents/singularity_simulator/main.py
+  task: Serve /simulate endpoint for intelligence growth projection
+  test: agents/singularity_simulator/main.test.py
+  status: todo
+- commit: Map singularity simulator pipeline
+  path: pipeline_config.yaml
+  task: Map simulate_singularity to singularity-simulator with CREP threshold
+  test: ""
+  status: todo
+- commit: Extend docker-compose with singularity simulator service
+  path: docker-compose.yml
+  task: Add singularity_simulator service with build and ports
+  test: ""
+  status: todo
+- commit: Create SingularitySimulatorPanel component
+  path: packages/unifiedmandala-ui/components/SingularitySimulatorPanel.tsx
+  task: Interactive UI to run Singularity simulation and chart results
+  test: packages/unifiedmandala-ui/components/SingularitySimulatorPanel.test.tsx
+  status: todo
+- commit: Define Singularity-Simulator sigillin
+  path: docs/sigillin.examples/singularity-simulator.sigil.yaml
+  task: Poetic sigillin for Singularity Simulator trigger
+  test: scripts/validate-sigillin-examples.ts
+  status: todo

--- a/plugins/singularity-simulator.yaml
+++ b/plugins/singularity-simulator.yaml
@@ -1,0 +1,33 @@
+id: singularity-simulator
+title: Singularity Simulator
+type: simulation
+agent: SingularitySimulatorAgent
+entrypoint: agents/singularity_simulator/main.py
+config:
+  base_intelligence: 1.0            # Normierte Baseline (2025)
+  doubling_period_months: 6         # Verdopplung alle 6 Monate
+  merge_advantage_factor: 2.0       # Maximaler Boost-Faktor bei voller Verschmelzung
+  simulation_step_months: 12        # Schrittweite in Monaten für die Ausgabe
+api:
+  /simulate:
+    post:
+      description: Run singularity growth projection
+      request:
+        contentType: application/json
+        body:
+          name: string
+          timeline_years: integer  # 1-50
+          merge_depth: number      # 0.0-1.0
+      response:
+        contentType: application/json
+        body:
+          scenario:
+            name: string
+            timeline_years: integer
+            merge_depth: number
+          results:
+            - time_months: integer
+              year: number
+              raw_intelligence: number
+              merge_boost: number
+              effective_intelligence: number


### PR DESCRIPTION
## Summary
- track tasks for Singularity Simulator plugin, agent, pipeline, docker service, UI and sigillin definition
- cross-reference new tasks in advancedToDo.yaml
- describe `/simulate` request/response JSON schemas in Singularity Simulator plugin manifest

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68986676dccc83228dfe5f7cf26c1c2a