### PR TITLE
Add Singularity Simulator tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12086,5 +12086,54 @@
     "task": "Display ethically grounded refusal messages",
     "test": "packages/unifiedmandala-ui/components/RefusalNotice.test.tsx",
     "status": "todo"
+  },
+  {
+    "commit": "Add Singularity Simulator plugin manifest",
+    "path": "plugins/singularity-simulator.yaml",
+    "task": "Define plugin manifest for SingularitySimulatorAgent",
+    "test": "",
+    "status": "todo"
+  },
+  {
+    "commit": "Implement SingularitySimulatorAgent skeleton",
+    "path": "agents/singularity_simulator/main.py",
+    "task": "FastAPI service for singularity growth simulation",
+    "test": "agents/singularity_simulator/main.test.py",
+    "status": "todo"
+  },
+  {
+    "commit": "Add Dockerfile and requirements for Singularity Simulator agent",
+    "path": "agents/singularity_simulator/Dockerfile",
+    "task": "Create Dockerfile and requirements for Singularity Simulator agent",
+    "test": "agents/singularity_simulator/main.test.py",
+    "status": "todo"
+  },
+  {
+    "commit": "Map simulate_singularity pipeline",
+    "path": "pipeline_config.yaml",
+    "task": "Add singularity-simulator mapping and threshold",
+    "test": "",
+    "status": "todo"
+  },
+  {
+    "commit": "Extend docker-compose with singularity simulator service",
+    "path": "docker-compose.yml",
+    "task": "Add singularity_simulator service definition",
+    "test": "",
+    "status": "todo"
+  },
+  {
+    "commit": "Create SingularitySimulatorPanel component",
+    "path": "packages/unifiedmandala-ui/components/SingularitySimulatorPanel.tsx",
+    "task": "Interactive panel for running singularity simulations",
+    "test": "packages/unifiedmandala-ui/components/SingularitySimulatorPanel.test.tsx",
+    "status": "todo"
+  },
+  {
+    "commit": "Define Singularity Simulator sigillin",
+    "path": "docs/sigils/um-2025-0806-singularity-sim.yaml",
+    "task": "Sigillin to trigger Singularity Simulator",
+    "test": "",
+    "status": "todo"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11900,3 +11900,38 @@
   task: Display ethically grounded refusal messages
   test: "packages/unifiedmandala-ui/components/RefusalNotice.test.tsx"
   status: todo
+- commit: Add Singularity Simulator plugin manifest
+  path: plugins/singularity-simulator.yaml
+  task: Define plugin manifest for SingularitySimulatorAgent
+  test: ""
+  status: todo
+- commit: Implement SingularitySimulatorAgent skeleton
+  path: agents/singularity_simulator/main.py
+  task: FastAPI service for singularity growth simulation
+  test: agents/singularity_simulator/main.test.py
+  status: todo
+- commit: Add Dockerfile and requirements for Singularity Simulator agent
+  path: agents/singularity_simulator/Dockerfile
+  task: Create Dockerfile and requirements for Singularity Simulator agent
+  test: agents/singularity_simulator/main.test.py
+  status: todo
+- commit: Map simulate_singularity pipeline
+  path: pipeline_config.yaml
+  task: Add singularity-simulator mapping and threshold
+  test: ""
+  status: todo
+- commit: Extend docker-compose with singularity simulator service
+  path: docker-compose.yml
+  task: Add singularity_simulator service definition
+  test: ""
+  status: todo
+- commit: Create SingularitySimulatorPanel component
+  path: packages/unifiedmandala-ui/components/SingularitySimulatorPanel.tsx
+  task: Interactive panel for running singularity simulations
+  test: packages/unifiedmandala-ui/components/SingularitySimulatorPanel.test.tsx
+  status: todo
+- commit: Define Singularity Simulator sigillin
+  path: docs/sigils/um-2025-0806-singularity-sim.yaml
+  task: Sigillin to trigger Singularity Simulator
+  test: ""
+  status: todo


### PR DESCRIPTION
## Summary
- track Singularity Simulator plugin and agent setup in repo ToDos
- reference Singularity Simulator panel and sigillin tasks in YAML overview

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68986ec5b8b483228d5936830764c32c