### PR TITLE
feat(chat-migration): log trigger phrases and pending todos

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12148,7 +12148,7 @@
     "path": "scripts/chat_migration/log_triggers.ts",
     "task": "Collect last trigger phrases and open ToDos from advancedToDo.yaml into migration log",
     "test": "scripts/chat_migration/log_triggers.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Initialize core modules for new chat",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11944,7 +11944,7 @@
   path: scripts/chat_migration/log_triggers.ts
   task: Collect last trigger phrases and open ToDos from advancedToDo.yaml into migration log
   test: scripts/chat_migration/log_triggers.test.ts
-  status: todo
+  status: done
 - commit: Initialize core modules for new chat
   path: scripts/chat_migration/init_modules.ts
   task: Load Ethical Refusal, Singularity Simulator, and Weltinnenpolitik-Simulator modules

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1414,6 +1414,10 @@
       "status": "done"
     },
     {
+      "commit": "Log trigger phrases and pending todos",
+      "status": "done"
+    },
+    {
       "commit": "Plan moderation and URL validation tasks",
       "status": "todo"
     }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -2,3 +2,5 @@
 Diese Datei beschreibt MetaCommits, also Arbeitsaufträge, die zu umfangreich für einen einzelnen Commit sind.
 Alle offenen MetaCommits werden in `metacommit.yaml` und `metacommit.json` referenziert.
 Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren deren Aufgaben, bis sie erledigt und die Dateien gelöscht wurden.
+
+- Implemented `log_triggers` script to collect latest trigger phrases and open ToDos for chat migration.

--- a/scripts/chat_migration/log_triggers.test.ts
+++ b/scripts/chat_migration/log_triggers.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { promises as fs } from 'fs';
+import { logTriggers } from './log_triggers';
+
+describe('logTriggers', () => {
+  it('writes trigger phrases and open todos to log file', async () => {
+    const conversationsPath = path.join(__dirname, '../../tests/fixtures/sample-newadvancedconversations.json');
+    const todoPath = path.join(__dirname, '../../tests/fixtures/sample-advancedToDo.yaml');
+    const outPath = path.join(__dirname, 'tmp-migration-log.json');
+
+    await fs.rm(outPath, { force: true });
+
+    const result = await logTriggers({
+      conversationsPath,
+      todoPath,
+      outPath,
+      limit: 2,
+    });
+
+    const written = JSON.parse(await fs.readFile(outPath, 'utf8'));
+    expect(written).toEqual(result);
+    expect(result.triggerPhrases).toEqual(['Beta', 'Gamma']);
+    expect(result.openTodos).toEqual(['pending task']);
+
+    await fs.rm(outPath, { force: true });
+  });
+});

--- a/scripts/chat_migration/log_triggers.ts
+++ b/scripts/chat_migration/log_triggers.ts
@@ -1,0 +1,49 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+interface LogOptions {
+  conversationsPath?: string;
+  todoPath?: string;
+  outPath?: string;
+  limit?: number;
+}
+
+export async function logTriggers(options: LogOptions = {}) {
+  const conversationsPath = options.conversationsPath || path.resolve('docs/sigils/newadvancedconversations.json');
+  const todoPath = options.todoPath || path.resolve('advancedToDo.yaml');
+  const outPath = options.outPath || path.resolve('scripts/chat_migration/migration_log.json');
+  const limit = options.limit ?? 5;
+
+  // Load conversations and extract latest titles as trigger phrases
+  const convRaw = await fs.readFile(conversationsPath, 'utf8');
+  let convos: any[] = [];
+  try {
+    convos = JSON.parse(convRaw);
+    if (!Array.isArray(convos)) {
+      throw new Error('Expected conversations JSON array');
+    }
+  } catch (err) {
+    throw new Error(`Failed to parse conversations at ${conversationsPath}: ${err}`);
+  }
+  const triggerPhrases = convos.slice(-limit).map(c => c.title).filter(Boolean);
+
+  // Load advanced ToDos and filter open ones
+  const todoRaw = await fs.readFile(todoPath, 'utf8');
+  const todos = (yaml.load(todoRaw) as any[]) || [];
+  const openTodos = todos
+    .filter(t => t && t.commit && t.status !== 'done')
+    .map(t => t.commit as string);
+
+  const log = { triggerPhrases, openTodos };
+  await fs.mkdir(path.dirname(outPath), { recursive: true });
+  await fs.writeFile(outPath, JSON.stringify(log, null, 2));
+  return log;
+}
+
+if (require.main === module) {
+  logTriggers().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/fixtures/sample-advancedToDo.yaml
+++ b/tests/fixtures/sample-advancedToDo.yaml
@@ -1,0 +1,4 @@
+- commit: completed task
+  status: done
+- commit: pending task
+  status: todo

--- a/tests/fixtures/sample-newadvancedconversations.json
+++ b/tests/fixtures/sample-newadvancedconversations.json
@@ -1,0 +1,5 @@
+[
+  {"title": "Alpha"},
+  {"title": "Beta"},
+  {"title": "Gamma"}
+]


### PR DESCRIPTION
## Summary
- add log_triggers script to capture recent conversation titles and pending advanced ToDos
- mark log_triggers task complete and record progress update
- note addition in feedbackcodex

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx vitest run scripts/chat_migration/log_triggers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6898933bfa488322813068e9d7379c84