### PR TITLE
feat: export sigillin for chat migration

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12141,7 +12141,7 @@
     "path": "scripts/chat_migration/export_sigillin.ts",
     "task": "Export all active Sigillin from GenesisAeonZIPMEM into JSON and YAML files",
     "test": "scripts/chat_migration/export_sigillin.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Log trigger phrases and pending todos",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11939,7 +11939,7 @@
   path: scripts/chat_migration/export_sigillin.ts
   task: Export all active Sigillin from GenesisAeonZIPMEM into JSON and YAML files
   test: scripts/chat_migration/export_sigillin.test.ts
-  status: todo
+  status: done
 - commit: Log trigger phrases and pending todos
   path: scripts/chat_migration/log_triggers.ts
   task: Collect last trigger phrases and open ToDos from advancedToDo.yaml into migration log

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5,7 +5,7 @@
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added validation for message metadata flags; continue exploring metadata structure in conversations.",
+  "notes": "Added validation for message metadata flags; continue exploring metadata structure in conversations. Implemented Sigillin export for chat migration.",
   "pendingTasks": [
     {
       "commit": "Validate moderation results in conversations",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -4,3 +4,4 @@ Alle offenen MetaCommits werden in `metacommit.yaml` und `metacommit.json` refer
 Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren deren Aufgaben, bis sie erledigt und die Dateien gelöscht wurden.
 
 - Implemented `log_triggers` script to collect latest trigger phrases and open ToDos for chat migration.
+- Implemented `export_sigillin` script to aggregate active Sigillin into JSON and YAML for chat migration.

--- a/scripts/chat_migration/export_sigillin.test.ts
+++ b/scripts/chat_migration/export_sigillin.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { promises as fs } from 'fs';
+import yaml from 'js-yaml';
+import { exportSigillin } from './export_sigillin';
+
+describe('exportSigillin', () => {
+  it('exports sigils to JSON and YAML files', async () => {
+    const memoryPath = path.join(__dirname, '../../tests/fixtures/sample-sigils');
+    const outJsonPath = path.join(__dirname, 'tmp-sigils.json');
+    const outYamlPath = path.join(__dirname, 'tmp-sigils.yaml');
+
+    await fs.rm(outJsonPath, { force: true });
+    await fs.rm(outYamlPath, { force: true });
+
+    const result = await exportSigillin({ memoryPath, outJsonPath, outYamlPath });
+
+    const writtenJson = JSON.parse(await fs.readFile(outJsonPath, 'utf8'));
+    const writtenYaml = yaml.load(await fs.readFile(outYamlPath, 'utf8')) as any;
+
+    expect(writtenJson).toEqual(result);
+    expect(writtenYaml).toEqual(result);
+    expect(result.length).toBe(2);
+
+    await fs.rm(outJsonPath, { force: true });
+    await fs.rm(outYamlPath, { force: true });
+  });
+});

--- a/scripts/chat_migration/export_sigillin.ts
+++ b/scripts/chat_migration/export_sigillin.ts
@@ -1,0 +1,52 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+interface ExportOptions {
+  memoryPath?: string;
+  outJsonPath?: string;
+  outYamlPath?: string;
+}
+
+async function collectSigils(dir: string, base: string): Promise<any[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const results: any[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...await collectSigils(full, base));
+    } else if (entry.isFile()) {
+      if (/conversations/i.test(entry.name)) continue;
+      const rel = path.relative(base, full);
+      if (entry.name.endsWith('.yaml') || entry.name.endsWith('.yml')) {
+        const data = yaml.load(await fs.readFile(full, 'utf8'));
+        results.push({ file: rel, data });
+      } else if (entry.name.endsWith('.json')) {
+        const data = JSON.parse(await fs.readFile(full, 'utf8'));
+        results.push({ file: rel, data });
+      }
+    }
+  }
+  return results;
+}
+
+export async function exportSigillin(options: ExportOptions = {}) {
+  const memoryPath = options.memoryPath || path.resolve('docs/sigils');
+  const outJsonPath = options.outJsonPath || path.resolve('scripts/chat_migration/exported_sigillin.json');
+  const outYamlPath = options.outYamlPath || path.resolve('scripts/chat_migration/exported_sigillin.yaml');
+
+  const sigils = await collectSigils(memoryPath, memoryPath);
+
+  await fs.mkdir(path.dirname(outJsonPath), { recursive: true });
+  await fs.writeFile(outJsonPath, JSON.stringify(sigils, null, 2));
+  await fs.writeFile(outYamlPath, yaml.dump(sigils));
+
+  return sigils;
+}
+
+if (require.main === module) {
+  exportSigillin().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/fixtures/sample-sigils/alpha.yaml
+++ b/tests/fixtures/sample-sigils/alpha.yaml
@@ -1,0 +1,2 @@
+name: Alpha
+active: true

--- a/tests/fixtures/sample-sigils/beta.json
+++ b/tests/fixtures/sample-sigils/beta.json
@@ -1,0 +1,4 @@
+{
+  "name": "Beta",
+  "active": true
+}


### PR DESCRIPTION
## Summary
- add `export_sigillin` script to gather Sigillin definitions and output combined JSON/YAML files
- test coverage for Sigillin export and update advanced task statuses and progress notes

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest scripts/chat_migration/export_sigillin.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6898c63ee81483228f454a4ea5add784