### PR TITLE
Validate moderation results and URL lists

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11469,14 +11469,14 @@
     "path": "scripts/validate-newadvanced-conversations.ts",
     "task": "Ensure moderation_results entries include category and flagged fields",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Validate blocked and safe URLs in conversations",
     "path": "scripts/validate-newadvanced-conversations.ts",
     "task": "Verify blocked_urls and safe_urls contain valid URLs",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add agent profile switching to ChatPanel",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11456,12 +11456,12 @@
   path: scripts/validate-newadvanced-conversations.ts
   task: Ensure moderation_results entries include category and flagged fields
   test: scripts/validate-newadvanced-conversations.test.ts
-  status: todo
+  status: done
 - commit: Validate blocked and safe URLs in conversations
   path: scripts/validate-newadvanced-conversations.ts
   task: Verify blocked_urls and safe_urls contain valid URLs
   test: scripts/validate-newadvanced-conversations.test.ts
-  status: todo
+  status: done
 - commit: Add agent profile switching to ChatPanel
   path: packages/unifiedmandala-ui/components/ChatPanel.tsx
   task: Allow ChatPanel to switch between local and external agent backends and

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5,15 +5,15 @@
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added validation for message metadata flags; continue exploring metadata structure in conversations. Implemented Sigillin export for chat migration.",
+  "notes": "Added validation for message metadata flags; continue exploring metadata structure in conversations. Implemented Sigillin export for chat migration. Completed validation for moderation results and URL lists.",
   "pendingTasks": [
     {
       "commit": "Validate moderation results in conversations",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Validate blocked and safe URLs in conversations",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Add agent profile switching to ChatPanel",

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -447,4 +447,31 @@ describe('validateNewAdvancedConversations', () => {
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithInvalidOriginFields).toEqual([0]);
   });
+
+  it('flags invalid moderation results', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-moderation-results.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidModerationResults).toEqual([0]);
+  });
+
+  it('flags invalid blocked urls', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-blocked-urls.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidBlockedUrls).toEqual([0]);
+  });
+
+  it('flags invalid safe urls', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-safe-urls.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidSafeUrls).toEqual([0]);
+  });
 });

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -41,6 +41,7 @@ export interface ValidationResult {
   conversationsWithInvalidDisabledToolIds: number[];
   conversationsWithInvalidBlockedUrls: number[];
   conversationsWithInvalidSafeUrls: number[];
+  conversationsWithInvalidModerationResults: number[];
   conversationsWithInvalidMessageStatuses: number[];
   conversationsWithInvalidMessageChannels: number[];
   conversationsWithInvalidMessageRecipients: number[];
@@ -105,6 +106,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const invalidDisabledToolIds: number[] = [];
   const invalidBlockedUrls: number[] = [];
   const invalidSafeUrls: number[] = [];
+  const invalidModerationResults: number[] = [];
   const invalidMessageStatuses: number[] = [];
   const invalidMessageChannels: number[] = [];
   const invalidMessageRecipients: number[] = [];
@@ -295,7 +297,15 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     if (conv.blocked_urls !== undefined) {
       if (
         !Array.isArray(conv.blocked_urls) ||
-        conv.blocked_urls.some((u: any) => typeof u !== 'string')
+        conv.blocked_urls.some((u: any) => {
+          if (typeof u !== 'string') return true;
+          try {
+            new URL(u);
+            return false;
+          } catch {
+            return true;
+          }
+        })
       ) {
         invalidBlockedUrls.push(idx);
       }
@@ -303,9 +313,30 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     if (conv.safe_urls !== undefined) {
       if (
         !Array.isArray(conv.safe_urls) ||
-        conv.safe_urls.some((u: any) => typeof u !== 'string')
+        conv.safe_urls.some((u: any) => {
+          if (typeof u !== 'string') return true;
+          try {
+            new URL(u);
+            return false;
+          } catch {
+            return true;
+          }
+        })
       ) {
         invalidSafeUrls.push(idx);
+      }
+    }
+    if (conv.moderation_results !== undefined) {
+      if (
+        !Array.isArray(conv.moderation_results) ||
+        conv.moderation_results.some(
+          (m: any) =>
+            typeof m !== 'object' ||
+            typeof m.category !== 'string' ||
+            typeof m.flagged !== 'boolean'
+        )
+      ) {
+        invalidModerationResults.push(idx);
       }
     }
     if (
@@ -739,6 +770,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationsWithInvalidDisabledToolIds: invalidDisabledToolIds,
     conversationsWithInvalidBlockedUrls: invalidBlockedUrls,
     conversationsWithInvalidSafeUrls: invalidSafeUrls,
+    conversationsWithInvalidModerationResults: invalidModerationResults,
     conversationsWithInvalidMessageStatuses: invalidMessageStatuses,
     conversationsWithInvalidMessageChannels: invalidMessageChannels,
     conversationsWithInvalidMessageRecipients: invalidMessageRecipients,
@@ -799,6 +831,7 @@ if (require.main === module) {
     result.conversationsWithInvalidDisabledToolIds.length ||
     result.conversationsWithInvalidBlockedUrls.length ||
     result.conversationsWithInvalidSafeUrls.length ||
+    result.conversationsWithInvalidModerationResults.length ||
     result.conversationsWithInvalidMessageStatuses.length ||
     result.conversationsWithInvalidMessageChannels.length ||
     result.conversationsWithInvalidMessageRecipients.length ||

--- a/tests/fixtures/newadvanced-invalid-blocked-urls.json
+++ b/tests/fixtures/newadvanced-invalid-blocked-urls.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000200",
+    "conversation_id": "00000000-0000-0000-0000-000000000200",
+    "title": "Invalid blocked URLs",
+    "create_time": 1,
+    "update_time": 2,
+    "current_node": "root",
+    "mapping": {
+      "root": {
+        "id": "root",
+        "message": {
+          "id": "00000000-0000-0000-0000-000000000201",
+          "author": { "role": "user" },
+          "create_time": 1,
+          "update_time": 1,
+          "content": { "parts": ["hi"] }
+        },
+        "parent": null,
+        "children": []
+      }
+    },
+    "blocked_urls": ["not a url"]
+  }
+]

--- a/tests/fixtures/newadvanced-invalid-moderation-results.json
+++ b/tests/fixtures/newadvanced-invalid-moderation-results.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000100",
+    "conversation_id": "00000000-0000-0000-0000-000000000100",
+    "title": "Invalid moderation results",
+    "create_time": 1,
+    "update_time": 2,
+    "current_node": "root",
+    "mapping": {
+      "root": {
+        "id": "root",
+        "message": {
+          "id": "00000000-0000-0000-0000-000000000101",
+          "author": { "role": "user" },
+          "create_time": 1,
+          "update_time": 1,
+          "content": { "parts": ["hi"] }
+        },
+        "parent": null,
+        "children": []
+      }
+    },
+    "moderation_results": [
+      { "category": "violence", "flagged": "yes" }
+    ]
+  }
+]

--- a/tests/fixtures/newadvanced-invalid-safe-urls.json
+++ b/tests/fixtures/newadvanced-invalid-safe-urls.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000300",
+    "conversation_id": "00000000-0000-0000-0000-000000000300",
+    "title": "Invalid safe URLs",
+    "create_time": 1,
+    "update_time": 2,
+    "current_node": "root",
+    "mapping": {
+      "root": {
+        "id": "root",
+        "message": {
+          "id": "00000000-0000-0000-0000-000000000301",
+          "author": { "role": "user" },
+          "create_time": 1,
+          "update_time": 1,
+          "content": { "parts": ["hi"] }
+        },
+        "parent": null,
+        "children": []
+      }
+    },
+    "safe_urls": ["not a url"]
+  }
+]


### PR DESCRIPTION
## Summary
- extend conversation validator to check moderation_results and ensure blocked_urls/safe_urls are valid URLs
- add tests and fixtures for moderation and URL validation
- mark related tasks done in advanced progress files

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`
- `npx ts-node scripts/validate-newadvanced-conversations.ts tests/fixtures/sample-newadvancedconversations.json`


------
https://chatgpt.com/codex/tasks/task_e_6898d6ba2a3083228743c46c444665ad