### PR TITLE
feat: add chat transition bootstrap

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12162,7 +12162,7 @@
     "path": "scripts/chat_migration/bootstrap_new_chat.ts",
     "task": "Run SigillinLoader.load calls and start new chat with Mandala state prompt",
     "test": "scripts/chat_migration/bootstrap_new_chat.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add open-source chat services to compose",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11954,7 +11954,7 @@
   path: scripts/chat_migration/bootstrap_new_chat.ts
   task: Run SigillinLoader.load calls and start new chat with Mandala state prompt
   test: scripts/chat_migration/bootstrap_new_chat.test.ts
-  status: todo
+  status: done
 - commit: Add open-source chat services to compose
   path: docker-compose.yml
   task: Define GPT4All, OpenAssistant, h2oGPT, text-generation-webui and AutoGen microservices

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1426,6 +1426,10 @@
       "status": "done"
     },
     {
+      "commit": "Create chat transition bootstrap",
+      "status": "done"
+    },
+    {
       "commit": "Plan moderation and URL validation tasks",
       "status": "todo"
     }

--- a/scripts/chat_migration/bootstrap_new_chat.test.ts
+++ b/scripts/chat_migration/bootstrap_new_chat.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { bootstrapNewChat, SIGILLIN_IDS, SigillinLoader } from './bootstrap_new_chat';
+
+describe('bootstrapNewChat', () => {
+  it('loads predefined sigillin ids and returns prompt', async () => {
+    const loaded: string[] = [];
+    const loader: SigillinLoader = {
+      load(id: string) {
+        loaded.push(id);
+      }
+    };
+
+    const prompt = await bootstrapNewChat(loader);
+
+    expect(loaded).toEqual(SIGILLIN_IDS);
+    expect(prompt).toMatch(/Mandala state/);
+  });
+});

--- a/scripts/chat_migration/bootstrap_new_chat.ts
+++ b/scripts/chat_migration/bootstrap_new_chat.ts
@@ -1,0 +1,27 @@
+export interface SigillinLoader {
+  load(id: string): void | Promise<void>;
+}
+
+export const SIGILLIN_IDS = [
+  'um:2025-0806-ANCHOR-NEWADV',
+  'um:2025-0806-GOV-SIM',
+  'um:2025-0806-SINGULARITY-SIM'
+];
+
+const defaultLoader: SigillinLoader = {
+  load(id: string) {
+    console.log(`Loading sigillin ${id}`);
+  }
+};
+
+export async function bootstrapNewChat(loader: SigillinLoader = defaultLoader) {
+  for (const id of SIGILLIN_IDS) {
+    await loader.load(id);
+  }
+  const prompt = 'Mandala state ready';
+  return prompt;
+}
+
+if (require.main === module) {
+  bootstrapNewChat().then(p => console.log(p));
+}


### PR DESCRIPTION
## Summary
- add `bootstrap_new_chat` script to preload sigillin anchors and return a Mandala state prompt
- cover chat bootstrap with a Vitest unit test
- mark chat transition bootstrap as done in advanced ToDo and progress logs

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test:agents scripts/chat_migration/bootstrap_new_chat.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6898f46abe0083229dd1ce38781a90d6