### PR TITLE
feat: add refusal notice component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12085,7 +12085,7 @@
     "path": "packages/unifiedmandala-ui/components/RefusalNotice.tsx",
     "task": "Display ethically grounded refusal messages",
     "test": "packages/unifiedmandala-ui/components/RefusalNotice.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add Singularity Simulator plugin manifest",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11899,7 +11899,7 @@
   path: packages/unifiedmandala-ui/components/RefusalNotice.tsx
   task: Display ethically grounded refusal messages
   test: "packages/unifiedmandala-ui/components/RefusalNotice.test.tsx"
-  status: todo
+  status: done
 - commit: Add Singularity Simulator plugin manifest
   path: plugins/singularity-simulator.yaml
   task: Define plugin manifest for SingularitySimulatorAgent

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1446,6 +1446,10 @@
       "status": "done"
     },
     {
+      "commit": "Create RefusalNotice component",
+      "status": "done"
+    },
+    {
       "commit": "Plan moderation and URL validation tasks",
       "status": "todo"
     }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -9,3 +9,5 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 
 - Added onboarding service catalog and agent service mapping configurations.
 - Added DefensiveShieldAgent plugin and sanitization service.
+
+- Implemented RefusalNotice component to show ethical refusal messages.

--- a/packages/unifiedmandala-ui/components/RefusalNotice.test.tsx
+++ b/packages/unifiedmandala-ui/components/RefusalNotice.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import RefusalNotice from './RefusalNotice';
+
+test('displays refusal message', () => {
+  render(<RefusalNotice message="Policy prohibits this action" />);
+  expect(screen.getByText('Policy prohibits this action')).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/RefusalNotice.tsx
+++ b/packages/unifiedmandala-ui/components/RefusalNotice.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export interface RefusalNoticeProps {
+  message: string;
+}
+
+const RefusalNotice: React.FC<RefusalNoticeProps> = ({ message }) => (
+  <div role="alert" aria-label="refusal notice">
+    <p>{message}</p>
+  </div>
+);
+
+export default RefusalNotice;


### PR DESCRIPTION
## Summary
- add `RefusalNotice` UI component to display ethical refusal messages
- mark RefusalNotice task complete in advanced ToDo tracker and progress log
- record addition in feedback codex

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest packages/unifiedmandala-ui/components/RefusalNotice.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68992b75d7788322bfd4d90349ff1150