### PR TITLE
feat: add SentimentBadge component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11999,7 +11999,7 @@
   {
     "commit": "Create SentimentBadge component",
     "path": "packages/unifiedmandala-ui/components/SentimentBadge.tsx",
-    "status": "todo",
+    "status": "done",
     "task": "Show real-time sentiment analysis badge",
     "test": "packages/unifiedmandala-ui/components/SentimentBadge.test.tsx"
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11839,7 +11839,7 @@
   path: packages/unifiedmandala-ui/components/SentimentBadge.tsx
   task: Show real-time sentiment analysis badge
   test: packages/unifiedmandala-ui/components/SentimentBadge.test.tsx
-  status: todo
+  status: done
 - commit: Create ArtGallery component
   path: packages/unifiedmandala-ui/components/ArtGallery.tsx
   task: Render generative art pieces

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: integrate singularity simulator pipeline",
+  "lastCommit": "feat: add SentimentBadge component",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added validation for message metadata flags; continue exploring metadata structure in conversations. Implemented Sigillin export for chat migration. Completed validation for moderation results and URL lists.",
+  "notes": "Added SentimentBadge UI component and updated advanced ToDo entries. Previous: validation for message metadata flags; continue exploring metadata structure in conversations. Implemented Sigillin export for chat migration. Completed validation for moderation results and URL lists.",
   "pendingTasks": [
     {
       "commit": "Add agent profile switching to ChatPanel",

--- a/packages/unifiedmandala-ui/components/SentimentBadge.test.tsx
+++ b/packages/unifiedmandala-ui/components/SentimentBadge.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SentimentBadge from './SentimentBadge';
+
+test('renders positive sentiment', () => {
+  render(<SentimentBadge score={0.5} />);
+  const badge = screen.getByTestId('sentiment-badge');
+  expect(badge).toHaveTextContent('positive');
+});
+
+test('renders negative sentiment', () => {
+  render(<SentimentBadge score={-0.7} />);
+  const badge = screen.getByTestId('sentiment-badge');
+  expect(badge).toHaveTextContent('negative');
+});
+
+test('renders neutral sentiment for zero score', () => {
+  render(<SentimentBadge score={0} />);
+  const badge = screen.getByTestId('sentiment-badge');
+  expect(badge).toHaveTextContent('neutral');
+});
+
+test('renders neutral sentiment for slight positive score', () => {
+  render(<SentimentBadge score={0.19} />);
+  const badge = screen.getByTestId('sentiment-badge');
+  expect(badge).toHaveTextContent('neutral');
+});

--- a/packages/unifiedmandala-ui/components/SentimentBadge.tsx
+++ b/packages/unifiedmandala-ui/components/SentimentBadge.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface SentimentBadgeProps {
+  /** Sentiment score between -1 (negative) and 1 (positive) */
+  score: number;
+}
+
+/**
+ * Displays a badge representing sentiment based on score.
+ */
+const SentimentBadge: React.FC<SentimentBadgeProps> = ({ score }) => {
+  const label = score > 0.2 ? 'positive' : score < -0.2 ? 'negative' : 'neutral';
+  const color = label === 'positive' ? 'green' : label === 'negative' ? 'red' : 'gray';
+  return (
+    <span
+      data-testid="sentiment-badge"
+      style={{
+        backgroundColor: color,
+        color: 'white',
+        padding: '0.25rem 0.5rem',
+        borderRadius: '4px',
+        textTransform: 'capitalize',
+      }}
+    >
+      {label}
+    </span>
+  );
+};
+
+export default SentimentBadge;


### PR DESCRIPTION
## Summary
- add SentimentBadge component for visualizing sentiment scores
- mark SentimentBadge todo entries complete and update progress log
- test neutral sentiment cases to cover all branches

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json --noEmit`
- `npx jest packages/unifiedmandala-ui/components/SentimentBadge.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6899385856f88322bf359f7368cefaa4