### PR TITLE
feat: add open-source chat services

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12169,14 +12169,14 @@
     "path": "docker-compose.yml",
     "task": "Define GPT4All, OpenAssistant, h2oGPT, text-generation-webui and AutoGen microservices",
     "test": "",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Map chat services in pipeline config",
     "path": "pipeline_config.yaml",
     "task": "Link gpt4all, openassistant, and h2ogpt services with CREP thresholds",
     "test": "",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Schedule nightly model fine-tuning",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11962,12 +11962,12 @@
   task: Define GPT4All, OpenAssistant, h2oGPT, text-generation-webui and AutoGen
     microservices
   test: ""
-  status: todo
+  status: done
 - commit: Map chat services in pipeline config
   path: pipeline_config.yaml
   task: Link gpt4all, openassistant, and h2ogpt services with CREP thresholds
   test: ""
-  status: todo
+  status: done
 - commit: Schedule nightly model fine-tuning
   path: memory-jobs.yaml
   task: Add fine_tune_models cron calling Mistral CodeAgent

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -337,11 +337,11 @@
     },
     {
       "commit": "Add open-source chat services to compose",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Map chat services in pipeline config",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Schedule nightly model fine-tuning",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,3 +58,29 @@ services:
       context: ./agents/singularity_simulator
     ports:
       - "8107:8000"
+
+  # --- Open-source chat services ---
+  gpt4all_service:
+    image: ghcr.io/nomic-ai/gpt4all:latest
+    ports:
+      - "8201:80"
+
+  openassistant_service:
+    image: ghcr.io/laion-ai/open-assistant:latest
+    ports:
+      - "8202:80"
+
+  h2ogpt_service:
+    image: ghcr.io/h2oai/h2ogpt-server:latest
+    ports:
+      - "8203:80"
+
+  text_generation_webui_service:
+    image: ghcr.io/oobabooga/text-generation-webui:latest
+    ports:
+      - "8204:7860"
+
+  autogen_service:
+    image: ghcr.io/microsoft/autogen:latest
+    ports:
+      - "8205:80"

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -13,3 +13,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented RefusalNotice component to show ethical refusal messages.
 - Added singularity simulator service and pipeline mapping for advanced simulations.
 - Added EthicsPolicy agent and plugin.
+- Integrated open-source chat microservices and linked them in the pipeline configuration.

--- a/unifiedmandala-orchestrator/orchestrator/pipeline_config.yaml
+++ b/unifiedmandala-orchestrator/orchestrator/pipeline_config.yaml
@@ -7,6 +7,9 @@ sigillin_map:
   physics_sim:      kan_service
   on_device_task:   npu_service
   simulate_singularity: singularity_simulator_service
+  gpt4all_chat:     gpt4all_service
+  openassistant_chat: openassistant_service
+  h2ogpt_chat:      h2ogpt_service
 
 crep_thresholds:
   gnn_service: 0.60
@@ -17,3 +20,6 @@ crep_thresholds:
   kan_service: 0.70
   npu_service: 0.50
   singularity_simulator_service: 0.75
+  gpt4all_service: 0.55
+  openassistant_service: 0.60
+  h2ogpt_service: 0.58


### PR DESCRIPTION
## Summary
- add GPT4All, OpenAssistant, h2oGPT, text-generation-webui and AutoGen microservices to docker compose
- map new chat services into orchestrator pipeline config with CREP thresholds
- mark related advanced tasks done and log change in feedback codex

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6899ac615a3083228f0ef9031d9dc0b7