### PR TITLE
feat(ui): add security dashboard component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12071,7 +12071,7 @@
     "path": "packages/unifiedmandala-ui/components/SecurityDashboard.tsx",
     "task": "Visualize vulnerabilities from security scans",
     "test": "packages/unifiedmandala-ui/components/SecurityDashboard.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Create GovernanceSimulatorPanel component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11889,7 +11889,7 @@
   path: packages/unifiedmandala-ui/components/SecurityDashboard.tsx
   task: Visualize vulnerabilities from security scans
   test: packages/unifiedmandala-ui/components/SecurityDashboard.test.tsx
-  status: todo
+  status: done
 - commit: Create GovernanceSimulatorPanel component
   path: packages/unifiedmandala-ui/components/GovernanceSimulatorPanel.tsx
   task: Run world policy simulations interactively

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -325,7 +325,7 @@
     },
     {
       "commit": "Create SecurityDashboard component",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Create GovernanceSimulatorPanel component",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -14,3 +14,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added singularity simulator service and pipeline mapping for advanced simulations.
 - Added EthicsPolicy agent and plugin.
 - Integrated open-source chat microservices and linked them in the pipeline configuration.
+- Implemented SecurityDashboard component for vulnerability visualization.

--- a/packages/unifiedmandala-ui/components/SecurityDashboard.test.tsx
+++ b/packages/unifiedmandala-ui/components/SecurityDashboard.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SecurityDashboard from './SecurityDashboard';
+
+test('renders vulnerabilities', () => {
+  const vulnerabilities: { id: string; description: string; severity: 'high' | 'medium' | 'low' }[] = [
+    { id: '1', description: 'SQL injection', severity: 'high' },
+    { id: '2', description: 'XSS issue', severity: 'medium' }
+  ];
+  render(<SecurityDashboard vulnerabilities={vulnerabilities} />);
+  expect(screen.getByText(/SQL injection/)).toBeInTheDocument();
+  expect(screen.getByText(/XSS issue/)).toBeInTheDocument();
+  expect(screen.getByText(/HIGH/)).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/SecurityDashboard.tsx
+++ b/packages/unifiedmandala-ui/components/SecurityDashboard.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export interface Vulnerability {
+  id: string;
+  description: string;
+  severity: 'low' | 'medium' | 'high';
+}
+
+export interface SecurityDashboardProps {
+  vulnerabilities: Vulnerability[];
+}
+
+const SecurityDashboard: React.FC<SecurityDashboardProps> = ({ vulnerabilities }) => (
+  <div>
+    <h2>Security Dashboard</h2>
+    <ul>
+      {vulnerabilities.map((v) => (
+        <li key={v.id}>
+          <strong>{v.severity.toUpperCase()}:</strong> {v.description}
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default SecurityDashboard;


### PR DESCRIPTION
## Summary
- add SecurityDashboard component to visualize scan vulnerabilities
- mark SecurityDashboard task as complete in advancedToDo and progress
- log component addition in feedback codex

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx tsc -p tsconfig.json` *(no output, command hung)*
- `npx pyright` *(no output, command hung)*
- `pnpm test packages/unifiedmandala-ui/components/SecurityDashboard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6899b2454e8c83229d8da7f95d6d2415