### PR TITLE
feat: enable agent backend switching in ChatPanel

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11483,7 +11483,7 @@
     "path": "packages/unifiedmandala-ui/components/ChatPanel.tsx",
     "task": "Allow ChatPanel to switch between local and external agent backends and show service toolbar",
     "test": "packages/unifiedmandala-ui/components/ChatPanel.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Create AgentControlPanel component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11467,7 +11467,7 @@
   task: Allow ChatPanel to switch between local and external agent backends and
     show service toolbar
   test: packages/unifiedmandala-ui/components/ChatPanel.test.tsx
-  status: todo
+  status: done
 - commit: Create AgentControlPanel component
   path: packages/unifiedmandala-ui/components/AgentControlPanel.tsx
   task: UI panel for selecting agent backend, modes and CREP thresholds

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -9,7 +9,7 @@
   "pendingTasks": [
     {
       "commit": "Add agent profile switching to ChatPanel",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Create AgentControlPanel component",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -15,3 +15,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added EthicsPolicy agent and plugin.
 - Integrated open-source chat microservices and linked them in the pipeline configuration.
 - Implemented SecurityDashboard component for vulnerability visualization.
+- Added agent backend switching in ChatPanel with service toolbar.

--- a/packages/unifiedmandala-ui/components/ChatPanel.test.tsx
+++ b/packages/unifiedmandala-ui/components/ChatPanel.test.tsx
@@ -6,14 +6,29 @@ import * as chat from '../../gpt-bridges/ChatGPTWrapper';
 
 jest.spyOn(chat, 'chatWithContext').mockResolvedValue('ok');
 
+const fetchMock = jest.fn().mockResolvedValue({ text: () => Promise.resolve('ok') });
+beforeEach(() => {
+  (global as any).fetch = fetchMock;
+  fetchMock.mockClear();
+});
+
 const wrapper: React.FC<{children: React.ReactNode}> = ({ children }) => (
   <CREPProvider>{children}</CREPProvider>
 );
 
-test('sends message and shows reply', async () => {
+test('switches between local and external backends', async () => {
   const { getByLabelText, getByText } = render(<ChatPanel />, { wrapper });
+  expect(getByLabelText('service-toolbar')).toBeTruthy();
+
   fireEvent.change(getByLabelText('chat-input'), { target: { value: 'hi' } });
   fireEvent.click(getByText('Send'));
   await waitFor(() => getByText(/AI:/));
   expect(chat.chatWithContext).toHaveBeenCalledWith('hi', undefined);
+
+  fireEvent.click(getByLabelText('external-service'));
+  fireEvent.change(getByLabelText('chat-input'), { target: { value: 'yo' } });
+  fireEvent.click(getByText('Send'));
+  await waitFor(() => getByText(/AI: ok/));
+  expect(fetchMock).toHaveBeenCalled();
+  expect(chat.chatWithContext).toHaveBeenCalledTimes(1);
 });

--- a/packages/unifiedmandala-ui/components/ChatPanel.tsx
+++ b/packages/unifiedmandala-ui/components/ChatPanel.tsx
@@ -7,6 +7,7 @@ interface Message { sender: 'user' | 'ai'; text: string }
 export const ChatPanel: React.FC<{ context?: string }> = ({ context }) => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
+  const [backend, setBackend] = useState<'local' | 'external'>('local');
   const { triggerCREP } = useCREP();
 
   const send = async () => {
@@ -15,12 +16,38 @@ export const ChatPanel: React.FC<{ context?: string }> = ({ context }) => {
     setMessages(m => [...m, userMsg]);
     setInput('');
     triggerCREP({ C: 1, R: 1, E: 1, P: 1 });
-    const reply = await chatWithContext(input, context);
+    let reply: string;
+    if (backend === 'local') {
+      reply = await chatWithContext(input, context);
+    } else {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: input, context, service: 'external' }),
+      });
+      reply = await res.text();
+    }
     setMessages(m => [...m, { sender: 'ai', text: reply }]);
   };
 
   return (
     <div>
+      <div aria-label="service-toolbar" className="mb-2">
+        <button
+          aria-label="local-service"
+          onClick={() => setBackend('local')}
+          disabled={backend === 'local'}
+        >
+          Local
+        </button>
+        <button
+          aria-label="external-service"
+          onClick={() => setBackend('external')}
+          disabled={backend === 'external'}
+        >
+          External
+        </button>
+      </div>
       <div aria-label="conversation" className="border p-2 h-40 overflow-y-auto">
         {messages.map((m, i) => (
           <div key={i} className={m.sender === 'user' ? 'text-right' : ''}>


### PR DESCRIPTION
## Summary
- add service toolbar to ChatPanel to toggle between local and external backends
- test backend switching and mark associated tasks as complete
- log new ChatPanel feature in feedback codex

## Testing
- `pnpm install`
- `poetry install --with test`
- `pnpm lint`
- `pnpm test packages/unifiedmandala-ui/components/ChatPanel.test.tsx`
- `pnpm run docs:build`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6899b8be1b5c8322a2c92822ba2c1e16