### PR TITLE
feat: add governance simulator panel

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12078,7 +12078,7 @@
     "path": "packages/unifiedmandala-ui/components/GovernanceSimulatorPanel.tsx",
     "task": "Run world policy simulations interactively",
     "test": "packages/unifiedmandala-ui/components/GovernanceSimulatorPanel.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Create RefusalNotice component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11894,7 +11894,7 @@
   path: packages/unifiedmandala-ui/components/GovernanceSimulatorPanel.tsx
   task: Run world policy simulations interactively
   test: packages/unifiedmandala-ui/components/GovernanceSimulatorPanel.test.tsx
-  status: todo
+  status: done
 - commit: Create RefusalNotice component
   path: packages/unifiedmandala-ui/components/RefusalNotice.tsx
   task: Display ethically grounded refusal messages

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -329,7 +329,7 @@
     },
     {
       "commit": "Create GovernanceSimulatorPanel component",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Create SingularitySimulatorPanel component",

--- a/packages/unifiedmandala-ui/components/GovernanceSimulatorPanel.test.tsx
+++ b/packages/unifiedmandala-ui/components/GovernanceSimulatorPanel.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import GovernanceSimulatorPanel from './GovernanceSimulatorPanel';
+
+beforeAll(() => {
+  (window as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+test('renders simulator controls', () => {
+  render(<GovernanceSimulatorPanel />);
+  expect(screen.getByText(/Weltinnenpolitik-Simulator/)).toBeInTheDocument();
+  expect(screen.getByText(/Aid-Investition/)).toBeInTheDocument();
+  expect(screen.getByText(/Zeithorizont/)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Simulate/ })).toBeInTheDocument();
+});

--- a/packages/unifiedmandala-ui/components/GovernanceSimulatorPanel.tsx
+++ b/packages/unifiedmandala-ui/components/GovernanceSimulatorPanel.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+
+/**
+ * GovernanceSimulatorPanel allows interactive experiments with
+ * Weltinnenpolitik scenarios. Users can adjust aid investment
+ * and simulation time span then visualise resulting GDP trends.
+ */
+const GovernanceSimulatorPanel: React.FC = () => {
+  const [aid, setAid] = useState(1000); // in Mio. USD
+  const [years, setYears] = useState(10);
+  const [data, setData] = useState<any[]>([]);
+
+  const run = async () => {
+    const payload = {
+      name: 'Test-Szenario',
+      policies: { aid_investment: aid * 1_000_000 },
+      years
+    };
+    const res = await fetch('/simulate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    const json = await res.json();
+    setData(json.results);
+  };
+
+  return (
+    <div className="my-4 border p-4 rounded">
+      <h3>Weltinnenpolitik-Simulator</h3>
+      <div className="space-y-4">
+        <div>
+          <label>Aid-Investition (Mio USD):</label>
+          <input
+            type="range"
+            min={0}
+            max={5000}
+            step={100}
+            value={aid}
+            onChange={(e) => setAid(parseInt(e.target.value, 10))}
+          />
+          <span>{aid} Mio USD</span>
+        </div>
+        <div>
+          <label>Zeithorizont (Jahre):</label>
+          <input
+            type="number"
+            value={years}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setYears(parseInt(e.target.value, 10))}
+          />
+        </div>
+        <button onClick={run}>Simulate</button>
+        <div className="h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={data}>
+              <XAxis dataKey="year" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="gdp" stroke="#8884d8" />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GovernanceSimulatorPanel;


### PR DESCRIPTION
## Summary
- add GovernanceSimulatorPanel React component with interactive simulation controls
- cover simulator with basic rendering test
- mark GovernanceSimulatorPanel task complete in advanced ToDo and progress files

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright packages/unifiedmandala-ui/components/GovernanceSimulatorPanel.tsx packages/unifiedmandala-ui/components/GovernanceSimulatorPanel.test.tsx`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/unifiedmandala-ui/components/GovernanceSimulatorPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6899bd2ac038832280224b2ff49aae71