### PR TITLE
feat(ui): add SingularitySimulatorPanel component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12127,7 +12127,7 @@
     "path": "packages/unifiedmandala-ui/components/SingularitySimulatorPanel.tsx",
     "task": "Interactive panel for running singularity simulations",
     "test": "packages/unifiedmandala-ui/components/SingularitySimulatorPanel.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Define Singularity Simulator sigillin",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11929,7 +11929,7 @@
   path: packages/unifiedmandala-ui/components/SingularitySimulatorPanel.tsx
   task: Interactive panel for running singularity simulations
   test: packages/unifiedmandala-ui/components/SingularitySimulatorPanel.test.tsx
-  status: todo
+  status: done
 - commit: Define Singularity Simulator sigillin
   path: docs/sigils/um-2025-0806-singularity-sim.yaml
   task: Sigillin to trigger Singularity Simulator

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -333,7 +333,7 @@
     },
     {
       "commit": "Create SingularitySimulatorPanel component",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Add open-source chat services to compose",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -16,3 +16,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Integrated open-source chat microservices and linked them in the pipeline configuration.
 - Implemented SecurityDashboard component for vulnerability visualization.
 - Added agent backend switching in ChatPanel with service toolbar.
+- Implemented SingularitySimulatorPanel for interactive singularity simulations.

--- a/packages/unifiedmandala-ui/components/SingularitySimulatorPanel.test.tsx
+++ b/packages/unifiedmandala-ui/components/SingularitySimulatorPanel.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SingularitySimulatorPanel from './SingularitySimulatorPanel';
+
+beforeAll(() => {
+  (window as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+test('renders singularity simulator controls', () => {
+  render(<SingularitySimulatorPanel />);
+  expect(screen.getByText(/Singularity-Simulator/)).toBeInTheDocument();
+  expect(screen.getByText(/Zeithorizont/)).toBeInTheDocument();
+  expect(screen.getByText(/Verschmelzungs-Tiefe/)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Simulation starten/ })).toBeInTheDocument();
+});
+

--- a/packages/unifiedmandala-ui/components/SingularitySimulatorPanel.tsx
+++ b/packages/unifiedmandala-ui/components/SingularitySimulatorPanel.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+
+/**
+ * SingularitySimulatorPanel allows interactive simulations of
+ * intelligence growth depending on merge depth between humans and AI.
+ */
+const SingularitySimulatorPanel: React.FC = () => {
+  const [years, setYears] = useState(10);
+  const [mergeDepth, setMergeDepth] = useState(0.5);
+  const [data, setData] = useState<any[]>([]);
+
+  const run = async () => {
+    const payload = {
+      name: 'Standard-Szenario',
+      timeline_years: years,
+      merge_depth: mergeDepth
+    };
+    const res = await fetch('/simulate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    const json = await res.json();
+    setData(json.results);
+  };
+
+  return (
+    <div className="my-4 border p-4 rounded">
+      <h3>Singularity-Simulator</h3>
+      <div className="space-y-4">
+        <div>
+          <label>Zeithorizont (Jahre): {years}</label>
+          <input
+            type="range"
+            min={1}
+            max={50}
+            step={1}
+            value={years}
+            onChange={(e) => setYears(parseInt(e.target.value, 10))}
+          />
+        </div>
+        <div>
+          <label>Verschmelzungs-Tiefe: {Math.round(mergeDepth * 100)}%</label>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={mergeDepth}
+            onChange={(e) => setMergeDepth(parseFloat(e.target.value))}
+          />
+        </div>
+        <button onClick={run}>Simulation starten</button>
+        {data.length > 0 && (
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={data}>
+                <XAxis dataKey="year" label={{ value: 'Jahr', position: 'insideBottomRight', offset: -5 }} />
+                <YAxis label={{ value: 'Intelligenz-Faktor', angle: -90, position: 'insideLeft' }} />
+                <Tooltip />
+                <Line dataKey="raw_intelligence" name="Basis-Intelligenz" dot={false} />
+                <Line dataKey="effective_intelligence" name="Effektive Intelligenz" dot={false} strokeDasharray="3 3" />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SingularitySimulatorPanel;
+


### PR DESCRIPTION
## Summary
- add SingularitySimulatorPanel for interactive intelligence growth simulations
- cover singularity panel with unit test
- mark SingularitySimulatorPanel task as complete in advanced progress tracking files

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest packages/unifiedmandala-ui/components/SingularitySimulatorPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6899c4e96e0483228cab111c7f8208f1