### PR TITLE
feat: track duplicate title indices

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8308,6 +8308,13 @@
     "status": "done"
   },
   {
+    "commit": "Report duplicate conversation title indices",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Record indices of duplicate titles in validation result",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
+  },
+  {
     "commit": "Implement HookTriggererAgent webhook",
     "path": "packages/agents/HookTriggererAgent.ts",
     "task": "Add webhook POST trigger based on task.url",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -33,6 +33,11 @@
   task: Treat conversation titles as case-insensitive when checking duplicates
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Report duplicate conversation title indices
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Record indices of duplicate titles in validation result
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done
 - commit: Validate message IDs in conversations
   path: scripts/validate-newadvanced-conversations.ts
   task: Ensure each node message has an id field

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1534,6 +1534,10 @@
       "status": "done"
     },
     {
+      "commit": "Report duplicate conversation title indices",
+      "status": "done"
+    },
+    {
       "commit": "Plan moderation and URL validation tasks",
       "status": "todo"
     },

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -17,3 +17,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented SecurityDashboard component for vulnerability visualization.
 - Added agent backend switching in ChatPanel with service toolbar.
 - Implemented SingularitySimulatorPanel for interactive singularity simulations.
+- Added duplicate conversation title index tracking in validator.

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -10,6 +10,7 @@ describe('validateNewAdvancedConversations', () => {
     );
     const res = validateNewAdvancedConversations(file);
     expect(res.duplicateTitles).toEqual(['foo']);
+    expect(res.duplicateTitleIndices).toEqual([1]);
   });
 
   it('flags duplicate titles case-insensitively', () => {
@@ -19,6 +20,7 @@ describe('validateNewAdvancedConversations', () => {
     );
     const res = validateNewAdvancedConversations(file);
     expect(res.duplicateTitles).toEqual(['foo']);
+    expect(res.duplicateTitleIndices).toEqual([1]);
   });
 
   it('flags titles with extra whitespace and normalizes for duplicates', () => {
@@ -28,6 +30,7 @@ describe('validateNewAdvancedConversations', () => {
     );
     const res = validateNewAdvancedConversations(file);
     expect(res.duplicateTitles).toEqual(['foo']);
+    expect(res.duplicateTitleIndices).toEqual([1]);
     expect(res.conversationsWithTitleWhitespace).toEqual([1]);
   });
 

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -6,6 +6,7 @@ export interface ValidationResult {
   conversationCount: number;
   duplicateIds: string[];
   duplicateTitles: string[];
+  duplicateTitleIndices: number[];
   conversationsWithTitleWhitespace: number[];
   conversationsWithInvalidTitleChars: number[];
   conversationsWithLongTitles: number[];
@@ -67,6 +68,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
   const seenTitles = new Set<string>();
   const duplicateIds: string[] = [];
   const duplicateTitles: string[] = [];
+  const duplicateTitleIndices: number[] = [];
   const titlesWithWhitespace: number[] = [];
   const titlesWithInvalidChars: number[] = [];
   const longTitles: number[] = [];
@@ -380,8 +382,12 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
       if (conv.title.length > 100) {
         longTitles.push(idx);
       }
-      if (seenTitles.has(normalized)) duplicateTitles.push(normalized);
-      else seenTitles.add(normalized);
+      if (seenTitles.has(normalized)) {
+        duplicateTitles.push(normalized);
+        duplicateTitleIndices.push(idx);
+      } else {
+        seenTitles.add(normalized);
+      }
     }
 
     const nodes: any[] = Object.values(conv.mapping || {});
@@ -735,6 +741,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     conversationCount: raw.length,
     duplicateIds,
     duplicateTitles,
+    duplicateTitleIndices,
   conversationsWithTitleWhitespace: titlesWithWhitespace,
   conversationsWithInvalidTitleChars: titlesWithInvalidChars,
   conversationsWithLongTitles: longTitles,


### PR DESCRIPTION
## Summary
- track indices of duplicate conversation titles in validator
- document new validator capability in todo/progress records
- note duplicate title index tracking in feedback codex

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6899df3ebe408322a27d90e284348fb6