### PR TITLE
feat: expose service avatars in PyramidVRMeetingRoom

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11511,7 +11511,7 @@
     "path": "packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.tsx",
     "task": "Render avatars for local and external services with interaction hooks",
     "test": "packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Implement chat proxy route for local and external agents",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11487,7 +11487,7 @@
   path: packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.tsx
   task: Render avatars for local and external services with interaction hooks
   test: packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx
-  status: todo
+  status: done
 - commit: Implement chat proxy route for local and external agents
   path: services/chat-proxy.ts
   task: Route /api/chat requests to local or external services based on agent profile

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,15 +1,15 @@
 {
-  "lastCommit": "feat: add training data extraction script",
+  "lastCommit": "feat: expose service avatars in PyramidVRMeetingRoom",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added script to extract training data from newadvancedconversations JSON.",
+  "notes": "Implemented dynamic service avatars with interaction hooks in PyramidVRMeetingRoom.",
   "pendingTasks": [
     {
       "commit": "Expose service avatars in PyramidVRMeetingRoom",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Implement chat proxy route for local and external agents",

--- a/packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx
+++ b/packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import PyramidVRMeetingRoom from './PyramidVRMeetingRoom';
 
@@ -11,7 +11,15 @@ jest.mock('@react-three/fiber', () => ({
   ambientLight: 'ambientLight',
 }));
 
-test('renders avatars', () => {
-  const { getAllByLabelText } = render(<PyramidVRMeetingRoom />);
-  expect(getAllByLabelText('avatar').length).toBeGreaterThan(0);
+test('renders avatars and handles selection', () => {
+  const onSelect = jest.fn();
+  const services = [
+    { id: 'local', position: [0, 0, 0] as [number, number, number], color: 'red', onSelect },
+    { id: 'external', position: [1, 0, 0] as [number, number, number], color: 'blue', onSelect },
+  ];
+  const { getAllByLabelText } = render(<PyramidVRMeetingRoom services={services} />);
+  const avatars = getAllByLabelText('avatar');
+  expect(avatars).toHaveLength(2);
+  fireEvent.click(avatars[0]);
+  expect(onSelect).toHaveBeenCalledWith('local');
 });

--- a/packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.tsx
+++ b/packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.tsx
@@ -1,18 +1,45 @@
 import React from 'react';
 import { Canvas } from '@react-three/fiber';
 
-const Avatar: React.FC<{ position: [number, number, number]; color: string }> = ({ position, color }) => (
-  <mesh position={position} aria-label="avatar">
+interface ServiceAvatar {
+  id: string;
+  position: [number, number, number];
+  color: string;
+  onSelect?: (id: string) => void;
+}
+
+const Avatar: React.FC<{
+  position: [number, number, number];
+  color: string;
+  onSelect?: () => void;
+}> = ({ position, color, onSelect }) => (
+  <mesh position={position} aria-label="avatar" onClick={onSelect}>
     <sphereGeometry args={[0.3, 16, 16]} />
     <meshStandardMaterial color={color} />
   </mesh>
 );
 
-const PyramidVRMeetingRoom: React.FC = () => (
-  <Canvas onCreated={({ gl }) => { if ((gl as any).xr) { (gl as any).xr.enabled = true; } }}>
+interface Props {
+  services?: ServiceAvatar[];
+}
+
+const PyramidVRMeetingRoom: React.FC<Props> = ({ services = [] }) => (
+  <Canvas
+    onCreated={({ gl }) => {
+      if ((gl as any).xr) {
+        (gl as any).xr.enabled = true;
+      }
+    }}
+  >
     <ambientLight intensity={0.5} />
-    <Avatar position={[0, 0, -2]} color="hotpink" />
-    <Avatar position={[1, 0, -2]} color="cyan" />
+    {services.map((svc) => (
+      <Avatar
+        key={svc.id}
+        position={svc.position}
+        color={svc.color}
+        onSelect={() => svc.onSelect?.(svc.id)}
+      />
+    ))}
   </Canvas>
 );
 


### PR DESCRIPTION
## Summary
- render service avatars dynamically in PyramidVRMeetingRoom with click hooks
- test avatar rendering and selection handling
- mark PyramidVRMeetingRoom avatar task as complete in advanced tracking files

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6899f11778248322b7d10b40314cb6c4