### PR TITLE
feat: implement chat proxy route

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11518,7 +11518,7 @@
     "path": "services/chat-proxy.ts",
     "task": "Route /api/chat requests to local or external services based on agent profile",
     "test": "services/chat-proxy.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add hybrid service aggregator",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11492,7 +11492,7 @@
   path: services/chat-proxy.ts
   task: Route /api/chat requests to local or external services based on agent profile
   test: services/chat-proxy.test.ts
-  status: todo
+  status: done
 - commit: Add hybrid service aggregator
   path: packages/unifiedmandala-ui/hooks/useHybridService.ts
   task: Query all enabled services in parallel and select response with highest

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: implement ZIPMEM RAG indexer",
+  "lastCommit": "feat: implement chat proxy route for local and external agents",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -13,7 +13,7 @@
     },
     {
       "commit": "Implement chat proxy route for local and external agents",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Add hybrid service aggregator",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -19,3 +19,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented SingularitySimulatorPanel for interactive singularity simulations.
 - Added duplicate conversation title index tracking in validator.
 - Added live suggestion badges to CREPVisualizer and synced progress files.
+- Implemented chat proxy route to forward /api/chat requests to configured services.

--- a/services/chat-proxy.test.ts
+++ b/services/chat-proxy.test.ts
@@ -1,0 +1,33 @@
+import { TextEncoder, TextDecoder } from 'util';
+// polyfill for jest/supertest
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).TextEncoder = TextEncoder;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).TextDecoder = TextDecoder;
+
+import router from './chat-proxy';
+import express from 'express';
+import request from 'supertest';
+import fetch from 'node-fetch';
+
+jest.mock('node-fetch', () => jest.fn());
+
+const app = express();
+app.use(express.json());
+app.use('/', router);
+
+test('returns 400 without message', async () => {
+  await request(app).post('/api/chat').expect(400);
+});
+
+test('forwards message to configured service', async () => {
+  (fetch as unknown as jest.Mock).mockResolvedValue({ json: () => Promise.resolve({ ok: true }) });
+  await request(app).post('/api/chat').send({ serviceId: 'gpt4all', message: 'hi' }).expect(200);
+  expect(fetch).toHaveBeenCalledWith(
+    'http://gpt4all:8080/api/chat',
+    expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ message: 'hi' })
+    })
+  );
+});

--- a/services/chat-proxy.ts
+++ b/services/chat-proxy.ts
@@ -1,0 +1,49 @@
+import express from 'express';
+import fetch from 'node-fetch';
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+interface ServiceConfig {
+  endpoint: string;
+  crep_threshold?: number;
+}
+
+interface ConfigFile {
+  services: Record<string, ServiceConfig>;
+}
+
+const configPath = path.resolve(__dirname, '../config/agent-services.yaml');
+let serviceConfig: ConfigFile = { services: {} };
+try {
+  const file = fs.readFileSync(configPath, 'utf8');
+  serviceConfig = yaml.load(file) as ConfigFile;
+} catch {
+  // ignore, use empty config
+}
+
+const router = express.Router();
+
+router.post('/api/chat', async (req, res) => {
+  const { serviceId, message, externalUrl } = req.body || {};
+  if (!message) return res.status(400).json({ error: 'message required' });
+
+  const target =
+    (serviceId && serviceConfig.services?.[serviceId]?.endpoint) ||
+    externalUrl;
+  if (!target) return res.status(400).json({ error: 'serviceId or externalUrl required' });
+
+  try {
+    const resp = await fetch(target, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message })
+    });
+    const data = await (resp as any).json();
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'chat proxy request failed' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add chat proxy service to route `/api/chat` requests to configured agent endpoints or external URLs
- mark chat proxy task as done in advanced ToDo files and progress tracker
- note chat proxy addition in feedback codex

## Testing
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx jest services/chat-proxy.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6899f58ad1f48322bf1a36fc610def05