### PR TITLE
chore: schedule nightly model fine-tuning

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12190,7 +12190,7 @@
     "path": "memory-jobs.yaml",
     "task": "Add fine_tune_models cron calling Mistral CodeAgent",
     "test": "",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Implement ZIPMEM RAG indexer",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11977,7 +11977,7 @@
   path: memory-jobs.yaml
   task: Add fine_tune_models cron calling Mistral CodeAgent
   test: ""
-  status: todo
+  status: done
 - commit: Implement ZIPMEM RAG indexer
   path: services/rag/indexer.py
   task: Index ZIPMEM fragments with FAISS or Elastic for retrieval

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -305,7 +305,7 @@
     },
     {
       "commit": "Schedule nightly model fine-tuning",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Implement ZIPMEM RAG indexer",

--- a/memory-jobs.yaml
+++ b/memory-jobs.yaml
@@ -1,0 +1,7 @@
+jobs:
+  - job_name: nightly_fine_tune
+    schedule: "0 2 * * *"
+    actions:
+      - type: fine_tune_models
+        agent: mistral_code_agent
+        description: Nightly fine-tuning via Mistral CodeAgent


### PR DESCRIPTION
## Summary
- add nightly fine_tune_models job for Mistral CodeAgent
- mark fine-tuning task complete in advanced ToDo and progress trackers

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6899fcf6c5508322a17e87acf41ae19a