### PR TITLE
feat: expose service avatars in PyramidVRMeetingRoom

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11511,7 +11511,7 @@
     "path": "packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.tsx",
     "task": "Render avatars for local and external services with interaction hooks",
     "test": "packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Implement chat proxy route for local and external agents",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11487,7 +11487,7 @@
   path: packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.tsx
   task: Render avatars for local and external services with interaction hooks
   test: packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx
-  status: todo
+  status: done
 - commit: Implement chat proxy route for local and external agents
   path: services/chat-proxy.ts
   task: Route /api/chat requests to local or external services based on agent profile

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: implement chat proxy route for local and external agents",
+  "lastCommit": "feat: expose service avatars in PyramidVRMeetingRoom",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -9,7 +9,7 @@
   "pendingTasks": [
     {
       "commit": "Expose service avatars in PyramidVRMeetingRoom",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Implement chat proxy route for local and external agents",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -20,3 +20,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added duplicate conversation title index tracking in validator.
 - Added live suggestion badges to CREPVisualizer and synced progress files.
 - Implemented chat proxy route to forward /api/chat requests to configured services.
+- Exposed service avatars in PyramidVRMeetingRoom for interactive local/external agents.

--- a/packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx
+++ b/packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx
@@ -1,17 +1,24 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import PyramidVRMeetingRoom from './PyramidVRMeetingRoom';
 
 jest.mock('@react-three/fiber', () => ({
   Canvas: ({ children }: any) => <div role="presentation">{children}</div>,
   sphereGeometry: 'sphereGeometry',
-  mesh: 'mesh',
+  mesh: ({ children, ...props }: any) => <div {...props}>{children}</div>,
   meshStandardMaterial: 'meshStandardMaterial',
   ambientLight: 'ambientLight',
 }));
 
-test('renders avatars', () => {
-  const { getAllByLabelText } = render(<PyramidVRMeetingRoom />);
-  expect(getAllByLabelText('avatar').length).toBeGreaterThan(0);
+test('renders service avatars and handles interaction', () => {
+  const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  const { getByLabelText } = render(<PyramidVRMeetingRoom />);
+  const localAvatar = getByLabelText('avatar-local');
+  const externalAvatar = getByLabelText('avatar-external');
+  expect(localAvatar).toBeInTheDocument();
+  expect(externalAvatar).toBeInTheDocument();
+  fireEvent.click(localAvatar);
+  expect(logSpy).toHaveBeenCalledWith('local service selected');
+  logSpy.mockRestore();
 });

--- a/packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.tsx
+++ b/packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.tsx
@@ -1,8 +1,30 @@
 import React from 'react';
 import { Canvas } from '@react-three/fiber';
 
-const Avatar: React.FC<{ position: [number, number, number]; color: string }> = ({ position, color }) => (
-  <mesh position={position} aria-label="avatar">
+interface ServiceAvatar {
+  id: string;
+  position: [number, number, number];
+  color: string;
+  onSelect: () => void;
+}
+
+const serviceAvatars: ServiceAvatar[] = [
+  {
+    id: 'local',
+    position: [0, 0, -2],
+    color: 'hotpink',
+    onSelect: () => console.log('local service selected'),
+  },
+  {
+    id: 'external',
+    position: [1, 0, -2],
+    color: 'cyan',
+    onSelect: () => console.log('external service selected'),
+  },
+];
+
+const Avatar: React.FC<ServiceAvatar> = ({ id, position, color, onSelect }) => (
+  <mesh position={position} onClick={onSelect} aria-label={`avatar-${id}`}>
     <sphereGeometry args={[0.3, 16, 16]} />
     <meshStandardMaterial color={color} />
   </mesh>
@@ -11,8 +33,9 @@ const Avatar: React.FC<{ position: [number, number, number]; color: string }> = 
 const PyramidVRMeetingRoom: React.FC = () => (
   <Canvas onCreated={({ gl }) => { if ((gl as any).xr) { (gl as any).xr.enabled = true; } }}>
     <ambientLight intensity={0.5} />
-    <Avatar position={[0, 0, -2]} color="hotpink" />
-    <Avatar position={[1, 0, -2]} color="cyan" />
+    {serviceAvatars.map((avatar) => (
+      <Avatar key={avatar.id} {...avatar} />
+    ))}
   </Canvas>
 );
 


### PR DESCRIPTION
## Summary
- render local and external service avatars in the PyramidVRMeetingRoom with click handlers
- verify interactive avatars via component test
- update advanced progress and task tracking, plus feedback entry

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/unifiedmandala-ui/components/PyramidVRMeetingRoom.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689a0d39a4ac8322a5d10bbd71a8f71f