### PR TITLE
feat: add hybrid service aggregator hook

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11525,7 +11525,7 @@
     "path": "packages/unifiedmandala-ui/hooks/useHybridService.ts",
     "task": "Query all enabled services in parallel and select response with highest CREP score",
     "test": "packages/unifiedmandala-ui/hooks/useHybridService.test.ts",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add onboarding service catalog",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11498,7 +11498,7 @@
   task: Query all enabled services in parallel and select response with highest
     CREP score
   test: packages/unifiedmandala-ui/hooks/useHybridService.test.ts
-  status: todo
+  status: done
 - commit: Add onboarding service catalog
   path: config/onboarding/services.yaml
   task: List available local and external agent services for onboarding

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: expose service avatars in PyramidVRMeetingRoom",
+  "lastCommit": "feat: add hybrid service aggregator hook",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented baseline TF-IDF indexer for ZIPMEM fragments.",
+  "notes": "Added hybrid service aggregator hook and tests.",
   "pendingTasks": [
     {
       "commit": "Expose service avatars in PyramidVRMeetingRoom",
@@ -17,7 +17,7 @@
     },
     {
       "commit": "Add hybrid service aggregator",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Extend onboarding ritual documentation for service selection",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -21,3 +21,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added live suggestion badges to CREPVisualizer and synced progress files.
 - Implemented chat proxy route to forward /api/chat requests to configured services.
 - Exposed service avatars in PyramidVRMeetingRoom for interactive local/external agents.
+- Implemented hybrid service aggregator hook to select highest CREP response.

--- a/packages/unifiedmandala-ui/hooks/useHybridService.test.ts
+++ b/packages/unifiedmandala-ui/hooks/useHybridService.test.ts
@@ -1,0 +1,20 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useHybridService } from './useHybridService';
+
+test('selects response with highest CREP', async () => {
+  const responses: Record<string, any> = {
+    '/a': { result: 'a', crep: 0.2 },
+    '/b': { result: 'b', crep: 0.9 },
+    '/c': { result: 'c', crep: 0.5 },
+  };
+
+  global.fetch = jest.fn((url: string) =>
+    Promise.resolve({ json: () => Promise.resolve(responses[url]) })
+  ) as any;
+
+  const { result } = renderHook(() => useHybridService(['/a', '/b', '/c']));
+  await waitFor(() => expect(result.current).not.toBeNull());
+  expect(result.current?.result).toBe('b');
+  expect((global.fetch as any).mock.calls.length).toBeGreaterThanOrEqual(3);
+});

--- a/packages/unifiedmandala-ui/hooks/useHybridService.ts
+++ b/packages/unifiedmandala-ui/hooks/useHybridService.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+
+export interface HybridResponse<T = any> {
+  result: T;
+  crep: number;
+}
+
+/**
+ * Query multiple service endpoints in parallel and return the response
+ * with the highest CREP score.
+ */
+export function useHybridService<T = any>(services: string[]) {
+  const [response, setResponse] = useState<HybridResponse<T> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchServices() {
+      const results = await Promise.all(
+        services.map((url) =>
+          fetch(url)
+            .then((r) => r.json())
+            .catch(() => null)
+        )
+      );
+
+      const valid = results.filter(
+        (r): r is HybridResponse<T> => !!r && typeof r.crep === 'number'
+      );
+
+      if (!cancelled) {
+        if (valid.length === 0) {
+          setResponse(null);
+        } else {
+          const best = valid.reduce((a, b) => (b.crep > a.crep ? b : a));
+          setResponse(best);
+        }
+      }
+    }
+
+    fetchServices();
+    return () => {
+      cancelled = true;
+    };
+  }, [services]);
+
+  return response;
+}


### PR DESCRIPTION
## Summary
- add `useHybridService` hook to query parallel services and return highest CREP response
- track progress by marking hybrid service aggregator task complete
- note progress in feedback codex

## Testing
- `npx jest packages/unifiedmandala-ui/hooks/useHybridService.test.ts`
- `npx pyright`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_689a12b975b08322a4bc61ad3430b02a