### PR TITLE
feat: scaffold news fetcher microservice

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11566,8 +11566,8 @@
     "commit": "Scaffold news_fetcher microservice",
     "path": "services/news_fetcher/app.py",
     "task": "Fetch top headlines from RSS feeds and NewsAPI",
-    "test": "services/news_fetcher/app.test.py",
-    "status": "todo"
+    "test": "services/news_fetcher/app_test.py",
+    "status": "done"
   },
   {
     "commit": "Scaffold script_gen microservice",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11528,8 +11528,8 @@
 - commit: Scaffold news_fetcher microservice
   path: services/news_fetcher/app.py
   task: Fetch top headlines from RSS feeds and NewsAPI
-  test: services/news_fetcher/app.test.py
-  status: todo
+  test: services/news_fetcher/app_test.py
+  status: done
 - commit: Scaffold script_gen microservice
   path: services/script_gen/app.py
   task: Generate news scripts using LLM API

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add drift detection agent",
+  "lastCommit": "feat: scaffold news fetcher microservice",
   "fractalStep": "monitoring",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added drift detection plugin and agent for monitoring data streams.",
+  "notes": "Scaffolded RSS and NewsAPI fetcher service.",
   "pendingTasks": [
     {
       "commit": "Expose service avatars in PyramidVRMeetingRoom",
@@ -33,7 +33,7 @@
     },
     {
       "commit": "Scaffold news_fetcher microservice",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Scaffold script_gen microservice",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -23,3 +23,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Exposed service avatars in PyramidVRMeetingRoom for interactive local/external agents.
 - Implemented hybrid service aggregator hook to select highest CREP response.
 - Introduced DriftDetectionAgent plugin for monitoring data drift.
+- Scaffolded standalone news_fetcher microservice for RSS and NewsAPI aggregation.

--- a/services/news_fetcher/__init__.py
+++ b/services/news_fetcher/__init__.py
@@ -1,0 +1,1 @@
+"""News fetcher microservice package."""

--- a/services/news_fetcher/app.py
+++ b/services/news_fetcher/app.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Fetch headlines from RSS feeds and NewsAPI."""
+
+from typing import Dict, List
+import os
+
+from typing import Any
+
+from fastapi import FastAPI  # type: ignore[import]
+import requests  # type: ignore[import]
+
+try:  # pragma: no cover - handled in tests via monkeypatch
+    import feedparser  # type: ignore[import]
+except Exception:  # pragma: no cover - dependency optional for tests
+    feedparser = None  # type: ignore
+
+app: Any = FastAPI()
+
+RSS_FEEDS: List[str] = [
+    "https://news.google.com/rss?hl=en-US&gl=US&ceid=US:en",
+]
+
+NEWSAPI_URL = "https://newsapi.org/v2/top-headlines"
+
+
+def _fetch_rss() -> List[Dict[str, str]]:
+    items: List[Dict[str, str]] = []
+    if feedparser is None:
+        return items
+    for url in RSS_FEEDS:
+        parsed = feedparser.parse(url)
+        for entry in getattr(parsed, "entries", []):
+            items.append({
+                "title": entry.get("title", ""),
+                "link": entry.get("link", ""),
+            })
+    return items
+
+
+def _fetch_newsapi(api_key: str) -> List[Dict[str, str]]:
+    params = {"apiKey": api_key, "country": "us"}
+    response = requests.get(NEWSAPI_URL, params=params, timeout=10)
+    response.raise_for_status()
+    articles = response.json().get("articles", [])
+    return [{"title": a.get("title", ""), "link": a.get("url", "")} for a in articles]
+
+
+@app.get("/fetch")
+async def fetch_news() -> Dict[str, List[Dict[str, str]]]:
+    """Aggregate news items from RSS feeds and optionally NewsAPI."""
+    items = _fetch_rss()
+    api_key = os.getenv("NEWSAPI_KEY")
+    if api_key:
+        try:
+            items.extend(_fetch_newsapi(api_key))
+        except Exception:
+            pass
+    return {"items": items}

--- a/services/news_fetcher/app_test.py
+++ b/services/news_fetcher/app_test.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from . import app as news_app
+
+
+def test_fetch_news_combines_sources(monkeypatch):
+    """Ensure RSS and NewsAPI items are aggregated."""
+
+    def fake_parse(url):
+        return SimpleNamespace(entries=[{"title": "RSS Title", "link": "http://rss"}])
+
+    class FakeResponse:
+        def json(self):
+            return {"articles": [{"title": "API Title", "url": "http://api"}]}
+
+        def raise_for_status(self) -> None:
+            return None
+
+    monkeypatch.setattr(news_app, "feedparser", SimpleNamespace(parse=fake_parse))
+    monkeypatch.setattr(news_app.requests, "get", lambda url, params, timeout=10: FakeResponse())
+    monkeypatch.setenv("NEWSAPI_KEY", "test")
+
+    client = TestClient(news_app.app)  # type: ignore[arg-type]
+    resp = client.get("/fetch")
+    assert resp.status_code == 200
+    assert resp.json()["items"] == [
+        {"title": "RSS Title", "link": "http://rss"},
+        {"title": "API Title", "link": "http://api"},
+    ]


### PR DESCRIPTION
## Summary
- add FastAPI-based `news_fetcher` service that aggregates RSS and optional NewsAPI headlines
- cover `news_fetcher` with integration test
- mark news_fetcher task complete in advanced progress and to-do files and log in feedback codex

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pytest services/news_fetcher/app_test.py`


------
https://chatgpt.com/codex/tasks/task_e_689a67aec0d48322b0dd14040f8993f1