### PR TITLE
test: cover avatar renderer and streamer microservices

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11585,17 +11585,17 @@
   },
   {
     "commit": "Scaffold avatar_renderer microservice",
-    "path": "services/avatar_renderer/app.py",
+    "path": "services/newsbot/avatar_renderer/app.py",
     "task": "Render avatar video using audio narration",
-    "test": "services/avatar_renderer/app.test.py",
-    "status": "todo"
+    "test": "services/newsbot/avatar_renderer/app_test.py",
+    "status": "done"
   },
   {
     "commit": "Scaffold streamer microservice",
-    "path": "services/streamer/app.py",
+    "path": "services/newsbot/streamer/app.py",
     "task": "Stream rendered news videos to YouTube",
-    "test": "services/streamer/app.test.py",
-    "status": "todo"
+    "test": "services/newsbot/streamer/app_test.py",
+    "status": "done"
   },
   {
     "commit": "Implement newsbot orchestrator service",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11541,15 +11541,15 @@
   test: services/newsbot/tts/app_test.py
   status: done
 - commit: Scaffold avatar_renderer microservice
-  path: services/avatar_renderer/app.py
+  path: services/newsbot/avatar_renderer/app.py
   task: Render avatar video using audio narration
-  test: services/avatar_renderer/app.test.py
-  status: todo
+  test: services/newsbot/avatar_renderer/app_test.py
+  status: done
 - commit: Scaffold streamer microservice
-  path: services/streamer/app.py
+  path: services/newsbot/streamer/app.py
   task: Stream rendered news videos to YouTube
-  test: services/streamer/app.test.py
-  status: todo
+  test: services/newsbot/streamer/app_test.py
+  status: done
 - commit: Implement newsbot orchestrator service
   path: orchestrator/newsbot_orchestrator.py
   task: Coordinate news fetch, script, TTS, render and stream services

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add TTS microservice",
+  "lastCommit": "feat: add avatar and streamer tests",
   "fractalStep": "monitoring",
   "openBranches": [
     "work"
@@ -45,11 +45,11 @@
     },
     {
       "commit": "Scaffold avatar_renderer microservice",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Scaffold streamer microservice",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Implement newsbot orchestrator service",

--- a/services/newsbot/avatar_renderer/app_test.py
+++ b/services/newsbot/avatar_renderer/app_test.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+import services.newsbot.avatar_renderer.app as app_module
+
+
+def test_render_returns_video_path() -> None:
+    client = TestClient(app_module.app)  # type: ignore[arg-type]
+    resp = client.post("/render", json={"audio_path": "/tmp/example.mp3"})
+    assert resp.status_code == 200
+    assert resp.json()["video_path"] == "/tmp/news_video.mp4"

--- a/services/newsbot/streamer/app_test.py
+++ b/services/newsbot/streamer/app_test.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+import services.newsbot.streamer.app as app_module
+
+
+def test_stream_returns_status() -> None:
+    client = TestClient(app_module.app)  # type: ignore[arg-type]
+    resp = client.post("/stream", json={"video_path": "/tmp/news_video.mp4"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "streaming"


### PR DESCRIPTION
## Summary
- add FastAPI endpoint tests for avatar_renderer and streamer services
- mark avatar and streamer microservice tasks complete in advanced ToDo trackers
- note progress in advancedprogress.json

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pytest services/newsbot/avatar_renderer/app_test.py services/newsbot/streamer/app_test.py`

------
https://chatgpt.com/codex/tasks/task_e_689a7b404b7c8322bb75d72fac6063fc