### PR TITLE
feat: enhance usecase components with backend fetch

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,12 +1,16 @@
 {
-  "lastCommit": "feat: add TTS microservice",
+  "lastCommit": "feat: enhance usecase components with backend fetch",
   "fractalStep": "monitoring",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented TTS microservice converting scripts to audio clips.",
+  "notes": "Implemented UI component triggering sigil generation, TODO parsing and SocialGood matching.",
   "pendingTasks": [
+    {
+      "commit": "Add React use-case components for Sigil generation, ToDo parsing, and SocialGood matching",
+      "status": "done"
+    },
     {
       "commit": "Expose service avatars in PyramidVRMeetingRoom",
       "status": "done"

--- a/apps/socialgood-ui/src/components/UsecaseComponents.tsx
+++ b/apps/socialgood-ui/src/components/UsecaseComponents.tsx
@@ -2,21 +2,43 @@ import React from 'react';
 import TodoButton from './TodoButton';
 
 interface Props {
-  onSigil?: () => void;
+  onSigil?: (data: any) => void;
   onTodos?: (data: any) => void;
-  onMatch?: () => void;
+  onMatch?: (data: any) => void;
 }
 
-const UsecaseComponents: React.FC<Props> = ({ onSigil, onTodos, onMatch }) => (
-  <div aria-label="Usecase Components">
-    <button aria-label="Generate Sigil" onClick={onSigil}>
-      Generate Sigil
-    </button>
-    <TodoButton onComplete={onTodos} />
-    <button aria-label="Match SocialGood" onClick={onMatch}>
-      Match SocialGood
-    </button>
-  </div>
-);
+const UsecaseComponents: React.FC<Props> = ({ onSigil, onTodos, onMatch }) => {
+  const handleSigil = async () => {
+    try {
+      const res = await fetch('/usecases/sigil/generate');
+      const data = await res.json();
+      onSigil?.(data);
+    } catch {
+      onSigil?.(null);
+    }
+  };
+
+  const handleMatch = async () => {
+    try {
+      const res = await fetch('/usecases/socialgood/match');
+      const data = await res.json();
+      onMatch?.(data);
+    } catch {
+      onMatch?.(null);
+    }
+  };
+
+  return (
+    <div aria-label="Usecase Components">
+      <button aria-label="Generate Sigil" onClick={handleSigil}>
+        Generate Sigil
+      </button>
+      <TodoButton onComplete={onTodos} />
+      <button aria-label="Match SocialGood" onClick={handleMatch}>
+        Match SocialGood
+      </button>
+    </div>
+  );
+};
 
 export default UsecaseComponents;

--- a/apps/socialgood-ui/src/components/__tests__/UsecaseComponents.test.tsx
+++ b/apps/socialgood-ui/src/components/__tests__/UsecaseComponents.test.tsx
@@ -7,15 +7,17 @@ const mockFetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({}
 // @ts-ignore
 global.fetch = mockFetch;
 
-test('triggers callbacks', async () => {
+test('triggers callbacks and fetches', async () => {
   const sigil = jest.fn();
   const todos = jest.fn();
   const match = jest.fn();
   render(<UsecaseComponents onSigil={sigil} onTodos={todos} onMatch={match} />);
+
   fireEvent.click(screen.getByLabelText('Generate Sigil'));
   fireEvent.click(screen.getByLabelText('Parse TODOs'));
-  await waitFor(() => expect(mockFetch).toHaveBeenCalled());
   fireEvent.click(screen.getByLabelText('Match SocialGood'));
+
+  await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(3));
   expect(sigil).toHaveBeenCalled();
   expect(todos).toHaveBeenCalled();
   expect(match).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- trigger backend calls for sigil generation, todo parsing, and SocialGood matching in UsecaseComponents
- verify new async interactions through dedicated tests
- record progress for usecase component work in advancedprogress.json

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest apps/socialgood-ui/src/components/__tests__/UsecaseComponents.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689a7b404b7c8322bb75d72fac6063fc