### PR TITLE
feat: add review agent service

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11643,8 +11643,8 @@
     "commit": "Introduce review agent service",
     "path": "agents/review/main.py",
     "task": "Evaluate drafts and recommend approval",
-    "test": "agents/review/main.test.py",
-    "status": "todo"
+    "test": "agents/review/test_main.py",
+    "status": "done"
   },
   {
     "commit": "Add draft review UI",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11583,8 +11583,8 @@
 - commit: Introduce review agent service
   path: agents/review/main.py
   task: Evaluate drafts and recommend approval
-  test: agents/review/main.test.py
-  status: todo
+  test: agents/review/test_main.py
+  status: done
 - commit: Add draft review UI
   path: packages/unifiedmandala-ui/components/DraftList.tsx
   task: List drafts with approve or reject actions

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -33,7 +33,7 @@
     },
     {
       "commit": "Introduce review agent service",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Add draft review UI",

--- a/agents/review/__init__.py
+++ b/agents/review/__init__.py
@@ -1,0 +1,6 @@
+"""Review agent package."""
+
+from .main import ReviewAgent, ReviewResult
+
+__all__ = ["ReviewAgent", "ReviewResult"]
+

--- a/agents/review/main.py
+++ b/agents/review/main.py
@@ -1,0 +1,62 @@
+"""Review agent module.
+
+This agent evaluates text drafts and recommends whether they should be
+approved for publishing.  The logic is intentionally simple: drafts that
+contain common placeholder keywords such as ``TODO`` or ``FIXME`` are
+rejected.  All other drafts are approved.  The result includes the reasons
+for a rejection so that callers can provide feedback to authors.
+"""
+
+from dataclasses import dataclass
+from typing import List, Iterable
+
+
+@dataclass
+class ReviewResult:
+    """Outcome returned by :class:`ReviewAgent`.
+
+    Attributes
+    ----------
+    approved:
+        Indicates if the draft passed review.
+    reasons:
+        List of keywords that triggered a rejection.
+    """
+
+    approved: bool
+    reasons: List[str]
+
+
+class ReviewAgent:
+    """Light‑weight draft reviewer.
+
+    Parameters
+    ----------
+    disallowed_keywords:
+        Iterable of keywords that, if present in a draft, cause the review to
+        reject it.  Keywords are compared case‑insensitively.
+    """
+
+    def __init__(self, disallowed_keywords: Iterable[str] | None = None) -> None:
+        if disallowed_keywords is None:
+            disallowed_keywords = ["todo", "fixme", "wip"]
+        self.disallowed = {kw.lower() for kw in disallowed_keywords}
+
+    def evaluate(self, text: str) -> ReviewResult:
+        """Evaluate ``text`` and return a :class:`ReviewResult`.
+
+        Empty drafts are rejected.  Otherwise the draft is rejected only if it
+        contains one of the disallowed keywords.
+        """
+
+        if not text or not text.strip():
+            return ReviewResult(False, ["empty draft"])
+
+        lowered = text.lower()
+        reasons = [kw for kw in self.disallowed if kw in lowered]
+        approved = not reasons
+        return ReviewResult(approved, reasons)
+
+
+__all__ = ["ReviewAgent", "ReviewResult"]
+

--- a/agents/review/test_main.py
+++ b/agents/review/test_main.py
@@ -1,0 +1,18 @@
+"""Tests for the review agent."""
+
+from agents.review.main import ReviewAgent
+
+
+def test_approves_clean_draft() -> None:
+    agent = ReviewAgent()
+    result = agent.evaluate("This draft is ready for publication.")
+    assert result.approved
+    assert result.reasons == []
+
+
+def test_rejects_draft_with_todo() -> None:
+    agent = ReviewAgent()
+    result = agent.evaluate("TODO: add introduction")
+    assert not result.approved
+    assert "todo" in result.reasons
+

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -27,3 +27,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented script_gen microservice with optional OpenAI-based script generation.
 
 - Documented NewsBot flows for live cycle, training, and publishing.
+- Introduced review agent service for evaluating drafts and recommending approval.


### PR DESCRIPTION
## Summary
- add lightweight ReviewAgent for evaluating draft content
- track completion of review agent task in advanced progress files
- document review agent addition in feedback codex

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pytest agents/review/test_main.py`
- `node scripts/parse-newadvanced-conversations.js TODO`


------
https://chatgpt.com/codex/tasks/task_e_689a8c87d42883229f2777a387a6f738