### PR TITLE
feat: integrate NewsBot services

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11609,14 +11609,14 @@
     "path": "docker-compose.yml",
     "task": "Add newsbot microservices and orchestrator to compose stack",
     "test": "",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Register newsbot services in pipeline configuration",
     "path": "pipeline_config.yaml",
     "task": "Add sigillin_map and CREP thresholds for newsbot pipeline",
     "test": "",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Implement training data collection endpoint",

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Implement newsbot orchestrator service",
+  "lastCommit": "Integrate newsbot services into compose and pipeline",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added NewsBot orchestrator coordinating fetch, script and TTS services.",
+  "notes": "Added NewsBot services to docker-compose and mapped sigillin thresholds.",
   "pendingTasks": [
     {
       "commit": "Implement newsbot orchestrator service",
@@ -13,11 +13,11 @@
     },
     {
       "commit": "Integrate newsbot services into docker-compose",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Register newsbot services in pipeline configuration",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Implement training data collection endpoint",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,22 @@ services:
     command: ./scripts/run-all-tests.sh
 
   # --- NewsBot microservices ---
+  newsbot_orchestrator:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: python orchestrator/newsbot_orchestrator.py
+    volumes:
+      - .:/workspace/unified-mandala
+    ports:
+      - "8100:8000"
+    depends_on:
+      - news_fetcher_service
+      - script_gen_service
+      - tts_service
+      - avatar_renderer_service
+      - streamer_service
+
   news_fetcher_service:
     build:
       context: ./services/newsbot/news_fetcher

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -28,3 +28,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 
 - Documented NewsBot flows for live cycle, training, and publishing.
 - Introduced review agent service for evaluating drafts and recommending approval.
+- Integrated NewsBot services into docker-compose and pipeline configuration.

--- a/unifiedmandala-orchestrator/orchestrator/pipeline_config.yaml
+++ b/unifiedmandala-orchestrator/orchestrator/pipeline_config.yaml
@@ -10,6 +10,11 @@ sigillin_map:
   gpt4all_chat:     gpt4all_service
   openassistant_chat: openassistant_service
   h2ogpt_chat:      h2ogpt_service
+  news_fetch:       news_fetcher_service
+  script_gen:       script_gen_service
+  tts:              tts_service
+  avatar:           avatar_renderer_service
+  stream:           streamer_service
 
 crep_thresholds:
   gnn_service: 0.60
@@ -23,3 +28,8 @@ crep_thresholds:
   gpt4all_service: 0.55
   openassistant_service: 0.60
   h2ogpt_service: 0.58
+  news_fetcher_service: 0.50
+  script_gen_service: 0.60
+  tts_service: 0.40
+  avatar_renderer_service: 0.40
+  streamer_service: 0.30


### PR DESCRIPTION
## Summary
- add NewsBot orchestrator service and register microservices in docker-compose
- map NewsBot sigillins and thresholds in pipeline configuration
- sync progress and ToDo entries for NewsBot integration

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689a9a8813b88322ae79dda5b8bd8a38