### PR TITLE
feat: add training data collection endpoint

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11622,8 +11622,8 @@
     "commit": "Implement training data collection endpoint",
     "path": "orchestrator/main.py",
     "task": "Store event payloads in TrainingStore via /training/collect",
-    "test": "orchestrator/training_collect.test.py",
-    "status": "todo"
+    "test": "orchestrator/training_collect_test.py",
+    "status": "done"
   },
   {
     "commit": "Scaffold finetune microservice",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11559,17 +11559,17 @@
   path: docker-compose.yml
   task: Add newsbot microservices and orchestrator to compose stack
   test: ""
-  status: todo
+  status: done
 - commit: Register newsbot services in pipeline configuration
   path: pipeline_config.yaml
   task: Add sigillin_map and CREP thresholds for newsbot pipeline
   test: ""
-  status: todo
+  status: done
 - commit: Implement training data collection endpoint
   path: orchestrator/main.py
   task: Store event payloads in TrainingStore via /training/collect
-  test: orchestrator/training_collect.test.py
-  status: todo
+  test: orchestrator/training_collect_test.py
+  status: done
 - commit: Scaffold finetune microservice
   path: services/finetune/app.py
   task: Run LoRA fine-tuning on collected samples

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -21,7 +21,7 @@
     },
     {
       "commit": "Implement training data collection endpoint",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Scaffold finetune microservice",

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+import json
+
+from fastapi import FastAPI  # type: ignore[import]
+
+
+class TrainingStore:
+    """Simple JSON file-based store for collected training events."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or Path("training_store.json")
+
+    def _load(self) -> List[Dict[str, Any]]:
+        if self.path.exists():
+            return json.loads(self.path.read_text())
+        return []
+
+    def append(self, item: Dict[str, Any]) -> int:
+        data = self._load()
+        data.append(item)
+        self.path.write_text(json.dumps(data))
+        return len(data)
+
+
+def get_app(store: TrainingStore | None = None) -> FastAPI:
+    """Create the FastAPI application."""
+
+    training_store = store if store is not None else TrainingStore()
+    app = FastAPI()
+
+    @app.post("/training/collect")  # type: ignore[misc]
+    async def collect(payload: Dict[str, Any]) -> Dict[str, int]:
+        count = training_store.append(payload)
+        return {"count": count}
+
+    return app
+
+
+app = get_app()

--- a/orchestrator/training_collect_test.py
+++ b/orchestrator/training_collect_test.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient  # type: ignore[import]
+
+from orchestrator.main import TrainingStore, get_app
+
+
+def test_collect_appends_to_store(tmp_path: Path) -> None:
+    store_path = tmp_path / "store.json"
+    store = TrainingStore(store_path)
+    app = get_app(store)
+    client = TestClient(app)  # type: ignore[arg-type]
+
+    payload = {"event": "hello"}
+    resp = client.post("/training/collect", json=payload)
+    assert resp.status_code == 200
+    assert store_path.exists()
+    data = json.loads(store_path.read_text())
+    assert data == [payload]
+    assert resp.json()["count"] == 1


### PR DESCRIPTION
## Summary
- add FastAPI training data collection endpoint backed by a file-based TrainingStore
- cover training endpoint with tests
- mark newsbot training collection tasks as complete in advanced tracking files

## Testing
- `pytest orchestrator`
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false && echo tsc_done`


------
https://chatgpt.com/codex/tasks/task_e_689aa055059483228add1df27781a825