### PR TITLE
feat: add newsbot training controls

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11637,7 +11637,7 @@
     "path": "packages/unifiedmandala-ui/components/NewsBotPanel.tsx",
     "task": "Buttons to collect training data and launch finetune",
     "test": "packages/unifiedmandala-ui/components/NewsBotPanel.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Introduce review agent service",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11579,7 +11579,7 @@
   path: packages/unifiedmandala-ui/components/NewsBotPanel.tsx
   task: Buttons to collect training data and launch finetune
   test: packages/unifiedmandala-ui/components/NewsBotPanel.test.tsx
-  status: todo
+  status: done
 - commit: Introduce review agent service
   path: agents/review/main.py
   task: Evaluate drafts and recommend approval

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Integrate newsbot services into compose and pipeline",
+  "lastCommit": "Extend NewsBotPanel with training controls",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -29,7 +29,7 @@
     },
     {
       "commit": "Extend NewsBotPanel with training controls",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Introduce review agent service",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -29,3 +29,5 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Documented NewsBot flows for live cycle, training, and publishing.
 - Introduced review agent service for evaluating drafts and recommending approval.
 - Integrated NewsBot services into docker-compose and pipeline configuration.
+
+- Added training controls to NewsBotPanel for collecting data and starting finetunes.

--- a/packages/unifiedmandala-ui/components/NewsBotPanel.test.tsx
+++ b/packages/unifiedmandala-ui/components/NewsBotPanel.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import NewsBotPanel from './NewsBotPanel';
+
+describe('NewsBotPanel', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn().mockResolvedValue({ json: async () => ({}) });
+  });
+
+  test('renders training controls and triggers endpoints', async () => {
+    render(<NewsBotPanel />);
+    expect(screen.getByText(/NewsBot Training/)).toBeInTheDocument();
+    const toggle = screen.getByLabelText(/Training-Modus aktiv/);
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByRole('button', { name: /Sammle Trainingsdaten/ }));
+    expect(fetch).toHaveBeenCalledWith('/training/collect', { method: 'POST' });
+    fireEvent.click(screen.getByRole('button', { name: /Finetune starten/ }));
+    expect(fetch).toHaveBeenCalledWith(
+      '/finetune',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+});

--- a/packages/unifiedmandala-ui/components/NewsBotPanel.tsx
+++ b/packages/unifiedmandala-ui/components/NewsBotPanel.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+
+/**
+ * NewsBotPanel offers controls for collecting training data and
+ * launching fine-tuning jobs for the NewsBot services.
+ */
+const NewsBotPanel: React.FC = () => {
+  const [trainingMode, setTrainingMode] = useState(false);
+
+  const collectTrainingData = async () => {
+    await fetch('/training/collect', { method: 'POST' });
+  };
+
+  const startFinetune = async () => {
+    const payload = {
+      base_model: 'vicuna-13b',
+      output_dir: '/models/latest'
+    };
+    await fetch('/finetune', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+  };
+
+  return (
+    <div className="my-4 border p-4 rounded">
+      <h3>NewsBot Training</h3>
+      <label className="block mb-2">
+        <input
+          type="checkbox"
+          checked={trainingMode}
+          onChange={(e) => setTrainingMode(e.target.checked)}
+        />{' '}
+        Training-Modus aktiv
+      </label>
+      <div className="space-x-4">
+        <button onClick={collectTrainingData} disabled={!trainingMode}>
+          Sammle Trainingsdaten
+        </button>
+        <button onClick={startFinetune} disabled={!trainingMode}>
+          Finetune starten
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default NewsBotPanel;


### PR DESCRIPTION
## Summary
- add NewsBotPanel with training mode and data/finetune triggers
- record progress for NewsBot training controls in advanced todo files
- note training control work in feedback codex

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/unifiedmandala-ui/components/NewsBotPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689b0d7cadd48322ae1e3757c579d074