### PR TITLE
feat: add draft review UI

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11651,7 +11651,7 @@
     "path": "packages/unifiedmandala-ui/components/DraftList.tsx",
     "task": "List drafts with approve or reject actions",
     "test": "packages/unifiedmandala-ui/components/DraftList.test.tsx",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Add publish endpoint for approved drafts",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11589,7 +11589,7 @@
   path: packages/unifiedmandala-ui/components/DraftList.tsx
   task: List drafts with approve or reject actions
   test: packages/unifiedmandala-ui/components/DraftList.test.tsx
-  status: todo
+  status: done
 - commit: Add publish endpoint for approved drafts
   path: orchestrator/main.py
   task: Move approved drafts to live store and emit sigillins via /publish

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Extend NewsBotPanel with training controls",
+  "lastCommit": "Add draft review UI",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -37,7 +37,7 @@
     },
     {
       "commit": "Add draft review UI",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Add publish endpoint for approved drafts",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -34,3 +34,5 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 
 - Added desertification tracker plugin and agent stub.
 - Added forest dynamics plugin and agent stub.
+
+- Implemented DraftList component for reviewing drafts with approve/reject controls.

--- a/packages/unifiedmandala-ui/components/DraftList.test.tsx
+++ b/packages/unifiedmandala-ui/components/DraftList.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DraftList from './DraftList';
+
+describe('DraftList', () => {
+  test('renders drafts and triggers actions', () => {
+    const drafts = [
+      { id: '1', title: 'First draft' },
+      { id: '2', title: 'Second draft' }
+    ];
+    const onApprove = jest.fn();
+    const onReject = jest.fn();
+
+    render(
+      <DraftList drafts={drafts} onApprove={onApprove} onReject={onReject} />
+    );
+
+    expect(screen.getByText('First draft')).toBeInTheDocument();
+    expect(screen.getByText('Second draft')).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByText('Approve')[0]);
+    expect(onApprove).toHaveBeenCalledWith('1');
+
+    fireEvent.click(screen.getAllByText('Reject')[1]);
+    expect(onReject).toHaveBeenCalledWith('2');
+  });
+});

--- a/packages/unifiedmandala-ui/components/DraftList.tsx
+++ b/packages/unifiedmandala-ui/components/DraftList.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface Draft {
+  id: string;
+  title: string;
+}
+
+interface DraftListProps {
+  drafts: Draft[];
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
+}
+
+/**
+ * DraftList renders a list of drafts with approve and reject controls.
+ */
+const DraftList: React.FC<DraftListProps> = ({ drafts, onApprove, onReject }) => {
+  return (
+    <div className="my-4">
+      <h3>Entwurfsübersicht</h3>
+      <ul>
+        {drafts.map((draft) => (
+          <li key={draft.id} className="mb-2 flex items-center space-x-2">
+            <span className="flex-1">{draft.title}</span>
+            <button onClick={() => onApprove(draft.id)}>Approve</button>
+            <button onClick={() => onReject(draft.id)}>Reject</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default DraftList;


### PR DESCRIPTION
## Summary
- implement DraftList component with approve/reject controls
- update advanced progress tracking and ToDo entries
- note change in feedbackcodex

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest packages/unifiedmandala-ui/components/DraftList.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689b239ae70c8322b4dd3b6175d53d7a