### PR TITLE
Enforce http/https validation for conversation URLs

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12219,5 +12219,12 @@
     "status": "done",
     "task": "Monitor expansion of arid regions using UNCCD data",
     "test": "agents/desert_tracker/test_main.py"
+  },
+  {
+    "commit": "Enforce HTTP/HTTPS schemes for conversation URLs",
+    "path": "scripts/validate-newadvanced-conversations.ts",
+    "task": "Reject blocked_urls and safe_urls with unsupported protocols",
+    "test": "scripts/validate-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11994,3 +11994,8 @@
   task: Allow switching between local and external agent backends
   test: packages/unifiedmandala-ui/components/AgentControlPanel.test.tsx
   status: done
+- commit: Enforce HTTP/HTTPS schemes for conversation URLs
+  path: scripts/validate-newadvanced-conversations.ts
+  task: Reject blocked_urls and safe_urls with unsupported protocols
+  test: scripts/validate-newadvanced-conversations.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1159 from GenesisAeon/cdqn9t-codex/implement-features-from-advancedtodo.yaml",
+  "lastCommit": "feat: enforce HTTP/HTTPS schemes for conversation URLs",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -1427,7 +1427,11 @@
     },
     {
       "commit": "Plan moderation and URL validation tasks",
-      "status": "todo"
+      "status": "done"
+    },
+    {
+      "commit": "Enforce HTTP/HTTPS schemes for conversation URLs",
+      "status": "done"
     },
     {
       "commit": "Map simulate_singularity pipeline",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -36,3 +36,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added forest dynamics plugin and agent stub.
 
 - Implemented DraftList component for reviewing drafts with approve/reject controls.
+- Enforced HTTP/HTTPS scheme validation for conversation URLs and updated progress trackers.

--- a/scripts/validate-newadvanced-conversations.test.ts
+++ b/scripts/validate-newadvanced-conversations.test.ts
@@ -469,10 +469,28 @@ describe('validateNewAdvancedConversations', () => {
     expect(res.conversationsWithInvalidBlockedUrls).toEqual([0]);
   });
 
+  it('flags blocked urls with unsupported protocols', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-blocked-url-scheme.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidBlockedUrls).toEqual([0]);
+  });
+
   it('flags invalid safe urls', () => {
     const file = path.join(
       __dirname,
       '../tests/fixtures/newadvanced-invalid-safe-urls.json'
+    );
+    const res = validateNewAdvancedConversations(file);
+    expect(res.conversationsWithInvalidSafeUrls).toEqual([0]);
+  });
+
+  it('flags safe urls with unsupported protocols', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-invalid-safe-url-scheme.json'
     );
     const res = validateNewAdvancedConversations(file);
     expect(res.conversationsWithInvalidSafeUrls).toEqual([0]);

--- a/scripts/validate-newadvanced-conversations.ts
+++ b/scripts/validate-newadvanced-conversations.ts
@@ -181,6 +181,7 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
     'global_enabled',
     'global_disabled',
   ];
+  const allowedProtocols = ['http:', 'https:'];
   const mimeByExt: Record<string, string> = {
     '.md': 'text/markdown',
     '.json': 'application/json',
@@ -302,8 +303,8 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
         conv.blocked_urls.some((u: any) => {
           if (typeof u !== 'string') return true;
           try {
-            new URL(u);
-            return false;
+            const url = new URL(u);
+            return !allowedProtocols.includes(url.protocol);
           } catch {
             return true;
           }
@@ -318,8 +319,8 @@ export function validateNewAdvancedConversations(filePath: string): ValidationRe
         conv.safe_urls.some((u: any) => {
           if (typeof u !== 'string') return true;
           try {
-            new URL(u);
-            return false;
+            const url = new URL(u);
+            return !allowedProtocols.includes(url.protocol);
           } catch {
             return true;
           }

--- a/tests/fixtures/newadvanced-invalid-blocked-url-scheme.json
+++ b/tests/fixtures/newadvanced-invalid-blocked-url-scheme.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000400",
+    "conversation_id": "00000000-0000-0000-0000-000000000400",
+    "title": "Blocked URL with unsupported protocol",
+    "create_time": 1,
+    "update_time": 2,
+    "current_node": "root",
+    "mapping": {
+      "root": {
+        "id": "root",
+        "message": {
+          "id": "00000000-0000-0000-0000-000000000401",
+          "author": { "role": "user" },
+          "create_time": 1,
+          "update_time": 1,
+          "content": { "parts": ["hi"] }
+        },
+        "parent": null,
+        "children": []
+      }
+    },
+    "blocked_urls": ["ftp://example.com"]
+  }
+]

--- a/tests/fixtures/newadvanced-invalid-safe-url-scheme.json
+++ b/tests/fixtures/newadvanced-invalid-safe-url-scheme.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000500",
+    "conversation_id": "00000000-0000-0000-0000-000000000500",
+    "title": "Safe URL with unsupported protocol",
+    "create_time": 1,
+    "update_time": 2,
+    "current_node": "root",
+    "mapping": {
+      "root": {
+        "id": "root",
+        "message": {
+          "id": "00000000-0000-0000-0000-000000000501",
+          "author": { "role": "user" },
+          "create_time": 1,
+          "update_time": 1,
+          "content": { "parts": ["hi"] }
+        },
+        "parent": null,
+        "children": []
+      }
+    },
+    "safe_urls": ["ftp://example.com"]
+  }
+]


### PR DESCRIPTION
## Summary
- validate blocked_urls and safe_urls use only http or https schemes
- add tests and fixtures for unsupported URL protocols
- track task completion in advancedToDo and progress files

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx vitest run scripts/validate-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b2e6f48608322a85d593d7ce4c376