### PR TITLE
chore: schedule news publish cron job

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11665,7 +11665,7 @@
     "path": "memory-jobs.yaml",
     "task": "Add mandala-news-publish job invoking orchestrator /publish",
     "test": "",
-    "status": "todo"
+    "status": "done"
   },
   {
     "commit": "Integrate finetune and review services in compose",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11599,7 +11599,7 @@
   path: memory-jobs.yaml
   task: Add mandala-news-publish job invoking orchestrator /publish
   test: ""
-  status: todo
+  status: done
 - commit: Integrate finetune and review services in compose
   path: docker-compose.yml
   task: Add finetune and review service containers

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1444,6 +1444,10 @@
     {
       "commit": "Add publish endpoint for approved drafts",
       "status": "done"
+    },
+    {
+      "commit": "Schedule publish cron job",
+      "status": "done"
     }
   ],
   "metacommitTags": [

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -38,3 +38,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented DraftList component for reviewing drafts with approve/reject controls.
 - Enforced HTTP/HTTPS scheme validation for conversation URLs and updated progress trackers.
 - Added publish endpoint to move approved drafts into live store.
+- Scheduled mandala-news-publish job to automate draft publishing.

--- a/memory-jobs.yaml
+++ b/memory-jobs.yaml
@@ -5,3 +5,10 @@ jobs:
       - type: fine_tune_models
         agent: mistral_code_agent
         description: Nightly fine-tuning via Mistral CodeAgent
+  - job_name: mandala-news-publish
+    schedule: "0 6 * * *"
+    actions:
+      - type: http_request
+        method: POST
+        url: http://orchestrator:8000/publish
+        description: Publish approved drafts via orchestrator


### PR DESCRIPTION
## Summary
- schedule `mandala-news-publish` memory job to hit orchestrator `/publish`
- mark publish cron task as done in advanced ToDo files and progress tracker
- note scheduled job in feedback codex

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`


------
https://chatgpt.com/codex/tasks/task_e_689b3aaa7ffc8322824a4fc9ac691ea0