### PR TITLE
feat: add JSON export to conversation analyzer

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12226,5 +12226,12 @@
     "task": "Reject blocked_urls and safe_urls with unsupported protocols",
     "test": "scripts/validate-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add JSON summary export to conversation analyzer",
+    "path": "scripts/analyze-newadvanced-conversations.ts",
+    "task": "Allow writing conversation stats to JSON via --json flag",
+    "test": "scripts/analyze-newadvanced-conversations.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11999,3 +11999,8 @@
   task: Reject blocked_urls and safe_urls with unsupported protocols
   test: scripts/validate-newadvanced-conversations.test.ts
   status: done
+- commit: Add JSON summary export to conversation analyzer
+  path: scripts/analyze-newadvanced-conversations.ts
+  task: Allow writing conversation stats to JSON via --json flag
+  test: scripts/analyze-newadvanced-conversations.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "meta:implement-features – add publish endpoint for approved drafts",
+  "lastCommit": "Add JSON summary export to conversation analyzer",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added NewsBot services to docker-compose and mapped sigillin thresholds.",
+  "notes": "Enabled JSON summary export in conversation analyzer.",
   "pendingTasks": [
     {
       "commit": "Scaffold finetune microservice",
@@ -1447,6 +1447,10 @@
     },
     {
       "commit": "Schedule publish cron job",
+      "status": "done"
+    },
+    {
+      "commit": "Add JSON summary export to conversation analyzer",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -39,3 +39,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Enforced HTTP/HTTPS scheme validation for conversation URLs and updated progress trackers.
 - Added publish endpoint to move approved drafts into live store.
 - Scheduled mandala-news-publish job to automate draft publishing.
+- Added JSON summary export to analyze-newadvanced-conversations script.

--- a/scripts/analyze-newadvanced-conversations.test.ts
+++ b/scripts/analyze-newadvanced-conversations.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import { execSync } from 'child_process';
 import { analyzeNewAdvancedConversations } from './analyze-newadvanced-conversations';
 
 describe('analyzeNewAdvancedConversations', () => {
@@ -27,5 +30,14 @@ describe('analyzeNewAdvancedConversations', () => {
     expect(stats.authorCounts.assistant).toBe(1);
     expect(stats.titles).toEqual(['Second']);
     expect(stats.todoCount).toBe(0);
+  });
+
+  it('writes JSON stats when using --json flag', () => {
+    const file = path.join(__dirname, '../tests/fixtures/newadvanced-sample.json');
+    const out = path.join(os.tmpdir(), 'newadvanced-stats.json');
+    const script = path.join(__dirname, 'analyze-newadvanced-conversations.ts');
+    execSync(`npx ts-node ${script} ${file} --json ${out}`);
+    const written = JSON.parse(fs.readFileSync(out, 'utf8'));
+    expect(written.conversationCount).toBe(1);
   });
 });

--- a/scripts/analyze-newadvanced-conversations.ts
+++ b/scripts/analyze-newadvanced-conversations.ts
@@ -61,17 +61,20 @@ export function analyzeNewAdvancedConversations(
 }
 
 if (require.main === module) {
-  const fileArgIndex = process.argv.findIndex((a: string) => !a.startsWith('--'));
+  const args = process.argv.slice(2);
+  const fileArgIndex = args.findIndex((a: string) => !a.startsWith('--'));
   const file =
-    fileArgIndex > 1
-      ? process.argv[fileArgIndex]
+    fileArgIndex >= 0
+      ? args[fileArgIndex]
       : path.join(__dirname, '../docs/sigils/newadvancedconversations.json');
-  const summaryIndex = process.argv.indexOf('--summary');
-  const summaryPath = summaryIndex >= 0 ? process.argv[summaryIndex + 1] : null;
-  const titlesArgIndex = process.argv.indexOf('--titles');
+  const summaryIndex = args.indexOf('--summary');
+  const summaryPath = summaryIndex >= 0 ? args[summaryIndex + 1] : null;
+  const jsonIndex = args.indexOf('--json');
+  const jsonPath = jsonIndex >= 0 ? args[jsonIndex + 1] : null;
+  const titlesArgIndex = args.indexOf('--titles');
   const titleList =
     titlesArgIndex >= 0
-      ? process.argv[titlesArgIndex + 1]
+      ? args[titlesArgIndex + 1]
           .split(',')
           .map((t: string) => t.trim())
       : undefined;
@@ -97,5 +100,9 @@ if (require.main === module) {
     ];
     fs.writeFileSync(summaryPath, lines.join('\n') + '\n');
     console.log(`Summary written to ${summaryPath}`);
+  }
+  if (jsonPath) {
+    fs.writeFileSync(jsonPath, JSON.stringify(stats, null, 2));
+    console.log(`JSON summary written to ${jsonPath}`);
   }
 }


### PR DESCRIPTION
## Summary
- allow `analyze-newadvanced-conversations.ts` to write stats as JSON via `--json`
- cover JSON output with a new vitest
- track the feature in advanced progress & todo records

## Testing
- `pnpm test:agents scripts/analyze-newadvanced-conversations.test.ts`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689b4511ae6c8322af2b0288c10c7dd4