### PR TITLE
feat: add global events microservices

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11811,28 +11811,28 @@
   {
     "commit": "Scaffold science_service microservice",
     "path": "agents/global_events/science_service.py",
-    "status": "todo",
+    "status": "done",
     "task": "Fetch science breakthroughs from API",
     "test": "agents/global_events/science_service.test.py"
   },
   {
     "commit": "Scaffold tech_service microservice",
     "path": "agents/global_events/tech_service.py",
-    "status": "todo",
+    "status": "done",
     "task": "Fetch tech innovations from API",
     "test": "agents/global_events/tech_service.test.py"
   },
   {
     "commit": "Scaffold environment_service microservice",
     "path": "agents/global_events/environment_service.py",
-    "status": "todo",
+    "status": "done",
     "task": "Fetch environmental success stories",
     "test": "agents/global_events/environment_service.test.py"
   },
   {
     "commit": "Extend global_events orchestrator with positive streams",
     "path": "agents/global_events/orchestrator.py",
-    "status": "todo",
+    "status": "done",
     "task": "Collect science, tech and environment events",
     "test": "agents/global_events/orchestrator.test.py"
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11705,22 +11705,22 @@
   path: agents/global_events/science_service.py
   task: Fetch science breakthroughs from API
   test: agents/global_events/science_service.test.py
-  status: todo
+  status: done
 - commit: Scaffold tech_service microservice
   path: agents/global_events/tech_service.py
   task: Fetch tech innovations from API
   test: agents/global_events/tech_service.test.py
-  status: todo
+  status: done
 - commit: Scaffold environment_service microservice
   path: agents/global_events/environment_service.py
   task: Fetch environmental success stories
   test: agents/global_events/environment_service.test.py
-  status: todo
+  status: done
 - commit: Extend global_events orchestrator with positive streams
   path: agents/global_events/orchestrator.py
   task: Collect science, tech and environment events
   test: agents/global_events/orchestrator.test.py
-  status: todo
+  status: done
 - commit: Create GlobalEventsPanel UI
   path: packages/unifiedmandala-ui/components/GlobalEventsPanel.tsx
   task: Display cosmic, crisis and positive events

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Add JSON summary export to conversation analyzer",
+  "lastCommit": "Merge pull request #1165 from GenesisAeon/0x1pxe-codex/implement-features-from-advancedtodo.yaml",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -9,10 +9,6 @@
   "pendingTasks": [
     {
       "commit": "Scaffold finetune microservice",
-      "status": "todo"
-    },
-    {
-      "commit": "Schedule publish cron job",
       "status": "todo"
     },
     {
@@ -69,22 +65,6 @@
     },
     {
       "commit": "Add global events plugin with positive progress services",
-      "status": "todo"
-    },
-    {
-      "commit": "Scaffold science_service microservice",
-      "status": "todo"
-    },
-    {
-      "commit": "Scaffold tech_service microservice",
-      "status": "todo"
-    },
-    {
-      "commit": "Scaffold environment_service microservice",
-      "status": "todo"
-    },
-    {
-      "commit": "Extend global_events orchestrator with positive streams",
       "status": "todo"
     },
     {
@@ -1455,6 +1435,22 @@
     },
     {
       "commit": "Add ExportFormats utilities",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold science_service microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold tech_service microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold environment_service microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Extend global_events orchestrator with positive streams",
       "status": "done"
     }
   ],

--- a/agents/global_events/__init__.py
+++ b/agents/global_events/__init__.py
@@ -1,0 +1,1 @@
+"""Global events microservices."""

--- a/agents/global_events/environment_service.py
+++ b/agents/global_events/environment_service.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Microservice providing environmental success stories."""
+
+import httpx
+from fastapi import FastAPI
+from fastapi.exceptions import HTTPException
+
+API_URL = "https://example.com/environment"
+
+app = FastAPI(title="Environment Service")
+
+async def fetch_environment() -> list[dict]:
+    """Fetch environmental success stories from an external API."""
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.get(API_URL)
+        response.raise_for_status()
+        data = response.json()
+        return data.get("results", [])
+
+@app.get("/events")  # type: ignore[misc]
+async def events() -> dict[str, list[dict]]:
+    """Return environmental success stories."""
+    try:
+        items = await fetch_environment()
+    except httpx.HTTPError as exc:  # pragma: no cover
+        raise HTTPException(502, str(exc))
+    return {"events": items}
+
+if __name__ == "__main__":  # pragma: no cover
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)  # type: ignore[arg-type]

--- a/agents/global_events/orchestrator.py
+++ b/agents/global_events/orchestrator.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Orchestrator collecting global positive events."""
+
+import asyncio
+from dataclasses import dataclass
+from typing import Dict, List
+
+from .science_service import fetch_science
+from .tech_service import fetch_tech
+from .environment_service import fetch_environment
+
+
+@dataclass
+class GlobalEventsOrchestrator:
+    """Gather science, technology and environment events."""
+
+    async def gather_events(self) -> Dict[str, List[dict]]:
+        science, tech, environment = await asyncio.gather(
+            fetch_science(),
+            fetch_tech(),
+            fetch_environment(),
+        )
+        return {
+            "science": science,
+            "tech": tech,
+            "environment": environment,
+        }

--- a/agents/global_events/science_service.py
+++ b/agents/global_events/science_service.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Microservice providing science breakthroughs."""
+
+import httpx
+from fastapi import FastAPI
+from fastapi.exceptions import HTTPException
+
+API_URL = "https://example.com/science"
+
+app = FastAPI(title="Science Service")
+
+async def fetch_science() -> list[dict]:
+    """Fetch science breakthroughs from an external API."""
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.get(API_URL)
+        response.raise_for_status()
+        data = response.json()
+        return data.get("results", [])
+
+@app.get("/events")  # type: ignore[misc]
+async def events() -> dict[str, list[dict]]:
+    """Return science breakthroughs."""
+    try:
+        items = await fetch_science()
+    except httpx.HTTPError as exc:  # pragma: no cover - network errors are rare in tests
+        raise HTTPException(502, str(exc))
+    return {"events": items}
+
+if __name__ == "__main__":  # pragma: no cover - manual execution only
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)  # type: ignore[arg-type]

--- a/agents/global_events/tech_service.py
+++ b/agents/global_events/tech_service.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Microservice providing technology innovations."""
+
+import httpx
+from fastapi import FastAPI
+from fastapi.exceptions import HTTPException
+
+API_URL = "https://example.com/technology"
+
+app = FastAPI(title="Tech Service")
+
+async def fetch_tech() -> list[dict]:
+    """Fetch technology innovations from an external API."""
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.get(API_URL)
+        response.raise_for_status()
+        data = response.json()
+        return data.get("results", [])
+
+@app.get("/events")  # type: ignore[misc]
+async def events() -> dict[str, list[dict]]:
+    """Return technology innovations."""
+    try:
+        items = await fetch_tech()
+    except httpx.HTTPError as exc:  # pragma: no cover
+        raise HTTPException(502, str(exc))
+    return {"events": items}
+
+if __name__ == "__main__":  # pragma: no cover
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)  # type: ignore[arg-type]

--- a/agents/global_events/test_environment_service.py
+++ b/agents/global_events/test_environment_service.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+
+from agents.global_events import environment_service
+
+
+def test_events_endpoint(monkeypatch) -> None:
+    async def mock_fetch() -> list[dict]:
+        return [{"title": "Success"}]
+
+    monkeypatch.setattr(environment_service, "fetch_environment", mock_fetch)
+    client = TestClient(environment_service.app)  # type: ignore[arg-type]
+    resp = client.get("/events")
+    assert resp.status_code == 200
+    assert resp.json() == {"events": [{"title": "Success"}]}

--- a/agents/global_events/test_orchestrator.py
+++ b/agents/global_events/test_orchestrator.py
@@ -1,0 +1,21 @@
+import asyncio
+
+import agents.global_events.orchestrator as orchestrator
+
+
+def test_gather_events(monkeypatch) -> None:
+    async def mock_science() -> list[dict]:
+        return [{"a": 1}]
+
+    async def mock_tech() -> list[dict]:
+        return [{"b": 2}]
+
+    async def mock_environment() -> list[dict]:
+        return [{"c": 3}]
+
+    monkeypatch.setattr(orchestrator, "fetch_science", mock_science)
+    monkeypatch.setattr(orchestrator, "fetch_tech", mock_tech)
+    monkeypatch.setattr(orchestrator, "fetch_environment", mock_environment)
+
+    results = asyncio.run(orchestrator.GlobalEventsOrchestrator().gather_events())
+    assert results == {"science": [{"a": 1}], "tech": [{"b": 2}], "environment": [{"c": 3}]}

--- a/agents/global_events/test_science_service.py
+++ b/agents/global_events/test_science_service.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+
+from agents.global_events import science_service
+
+
+def test_events_endpoint(monkeypatch) -> None:
+    async def mock_fetch() -> list[dict]:
+        return [{"title": "Discovery"}]
+
+    monkeypatch.setattr(science_service, "fetch_science", mock_fetch)
+    client = TestClient(science_service.app)  # type: ignore[arg-type]
+    resp = client.get("/events")
+    assert resp.status_code == 200
+    assert resp.json() == {"events": [{"title": "Discovery"}]}

--- a/agents/global_events/test_tech_service.py
+++ b/agents/global_events/test_tech_service.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+
+from agents.global_events import tech_service
+
+
+def test_events_endpoint(monkeypatch) -> None:
+    async def mock_fetch() -> list[dict]:
+        return [{"title": "Innovation"}]
+
+    monkeypatch.setattr(tech_service, "fetch_tech", mock_fetch)
+    client = TestClient(tech_service.app)  # type: ignore[arg-type]
+    resp = client.get("/events")
+    assert resp.status_code == 200
+    assert resp.json() == {"events": [{"title": "Innovation"}]}


### PR DESCRIPTION
## Summary
- add science, tech, and environment microservices for global events
- orchestrate positive event streams
- track completion in advanced TODO files

## Testing
- `pnpm install`
- `poetry install --with test`
- `pytest agents/global_events`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689b67006d788322af6d0957d65c4a55