### PR TITLE
Enhance usecase components with fetch actions

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1137,7 +1137,8 @@
     "commit": "Add React use-case components for Sigil generation, ToDo parsing, and SocialGood matching",
     "path": "apps/socialgood-ui/src/components/UsecaseComponents.tsx",
     "task": "Implement reusable UI components that trigger sigil generation, parse TODOs, and match SocialGood tags",
-    "test": "apps/socialgood-ui/src/components/__tests__/UsecaseComponents.test.tsx"
+    "test": "apps/socialgood-ui/src/components/__tests__/UsecaseComponents.test.tsx",
+    "status": "done"
   },
   {
     "commit": "Create Go todo_parser module",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -822,6 +822,7 @@
   task: Implement reusable UI components that trigger sigil generation, parse
     TODOs, and match SocialGood tags
   test: apps/socialgood-ui/src/components/__tests__/UsecaseComponents.test.tsx
+  status: done
 - commit: Create Go todo_parser module
   path: cmd/todo_parser.go
   task: Parse TODO blocks and expose them via REST endpoint /usecases/todo/parse

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1165 from GenesisAeon/0x1pxe-codex/implement-features-from-advancedtodo.yaml",
+  "lastCommit": "Merge pull request #1166 from GenesisAeon/4q6zj5-codex/implement-features-from-advancedtodo.yaml",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"

--- a/apps/socialgood-ui/src/components/UsecaseComponents.tsx
+++ b/apps/socialgood-ui/src/components/UsecaseComponents.tsx
@@ -2,21 +2,47 @@ import React from 'react';
 import TodoButton from './TodoButton';
 
 interface Props {
-  onSigil?: () => void;
+  onSigil?: (data: any) => void;
   onTodos?: (data: any) => void;
-  onMatch?: () => void;
+  onMatch?: (data: any) => void;
 }
 
-const UsecaseComponents: React.FC<Props> = ({ onSigil, onTodos, onMatch }) => (
-  <div aria-label="Usecase Components">
-    <button aria-label="Generate Sigil" onClick={onSigil}>
-      Generate Sigil
-    </button>
-    <TodoButton onComplete={onTodos} />
-    <button aria-label="Match SocialGood" onClick={onMatch}>
-      Match SocialGood
-    </button>
-  </div>
-);
+const UsecaseComponents: React.FC<Props> = ({ onSigil, onTodos, onMatch }) => {
+  const handleSigil = async () => {
+    try {
+      const res = await fetch('/sigil/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: '' }),
+      });
+      const data = await res.json();
+      onSigil?.(data);
+    } catch {
+      onSigil?.(null);
+    }
+  };
+
+  const handleMatch = async () => {
+    try {
+      const res = await fetch('/socialgood/match');
+      const data = await res.json();
+      onMatch?.(data);
+    } catch {
+      onMatch?.(null);
+    }
+  };
+
+  return (
+    <div aria-label="Usecase Components">
+      <button aria-label="Generate Sigil" onClick={handleSigil}>
+        Generate Sigil
+      </button>
+      <TodoButton onComplete={onTodos} />
+      <button aria-label="Match SocialGood" onClick={handleMatch}>
+        Match SocialGood
+      </button>
+    </div>
+  );
+};
 
 export default UsecaseComponents;

--- a/apps/socialgood-ui/src/components/__tests__/UsecaseComponents.test.tsx
+++ b/apps/socialgood-ui/src/components/__tests__/UsecaseComponents.test.tsx
@@ -7,15 +7,15 @@ const mockFetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({}
 // @ts-ignore
 global.fetch = mockFetch;
 
-test('triggers callbacks', async () => {
+test('triggers callbacks and fetches', async () => {
   const sigil = jest.fn();
   const todos = jest.fn();
   const match = jest.fn();
   render(<UsecaseComponents onSigil={sigil} onTodos={todos} onMatch={match} />);
   fireEvent.click(screen.getByLabelText('Generate Sigil'));
   fireEvent.click(screen.getByLabelText('Parse TODOs'));
-  await waitFor(() => expect(mockFetch).toHaveBeenCalled());
   fireEvent.click(screen.getByLabelText('Match SocialGood'));
+  await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(3));
   expect(sigil).toHaveBeenCalled();
   expect(todos).toHaveBeenCalled();
   expect(match).toHaveBeenCalled();

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -41,3 +41,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Scheduled mandala-news-publish job to automate draft publishing.
 - Added JSON summary export to analyze-newadvanced-conversations script.
 - Implemented ExportFormats utilities for CSV, JSON, DOT, MIDI and AEON outputs in nukleon-scanner.
+- Added default fetch handling in UsecaseComponents for sigil generation and SocialGood matching.


### PR DESCRIPTION
## Summary
- add async fetch handlers for sigil generation and SocialGood matching in UsecaseComponents
- expand tests to verify callbacks and remote calls
- mark usecase component task as complete in advancedToDo trackers and note in feedback codex

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689b79d17b2483229cc6da9916843822