### PR TITLE
feat: add repository map validation

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-12, in der Zeit des Tag.
+Am 2025-08-12, in der Zeit des Abend.
 
-Symbolphase: Aktivierung (Fokus: R)
+Symbolphase: Integration (Fokus: E)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12235,5 +12235,12 @@
     "task": "Allow writing conversation stats to JSON via --json flag",
     "test": "scripts/analyze-newadvanced-conversations.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add repository map validation script",
+    "path": "scripts/validate-repository-map.ts",
+    "task": "Validate repository_map.yaml structure",
+    "test": "scripts/validate-repository-map.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12006,3 +12006,8 @@
   task: Allow writing conversation stats to JSON via --json flag
   test: scripts/analyze-newadvanced-conversations.test.ts
   status: done
+- commit: Add repository map validation script
+  path: scripts/validate-repository-map.ts
+  task: Validate repository_map.yaml structure
+  test: scripts/validate-repository-map.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Complete finetune microservice scaffold",
+  "lastCommit": "Merge pull request #1169 from GenesisAeon/gmr2xr-codex/implement-features-from-advancedtodo.yaml",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -8,20 +8,8 @@
   "notes": "Enabled JSON summary export in conversation analyzer.",
   "pendingTasks": [
     {
-      "commit": "Scaffold finetune microservice",
-      "status": "done"
-    },
-    {
       "commit": "Integrate finetune and review services in compose",
       "status": "todo"
-    },
-    {
-      "commit": "Add island loss monitoring plugin and agent",
-      "status": "done"
-    },
-    {
-      "commit": "Add cosmic events monitoring plugin and agent",
-      "status": "done"
     },
     {
       "commit": "Add climate news plugin and orchestrator",
@@ -903,6 +891,10 @@
     },
     {
       "commit": "Add cosmic events monitoring plugin and agent",
+      "status": "done"
+    },
+    {
+      "commit": "Add repository map validation script",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -43,3 +43,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented ExportFormats utilities for CSV, JSON, DOT, MIDI and AEON outputs in nukleon-scanner.
 - Added default fetch handling in UsecaseComponents for sigil generation and SocialGood matching.
 - Added island loss and cosmic events monitoring agents and plugins.
+- Added repository map validation script to verify repository structure.

--- a/scripts/validate-repository-map.test.ts
+++ b/scripts/validate-repository-map.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import { validateRepositoryMap } from './validate-repository-map';
+
+describe('validateRepositoryMap', () => {
+  it('validates the default repository map', () => {
+    const file = path.join(__dirname, '../repositorypflege/repository_map.yaml');
+    expect(() => validateRepositoryMap(file)).not.toThrow();
+  });
+
+  it('throws on missing required fields', () => {
+    const tmp = path.join(os.tmpdir(), 'bad_repo_map.yaml');
+    fs.writeFileSync(tmp, 'repository_map:\n  - name: test\n    type: t\n    role: r\n');
+    expect(() => validateRepositoryMap(tmp)).toThrow(/modules/);
+  });
+});

--- a/scripts/validate-repository-map.ts
+++ b/scripts/validate-repository-map.ts
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+export interface RepositoryEntry {
+  name: string;
+  type: string;
+  role: string;
+  modules: unknown;
+}
+
+export function validateRepositoryMap(filePath: string): void {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const data = yaml.load(raw) as { repository_map?: RepositoryEntry[] };
+  if (!data || !Array.isArray(data.repository_map)) {
+    throw new Error('repository_map root missing or invalid');
+  }
+  data.repository_map.forEach((repo, idx) => {
+    ['name', 'type', 'role', 'modules'].forEach((key) => {
+      if (!(key in repo)) {
+        throw new Error(`Entry ${idx} missing required field: ${key}`);
+      }
+    });
+  });
+}
+
+if (require.main === module) {
+  const file = process.argv[2] || path.join(__dirname, '../repositorypflege/repository_map.yaml');
+  try {
+    validateRepositoryMap(file);
+    console.log('repository_map.yaml is valid');
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add script to validate repository_map.yaml structure
- test repository map validator
- record task completion in advanced ToDo and progress trackers

## Testing
- `pnpm install --silent`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx vitest run scripts/validate-repository-map.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b9c02a67c83228ef152647b188150