### PR TITLE
Add climate news plugin and climate metrics service stub

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11735,16 +11735,16 @@
   {
     "commit": "Add climate news plugin and orchestrator",
     "path": "plugins/news-climate.yaml",
-    "status": "todo",
+    "status": "done",
     "task": "Define climate and social data aggregator for NewsBot",
-    "test": "agents/news_climate/orchestrator.test.py"
+    "test": "agents/news_climate/test_orchestrator.py"
   },
   {
     "commit": "Scaffold climate_service microservice",
     "path": "agents/news_climate/climate_service.py",
-    "status": "todo",
+    "status": "done",
     "task": "Fetch glacier, desert, island and water metrics",
-    "test": "agents/news_climate/climate_service.test.py"
+    "test": "agents/news_climate/test_climate_service.py"
   },
   {
     "commit": "Scaffold forest_service microservice",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11650,13 +11650,13 @@
 - commit: Add climate news plugin and orchestrator
   path: plugins/news-climate.yaml
   task: Define climate and social data aggregator for NewsBot
-  test: agents/news_climate/orchestrator.test.py
-  status: todo
+  test: agents/news_climate/test_orchestrator.py
+  status: done
 - commit: Scaffold climate_service microservice
   path: agents/news_climate/climate_service.py
   task: Fetch glacier, desert, island and water metrics
-  test: agents/news_climate/climate_service.test.py
-  status: todo
+  test: agents/news_climate/test_climate_service.py
+  status: done
 - commit: Scaffold forest_service microservice
   path: agents/news_climate/forest_service.py
   task: Provide wildfire and deforestation data

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,22 +1,14 @@
 {
-  "lastCommit": "Merge pull request #1169 from GenesisAeon/gmr2xr-codex/implement-features-from-advancedtodo.yaml",
+  "lastCommit": "feat: add climate news aggregation stub",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Enabled JSON summary export in conversation analyzer.",
+  "notes": "Added climate news plugin and climate metrics service stub.",
   "pendingTasks": [
     {
       "commit": "Integrate finetune and review services in compose",
-      "status": "todo"
-    },
-    {
-      "commit": "Add climate news plugin and orchestrator",
-      "status": "todo"
-    },
-    {
-      "commit": "Scaffold climate_service microservice",
       "status": "todo"
     },
     {

--- a/agents/news_climate/__init__.py
+++ b/agents/news_climate/__init__.py
@@ -1,0 +1,1 @@
+"""Climate news aggregation agents."""

--- a/agents/news_climate/climate_service.py
+++ b/agents/news_climate/climate_service.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Placeholder microservice for climate metrics."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ClimateMetrics:
+    glacier: float = 0.0
+    desert: float = 0.0
+    island: float = 0.0
+    water: float = 0.0
+
+
+def fetch_metrics() -> ClimateMetrics:
+    """Fetch combined climate metrics.
+
+    This stub currently returns zero values for all metrics.
+    """
+
+    return ClimateMetrics()

--- a/agents/news_climate/orchestrator.py
+++ b/agents/news_climate/orchestrator.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Climate News Orchestrator.
+
+A small FastAPI service that aggregates climate and social news
+from configured sources. This is a placeholder implementation
+that returns dummy headlines for each source.
+"""
+
+from dataclasses import dataclass, field
+from typing import List
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+
+@dataclass
+class ClimateNewsConfig:
+    """Configuration for climate news aggregation."""
+
+    sources: List[str] = field(
+        default_factory=lambda: [
+            "https://example.com/climate",
+            "https://example.com/social",
+        ]
+    )
+
+
+class NewsItem(BaseModel):
+    source: str
+    headline: str
+
+
+app = FastAPI(title="Climate News Orchestrator")
+
+
+@app.get("/aggregate", response_model=list[NewsItem])  # type: ignore[misc]
+async def aggregate() -> list[NewsItem]:
+    """Return aggregated news items with dummy headlines."""
+
+    cfg = ClimateNewsConfig()
+    return [NewsItem(source=src, headline="dummy headline") for src in cfg.sources]
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)  # type: ignore[arg-type]

--- a/agents/news_climate/test_climate_service.py
+++ b/agents/news_climate/test_climate_service.py
@@ -1,0 +1,7 @@
+from agents.news_climate.climate_service import ClimateMetrics, fetch_metrics
+
+
+def test_fetch_metrics_returns_default_values() -> None:
+    metrics = fetch_metrics()
+    assert isinstance(metrics, ClimateMetrics)
+    assert metrics.glacier == metrics.desert == metrics.island == metrics.water == 0.0

--- a/agents/news_climate/test_orchestrator.py
+++ b/agents/news_climate/test_orchestrator.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+
+from agents.news_climate.orchestrator import app
+
+
+def test_aggregate_returns_dummy_items() -> None:
+    client = TestClient(app)  # type: ignore[arg-type]
+    response = client.get("/aggregate")
+    assert response.status_code == 200
+    assert response.json() == [
+        {"source": "https://example.com/climate", "headline": "dummy headline"},
+        {"source": "https://example.com/social", "headline": "dummy headline"},
+    ]

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -44,3 +44,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added default fetch handling in UsecaseComponents for sigil generation and SocialGood matching.
 - Added island loss and cosmic events monitoring agents and plugins.
 - Added repository map validation script to verify repository structure.
+- Added climate news plugin with basic climate service stub.

--- a/plugins/news-climate.yaml
+++ b/plugins/news-climate.yaml
@@ -1,0 +1,9 @@
+id: news-climate
+title: "Climate News Aggregator"
+type: news
+agent: ClimateNewsAgent
+entrypoint: agents/news_climate/orchestrator.py
+config:
+  sources:
+    - "https://example.com/climate"
+    - "https://example.com/social"

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -19,5 +19,9 @@
   "security-scanner": {
     "approved": false,
     "blacklisted": false
+  },
+  "news-climate": {
+    "approved": false,
+    "blacklisted": false
   }
 }


### PR DESCRIPTION
## Summary
- scaffold climate news plugin with FastAPI orchestrator and climate metrics service
- register new plugin and track progress in feedback and todo files

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pytest agents/news_climate/test_orchestrator.py agents/news_climate/test_climate_service.py`


------
https://chatgpt.com/codex/tasks/task_e_689ba0fe62148322a93ac9ac08bcb785