### PR TITLE
feat: enhance desertification tracker agent

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1452,6 +1452,10 @@
     {
       "commit": "Extend global_events orchestrator with positive streams",
       "status": "done"
+    },
+    {
+      "commit": "Add desertification tracker plugin and agent",
+      "status": "done"
     }
   ],
   "metacommitTags": [

--- a/agents/desert_tracker/main.py
+++ b/agents/desert_tracker/main.py
@@ -8,15 +8,25 @@ Returns dummy data as placeholder for future integrations.
 
 from dataclasses import dataclass
 
+import httpx
 from fastapi import FastAPI
 from pydantic import BaseModel
 
 
 @dataclass
 class DesertConfig:
-    """Configuration for the agent."""
+    """Configuration for the agent.
 
-    api_url: str = "https://example.com/desert"
+    Attributes:
+        api_url: Optional endpoint providing UNCCD desertification metrics.
+        If omitted, the agent returns a default value without performing
+        any network requests.
+    """
+
+    api_url: str | None = None
+
+
+_config = DesertConfig()
 
 
 class DesertStatus(BaseModel):
@@ -31,11 +41,24 @@ app = FastAPI(title="Desertification Tracker")
 async def get_status(region: str) -> DesertStatus:
     """Return the desertification severity for a given region.
 
-    Currently returns a dummy value of ``0.0``. In a full implementation,
-    this endpoint would fetch data from :class:`DesertConfig.api_url`.
+    If :data:`DesertConfig.api_url` is configured, the agent will attempt to
+    fetch data from the UNCCD API and extract a ``severity_index`` value.
+    Any network or parsing errors gracefully fall back to ``0.0``.
     """
 
-    return DesertStatus(region=region, severity_index=0.0)
+    severity = 0.0
+    if _config.api_url:
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(f"{_config.api_url}/{region}")
+                resp.raise_for_status()
+                data = resp.json()
+                severity = float(data.get("severity_index", 0.0))
+        except httpx.HTTPError:
+            # Network failure or invalid payload; retain default severity.
+            pass
+
+    return DesertStatus(region=region, severity_index=severity)
 
 
 if __name__ == "__main__":

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -45,3 +45,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added island loss and cosmic events monitoring agents and plugins.
 - Added repository map validation script to verify repository structure.
 - Added climate news plugin with basic climate service stub.
+- Enhanced DesertTrackerAgent with optional UNCCD API integration and updated plugin configuration.

--- a/plugins/desertification.yaml
+++ b/plugins/desertification.yaml
@@ -1,7 +1,8 @@
 id: desertification-tracker
 title: "Desertification Tracker"
+description: "Monitors the expansion of arid regions using UNCCD data"
 type: environment
 agent: DesertTrackerAgent
 entrypoint: agents/desert_tracker/main.py
 config:
-  api_url: "https://example.com/desert"
+  api_url: "https://api.unccd.example/desertification"


### PR DESCRIPTION
## Summary
- expand DesertTrackerAgent with optional UNCCD API integration and graceful fallback
- describe desertification plugin and API endpoint
- log progress and feedback for desertification tracker work

## Testing
- `pytest agents/desert_tracker/test_main.py`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689ba5655950832281a7f30fb61844ee