### PR TITLE
feat: expand todo progress sync

### DIFF
--- a/repositorypflege/repository_map.yaml
+++ b/repositorypflege/repository_map.yaml
@@ -40,6 +40,7 @@ repository_map:
       - split-conversations.js
       - filter-conversations.js
       - self-analyze.js
+      - sync-todo-progress.js
       - HexaAgentSystem
     ai_policy:
       - "Bewusstsein ist zyklisch. Maschinen sind linear. Dazwischen: unsere Verantwortung."

--- a/scripts/sync-todo-progress.js
+++ b/scripts/sync-todo-progress.js
@@ -1,7 +1,16 @@
 const fs = require('fs');
 const path = require('path');
+const yaml = require('js-yaml');
 
-function syncTodoProgress(partsDir, progressFile) {
+function loadTasks(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  const raw = fs.readFileSync(filePath, 'utf8');
+  if (ext === '.json') return JSON.parse(raw);
+  if (ext === '.yaml' || ext === '.yml') return yaml.load(raw);
+  return [];
+}
+
+function syncTodoProgress(partsDir, progressFile, extraFiles = []) {
   const progress = JSON.parse(fs.readFileSync(progressFile, 'utf8'));
   progress.progress = progress.progress || [];
   progress.pendingTasks = progress.pendingTasks || [];
@@ -9,11 +18,17 @@ function syncTodoProgress(partsDir, progressFile) {
   const doneSet = new Set(progress.progress.map(p => p.commit));
   const pendingSet = new Set(progress.pendingTasks.map(p => p.commit));
 
-  const files = fs.readdirSync(partsDir).filter(f => f.endsWith('.json'));
+  const partFiles = fs
+    .readdirSync(partsDir)
+    .filter(f => ['.json', '.yaml', '.yml'].includes(path.extname(f)));
 
-  files.forEach(file => {
-    const tasks = JSON.parse(fs.readFileSync(path.join(partsDir, file), 'utf8'));
-    tasks.forEach(task => {
+  const allFiles = partFiles.map(f => path.join(partsDir, f)).concat(extraFiles);
+
+  allFiles.forEach(file => {
+    if (!fs.existsSync(file)) return;
+    const tasks = loadTasks(file) || [];
+    (tasks || []).forEach(task => {
+      if (!task || !task.commit) return;
       if (task.status === 'done') {
         if (!doneSet.has(task.commit)) {
           progress.progress.push({ commit: task.commit, status: 'done' });
@@ -35,8 +50,12 @@ function syncTodoProgress(partsDir, progressFile) {
 if (require.main === module) {
   const partsDir = path.join(__dirname, '../advancedToDo_parts');
   const progressFile = path.join(__dirname, '../advancedprogress.json');
-  syncTodoProgress(partsDir, progressFile);
+  const extra = [
+    path.join(__dirname, '../advancedToDo.json'),
+    path.join(__dirname, '../advancedToDo.yaml'),
+  ];
+  syncTodoProgress(partsDir, progressFile, extra);
   console.log('Synchronized ToDo parts with progress file');
 }
 
-module.exports = { syncTodoProgress };
+module.exports = { syncTodoProgress, loadTasks };


### PR DESCRIPTION
## Summary
- extend sync-todo-progress script to parse main advancedToDo yaml and json alongside parts
- document sync-todo-progress.js in repository map

## Testing
- `node scripts/validate-repository-map.ts`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689baabc36448322becac086c1099e5f