### PR TITLE
feat: add repository map summary script

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12242,5 +12242,12 @@
     "task": "Validate repository_map.yaml structure",
     "test": "scripts/validate-repository-map.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add repository map summary script",
+    "path": "scripts/repository-map-summary.ts",
+    "task": "Output module counts from repository_map.yaml",
+    "test": "",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12011,3 +12011,8 @@
   task: Validate repository_map.yaml structure
   test: scripts/validate-repository-map.test.ts
   status: done
+- commit: Add repository map summary script
+  path: scripts/repository-map-summary.ts
+  task: Output module counts from repository_map.yaml
+  test: ""
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1456,6 +1456,10 @@
     {
       "commit": "Add desertification tracker plugin and agent",
       "status": "done"
+    },
+    {
+      "commit": "Add repository map summary script",
+      "status": "done"
     }
   ],
   "metacommitTags": [

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -46,3 +46,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added repository map validation script to verify repository structure.
 - Added climate news plugin with basic climate service stub.
 - Enhanced DesertTrackerAgent with optional UNCCD API integration and updated plugin configuration.
+- Added repository map summary script to list module counts for quick overview.

--- a/scripts/repository-map-summary.ts
+++ b/scripts/repository-map-summary.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env ts-node
+/**
+ * scripts/repository-map-summary.ts
+ *
+ * Small utility that prints a summary of modules defined in
+ * `repositorypflege/repository_map.yaml`.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+const file = path.join(__dirname, '../repositorypflege/repository_map.yaml');
+
+try {
+  const raw = fs.readFileSync(file, 'utf8');
+  const data = yaml.load(raw) as any;
+
+  const items = Array.isArray(data.repository_map) ? data.repository_map : [];
+  items.forEach((item: any) => {
+    const name = item.name || 'unnamed';
+    const modules = Array.isArray(item.modules) ? item.modules.length : 0;
+    console.log(`${name}: ${modules} module(s)`);
+  });
+} catch (err) {
+  console.error('Failed to read repository map:', err);
+  process.exit(1);
+}
+


### PR DESCRIPTION
## Summary
- add utility to list module counts from repository_map.yaml
- record script in advanced ToDo and progress trackers
- log addition in feedbackcodex

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx ts-node scripts/repository-map-summary.ts`


------
https://chatgpt.com/codex/tasks/task_e_689bae50d4f483228d1901ef6c5f9974