### PR TITLE
feat: scaffold forest service microservice

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11749,9 +11749,9 @@
   {
     "commit": "Scaffold forest_service microservice",
     "path": "agents/news_climate/forest_service.py",
-    "status": "todo",
+    "status": "done",
     "task": "Provide wildfire and deforestation data",
-    "test": "agents/news_climate/forest_service.test.py"
+    "test": "agents/news_climate/forest_service_test.py"
   },
   {
     "commit": "Scaffold flood_service microservice",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11660,8 +11660,8 @@
 - commit: Scaffold forest_service microservice
   path: agents/news_climate/forest_service.py
   task: Provide wildfire and deforestation data
-  test: agents/news_climate/forest_service.test.py
-  status: todo
+  test: agents/news_climate/forest_service_test.py
+  status: done
 - commit: Scaffold flood_service microservice
   path: agents/news_climate/flood_service.py
   task: Supply global flood mapping feeds

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add climate news aggregation stub",
+  "lastCommit": "feat: scaffold forest_service microservice",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added climate news plugin and climate metrics service stub.",
+  "notes": "Added climate news plugin and climate metrics service stub. Added forest service microservice stub for wildfire and deforestation metrics.",
   "pendingTasks": [
     {
       "commit": "Integrate finetune and review services in compose",
@@ -13,7 +13,7 @@
     },
     {
       "commit": "Scaffold forest_service microservice",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Scaffold flood_service microservice",
@@ -157,6 +157,10 @@
     }
   ],
   "progress": [
+    {
+      "commit": "Scaffold forest_service microservice",
+      "status": "done"
+    },
     {
       "commit": "Add live suggestion badges to CREPVisualizer",
       "status": "done"

--- a/agents/news_climate/forest_service.py
+++ b/agents/news_climate/forest_service.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Placeholder microservice for forest dynamics metrics."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ForestMetrics:
+    """Basic metrics describing forest dynamics.
+
+    Attributes:
+        wildfire: Index representing wildfire activity.
+        deforestation: Rate of deforestation in hectares per year.
+    """
+
+    wildfire: float = 0.0
+    deforestation: float = 0.0
+
+
+def fetch_forest_metrics() -> ForestMetrics:
+    """Fetch current forest metrics.
+
+    This stub returns zero values until real integrations are implemented.
+    """
+
+    return ForestMetrics()
+

--- a/agents/news_climate/forest_service_test.py
+++ b/agents/news_climate/forest_service_test.py
@@ -1,0 +1,7 @@
+from agents.news_climate.forest_service import ForestMetrics, fetch_forest_metrics
+
+
+def test_fetch_forest_metrics_returns_defaults() -> None:
+    metrics = fetch_forest_metrics()
+    assert isinstance(metrics, ForestMetrics)
+    assert metrics.wildfire == metrics.deforestation == 0.0


### PR DESCRIPTION
## Summary
- add forest_service stub returning wildfire and deforestation metrics
- add basic test verifying default metrics
- mark forest_service task done in advanced ToDo and progress files

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pytest agents/news_climate/forest_service_test.py`


------
https://chatgpt.com/codex/tasks/task_e_689bb2e05b5483229d0275ca6edb6166