### PR TITLE
feat: scaffold flood service microservice

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11756,9 +11756,9 @@
   {
     "commit": "Scaffold flood_service microservice",
     "path": "agents/news_climate/flood_service.py",
-    "status": "todo",
+    "status": "done",
     "task": "Supply global flood mapping feeds",
-    "test": "agents/news_climate/flood_service.test.py"
+    "test": "agents/news_climate/flood_service_test.py"
   },
   {
     "commit": "Scaffold economy_service microservice",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11665,8 +11665,8 @@
 - commit: Scaffold flood_service microservice
   path: agents/news_climate/flood_service.py
   task: Supply global flood mapping feeds
-  test: agents/news_climate/flood_service.test.py
-  status: todo
+  test: agents/news_climate/flood_service_test.py
+  status: done
 - commit: Scaffold economy_service microservice
   path: agents/news_climate/economy_service.py
   task: Aggregate income, wealth and land ownership stats

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: scaffold forest_service microservice",
+  "lastCommit": "feat: scaffold flood_service microservice",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added climate news plugin and climate metrics service stub. Added forest service microservice stub for wildfire and deforestation metrics.",
+  "notes": "Added climate news plugin and climate metrics service stub. Added forest service microservice stub for wildfire and deforestation metrics. Added flood service microservice stub for global flood mapping feeds.",
   "pendingTasks": [
     {
       "commit": "Integrate finetune and review services in compose",
@@ -17,7 +17,7 @@
     },
     {
       "commit": "Scaffold flood_service microservice",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Scaffold economy_service microservice",

--- a/agents/news_climate/flood_service.py
+++ b/agents/news_climate/flood_service.py
@@ -1,0 +1,23 @@
+"""Placeholder microservice for global flood mapping feeds."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class FloodMetrics:
+    """Basic metrics describing global flood activity.
+
+    Attributes:
+        inundation: Estimated area affected by floods in square kilometers.
+    """
+
+    inundation: float = 0.0
+
+
+def fetch_flood_metrics() -> FloodMetrics:
+    """Fetch current global flood metrics.
+
+    This stub returns zero values until real integrations are implemented.
+    """
+
+    return FloodMetrics()

--- a/agents/news_climate/flood_service_test.py
+++ b/agents/news_climate/flood_service_test.py
@@ -1,0 +1,7 @@
+from agents.news_climate.flood_service import FloodMetrics, fetch_flood_metrics
+
+
+def test_fetch_flood_metrics_returns_defaults() -> None:
+    metrics = fetch_flood_metrics()
+    assert isinstance(metrics, FloodMetrics)
+    assert metrics.inundation == 0.0

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -47,3 +47,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added climate news plugin with basic climate service stub.
 - Enhanced DesertTrackerAgent with optional UNCCD API integration and updated plugin configuration.
 - Added repository map summary script to list module counts for quick overview.
+- Scaffolded flood service microservice stub for global flood mapping feeds.


### PR DESCRIPTION
## Summary
- add placeholder flood service microservice for global flood mapping feeds
- cover flood service with basic test and mark todo entries as done
- update progress and feedback notes

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pytest agents/news_climate/flood_service_test.py`


------
https://chatgpt.com/codex/tasks/task_e_689bb7e933e08322abfc664b7b577ea5