### PR TITLE
feat: add ArtGallery component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12015,7 +12015,7 @@
   {
     "commit": "Create ArtGallery component",
     "path": "packages/unifiedmandala-ui/components/ArtGallery.tsx",
-    "status": "todo",
+    "status": "done",
     "task": "Render generative art pieces",
     "test": "packages/unifiedmandala-ui/components/ArtGallery.test.tsx"
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11851,7 +11851,7 @@
   path: packages/unifiedmandala-ui/components/ArtGallery.tsx
   task: Render generative art pieces
   test: packages/unifiedmandala-ui/components/ArtGallery.test.tsx
-  status: todo
+  status: done
 - commit: Create ImpactMap component
   path: packages/unifiedmandala-ui/components/ImpactMap.tsx
   task: Visualize societal impact metrics

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: scaffold flood_service microservice",
+  "lastCommit": "feat: add ArtGallery component",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -137,7 +137,7 @@
     },
     {
       "commit": "Create ArtGallery component",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Create ImpactMap component",
@@ -1463,6 +1463,10 @@
     },
     {
       "commit": "Add repository map summary script",
+      "status": "done"
+    },
+    {
+      "commit": "Implement ArtGallery component",
       "status": "done"
     }
   ],

--- a/packages/unifiedmandala-ui/components/ArtGallery.test.tsx
+++ b/packages/unifiedmandala-ui/components/ArtGallery.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ArtGallery from './ArtGallery';
+
+test('renders provided art pieces', () => {
+  const pieces = [
+    { id: 'one', url: '/img/one.png' },
+    { id: 'two', url: '/img/two.png' },
+  ];
+  render(<ArtGallery pieces={pieces} />);
+  const gallery = screen.getByTestId('art-gallery');
+  expect(gallery.querySelectorAll('img')).toHaveLength(2);
+});

--- a/packages/unifiedmandala-ui/components/ArtGallery.tsx
+++ b/packages/unifiedmandala-ui/components/ArtGallery.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface ArtPiece {
+  id: string;
+  url: string;
+  alt?: string;
+}
+
+interface ArtGalleryProps {
+  pieces: ArtPiece[];
+}
+
+/**
+ * Renders a simple gallery of generative art pieces.
+ */
+const ArtGallery: React.FC<ArtGalleryProps> = ({ pieces }) => (
+  <div
+    data-testid="art-gallery"
+    style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}
+  >
+    {pieces.map((piece) => (
+      <img
+        key={piece.id}
+        src={piece.url}
+        alt={piece.alt ?? `art-${piece.id}`}
+        style={{ maxWidth: '200px' }}
+      />
+    ))}
+  </div>
+);
+
+export default ArtGallery;


### PR DESCRIPTION
## Summary
- add ArtGallery component to render generative art pieces
- document completion in advancedToDo and progress log

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `pnpm test packages/unifiedmandala-ui/components/ArtGallery.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689bc5d36d1c83229c33df86c04eeb2a