### PR TITLE
feat: add global events integration

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-12, in der Zeit des Abend.
+Am 2025-08-12, in der Zeit des Nacht.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Reflexion (Fokus: P)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11805,7 +11805,7 @@
   {
     "commit": "Add global events plugin with positive progress services",
     "path": "plugins/global-events.yaml",
-    "status": "todo",
+    "status": "done",
     "task": "Define global & positive progress event layer",
     "test": ""
   },
@@ -11847,7 +11847,7 @@
   {
     "commit": "Register global events services in pipeline config",
     "path": "pipeline_config.yaml",
-    "status": "todo",
+    "status": "done",
     "task": "Add sigillin_map and CREP thresholds for global events",
     "test": ""
   },
@@ -11861,7 +11861,7 @@
   {
     "commit": "Schedule positive progress cron job",
     "path": "memory-jobs.yaml",
-    "status": "todo",
+    "status": "done",
     "task": "Add mandala-positive-hourly job for science_fetch",
     "test": ""
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11701,7 +11701,7 @@
   path: plugins/global-events.yaml
   task: Define global & positive progress event layer
   test: ""
-  status: todo
+  status: done
 - commit: Scaffold science_service microservice
   path: agents/global_events/science_service.py
   task: Fetch science breakthroughs from API
@@ -11731,7 +11731,7 @@
   path: pipeline_config.yaml
   task: Add sigillin_map and CREP thresholds for global events
   test: ""
-  status: todo
+  status: done
 - commit: Integrate global events services into compose
   path: docker-compose.yml
   task: Add global event microservices and orchestrator containers
@@ -11741,7 +11741,7 @@
   path: memory-jobs.yaml
   task: Add mandala-positive-hourly job for science_fetch
   test: ""
-  status: todo
+  status: done
 - commit: Define Auto-Resonanz sigillin
   path: codex-sigil.yaml
   task: Add um:2025-0804-AUTO-RESONANZ with trigger and services

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add ArtGallery component",
+  "lastCommit": "chore: finalize global events tracking",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -10,14 +10,6 @@
     {
       "commit": "Integrate finetune and review services in compose",
       "status": "todo"
-    },
-    {
-      "commit": "Scaffold forest_service microservice",
-      "status": "done"
-    },
-    {
-      "commit": "Scaffold flood_service microservice",
-      "status": "done"
     },
     {
       "commit": "Scaffold economy_service microservice",
@@ -44,23 +36,11 @@
       "status": "todo"
     },
     {
-      "commit": "Add global events plugin with positive progress services",
-      "status": "todo"
-    },
-    {
       "commit": "Create GlobalEventsPanel UI",
       "status": "todo"
     },
     {
-      "commit": "Register global events services in pipeline config",
-      "status": "todo"
-    },
-    {
       "commit": "Integrate global events services into compose",
-      "status": "todo"
-    },
-    {
-      "commit": "Schedule positive progress cron job",
       "status": "todo"
     },
     {
@@ -134,10 +114,6 @@
     {
       "commit": "Create IoTSensorWidget component",
       "status": "todo"
-    },
-    {
-      "commit": "Create ArtGallery component",
-      "status": "done"
     },
     {
       "commit": "Create ImpactMap component",
@@ -891,6 +867,3070 @@
     },
     {
       "commit": "Add repository map validation script",
+      "status": "done"
+    },
+    {
+      "commit": "Document Aeon Transition guidelines",
+      "status": "done"
+    },
+    {
+      "commit": "Draft Friendship system concept",
+      "status": "done"
+    },
+    {
+      "commit": "Add plugin registry and loader",
+      "status": "done"
+    },
+    {
+      "commit": "Implement Objective2UI service",
+      "status": "done"
+    },
+    {
+      "commit": "Add FeedbackButtons component",
+      "status": "done"
+    },
+    {
+      "commit": "Add bio sensor hooks and HapticService",
+      "status": "done"
+    },
+    {
+      "commit": "Add useABLayout hook",
+      "status": "done"
+    },
+    {
+      "commit": "Add PoeticSigillin module",
+      "status": "done"
+    },
+    {
+      "commit": "Add ResonanzMandala visualization",
+      "status": "done"
+    },
+    {
+      "commit": "Validate parent references in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Validate message IDs in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Validate message timestamps in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Detect self-referential child nodes",
+      "status": "done"
+    },
+    {
+      "commit": "Add SymbolMapper agent",
+      "status": "done"
+    },
+    {
+      "commit": "Implement Live CREP Timeline Visualization",
+      "status": "done"
+    },
+    {
+      "commit": "Implement komplexe Analyse und Kontextverarbeitung",
+      "status": "done"
+    },
+    {
+      "commit": "Integriere CREPManager History",
+      "status": "done"
+    },
+    {
+      "commit": "Aktivitätsdaten via Dispatcher laden",
+      "status": "done"
+    },
+    {
+      "commit": "Dispatch Befehl nutzt REST/gRPC Client",
+      "status": "done"
+    },
+    {
+      "commit": "Implement SigillinParser",
+      "status": "done"
+    },
+    {
+      "commit": "Implement ResonanzNavigator",
+      "status": "done"
+    },
+    {
+      "commit": "Add TriggerArchive utilities",
+      "status": "done"
+    },
+    {
+      "commit": "Add PoeticReactorAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Create AgentHeatmap dashboard",
+      "status": "done"
+    },
+    {
+      "commit": "Introduce AeonMemory",
+      "status": "done"
+    },
+    {
+      "commit": "Implement CollaborativeEditor",
+      "status": "done"
+    },
+    {
+      "commit": "Add CodexNavigatorAgent module",
+      "status": "done"
+    },
+    {
+      "commit": "Extend NucleonScanner with phi profile",
+      "status": "done"
+    },
+    {
+      "commit": "Implement AestheticsLayer",
+      "status": "done"
+    },
+    {
+      "commit": "Implement EthicsLayer",
+      "status": "done"
+    },
+    {
+      "commit": "Setup mTLS and Kong JWT Gateway",
+      "status": "done"
+    },
+    {
+      "commit": "Add OpenTelemetry and Storybook CI",
+      "status": "done"
+    },
+    {
+      "commit": "Provide Automerge-Federation with SyncStatus",
+      "status": "done"
+    },
+    {
+      "commit": "Run MetaLearnerAgent via GitHub Action",
+      "status": "done"
+    },
+    {
+      "commit": "Implement MandalaCoreLicense",
+      "status": "done"
+    },
+    {
+      "commit": "Create AeonKIResonanzAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Implement KIBewusstseinAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Extend NucleonScanner for v0.6 analysis",
+      "status": "done"
+    },
+    {
+      "commit": "Add ResonanzMetrics analyzer",
+      "status": "done"
+    },
+    {
+      "commit": "Add BewusstseinsResonanzComparator",
+      "status": "done"
+    },
+    {
+      "commit": "Implement AeonKIResonanzAnalyzer",
+      "status": "done"
+    },
+    {
+      "commit": "Add KIBewusstseinResonanzMonitor",
+      "status": "done"
+    },
+    {
+      "commit": "Expand NucleonScanner conversation import for v0.6",
+      "status": "done"
+    },
+    {
+      "commit": "Implement ConversationTodoExtractor",
+      "status": "done"
+    },
+    {
+      "commit": "Link CREP scores with todo priority",
+      "status": "done"
+    },
+    {
+      "commit": "Calendar integration for high priority todos",
+      "status": "done"
+    },
+    {
+      "commit": "Admin metrics dashboard",
+      "status": "done"
+    },
+    {
+      "commit": "Add codex-sync answer script and workflow",
+      "status": "done"
+    },
+    {
+      "commit": "Implement MetaScoreComposer aggregation",
+      "status": "done"
+    },
+    {
+      "commit": "Create MetaScoreChart component",
+      "status": "done"
+    },
+    {
+      "commit": "Add federation routes and SyncStatus UI",
+      "status": "done"
+    },
+    {
+      "commit": "Setup mTLS scripts and Kong JWT gateway",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate OpenTelemetry metrics and Storybook CI",
+      "status": "done"
+    },
+    {
+      "commit": "Implement CommonsAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Add CLI dispatch tool",
+      "status": "done"
+    },
+    {
+      "commit": "Add AdaptiveThreshold module",
+      "status": "done"
+    },
+    {
+      "commit": "Add DebounceManager utility",
+      "status": "done"
+    },
+    {
+      "commit": "Add withCircuit helper",
+      "status": "done"
+    },
+    {
+      "commit": "Add healthz route",
+      "status": "done"
+    },
+    {
+      "commit": "Add metaScores route",
+      "status": "done"
+    },
+    {
+      "commit": "Create Dashboard component",
+      "status": "done"
+    },
+    {
+      "commit": "Implement useBreakpoint hook",
+      "status": "done"
+    },
+    {
+      "commit": "Implement ResonanzpfadAgent analysis",
+      "status": "done"
+    },
+    {
+      "commit": "Add AutoDocGeneration to Nucleon-Scanner",
+      "status": "done"
+    },
+    {
+      "commit": "Add CREPFeedbackLoop module",
+      "status": "done"
+    },
+    {
+      "commit": "Add SigillinOnDemandGenerator CLI",
+      "status": "done"
+    },
+    {
+      "commit": "Add CREPToDoPrioritizer",
+      "status": "done"
+    },
+    {
+      "commit": "Add CREPConvoHeatmap component",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold universe-sim module",
+      "status": "done"
+    },
+    {
+      "commit": "Implement state manager and physics engine",
+      "status": "done"
+    },
+    {
+      "commit": "Add agent engine with interaction rules",
+      "status": "done"
+    },
+    {
+      "commit": "Add event logger and JSONL pipeline",
+      "status": "done"
+    },
+    {
+      "commit": "Add federation servers for gRPC and REST",
+      "status": "done"
+    },
+    {
+      "commit": "Implement CREP scanner and emergence analyzer",
+      "status": "done"
+    },
+    {
+      "commit": "Build visualization dashboard prototype",
+      "status": "done"
+    },
+    {
+      "commit": "Add sigil generator for simulation runs",
+      "status": "done"
+    },
+    {
+      "commit": "Set up CI/CD and tests",
+      "status": "done"
+    },
+    {
+      "commit": "Import country and region profiles",
+      "status": "done"
+    },
+    {
+      "commit": "Implement region profile REST endpoint",
+      "status": "done"
+    },
+    {
+      "commit": "Add style variant engine",
+      "status": "done"
+    },
+    {
+      "commit": "Implement basic A/B test for DE and FR",
+      "status": "done"
+    },
+    {
+      "commit": "Create project CRUD service",
+      "status": "done"
+    },
+    {
+      "commit": "Add match engine prototype",
+      "status": "done"
+    },
+    {
+      "commit": "Implement impact meter",
+      "status": "done"
+    },
+    {
+      "commit": "Add React UI for project views",
+      "status": "done"
+    },
+    {
+      "commit": "Add liveness and readiness endpoints",
+      "status": "done"
+    },
+    {
+      "commit": "Add self-healing and dead letter queue",
+      "status": "done"
+    },
+    {
+      "commit": "Expose Prometheus metrics",
+      "status": "done"
+    },
+    {
+      "commit": "Create Grafana dashboard template",
+      "status": "done"
+    },
+    {
+      "commit": "Implement dispatcher backoff and retry logic",
+      "status": "done"
+    },
+    {
+      "commit": "Configure Vault integration",
+      "status": "done"
+    },
+    {
+      "commit": "Add ML based task prioritization plugin",
+      "status": "done"
+    },
+    {
+      "commit": "Add KEDA and HPA scaling",
+      "status": "done"
+    },
+    {
+      "commit": "Implement RBAC and policy management",
+      "status": "done"
+    },
+    {
+      "commit": "Implement multi agent coordination handler",
+      "status": "done"
+    },
+    {
+      "commit": "Create LangChain adapter and sigil generator service",
+      "status": "done"
+    },
+    {
+      "commit": "Extend GitHub Actions for extras",
+      "status": "done"
+    },
+    {
+      "commit": "Write documentation and examples for extras",
+      "status": "done"
+    },
+    {
+      "commit": "Add append only chat writer",
+      "status": "done"
+    },
+    {
+      "commit": "Add schema validation hook script",
+      "status": "done"
+    },
+    {
+      "commit": "Add sigil trigger script",
+      "status": "done"
+    },
+    {
+      "commit": "Add vector indexer service",
+      "status": "done"
+    },
+    {
+      "commit": "Add policy enforcement stub",
+      "status": "done"
+    },
+    {
+      "commit": "Add event hook publisher",
+      "status": "done"
+    },
+    {
+      "commit": "Add event hook workflow test",
+      "status": "done"
+    },
+    {
+      "commit": "Update mock data generator",
+      "status": "done"
+    },
+    {
+      "commit": "Update shared schema utilities",
+      "status": "done"
+    },
+    {
+      "commit": "Extend CI pipeline for schema and vector tests",
+      "status": "done"
+    },
+    {
+      "commit": "Implement ImpactDashboard component with MandalaNetworkView",
+      "status": "done"
+    },
+    {
+      "commit": "Add ProjectListView and CustomRegionGallery components",
+      "status": "done"
+    },
+    {
+      "commit": "Add Friendship & SocialGood API Swagger spec",
+      "status": "done"
+    },
+    {
+      "commit": "Create MobileImpactDashboard for React Native",
+      "status": "done"
+    },
+    {
+      "commit": "Add Go-Bridge scaffold with CLI and REST client",
+      "status": "done"
+    },
+    {
+      "commit": "Add sync-todo-progress script",
+      "status": "done"
+    },
+    {
+      "commit": "Add ConvoMemoryBridge module",
+      "status": "done"
+    },
+    {
+      "commit": "Add MemorySonifier utility",
+      "status": "done"
+    },
+    {
+      "commit": "Add ToDoWeaver CLI",
+      "status": "done"
+    },
+    {
+      "commit": "Add UniversePulseSimulator",
+      "status": "done"
+    },
+    {
+      "commit": "Add next-sigil generation script",
+      "status": "done"
+    },
+    {
+      "commit": "Add MemoryMesh region archive service",
+      "status": "done"
+    },
+    {
+      "commit": "Add ReflectionEngine stub",
+      "status": "done"
+    },
+    {
+      "commit": "Add AdaptationService skeleton",
+      "status": "done"
+    },
+    {
+      "commit": "Add RelationshipMeter utility",
+      "status": "done"
+    },
+    {
+      "commit": "Add SymbolzeitOrchestrator module",
+      "status": "done"
+    },
+    {
+      "commit": "Add SigillinValidator CLI",
+      "status": "done"
+    },
+    {
+      "commit": "Add C-Tutor skeleton",
+      "status": "done"
+    },
+    {
+      "commit": "Add JavaHamster AI skeleton",
+      "status": "done"
+    },
+    {
+      "commit": "Add WeightedDispatcher",
+      "status": "done"
+    },
+    {
+      "commit": "Add patternReactivator",
+      "status": "done"
+    },
+    {
+      "commit": "Add ReplayController",
+      "status": "done"
+    },
+    {
+      "commit": "Add useEventGlow hook",
+      "status": "done"
+    },
+    {
+      "commit": "Add silenceWatcher util",
+      "status": "done"
+    },
+    {
+      "commit": "Add aggregateCREP util",
+      "status": "done"
+    },
+    {
+      "commit": "Add CREPMusicGenerator",
+      "status": "done"
+    },
+    {
+      "commit": "Add Go-Agent watcher",
+      "status": "done"
+    },
+    {
+      "commit": "Add POC Run Guide",
+      "status": "done"
+    },
+    {
+      "commit": "Validate Swagger Docs",
+      "status": "done"
+    },
+    {
+      "commit": "Implement ResonanzPoetik module",
+      "status": "done"
+    },
+    {
+      "commit": "MemoryMesh architecture sketch",
+      "status": "done"
+    },
+    {
+      "commit": "Transition sigil update",
+      "status": "done"
+    },
+    {
+      "commit": "Add agent registry YAML",
+      "status": "done"
+    },
+    {
+      "commit": "Gamification API routes",
+      "status": "done"
+    },
+    {
+      "commit": "Sigil Story component",
+      "status": "done"
+    },
+    {
+      "commit": "Add MandalaGraph visualization",
+      "status": "done"
+    },
+    {
+      "commit": "Add GenerativeOverlay stub",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - 42254d4e-d731-46fc-8f9d-f32a94ef3834",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add Go GPTBridge modules",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add mandala-gpt CLI",
+      "status": "done"
+    },
+    {
+      "commit": "Add Markdown ToDo parser",
+      "status": "done"
+    },
+    {
+      "commit": "Implement GhostShell session store",
+      "status": "done"
+    },
+    {
+      "commit": "Add GhostShell cluster manager",
+      "status": "done"
+    },
+    {
+      "commit": "Add WebSocket JWT middleware",
+      "status": "done"
+    },
+    {
+      "commit": "Add GhostShell rate limiter",
+      "status": "done"
+    },
+    {
+      "commit": "Expose GhostShell Prometheus metrics",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate Pino logger",
+      "status": "done"
+    },
+    {
+      "commit": "Add fragment watcher",
+      "status": "done"
+    },
+    {
+      "commit": "Implement adaptive scheduler",
+      "status": "done"
+    },
+    {
+      "commit": "Emit sigil alerts",
+      "status": "done"
+    },
+    {
+      "commit": "Client handler for sigil alerts",
+      "status": "done"
+    },
+    {
+      "commit": "Add GhostShell room support",
+      "status": "done"
+    },
+    {
+      "commit": "Add multi-stage Dockerfiles",
+      "status": "done"
+    },
+    {
+      "commit": "Create Kubernetes Helm chart",
+      "status": "done"
+    },
+    {
+      "commit": "Add CI pipeline",
+      "status": "done"
+    },
+    {
+      "commit": "Automate release tagging",
+      "status": "done"
+    },
+    {
+      "commit": "Add changelog generator",
+      "status": "done"
+    },
+    {
+      "commit": "Implement plugin registry admin panel",
+      "status": "done"
+    },
+    {
+      "commit": "Setup backup script",
+      "status": "done"
+    },
+    {
+      "commit": "Configure Dependabot",
+      "status": "done"
+    },
+    {
+      "commit": "Add NPM scripts for GhostShell start",
+      "status": "done"
+    },
+    {
+      "commit": "Blockchain-based plugin trust",
+      "status": "done"
+    },
+    {
+      "commit": "Add AgentCoordinator orchestrator",
+      "status": "done"
+    },
+    {
+      "commit": "Add SigillinIntegrityChecker",
+      "status": "done"
+    },
+    {
+      "commit": "Create RealTimeCollaborationChat",
+      "status": "done"
+    },
+    {
+      "commit": "Introduce PluginSecurityAuditor",
+      "status": "done"
+    },
+    {
+      "commit": "Implement ExternalIntegrationAPI",
+      "status": "done"
+    },
+    {
+      "commit": "Add WebhookSystem",
+      "status": "done"
+    },
+    {
+      "commit": "Create GuidedOnboardingTour",
+      "status": "done"
+    },
+    {
+      "commit": "Add AdaptiveUILayout component",
+      "status": "done"
+    },
+    {
+      "commit": "Upgrade Node version to 20",
+      "status": "done"
+    },
+    {
+      "commit": "Add ESLint configuration",
+      "status": "done"
+    },
+    {
+      "commit": "Convert agent tests to ESM",
+      "status": "done"
+    },
+    {
+      "commit": "Enable jest coverage in CI",
+      "status": "done"
+    },
+    {
+      "commit": "Introduce dotenv configuration loader",
+      "status": "done"
+    },
+    {
+      "commit": "Add package level tsconfig",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add ParticleForce module",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add ExportFormats utilities",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add MaterialModul for pyramid simulation",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add MassVerhaeltnisModul",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add KammerTopologie module",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add KlangRaumModul",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add KanalVerbindungModul",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add SternausrichtungModul",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add HieroglyphenParser",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add NightWorkScheduler agent",
+      "status": "done"
+    },
+    {
+      "commit": "docs: add FutureAI Vision paper",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add GenesisGPTGateway",
+      "status": "done"
+    },
+    {
+      "commit": "docs: add SocietyGPT Teamboard blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "feat: implement LegasthenieHelper",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add OvernightProgressReporter",
+      "status": "done"
+    },
+    {
+      "commit": "docs: add Genesis_Veröffentlichungsstrategie",
+      "status": "done"
+    },
+    {
+      "commit": "Extractor, generate-todo-sigil.js, repair-repo.sh)",
+      "status": "done"
+    },
+    {
+      "commit": "c & Manifest-Generator – Dokumentation auf Knopfdruck",
+      "status": "done"
+    },
+    {
+      "commit": "Implement PyramidConfig and loader",
+      "status": "done"
+    },
+    {
+      "commit": "Implement interactive PyramidView component",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate Web Audio pyramid sonification",
+      "status": "done"
+    },
+    {
+      "commit": "Add PyramidInit CLI and config generator",
+      "status": "done"
+    },
+    {
+      "commit": "Finalize AI-UI Pyramid Suite blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate CODEX Pyramid Init Sigil",
+      "status": "done"
+    },
+    {
+      "commit": "Add Sonification module",
+      "status": "done"
+    },
+    {
+      "commit": "Implement weighted node generation",
+      "status": "done"
+    },
+    {
+      "commit": "Add ARIA labels for PyramidView",
+      "status": "done"
+    },
+    {
+      "commit": "Add fallback audio and error markers",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add PyramidWeighting module",
+      "status": "done"
+    },
+    {
+      "commit": "feat: minimal Mandala UI with agent mapping",
+      "status": "done"
+    },
+    {
+      "commit": "Add todoSigilUpdater module",
+      "status": "done"
+    },
+    {
+      "commit": "Add todoCommentScanner tool",
+      "status": "done"
+    },
+    {
+      "commit": "Add conversationProgress tracker",
+      "status": "done"
+    },
+    {
+      "commit": "Extend selfAnalyzer module",
+      "status": "done"
+    },
+    {
+      "commit": "Create GespraechsfallGenerator utility",
+      "status": "done"
+    },
+    {
+      "commit": "Implement loadSymbolphasen helper",
+      "status": "done"
+    },
+    {
+      "commit": "Add simple RestClient module",
+      "status": "done"
+    },
+    {
+      "commit": "Implement MetaRunner script for fractal tasks",
+      "status": "done"
+    },
+    {
+      "commit": "Add MetaRunner blueprint YAML",
+      "status": "done"
+    },
+    {
+      "commit": "Create ZIPMEM manifest structure",
+      "status": "done"
+    },
+    {
+      "commit": "Implement ArchivAeon symbolic archive agent",
+      "status": "done"
+    },
+    {
+      "commit": "Add newadvancedconvo_splitter script",
+      "status": "done"
+    },
+    {
+      "commit": "Add SealCore integration interface",
+      "status": "done"
+    },
+    {
+      "commit": "Implement PyramidConfig interface and loader",
+      "status": "done"
+    },
+    {
+      "commit": "Add pyramid utils unit tests",
+      "status": "done"
+    },
+    {
+      "commit": "Add deployment snippets for Pyramid UI",
+      "status": "done"
+    },
+    {
+      "commit": "Add pyramid error and state management",
+      "status": "done"
+    },
+    {
+      "commit": "Optimize pyramid rendering performance",
+      "status": "done"
+    },
+    {
+      "commit": "Add accessibility helpers",
+      "status": "done"
+    },
+    {
+      "commit": "Create AutoDoc comment extractor",
+      "status": "done"
+    },
+    {
+      "commit": "Setup configuration schema with AJV",
+      "status": "done"
+    },
+    {
+      "commit": "Implement composite core framework",
+      "status": "done"
+    },
+    {
+      "commit": "Add React Three-Fiber skeleton",
+      "status": "done"
+    },
+    {
+      "commit": "Build audio engine with WebAudio",
+      "status": "done"
+    },
+    {
+      "commit": "Connect CosmicTheoryAgent UI bridge",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate OpenTelemetry instrumentation",
+      "status": "done"
+    },
+    {
+      "commit": "Setup CI tests and deployment",
+      "status": "done"
+    },
+    {
+      "commit": "Add AutoDocManifest generator script",
+      "status": "done"
+    },
+    {
+      "commit": "Split advanced conversations into fragments",
+      "status": "done"
+    },
+    {
+      "commit": "Archive outdated tasks",
+      "status": "done"
+    },
+    {
+      "commit": "Create Sigilcards UI prototype",
+      "status": "done"
+    },
+    {
+      "commit": "Draft dev-agent system blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Organize GenesisAeonZIPMEM",
+      "status": "done"
+    },
+    {
+      "commit": "Implement ZIPMEMManagementAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Add AeonSealAI integration blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Expand pyramid blueprint docs",
+      "status": "done"
+    },
+    {
+      "commit": "Add autodoc generator script",
+      "status": "done"
+    },
+    {
+      "commit": "Add RL weight adjustment for CosmicTheoryAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Add mutation crossover for CosmicTheoryAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Add trace context events",
+      "status": "done"
+    },
+    {
+      "commit": "Add live sigil alert bridge",
+      "status": "done"
+    },
+    {
+      "commit": "Create interactive PyramidView",
+      "status": "done"
+    },
+    {
+      "commit": "Add phi pi audio integration",
+      "status": "done"
+    },
+    {
+      "commit": "Optimize layer caching",
+      "status": "done"
+    },
+    {
+      "commit": "Add Cypress integration tests",
+      "status": "done"
+    },
+    {
+      "commit": "Setup ProtoTyp deployment environment",
+      "status": "done"
+    },
+    {
+      "commit": "Add fractal anchor metadata",
+      "status": "done"
+    },
+    {
+      "commit": "Extend CosmicTheoryAgent with SigilManager",
+      "status": "done"
+    },
+    {
+      "commit": "Implement AeonAI Pyramid UI blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Create LocalhostOffline Docker setup",
+      "status": "done"
+    },
+    {
+      "commit": "Generate Sigillin for CosmicTheoryAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate Sigillin hooks in CosmicTheoryAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Add UI Agent mapping matrix",
+      "status": "done"
+    },
+    {
+      "commit": "Add AeonNeuroNetz comparison docs",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from newadvancedconversations.json - AgentCoordinator",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from newadvancedconversations.json - EmergencePredictorAgent",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from newadvancedconversations.json - GPTContextSummarizer",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from newadvancedconversations.json - SigillinBlockchainIntegration",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from newadvancedconversations.json - PrivacyComplianceAgent",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from CosmicTheoryAgent conversation - implement gRPC call",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from CosmicTheoryAgent conversation - Python service access",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from CosmicTheoryAgent conversation - React Starter setup",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from CosmicTheoryAgent conversation - 3D canvas sketch",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from CosmicTheoryAgent conversation - Tone.js playground",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from CosmicTheoryAgent conversation - MetricsStore interface",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid-UI conversation - generate nested layers",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid-UI conversation - NestedPyramid component",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid-UI conversation - Sigillin initialization",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid-UI conversation - CREP tuning",
+      "status": "done"
+    },
+    {
+      "commit": "Add Pyramid VR mode",
+      "status": "done"
+    },
+    {
+      "commit": "Setup Proto-Deploy infrastructure",
+      "status": "done"
+    },
+    {
+      "commit": "Validate TheoryAgentConfig with AJV",
+      "status": "done"
+    },
+    {
+      "commit": "Add SigilAlert integration",
+      "status": "done"
+    },
+    {
+      "commit": "Setup CI pipeline with OTel Collector",
+      "status": "done"
+    },
+    {
+      "commit": "Add Cypress E2E tests for SigilAlert",
+      "status": "done"
+    },
+    {
+      "commit": "Add SigilManager module",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate SigilManager into CosmicTheoryAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Add FractalSigilGenerator",
+      "status": "done"
+    },
+    {
+      "commit": "Implement nested layer generator",
+      "status": "done"
+    },
+    {
+      "commit": "Create NestedPyramid component",
+      "status": "done"
+    },
+    {
+      "commit": "Add offline Docker Compose setup",
+      "status": "done"
+    },
+    {
+      "commit": "Draft AeonUniversal DSL grammar",
+      "status": "done"
+    },
+    {
+      "commit": "Update README and Handbuch with transition feedback",
+      "status": "done"
+    },
+    {
+      "commit": "Extend advanced_crep_eval with resonance correlation",
+      "status": "done"
+    },
+    {
+      "commit": "Add AeonAgent example using advanced_crep_eval",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from CosmicTheoryAgent conversation - CREPWaves component",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from CosmicTheoryAgent conversation - TaskDNA component",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - SigilCrudPanel component",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - CREPVisualizer component",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - NumericDashboard component",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - ThreeDPyramid component",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - AudioEngine module",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - ResonanceOverlay component",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - ErrorEmergence component",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - VRPortal component",
+      "status": "done"
+    },
+    {
+      "commit": "Improve assign_symbol with archetypes",
+      "status": "done"
+    },
+    {
+      "commit": "Add multi-metric CREP evaluation",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate LLM commentary service",
+      "status": "done"
+    },
+    {
+      "commit": "Add fractal feedback graph visualization",
+      "status": "done"
+    },
+    {
+      "commit": "Build Streamlit demo interface",
+      "status": "done"
+    },
+    {
+      "commit": "Extend memory store with mood and archetype metadata",
+      "status": "done"
+    },
+    {
+      "commit": "Add CosmicDataLoader module",
+      "status": "done"
+    },
+    {
+      "commit": "Add FractalAnalyzer utilities",
+      "status": "done"
+    },
+    {
+      "commit": "Implement SymbolicRegression module",
+      "status": "done"
+    },
+    {
+      "commit": "Add CosmicTheoryAgentEvents definitions",
+      "status": "done"
+    },
+    {
+      "commit": "Create CosmicTheoryPanel component",
+      "status": "done"
+    },
+    {
+      "commit": "Add AgentMapping blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Apply README and Handbuch feedback",
+      "status": "done"
+    },
+    {
+      "commit": "Create ZIP analysis script",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate Symbolic Regression to CosmicTheoryAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Add MandalaCREPCircle component",
+      "status": "done"
+    },
+    {
+      "commit": "Add MetricsDashboard component",
+      "status": "done"
+    },
+    {
+      "commit": "Add auto archive script",
+      "status": "done"
+    },
+    {
+      "commit": "Add FourierLayer plugin",
+      "status": "done"
+    },
+    {
+      "commit": "Add FourierLayerConfig schema",
+      "status": "done"
+    },
+    {
+      "commit": "Add createFourierLayerTree utility",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from CosmicTheoryAgent conversation - PySR service client",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from CosmicTheoryAgent conversation - metrics visualization event",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - EventBridge integration",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - Sigil archive service",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - CREPVisualizer timeline",
+      "status": "done"
+    },
+    {
+      "commit": "Add FourierLayer metrics API",
+      "status": "done"
+    },
+    {
+      "commit": "Split newadvancedconversations into fragments",
+      "status": "done"
+    },
+    {
+      "commit": "Implement AeonCompassionAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Add MandalaCycle core module",
+      "status": "done"
+    },
+    {
+      "commit": "Update Pyramid UI Spec blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Add EpisodicMemory storage",
+      "status": "done"
+    },
+    {
+      "commit": "Add CLI state visualization",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from newadvancedconversations.json - Fourier analysis REST API",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from newadvancedconversations.json - FrequencyMandala component",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from newadvancedconversations.json - FractalTaskRunner",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from newadvancedconversations.json - YAMLTaskGenerator UI",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from newadvancedconversations.json - Fourier observability setup",
+      "status": "done"
+    },
+    {
+      "commit": "Add FourierMetricsCLI",
+      "status": "done"
+    },
+    {
+      "commit": "Add CREPContext state manager",
+      "status": "done"
+    },
+    {
+      "commit": "SVG-Export oder WebSocket-Event für UI",
+      "status": "done"
+    },
+    {
+      "commit": "Add FourierMetricsServer",
+      "status": "done"
+    },
+    {
+      "commit": "Add parse-newadvanced-conversations test",
+      "status": "done"
+    },
+    {
+      "commit": "Implement CREPStatsCard component",
+      "status": "done"
+    },
+    {
+      "commit": "Add impulse CREP update route",
+      "status": "done"
+    },
+    {
+      "commit": "Return avg resonance via metaScores route",
+      "status": "done"
+    },
+    {
+      "commit": "Add feedback_log for adaptive systems",
+      "status": "done"
+    },
+    {
+      "commit": "Implement SystemComponent classification taxonomy",
+      "status": "done"
+    },
+    {
+      "commit": "Add Nullmembran SI Heatmap",
+      "status": "done"
+    },
+    {
+      "commit": "Provide OpenAPI interface for Nukleon Scanner",
+      "status": "done"
+    },
+    {
+      "commit": "Implement sigillin-cli features",
+      "status": "done"
+    },
+    {
+      "commit": "Send cached Fourier metrics on connection",
+      "status": "done"
+    },
+    {
+      "commit": "Add circuit breaker and caching to PySR service",
+      "status": "done"
+    },
+    {
+      "commit": "Add metrics instrumentation for PySR service",
+      "status": "done"
+    },
+    {
+      "commit": "Implement FourierLayerBridge for Pyramid UI integration",
+      "status": "done"
+    },
+    {
+      "commit": "Extend CosmicTheoryAgent with VR hooks",
+      "status": "done"
+    },
+    {
+      "commit": "Create PyramidVRMeetingRoom component",
+      "status": "done"
+    },
+    {
+      "commit": "Add scan-todo-comments script",
+      "status": "done"
+    },
+    {
+      "commit": "Add sigillin-cli grep-conversations command",
+      "status": "done"
+    },
+    {
+      "commit": "Implement parse-advanced-conversations script",
+      "status": "done"
+    },
+    {
+      "commit": "CosmicTheoryAgent gRPC REST access",
+      "status": "done"
+    },
+    {
+      "commit": "Add FourierLayer unit tests",
+      "status": "done"
+    },
+    {
+      "commit": "Add fourier analysis endpoint",
+      "status": "done"
+    },
+    {
+      "commit": "Create FourierVisual component",
+      "status": "done"
+    },
+    {
+      "commit": "Fetch real avgResonance in CREPStatsCard",
+      "status": "done"
+    },
+    {
+      "commit": "Add Mandala SVG export event",
+      "status": "done"
+    },
+    {
+      "commit": "Add PhanteonIntegration service",
+      "status": "done"
+    },
+    {
+      "commit": "Add BoundaryConditionManager",
+      "status": "done"
+    },
+    {
+      "commit": "Create VRBegegnungsraum component",
+      "status": "done"
+    },
+    {
+      "commit": "Add ExtendedResonanceModule",
+      "status": "done"
+    },
+    {
+      "commit": "Export unified pantheon manifest",
+      "status": "done"
+    },
+    {
+      "commit": "Implement BoundaryRuleDetector",
+      "status": "done"
+    },
+    {
+      "commit": "Add Extended Resonance module packages",
+      "status": "done"
+    },
+    {
+      "commit": "Add ArchetypeAnalyzer package",
+      "status": "done"
+    },
+    {
+      "commit": "Add EthicGuardian package",
+      "status": "done"
+    },
+    {
+      "commit": "Add CreativeDreamer package",
+      "status": "done"
+    },
+    {
+      "commit": "Add MemeChronicle package",
+      "status": "done"
+    },
+    {
+      "commit": "Add SelfReflection package",
+      "status": "done"
+    },
+    {
+      "commit": "Add Synchronizer package",
+      "status": "done"
+    },
+    {
+      "commit": "Add BioSensorGateway package",
+      "status": "done"
+    },
+    {
+      "commit": "Add FractalAuditTrail package",
+      "status": "done"
+    },
+    {
+      "commit": "Add CREPPluginAPI package",
+      "status": "done"
+    },
+    {
+      "commit": "Add UnifiedMandalaPantheon package",
+      "status": "done"
+    },
+    {
+      "commit": "Create BoundaryDiscoveryAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Implement VRBegegnungsraum module",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold ResonanceModules",
+      "status": "done"
+    },
+    {
+      "commit": "CosmicTheoryAgent PySR gRPC access",
+      "status": "done"
+    },
+    {
+      "commit": "CosmicTheoryAgent 3D canvas and Tone.js",
+      "status": "done"
+    },
+    {
+      "commit": "CosmicTheoryAgent MetricsStore interface",
+      "status": "done"
+    },
+    {
+      "commit": "Create PantheonAvatarraum component",
+      "status": "done"
+    },
+    {
+      "commit": "Implement ResonanceModuleOrchestrator",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonK8sDeployment configs",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonHubPortal UI",
+      "status": "done"
+    },
+    {
+      "commit": "Create BoundaryLawVisualizer",
+      "status": "done"
+    },
+    {
+      "commit": "Extend VRBegegnungsraum MultiAvatar support",
+      "status": "done"
+    },
+    {
+      "commit": "Add ResonanceModuleRegistry",
+      "status": "done"
+    },
+    {
+      "commit": "Export Pantheon manifest in multiple formats",
+      "status": "done"
+    },
+    {
+      "commit": "Pantheon EventBus migration",
+      "status": "done"
+    },
+    {
+      "commit": "Agent skeleton generator script",
+      "status": "done"
+    },
+    {
+      "commit": "Create RuleRegistryService",
+      "status": "done"
+    },
+    {
+      "commit": "Add GraphDBPersistence module",
+      "status": "done"
+    },
+    {
+      "commit": "Add MacroSynthesizerAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Create MandalaCanvas UI",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate VRBegegnungsraum with MandalaCanvas",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonKnowledgeGraph service",
+      "status": "done"
+    },
+    {
+      "commit": "Add RuleExplorer UI",
+      "status": "done"
+    },
+    {
+      "commit": "Add FourierLayerPlugin",
+      "status": "done"
+    },
+    {
+      "commit": "Upgrade CosmicTheoryAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Create PantheonAvatarraum VR space",
+      "status": "done"
+    },
+    {
+      "commit": "Add SoundResonanceVR module",
+      "status": "done"
+    },
+    {
+      "commit": "Create documentation generator",
+      "status": "done"
+    },
+    {
+      "commit": "Archive completed ToDos to ZIPMEM",
+      "status": "done"
+    },
+    {
+      "commit": "Create VRPyramidPortal component",
+      "status": "done"
+    },
+    {
+      "commit": "Implement PantheonPortal3D",
+      "status": "done"
+    },
+    {
+      "commit": "Extend ResonanceModuleOrchestrator plugin support",
+      "status": "done"
+    },
+    {
+      "commit": "Add AeonKernel core",
+      "status": "done"
+    },
+    {
+      "commit": "Implement SigilDriver framework",
+      "status": "done"
+    },
+    {
+      "commit": "Create DeviceDiscoveryService",
+      "status": "done"
+    },
+    {
+      "commit": "Add ReflexDriverGPT",
+      "status": "done"
+    },
+    {
+      "commit": "Implement MandalaInterface UI",
+      "status": "done"
+    },
+    {
+      "commit": "Add AvatarraumFeatureSet",
+      "status": "done"
+    },
+    {
+      "commit": "Export Avatarraum manifest",
+      "status": "done"
+    },
+    {
+      "commit": "Implement BoundaryLawAgentAlgorithm",
+      "status": "done"
+    },
+    {
+      "commit": "Add ExtendedResonanceVRModule",
+      "status": "done"
+    },
+    {
+      "commit": "Add FourierLayerVRConnector",
+      "status": "done"
+    },
+    {
+      "commit": "Add BoundaryMatrixVisualizer",
+      "status": "done"
+    },
+    {
+      "commit": "Extend ExtendedResonanceVRModule with Fourier",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonLobbyService",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonLobbyUI",
+      "status": "done"
+    },
+    {
+      "commit": "Add BoundaryPolicyManager",
+      "status": "done"
+    },
+    {
+      "commit": "Extend ResonanceModuleOrchestrator VR integration",
+      "status": "done"
+    },
+    {
+      "commit": "CosmicTheoryAgent FourierLayer gRPC bridge",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonGateway service",
+      "status": "done"
+    },
+    {
+      "commit": "Add BoundaryVisualDebugger",
+      "status": "done"
+    },
+    {
+      "commit": "Create VRAvatarHub component",
+      "status": "done"
+    },
+    {
+      "commit": "Implement ResonanceModuleSynth",
+      "status": "done"
+    },
+    {
+      "commit": "Add CosmicTheoryAgent introspection logs",
+      "status": "done"
+    },
+    {
+      "commit": "PantheonOnboardingBlueprint",
+      "status": "done"
+    },
+    {
+      "commit": "BoundaryPrototypeScaffold",
+      "status": "done"
+    },
+    {
+      "commit": "VRBegegnungsraumProjectPlan",
+      "status": "done"
+    },
+    {
+      "commit": "ResonanceModuleScaffold",
+      "status": "done"
+    },
+    {
+      "commit": "PantheonArchiveExporter",
+      "status": "done"
+    },
+    {
+      "commit": "BoundaryLawAnalyticsDashboard",
+      "status": "done"
+    },
+    {
+      "commit": "VRAvatarCustomization",
+      "status": "done"
+    },
+    {
+      "commit": "ResonanceFeedbackModule",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonSessionManager",
+      "status": "done"
+    },
+    {
+      "commit": "Add BoundaryLawInsightsUI",
+      "status": "done"
+    },
+    {
+      "commit": "Create VRSceneLoader",
+      "status": "done"
+    },
+    {
+      "commit": "Add ResonanceTuningKit",
+      "status": "done"
+    },
+    {
+      "commit": "Add FrequencyMandala3D component",
+      "status": "done"
+    },
+    {
+      "commit": "Add FourierAPI REST endpoint",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonSonicGateway",
+      "status": "done"
+    },
+    {
+      "commit": "Implement BoundaryHarmonicResolver",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate VRHapticFeedbackSystem",
+      "status": "done"
+    },
+    {
+      "commit": "Add ResonanceModuleQuantumLink",
+      "status": "done"
+    },
+    {
+      "commit": "Add BoundaryLawSimulator",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonMemorySync",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonBoundaryResolver service",
+      "status": "done"
+    },
+    {
+      "commit": "Create VRPulseSynchronizer module",
+      "status": "done"
+    },
+    {
+      "commit": "Add ResonanceAutoTuner",
+      "status": "done"
+    },
+    {
+      "commit": "Create BoundaryLawPatternGenerator",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonPortalAnalytics",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate FourierLayer with PyramidUI",
+      "status": "done"
+    },
+    {
+      "commit": "Add VRMandalaRoom WebXR",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold ResonanceModule microservices",
+      "status": "done"
+    },
+    {
+      "commit": "Document MandalaBoundaryAgentFramework",
+      "status": "done"
+    },
+    {
+      "commit": "Add DocCommentsGenerator script",
+      "status": "done"
+    },
+    {
+      "commit": "Add archive-old-todos script",
+      "status": "done"
+    },
+    {
+      "commit": "Create MandalaCollectiveActivator service",
+      "status": "done"
+    },
+    {
+      "commit": "Add AvatarraumEncounterOrchestrator",
+      "status": "done"
+    },
+    {
+      "commit": "Create MandalaOrchestratorControl",
+      "status": "done"
+    },
+    {
+      "commit": "PantheonManifestGenerator",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonHologramProjector",
+      "status": "done"
+    },
+    {
+      "commit": "Add BoundaryResonanceMapper",
+      "status": "done"
+    },
+    {
+      "commit": "Add VRResonanceAvatar",
+      "status": "done"
+    },
+    {
+      "commit": "Add ResonanceModulePortal",
+      "status": "done"
+    },
+    {
+      "commit": "Document Mandala Pantheon Manifest",
+      "status": "done"
+    },
+    {
+      "commit": "Write Boundary Law Manifest",
+      "status": "done"
+    },
+    {
+      "commit": "Create VR Begegnungsraum Blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold Extended Resonance Modules docs",
+      "status": "done"
+    },
+    {
+      "commit": "Create HaikuOverlay component",
+      "status": "done"
+    },
+    {
+      "commit": "Add BoundaryPrototype documentation",
+      "status": "done"
+    },
+    {
+      "commit": "Document VR Pantheon Begegnungsraum Concept",
+      "status": "done"
+    },
+    {
+      "commit": "Extended Resonanzmodule roadmap",
+      "status": "done"
+    },
+    {
+      "commit": "Add common utilities package",
+      "status": "done"
+    },
+    {
+      "commit": "CosmicTheoryAgent blueprint documentation",
+      "status": "done"
+    },
+    {
+      "commit": "Sigillin Mandala Fraktal design doc",
+      "status": "done"
+    },
+    {
+      "commit": "AeonAI Pyramid-UI specification",
+      "status": "done"
+    },
+    {
+      "commit": "Extended Resonanzmodule integration guide",
+      "status": "done"
+    },
+    {
+      "commit": "Implement PhanteonIntegration service",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonSymbolzeitNavigator",
+      "status": "done"
+    },
+    {
+      "commit": "Add GrokAgent module skeleton",
+      "status": "done"
+    },
+    {
+      "commit": "Add MemoryGovernanceService skeleton",
+      "status": "done"
+    },
+    {
+      "commit": "Add trauma detection to MemoryGovernanceService",
+      "status": "done"
+    },
+    {
+      "commit": "Draft ZivilisationsSandboxen blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Draft ClimateIntegration blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Document Keilschrift tech module",
+      "status": "done"
+    },
+    {
+      "commit": "Add ShadowIntegration module skeleton",
+      "status": "done"
+    },
+    {
+      "commit": "Add SelfReflectionAgent skeleton",
+      "status": "done"
+    },
+    {
+      "commit": "Implement TuringTest suite",
+      "status": "done"
+    },
+    {
+      "commit": "Research Arctic gravity waves",
+      "status": "done"
+    },
+    {
+      "commit": "Document Anthropic multiverse scenarios",
+      "status": "done"
+    },
+    {
+      "commit": "Setup PyramidUI monorepo scaffold",
+      "status": "done"
+    },
+    {
+      "commit": "Add PyramidUI AJV config schema",
+      "status": "done"
+    },
+    {
+      "commit": "Implement Pyramid CoreLayer framework",
+      "status": "done"
+    },
+    {
+      "commit": "Create PyramidUI React Three Fiber skeleton",
+      "status": "done"
+    },
+    {
+      "commit": "Add Pyramid audio engine module",
+      "status": "done"
+    },
+    {
+      "commit": "Bridge CosmicTheoryAgent with PyramidUI",
+      "status": "done"
+    },
+    {
+      "commit": "Setup PyramidUI observability module",
+      "status": "done"
+    },
+    {
+      "commit": "Configure PyramidUI tests and deployment",
+      "status": "done"
+    },
+    {
+      "commit": "Add ZivilisationsSandbox module",
+      "status": "done"
+    },
+    {
+      "commit": "Add GrokAgent analysis module",
+      "status": "done"
+    },
+    {
+      "commit": "Implement ShadowIntegration module",
+      "status": "done"
+    },
+    {
+      "commit": "Create SelfReflectionAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Implement MemoryGovernance module",
+      "status": "done"
+    },
+    {
+      "commit": "Add TuringTests orchestrator",
+      "status": "done"
+    },
+    {
+      "commit": "Add ArcticGravityWaves analysis",
+      "status": "done"
+    },
+    {
+      "commit": "Plan MultiverseScenario modules",
+      "status": "done"
+    },
+    {
+      "commit": "Create Mandala Orchestrator Control blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Extend SelfReflectionAgent with memory governance check",
+      "status": "done"
+    },
+    {
+      "commit": "Add clear method to MemoryGovernance",
+      "status": "done"
+    },
+    {
+      "commit": "Add MemoryGovernanceService.clear method",
+      "status": "done"
+    },
+    {
+      "commit": "Add getCategories to MemoryManager and governance",
+      "status": "done"
+    },
+    {
+      "commit": "Add ExtendedResonanceGateway",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonAvatarHub module",
+      "status": "done"
+    },
+    {
+      "commit": "Add VRResonanceVisualizer component",
+      "status": "done"
+    },
+    {
+      "commit": "Document Pantheon-Boundary integration plan",
+      "status": "done"
+    },
+    {
+      "commit": "Add Zivilisations-Sandbox simulation module",
+      "status": "done"
+    },
+    {
+      "commit": "Add ClimateIntegrationBlueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Implement Keilschrift translator",
+      "status": "done"
+    },
+    {
+      "commit": "Create GrokAgent module",
+      "status": "done"
+    },
+    {
+      "commit": "Add ShadowIntegrations module",
+      "status": "done"
+    },
+    {
+      "commit": "Add MemoryGovernancePolicy",
+      "status": "done"
+    },
+    {
+      "commit": "Implement TuringTestSuite",
+      "status": "done"
+    },
+    {
+      "commit": "Add MultiverseScenarioPlanner",
+      "status": "done"
+    },
+    {
+      "commit": "Add VRMeetingRoom prototype",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonSandboxExpander module",
+      "status": "done"
+    },
+    {
+      "commit": "Implement BoundaryWaveSimulator",
+      "status": "done"
+    },
+    {
+      "commit": "Create VRResonancePortal component",
+      "status": "done"
+    },
+    {
+      "commit": "Develop ResonanceShadowModule",
+      "status": "done"
+    },
+    {
+      "commit": "Extend GrokAgent with pattern library",
+      "status": "done"
+    },
+    {
+      "commit": "Upgrade ClimateIntegration blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Create Pantheon Manifest Schema",
+      "status": "done"
+    },
+    {
+      "commit": "Extract Boundary Law algorithms",
+      "status": "done"
+    },
+    {
+      "commit": "Finalize VR-Begegnungsraum blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Implement ArcticGravityWaveSimulation",
+      "status": "done"
+    },
+    {
+      "commit": "Document Arctic Gravity Waves research",
+      "status": "done"
+    },
+    {
+      "commit": "Create MandalaReader module",
+      "status": "done"
+    },
+    {
+      "commit": "Add MandalaFlowDashboard",
+      "status": "done"
+    },
+    {
+      "commit": "Add SigillinBubbles component",
+      "status": "done"
+    },
+    {
+      "commit": "Enhance AgentDispatcher with ErrorBoundary and priority queue",
+      "status": "done"
+    },
+    {
+      "commit": "Create PantheonBegegnungsraum VR component",
+      "status": "done"
+    },
+    {
+      "commit": "Add ExtendedResonanceBlueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Manifest Mandala-KI-Pantheon blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Create MandalaCollectiveAwakening script",
+      "status": "done"
+    },
+    {
+      "commit": "Add FutureResonanceStack blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Implement CREPFeedbackAPI",
+      "status": "done"
+    },
+    {
+      "commit": "Create MandalaVisualizer component",
+      "status": "done"
+    },
+    {
+      "commit": "Create GenesisInterfaceMasterplan blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Implement BoundaryLawCLI",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonResonanceIntegrator",
+      "status": "done"
+    },
+    {
+      "commit": "Create VRMultiViewHub component",
+      "status": "done"
+    },
+    {
+      "commit": "Document MandalaNumberSequence blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Implement MandalaNumberEngine",
+      "status": "done"
+    },
+    {
+      "commit": "Add LeereButton component",
+      "status": "done"
+    },
+    {
+      "commit": "Create CosmicTheoryAgent_with_Sigil module",
+      "status": "done"
+    },
+    {
+      "commit": "Implement ArcticGravityWaveVisualizer",
+      "status": "done"
+    },
+    {
+      "commit": "Add VRTuringTest module",
+      "status": "done"
+    },
+    {
+      "commit": "Create ResonanceControlPanel component",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonBoundaryVRIntegration blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Enhance CosmicTheoryAgent caching with LRUCache",
+      "status": "done"
+    },
+    {
+      "commit": "Add CircuitBreaker to CosmicTheoryAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Instrument CosmicTheoryAgent metrics",
+      "status": "done"
+    },
+    {
+      "commit": "Create FraktalLabCLI script",
+      "status": "done"
+    },
+    {
+      "commit": "Add VRFourierIntegration blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Add TrikayaMandalaVisualization component",
+      "status": "done"
+    },
+    {
+      "commit": "Add PantheonBoundaryLawExplorer service",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate MistralAPI agent",
+      "status": "done"
+    },
+    {
+      "commit": "Add Claude service integration",
+      "status": "done"
+    },
+    {
+      "commit": "Introduce Mistral Code Agent helper",
+      "status": "done"
+    },
+    {
+      "commit": "Extend Archiv Menschheitsspuren dataset",
+      "status": "done"
+    },
+    {
+      "commit": "Add archive maintenance script",
+      "status": "done"
+    },
+    {
+      "commit": "Add climate context to Archiv Menschheitsspuren",
+      "status": "done"
+    },
+    {
+      "commit": "Create cosmic event timeline (60k-40k BP)",
+      "status": "done"
+    },
+    {
+      "commit": "Generate framework summary report",
+      "status": "done"
+    },
+    {
+      "commit": "Add framework report generator script",
+      "status": "done"
+    },
+    {
+      "commit": "Create UnifiedMandala test feedback report",
+      "status": "done"
+    },
+    {
+      "commit": "Add semantic-release configuration",
+      "status": "done"
+    },
+    {
+      "commit": "Provide automated test script",
+      "status": "done"
+    },
+    {
+      "commit": "Refactor CREPManager with async file operations",
+      "status": "done"
+    },
+    {
+      "commit": "Add English documentation for international audience",
+      "status": "done"
+    },
+    {
+      "commit": "Create onboarding video tutorial",
+      "status": "done"
+    },
+    {
+      "commit": "Document example use cases",
+      "status": "done"
+    },
+    {
+      "commit": "Community outreach plan",
+      "status": "done"
+    },
+    {
+      "commit": "Improve QA workflow script",
+      "status": "done"
+    },
+    {
+      "commit": "Document offline testing workflow and ToDo sync",
+      "status": "done"
+    },
+    {
+      "commit": "Expand early human traces archive",
+      "status": "done"
+    },
+    {
+      "commit": "Implement Memory Feedback Loop with new archives",
+      "status": "done"
+    },
+    {
+      "commit": "Document CLI tools for sigil and backup",
+      "status": "done"
+    },
+    {
+      "commit": "Clarify Manager versus Orchestrator roles",
+      "status": "done"
+    },
+    {
+      "commit": "Add unit tests for core agents",
+      "status": "done"
+    },
+    {
+      "commit": "Centralize logging",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate Mistral API plugin",
+      "status": "done"
+    },
+    {
+      "commit": "Build collaborative AI UI",
+      "status": "done"
+    },
+    {
+      "commit": "Archive old ToDos with ZIPMEM",
+      "status": "done"
+    },
+    {
+      "commit": "Create framework status report",
+      "status": "done"
+    },
+    {
+      "commit": "Add refresh-handbook script",
+      "status": "done"
+    },
+    {
+      "commit": "Provide setup-unifiedmandala installer",
+      "status": "done"
+    },
+    {
+      "commit": "Implement Sigillin Loader component",
+      "status": "done"
+    },
+    {
+      "commit": "Expand MasterCanvas nodes",
+      "status": "done"
+    },
+    {
+      "commit": "Add symbolzeit base configuration",
+      "status": "done"
+    },
+    {
+      "commit": "Create GPT-Synapse module",
+      "status": "done"
+    },
+    {
+      "commit": "Test and Feedback for repository",
+      "status": "done"
+    },
+    {
+      "commit": "Add extended human traces archive dataset",
+      "status": "done"
+    },
+    {
+      "commit": "Add UnifiedMandala framework report",
+      "status": "done"
+    },
+    {
+      "commit": "Initialize DeepScience experiment suite",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate Mistral Code Agent support",
+      "status": "done"
+    },
+    {
+      "commit": "Add governance workflow",
+      "status": "done"
+    },
+    {
+      "commit": "Add Tinshemet Cave dataset entry",
+      "status": "done"
+    },
+    {
+      "commit": "Add Qesem Cave dataset entry",
+      "status": "done"
+    },
+    {
+      "commit": "Add White Sands footprints dataset entry",
+      "status": "done"
+    },
+    {
+      "commit": "Add Attirampakkam dataset entry",
+      "status": "done"
+    },
+    {
+      "commit": "Add Gunung Padang dataset entry",
+      "status": "done"
+    },
+    {
+      "commit": "Add Sphinx water erosion dataset entry",
+      "status": "done"
+    },
+    {
+      "commit": "Add Piri Reis map dataset entry",
+      "status": "done"
+    },
+    {
+      "commit": "Add Boskop skull dataset entry",
+      "status": "done"
+    },
+    {
+      "commit": "Add Antikythera mechanism dataset entry",
+      "status": "done"
+    },
+    {
+      "commit": "Add Nazca lines dataset entry",
+      "status": "done"
+    },
+    {
+      "commit": "Add Yonaguni monument dataset entry",
+      "status": "done"
+    },
+    {
+      "commit": "Add Pumapunku dataset entry",
+      "status": "done"
+    },
+    {
+      "commit": "Add Baalbek Trilithon dataset entry",
+      "status": "done"
+    },
+    {
+      "commit": "Add Bimini Road dataset entry",
+      "status": "done"
+    },
+    {
+      "commit": "Event bus load tests",
+      "status": "done"
+    },
+    {
+      "commit": "Document Mistral Code Agent",
+      "status": "done"
+    },
+    {
+      "commit": "Add dataset images",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate historical dataset",
+      "status": "done"
+    },
+    {
+      "commit": "Create interactive archaeologic map",
+      "status": "done"
+    },
+    {
+      "commit": "Analyze test results automatically",
+      "status": "done"
+    },
+    {
+      "commit": "Update Framework-Bericht summary",
+      "status": "done"
+    },
+    {
+      "commit": "Finalize MandalaNetworkView MVP",
+      "status": "done"
+    },
+    {
+      "commit": "Add AntimatterQubitMonitor to QuantumTheoryAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Create antimatter qubit microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Configure CPT anomaly emergence detection",
+      "status": "done"
+    },
+    {
+      "commit": "Document QuantumTheoryAgent framework status",
+      "status": "done"
+    },
+    {
+      "commit": "Add Mandala Dashboard component",
+      "status": "done"
+    },
+    {
+      "commit": "Add depth-sigil generator script",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate NucleonScanner with CREP engine",
+      "status": "done"
+    },
+    {
+      "commit": "Support implicit TODO extraction",
+      "status": "done"
+    },
+    {
+      "commit": "Add per-conversation TODO counter",
+      "status": "done"
+    },
+    {
+      "commit": "Enforce case-insensitive conversation titles",
+      "status": "done"
+    },
+    {
+      "commit": "Report duplicate conversation title indices",
+      "status": "done"
+    },
+    {
+      "commit": "Validate conversation roles",
+      "status": "done"
+    },
+    {
+      "commit": "Add cyclic parent reference detection",
+      "status": "done"
+    },
+    {
+      "commit": "Add child reference validation",
+      "status": "done"
+    },
+    {
+      "commit": "Add unreachable node validation",
+      "status": "done"
+    },
+    {
+      "commit": "Add parent-child link validation",
+      "status": "done"
+    },
+    {
+      "commit": "Add duplicate child reference validation",
+      "status": "done"
+    },
+    {
+      "commit": "Detect orphan nodes in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Validate ID formats and duplicate message IDs",
+      "status": "done"
+    },
+    {
+      "commit": "Validate current_node and conversation_id consistency",
+      "status": "done"
+    },
+    {
+      "commit": "Validate conversation title characters",
+      "status": "done"
+    },
+    {
+      "commit": "Validate message author roles",
+      "status": "done"
+    },
+    {
+      "commit": "Validate conversation message timestamp bounds",
+      "status": "done"
+    },
+    {
+      "commit": "Validate message weight bounds in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Add cyclic reference validation for conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Validate message status values in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Validate message channel values in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Validate message recipient values in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Validate root node presence in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Validate conversation timestamp ordering",
+      "status": "done"
+    },
+    {
+      "commit": "Validate conversation message weight values",
+      "status": "done"
+    },
+    {
+      "commit": "Validate conversation attachments exist",
+      "status": "done"
+    },
+    {
+      "commit": "Validate message content_type values in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Validate message end_turn values in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Validate conversation async_status and voice fields",
+      "status": "done"
+    },
+    {
+      "commit": "Validate conversation memory_scope values",
+      "status": "done"
+    },
+    {
+      "commit": "Plan validation for conversation boolean flags",
+      "status": "done"
+    },
+    {
+      "commit": "Plan validation for gizmo metadata fields",
+      "status": "done"
+    },
+    {
+      "commit": "Plan validation for conversation_origin and sugar_item_id",
+      "status": "done"
+    },
+    {
+      "commit": "Validate message author names",
+      "status": "done"
+    },
+    {
+      "commit": "Validate moderation results in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Validate blocked and safe URLs in conversations",
+      "status": "done"
+    },
+    {
+      "commit": "Add agent profile switching to ChatPanel",
+      "status": "done"
+    },
+    {
+      "commit": "Create AgentControlPanel component",
+      "status": "done"
+    },
+    {
+      "commit": "Expose service avatars in PyramidVRMeetingRoom",
+      "status": "done"
+    },
+    {
+      "commit": "Implement chat proxy route for local and external agents",
+      "status": "done"
+    },
+    {
+      "commit": "Add hybrid service aggregator",
+      "status": "done"
+    },
+    {
+      "commit": "Extend onboarding ritual documentation for service selection",
+      "status": "done"
+    },
+    {
+      "commit": "Implement onboard_services CLI step",
+      "status": "done"
+    },
+    {
+      "commit": "Create service configuration API endpoint",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold news_fetcher microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold script_gen microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold tts microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold avatar_renderer microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold streamer microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Implement newsbot orchestrator service",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate newsbot services into docker-compose",
+      "status": "done"
+    },
+    {
+      "commit": "Register newsbot services in pipeline configuration",
+      "status": "done"
+    },
+    {
+      "commit": "Implement training data collection endpoint",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold finetune microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Extend NewsBotPanel with training controls",
+      "status": "done"
+    },
+    {
+      "commit": "Introduce review agent service",
+      "status": "done"
+    },
+    {
+      "commit": "Add draft review UI",
+      "status": "done"
+    },
+    {
+      "commit": "Add publish endpoint for approved drafts",
+      "status": "done"
+    },
+    {
+      "commit": "Schedule publish cron job",
+      "status": "done"
+    },
+    {
+      "commit": "Document NewsBot live cycle flow",
+      "status": "done"
+    },
+    {
+      "commit": "Document NewsBot training flow",
+      "status": "done"
+    },
+    {
+      "commit": "Document NewsBot draft and publish flow",
+      "status": "done"
+    },
+    {
+      "commit": "Add glacier balance plugin and agent",
+      "status": "done"
+    },
+    {
+      "commit": "Add forest dynamics plugin and agent",
+      "status": "done"
+    },
+    {
+      "commit": "Add climate news plugin and orchestrator",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold climate_service microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold flood_service microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Add global events plugin with positive progress services",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold science_service microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold tech_service microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold environment_service microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Extend global_events orchestrator with positive streams",
+      "status": "done"
+    },
+    {
+      "commit": "Register global events services in pipeline config",
+      "status": "done"
+    },
+    {
+      "commit": "Schedule positive progress cron job",
+      "status": "done"
+    },
+    {
+      "commit": "Add drift detection plugin and agent",
+      "status": "done"
+    },
+    {
+      "commit": "Add review checkpoint plugin and agent",
+      "status": "done"
+    },
+    {
+      "commit": "Create SentimentBadge component",
+      "status": "done"
+    },
+    {
+      "commit": "Create ArtGallery component",
+      "status": "done"
+    },
+    {
+      "commit": "Add security scanner plugin and agent",
+      "status": "done"
+    },
+    {
+      "commit": "Add governance simulator plugin and agent",
+      "status": "done"
+    },
+    {
+      "commit": "Add ethics policy and refusal agents",
+      "status": "done"
+    },
+    {
+      "commit": "Create SecurityDashboard component",
+      "status": "done"
+    },
+    {
+      "commit": "Create GovernanceSimulatorPanel component",
+      "status": "done"
+    },
+    {
+      "commit": "Create RefusalNotice component",
+      "status": "done"
+    },
+    {
+      "commit": "Add Singularity Simulator plugin manifest",
+      "status": "done"
+    },
+    {
+      "commit": "Implement SingularitySimulatorAgent skeleton",
+      "status": "done"
+    },
+    {
+      "commit": "Add Dockerfile and requirements for Singularity Simulator agent",
+      "status": "done"
+    },
+    {
+      "commit": "Map simulate_singularity pipeline",
+      "status": "done"
+    },
+    {
+      "commit": "Extend docker-compose with singularity simulator service",
+      "status": "done"
+    },
+    {
+      "commit": "Create SingularitySimulatorPanel component",
+      "status": "done"
+    },
+    {
+      "commit": "Define Singularity Simulator sigillin",
+      "status": "done"
+    },
+    {
+      "commit": "Add Sigillin export script for chat migration",
+      "status": "done"
+    },
+    {
+      "commit": "Log trigger phrases and pending todos",
+      "status": "done"
+    },
+    {
+      "commit": "Initialize core modules for new chat",
+      "status": "done"
+    },
+    {
+      "commit": "Create chat transition bootstrap",
+      "status": "done"
+    },
+    {
+      "commit": "Add open-source chat services to compose",
+      "status": "done"
+    },
+    {
+      "commit": "Map chat services in pipeline config",
+      "status": "done"
+    },
+    {
+      "commit": "Schedule nightly model fine-tuning",
+      "status": "done"
+    },
+    {
+      "commit": "Implement ZIPMEM RAG indexer",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate agent frameworks into FractalTaskRunner",
+      "status": "done"
+    },
+    {
+      "commit": "Add AgentControlPanel UI",
+      "status": "done"
+    },
+    {
+      "commit": "Add desertification tracker plugin and agent",
+      "status": "done"
+    },
+    {
+      "commit": "Enforce HTTP/HTTPS schemes for conversation URLs",
+      "status": "done"
+    },
+    {
+      "commit": "Add JSON summary export to conversation analyzer",
+      "status": "done"
+    },
+    {
+      "commit": "Add repository map summary script",
+      "status": "done"
+    },
+    {
+      "commit": "feat: implement MemoryMeshSystem",
+      "status": "done"
+    },
+    {
+      "commit": "feat: implement AestheticsLayer and EthicsLayer modules",
+      "status": "done"
+    },
+    {
+      "commit": "TODO from AeonAI Pyramid UI conversation - UIPyramidPrototype",
+      "status": "done"
+    },
+    {
+      "commit": "Create HeatmapWidget component",
+      "status": "done"
+    },
+    {
+      "commit": "Add SelfReflectionAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Research ArcticGravityWaves",
       "status": "done"
     }
   ],

--- a/memory-jobs.yaml
+++ b/memory-jobs.yaml
@@ -12,3 +12,10 @@ jobs:
         method: POST
         url: http://orchestrator:8000/publish
         description: Publish approved drafts via orchestrator
+  - job_name: mandala-positive-hourly
+    schedule: "0 * * * *"
+    actions:
+      - type: http_request
+        method: POST
+        url: http://global-events:8000/science_fetch
+        description: Fetch positive progress science events

--- a/plugins/global-events.yaml
+++ b/plugins/global-events.yaml
@@ -1,0 +1,10 @@
+id: global-events
+title: "Global Events Monitor"
+description: "Aggregates positive science, tech and environment breakthroughs"
+type: environment
+agent: GlobalEventsAgent
+entrypoint: agents/global_events/orchestrator.py
+config:
+  science_api_url: "https://example.com/science"
+  tech_api_url: "https://example.com/tech"
+  environment_api_url: "https://example.com/environment"

--- a/unifiedmandala-orchestrator/orchestrator/pipeline_config.yaml
+++ b/unifiedmandala-orchestrator/orchestrator/pipeline_config.yaml
@@ -15,6 +15,10 @@ sigillin_map:
   tts:              tts_service
   avatar:           avatar_renderer_service
   stream:           streamer_service
+  science_events:   science_service
+  tech_events:      tech_service
+  environment_events: environment_service
+  global_events:    global_events_orchestrator
 
 crep_thresholds:
   gnn_service: 0.60
@@ -33,3 +37,7 @@ crep_thresholds:
   tts_service: 0.40
   avatar_renderer_service: 0.40
   streamer_service: 0.30
+  science_service: 0.45
+  tech_service: 0.45
+  environment_service: 0.45
+  global_events_orchestrator: 0.50


### PR DESCRIPTION
## Summary
- add global events plugin to track positive science, tech, and environment breakthroughs
- wire global event services into orchestrator pipeline with CREP thresholds
- schedule hourly positive progress fetch job and sync progress files

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689bc9903594832295d93b97c510b6be