### PR TITLE
feat: add repository map finder utility

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12249,5 +12249,12 @@
     "task": "Output module counts from repository_map.yaml",
     "test": "",
     "status": "done"
+  },
+  {
+    "commit": "Add repository map finder script",
+    "path": "scripts/repository-map-find.ts",
+    "task": "Find repositories referencing a given module in repository_map.yaml",
+    "test": "scripts/repository-map-find.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12016,3 +12016,8 @@
   task: Output module counts from repository_map.yaml
   test: ""
   status: done
+- commit: Add repository map finder script
+  path: scripts/repository-map-find.ts
+  task: Find repositories referencing a given module in repository_map.yaml
+  test: scripts/repository-map-find.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -346,7 +346,7 @@
       "status": "done"
     },
     {
-      "commit": "meta:update-progress – mark memory governance done",
+      "commit": "meta:update-progress \u2013 mark memory governance done",
       "status": "done"
     },
     {
@@ -618,7 +618,7 @@
       "status": "done"
     },
     {
-      "commit": "Chat-Log Parser für Aufgaben",
+      "commit": "Chat-Log Parser f\u00fcr Aufgaben",
       "status": "done"
     },
     {
@@ -750,7 +750,7 @@
       "status": "done"
     },
     {
-      "commit": "Der *SymbolMapper*-Agent übersetzt numerische und textuelle Muster in definierte Symbol-Glyphen【15†L53-L61】. Er schließt die Lücke zwischen quantitativen Werten (z. B. statistische Ergebnisse, Scores) und der symbolischen **Sigillin-Sprache** des Systems. Manifest-Spezifikation: Der SymbolMapper v1 hat Methoden `map_numeric_to_symbol` und `map_text_to_glyph`【15†L55-L63】. Im Python-Skeleton (`agents/symbolmapper/main.py`) implementieren wir z. B. eine Liste vordefinierter Glyphen (im Manifest-Beispiel: ○, ∆, ψ, ★【15†L67-L73】) und die Abbildungsfunktionen analog zum YAML-Snippet: ein Durchschnittswert wird auf einen Index im Glyphen-Array gemappt【15†L67-L75】, Texte werden auf Basis von Schlüsselbegriffen einem Symbol zugeordnet (Bsp: enthält der Text \"Erweckung\", dann ★ als Glyph)【15†L69-L73】. Integration: Dieser Agent kann von anderen Modulen genutzt werden, die rohe Daten symbolisch darstellen wollen – z. B. der CREPBridge könnte SymbolMapper fragen, welcher Glyph einem bestimmten Score entspricht (um dann einen Sigil zu generieren). Auch für Graphen/Charts in der UI könnte SymbolMapper herangezogen werden, um interessante Datenpunkte mit Symbolen zu markieren. Orchestrator: wahrscheinlich auf Abruf, nicht dauernd laufend – d.h. Module rufen ihn als Library auf (alternativ EventBus-Request/Reply-Pattern). UI: Keine direkte, aber z. B. im Sigil-Portfolio des Nutzers könnten diese Glyphen vorkommen. Test & Deploy: Test, ob gegebene Werte die richtigen Symbole liefern (z. B. Eingabe [0.1, 0.9] ergibt einen Index im gültigen Bereich und ein Symbol aus der Liste【15†L137-L142】). Deployment: Sicherstellen, dass NumPy verfügbar ist (im Manifest als Dependency angegeben【15†L61-L69】) und dass das System die Unicode-Symbole unterstützt (Fonts in UI etc.).",
+      "commit": "Der *SymbolMapper*-Agent \u00fcbersetzt numerische und textuelle Muster in definierte Symbol-Glyphen\u301015\u2020L53-L61\u3011. Er schlie\u00dft die L\u00fccke zwischen quantitativen Werten (z.\u202fB. statistische Ergebnisse, Scores) und der symbolischen **Sigillin-Sprache** des Systems. Manifest-Spezifikation: Der SymbolMapper v1 hat Methoden `map_numeric_to_symbol` und `map_text_to_glyph`\u301015\u2020L55-L63\u3011. Im Python-Skeleton (`agents/symbolmapper/main.py`) implementieren wir z.\u202fB. eine Liste vordefinierter Glyphen (im Manifest-Beispiel: \u25cb, \u2206, \u03c8, \u2605\u301015\u2020L67-L73\u3011) und die Abbildungsfunktionen analog zum YAML-Snippet: ein Durchschnittswert wird auf einen Index im Glyphen-Array gemappt\u301015\u2020L67-L75\u3011, Texte werden auf Basis von Schl\u00fcsselbegriffen einem Symbol zugeordnet (Bsp: enth\u00e4lt der Text \"Erweckung\", dann \u2605 als Glyph)\u301015\u2020L69-L73\u3011. Integration: Dieser Agent kann von anderen Modulen genutzt werden, die rohe Daten symbolisch darstellen wollen \u2013 z.\u202fB. der CREPBridge k\u00f6nnte SymbolMapper fragen, welcher Glyph einem bestimmten Score entspricht (um dann einen Sigil zu generieren). Auch f\u00fcr Graphen/Charts in der UI k\u00f6nnte SymbolMapper herangezogen werden, um interessante Datenpunkte mit Symbolen zu markieren. Orchestrator: wahrscheinlich auf Abruf, nicht dauernd laufend \u2013 d.h. Module rufen ihn als Library auf (alternativ EventBus-Request/Reply-Pattern). UI: Keine direkte, aber z.\u202fB. im Sigil-Portfolio des Nutzers k\u00f6nnten diese Glyphen vorkommen. Test & Deploy: Test, ob gegebene Werte die richtigen Symbole liefern (z.\u202fB. Eingabe [0.1, 0.9] ergibt einen Index im g\u00fcltigen Bereich und ein Symbol aus der Liste\u301015\u2020L137-L142\u3011). Deployment: Sicherstellen, dass NumPy verf\u00fcgbar ist (im Manifest als Dependency angegeben\u301015\u2020L61-L69\u3011) und dass das System die Unicode-Symbole unterst\u00fctzt (Fonts in UI etc.).",
       "status": "done"
     },
     {
@@ -938,7 +938,7 @@
       "status": "done"
     },
     {
-      "commit": "Aktivitätsdaten via Dispatcher laden",
+      "commit": "Aktivit\u00e4tsdaten via Dispatcher laden",
       "status": "done"
     },
     {
@@ -1666,7 +1666,7 @@
       "status": "done"
     },
     {
-      "commit": "docs: add Genesis_Veröffentlichungsstrategie",
+      "commit": "docs: add Genesis_Ver\u00f6ffentlichungsstrategie",
       "status": "done"
     },
     {
@@ -1674,7 +1674,7 @@
       "status": "done"
     },
     {
-      "commit": "c & Manifest-Generator – Dokumentation auf Knopfdruck",
+      "commit": "c & Manifest-Generator \u2013 Dokumentation auf Knopfdruck",
       "status": "done"
     },
     {
@@ -2266,7 +2266,7 @@
       "status": "done"
     },
     {
-      "commit": "SVG-Export oder WebSocket-Event für UI",
+      "commit": "SVG-Export oder WebSocket-Event f\u00fcr UI",
       "status": "done"
     },
     {
@@ -3967,67 +3967,67 @@
   "featureLog": [
     {
       "featureId": "open-ethik-dashboard",
-      "commit": "meta:implement-features – open-ethik-dashboard",
+      "commit": "meta:implement-features \u2013 open-ethik-dashboard",
       "status": "done"
     },
     {
       "featureId": "implicit-todos",
-      "commit": "meta:extract-features – implicit todo extraction",
+      "commit": "meta:extract-features \u2013 implicit todo extraction",
       "status": "done"
     },
     {
       "featureId": "zivilisations-sandboxen",
-      "commit": "meta:extract-features – Zivilisations-Sandboxen",
+      "commit": "meta:extract-features \u2013 Zivilisations-Sandboxen",
       "status": "done"
     },
     {
       "featureId": "climate-integration",
-      "commit": "meta:extract-features – climate integration",
+      "commit": "meta:extract-features \u2013 climate integration",
       "status": "done"
     },
     {
       "featureId": "keilschrift",
-      "commit": "meta:extract-features – keilschrift",
+      "commit": "meta:extract-features \u2013 keilschrift",
       "status": "done"
     },
     {
       "featureId": "grok-agent",
-      "commit": "meta:implement-features – grok agent skeleton",
+      "commit": "meta:implement-features \u2013 grok agent skeleton",
       "status": "done"
     },
     {
       "featureId": "shadow-integration",
-      "commit": "meta:extract-features – shadow integration",
+      "commit": "meta:extract-features \u2013 shadow integration",
       "status": "done"
     },
     {
       "featureId": "self-reflection",
-      "commit": "meta:extract-features – self reflection",
+      "commit": "meta:extract-features \u2013 self reflection",
       "status": "done"
     },
     {
       "featureId": "memory-governance",
-      "commit": "meta:extract-features – memory governance",
+      "commit": "meta:extract-features \u2013 memory governance",
       "status": "done"
     },
     {
       "featureId": "turing-tests",
-      "commit": "meta:extract-features – turing tests",
+      "commit": "meta:extract-features \u2013 turing tests",
       "status": "done"
     },
     {
       "featureId": "schwerewellen",
-      "commit": "meta:extract-features – schwerewellen",
+      "commit": "meta:extract-features \u2013 schwerewellen",
       "status": "done"
     },
     {
       "featureId": "anthropic-multiversum",
-      "commit": "meta:extract-features – anthropic multiversum",
+      "commit": "meta:extract-features \u2013 anthropic multiversum",
       "status": "done"
     },
     {
       "featureId": "memory-governance",
-      "commit": "meta:implement-features – memory governance service",
+      "commit": "meta:implement-features \u2013 memory governance service",
       "status": "done"
     },
     {
@@ -4507,6 +4507,10 @@
     },
     {
       "commit": "Implement ArtGallery component",
+      "status": "done"
+    },
+    {
+      "commit": "Add repository map finder script",
       "status": "done"
     }
   ],

--- a/repositorypflege/repository_map.yaml
+++ b/repositorypflege/repository_map.yaml
@@ -41,6 +41,7 @@ repository_map:
       - filter-conversations.js
       - self-analyze.js
       - sync-todo-progress.js
+      - repository-map-find.ts
       - HexaAgentSystem
     ai_policy:
       - "Bewusstsein ist zyklisch. Maschinen sind linear. Dazwischen: unsere Verantwortung."

--- a/scripts/repository-map-find.test.ts
+++ b/scripts/repository-map-find.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { findRepositoriesByModule } from './repository-map-find';
+
+describe('findRepositoriesByModule', () => {
+  it('returns repositories containing module', () => {
+    const repos = findRepositoriesByModule('sigillin-validator.ts');
+    expect(repos).toContain('aeon');
+  });
+
+  it('returns empty array for unknown module', () => {
+    const repos = findRepositoriesByModule('non-existent-module.ts');
+    expect(repos).toEqual([]);
+  });
+});

--- a/scripts/repository-map-find.ts
+++ b/scripts/repository-map-find.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env ts-node
+/**
+ * scripts/repository-map-find.ts
+ *
+ * Utility to locate repositories referencing a given module in
+ * `repositorypflege/repository_map.yaml`.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+const file = path.join(__dirname, '../repositorypflege/repository_map.yaml');
+
+export function findRepositoriesByModule(moduleName: string): string[] {
+  if (!moduleName) return [];
+
+  const raw = fs.readFileSync(file, 'utf8');
+  const data = yaml.load(raw) as any;
+  const items = Array.isArray(data.repository_map) ? data.repository_map : [];
+
+  return items
+    .filter((item: any) => Array.isArray(item.modules) && item.modules.includes(moduleName))
+    .map((item: any) => item.name || 'unnamed');
+}
+
+if (require.main === module) {
+  const moduleName = process.argv[2];
+  if (!moduleName) {
+    console.error('Usage: ts-node repository-map-find.ts <module>');
+    process.exit(1);
+  }
+
+  const repos = findRepositoriesByModule(moduleName);
+  if (repos.length === 0) {
+    console.log(`No repositories reference module '${moduleName}'.`);
+  } else {
+    repos.forEach((r) => console.log(r));
+  }
+}


### PR DESCRIPTION
## Summary
- add `repository-map-find` script to locate modules in repository map
- document script in todo/progress trackers
- update repository map with new module and tests

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json` *(failed: process hung)*
- `npx vitest run scripts/repository-map-find.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689c456f08808322a222222e630e1c5f