### PR TITLE
Implement null field wave simulation and update progress

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12256,5 +12256,12 @@
     "task": "Find repositories referencing a given module in repository_map.yaml",
     "test": "scripts/repository-map-find.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add null field wave simulation",
+    "path": "simulations/nullfield_wave.py",
+    "task": "Simulate wave propagation in a null field using finite difference method",
+    "test": "tests/nullfield_wave_test.py",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11113,10 +11113,11 @@
   test: ""
 - commit: ein einfaches Python-Programm schreiben, das die Wellenausbreitung im
     Nullfeld als Simulation darstellt
-  path: ""
+  path: simulations/nullfield_wave.py
   task: ein einfaches Python-Programm schreiben, das die Wellenausbreitung im
     Nullfeld als Simulation darstellt
-  test: ""
+  test: tests/nullfield_wave_test.py
+  status: done
 - commit: uns darauf konzentrieren, die grundlegenden Konzepte mit bekannten
     physikalischen Messdaten abzugleichen
   path: ""

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -4512,6 +4512,10 @@
     {
       "commit": "Add repository map finder script",
       "status": "done"
+    },
+    {
+      "commit": "Add null field wave simulation",
+      "status": "done"
     }
   ],
   "metacommitTags": [

--- a/simulations/nullfield_wave.py
+++ b/simulations/nullfield_wave.py
@@ -1,0 +1,48 @@
+# pyright: reportAttributeAccessIssue=false
+import numpy as np  # type: ignore
+
+
+def simulate_nullfield_wave(length: float = 1.0, duration: float = 1.0, dx: float = 0.01, dt: float = 0.005, c: float = 1.0):
+    """Simulate a 1D wave equation on a 'null field'.
+
+    Parameters
+    ----------
+    length: float
+        Physical length of the domain.
+    duration: float
+        Time to simulate.
+    dx: float
+        Spatial resolution.
+    dt: float
+        Time step size.
+    c: float
+        Wave propagation speed.
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape (timesteps, points) representing the field over time.
+    """
+    nx = int(length / dx) + 1
+    nt = int(duration / dt) + 1
+    u = np.zeros((nt, nx))
+
+    # initial condition: localized pulse in center
+    mid = nx // 2
+    u[0, mid] = 1.0
+
+    # first time step using finite difference
+    for i in range(1, nx - 1):
+        u[1, i] = u[0, i] + 0.5 * (c * dt / dx) ** 2 * (u[0, i + 1] - 2 * u[0, i] + u[0, i - 1])
+
+    coef = (c * dt / dx) ** 2
+    for n in range(1, nt - 1):
+        for i in range(1, nx - 1):
+            u[n + 1, i] = 2 * u[n, i] - u[n - 1, i] + coef * (u[n, i + 1] - 2 * u[n, i] + u[n, i - 1])
+
+    return u
+
+
+if __name__ == "__main__":
+    field = simulate_nullfield_wave()
+    print(field.shape)

--- a/tests/nullfield_wave_test.py
+++ b/tests/nullfield_wave_test.py
@@ -1,0 +1,17 @@
+# pyright: reportAttributeAccessIssue=false
+import os
+import sys
+import numpy as np  # type: ignore
+
+# Ensure repository root on path for direct module import
+sys.path.insert(0, os.getcwd())
+from simulations.nullfield_wave import simulate_nullfield_wave
+
+
+def test_wave_propagates():
+    field = simulate_nullfield_wave(length=1.0, duration=0.1, dx=0.1, dt=0.05)
+    assert field.shape == (3, 11)
+    # peak should move from center after second step
+    peak_idx_initial = np.argmax(field[0])
+    peak_idx_final = np.argmax(field[-1])
+    assert peak_idx_final != peak_idx_initial


### PR DESCRIPTION
## Summary
- simulate 1D null field wave via finite-difference Python module
- cover wave propagation with pytest
- record completion in advanced ToDo and progress trackers

## Testing
- `npx ts-node scripts/analyze-newadvanced-conversations.ts --json`
- `pytest tests/nullfield_wave_test.py`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689c4f71d464832294b5df2bb07bfa3c