### PR TITLE
feat: emit agent dependency updates

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1397,7 +1397,8 @@
     "commit": "Create AgentDependencyGraph module",
     "path": "packages/agents/AgentDependencyGraph.ts",
     "task": "Visualize agent dependencies in real time",
-    "test": "packages/agents/AgentDependencyGraph.test.ts"
+    "test": "packages/agents/AgentDependencyGraph.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add GPTContextSummarizer bridge",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1024,6 +1024,7 @@
   path: packages/agents/AgentDependencyGraph.ts
   task: Visualize agent dependencies in real time
   test: packages/agents/AgentDependencyGraph.test.ts
+  status: done
 - commit: Add GPTContextSummarizer bridge
   path: packages/gpt-bridges/GPTContextSummarizer.ts
   task: Summarize long conversations for quick reference

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -4516,6 +4516,10 @@
     {
       "commit": "Add null field wave simulation",
       "status": "done"
+    },
+    {
+      "commit": "Create AgentDependencyGraph module",
+      "status": "done"
     }
   ],
   "metacommitTags": [

--- a/packages/agents/AgentDependencyGraph.test.ts
+++ b/packages/agents/AgentDependencyGraph.test.ts
@@ -1,7 +1,19 @@
-import { describe, it, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { buildAgentGraph } from './AgentDependencyGraph';
+import { describe, it, expect, vi } from 'vitest';
+import { AgentDependencyGraph, buildAgentGraph } from './AgentDependencyGraph';
 
-test('builds adjacency list', () => {
-  const g = buildAgentGraph([{ from: 'a', to: 'b' }, { from: 'a', to: 'c' }]);
+it('builds adjacency list', () => {
+  const g = buildAgentGraph([
+    { from: 'a', to: 'b' },
+    { from: 'a', to: 'c' }
+  ]);
   expect(g).toEqual({ a: ['b', 'c'] });
+});
+
+it('emits update events when edges are added', () => {
+  const graph = new AgentDependencyGraph();
+  const listener = vi.fn();
+  graph.on('update', listener);
+  graph.addEdge({ from: 'x', to: 'y' });
+  expect(graph.getGraph()).toEqual({ x: ['y'] });
+  expect(listener).toHaveBeenCalledWith({ x: ['y'] });
 });

--- a/packages/agents/AgentDependencyGraph.ts
+++ b/packages/agents/AgentDependencyGraph.ts
@@ -1,10 +1,35 @@
+import { EventEmitter } from 'events';
+
 export interface AgentEdge { from: string; to: string; }
 
-export function buildAgentGraph(edges: AgentEdge[]): Record<string, string[]> {
-  const graph: Record<string, string[]> = {};
-  for (const { from, to } of edges) {
-    if (!graph[from]) graph[from] = [];
-    graph[from].push(to);
+/**
+ * Simple in-memory graph that emits an `update` event whenever
+ * edges are added. Consumers can subscribe to this event to
+ * react to dependency changes in real time.
+ */
+export class AgentDependencyGraph extends EventEmitter {
+  private graph: Record<string, string[]> = {};
+
+  /** Add a directed edge and emit the updated graph */
+  addEdge(edge: AgentEdge): void {
+    const { from, to } = edge;
+    if (!this.graph[from]) this.graph[from] = [];
+    this.graph[from].push(to);
+    this.emit('update', this.graph);
   }
-  return graph;
+
+  /** Retrieve a snapshot of the current adjacency list */
+  getGraph(): Record<string, string[]> {
+    return this.graph;
+  }
+}
+
+/**
+ * Build a simple adjacency list without emitting updates.
+ * Kept for backward compatibility with existing code.
+ */
+export function buildAgentGraph(edges: AgentEdge[]): Record<string, string[]> {
+  const graph = new AgentDependencyGraph();
+  for (const edge of edges) graph.addEdge(edge);
+  return graph.getGraph();
 }


### PR DESCRIPTION
## Summary
- add event-driven AgentDependencyGraph for real-time dependency updates
- test graph event emission and adjacency list building
- mark AgentDependencyGraph task as complete in advanced todo and progress trackers

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx vitest packages/agents/AgentDependencyGraph.test.ts`
- `npx tsc -p tsconfig.json` *(fails: command hung, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_689c58ab766083229495d93f3c03d75f