### PR TITLE
feat: enhance emergence predictor and summarizer

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1391,7 +1391,8 @@
     "commit": "Implement EmergencePredictorAgent",
     "path": "packages/agents/EmergencePredictorAgent.ts",
     "task": "Predict emergent states from historic data",
-    "test": "packages/agents/EmergencePredictorAgent.test.ts"
+    "test": "packages/agents/EmergencePredictorAgent.test.ts",
+    "status": "done"
   },
   {
     "commit": "Create AgentDependencyGraph module",
@@ -1404,7 +1405,8 @@
     "commit": "Add GPTContextSummarizer bridge",
     "path": "packages/gpt-bridges/GPTContextSummarizer.ts",
     "task": "Summarize long conversations for quick reference",
-    "test": "packages/gpt-bridges/GPTContextSummarizer.test.ts"
+    "test": "packages/gpt-bridges/GPTContextSummarizer.test.ts",
+    "status": "done"
   },
   {
     "commit": "Introduce GPTEthicsSupervisor",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1020,6 +1020,7 @@
   path: packages/agents/EmergencePredictorAgent.ts
   task: Predict emergent states from historic data
   test: packages/agents/EmergencePredictorAgent.test.ts
+  status: done
 - commit: Create AgentDependencyGraph module
   path: packages/agents/AgentDependencyGraph.ts
   task: Visualize agent dependencies in real time
@@ -1029,6 +1030,7 @@
   path: packages/gpt-bridges/GPTContextSummarizer.ts
   task: Summarize long conversations for quick reference
   test: packages/gpt-bridges/GPTContextSummarizer.test.ts
+  status: done
 - commit: Introduce GPTEthicsSupervisor
   path: packages/gpt-bridges/GPTEthicsSupervisor.ts
   task: Check GPT answers for ethical consistency

--- a/packages/agents/EmergencePredictorAgent.test.ts
+++ b/packages/agents/EmergencePredictorAgent.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { expect, test } from 'vitest';
 import { EmergencePredictorAgent } from './EmergencePredictorAgent';
 
-test('predict returns average of history', () => {
+test('predict uses linear trend', () => {
   const agent = new EmergencePredictorAgent([1, 2, 3]);
-  expect(agent.predict()).toBe(2);
+  expect(agent.predict()).toBeCloseTo(4, 5);
+});
+
+test('predict handles constant series', () => {
+  const agent = new EmergencePredictorAgent([5, 5, 5]);
+  expect(agent.predict()).toBeCloseTo(5, 5);
 });

--- a/packages/agents/EmergencePredictorAgent.ts
+++ b/packages/agents/EmergencePredictorAgent.ts
@@ -7,8 +7,21 @@ export class EmergencePredictorAgent {
     this.history.push(value);
   }
   predict(): number {
-    if (this.history.length === 0) return 0;
-    const sum = this.history.reduce((a, b) => a + b, 0);
-    return sum / this.history.length;
+    const n = this.history.length;
+    if (n === 0) return 0;
+    if (n === 1) return this.history[0];
+    const x = this.history.map((_, i) => i + 1);
+    const y = this.history;
+    const xMean = x.reduce((a, b) => a + b, 0) / n;
+    const yMean = y.reduce((a, b) => a + b, 0) / n;
+    let num = 0;
+    let den = 0;
+    for (let i = 0; i < n; i++) {
+      num += (x[i] - xMean) * (y[i] - yMean);
+      den += (x[i] - xMean) ** 2;
+    }
+    const slope = den === 0 ? 0 : num / den;
+    const intercept = yMean - slope * xMean;
+    return intercept + slope * (n + 1);
   }
 }

--- a/packages/gpt-bridges/GPTContextSummarizer.test.ts
+++ b/packages/gpt-bridges/GPTContextSummarizer.test.ts
@@ -1,6 +1,11 @@
 import { summarize } from './GPTContextSummarizer';
 
-test('summarizes long text', () => {
-  const txt = 'a'.repeat(150);
-  expect(summarize(txt, 10)).toBe('aaaaaaaaaa...');
+test('summarizes long text without breaking words', () => {
+  const txt = 'hello world from unified mandala';
+  expect(summarize(txt, 12)).toBe('hello world…');
+});
+
+test('returns original text when short enough', () => {
+  const txt = 'short text';
+  expect(summarize(txt, 50)).toBe(txt);
 });

--- a/packages/gpt-bridges/GPTContextSummarizer.ts
+++ b/packages/gpt-bridges/GPTContextSummarizer.ts
@@ -1,3 +1,16 @@
+/**
+ * Create a short contextual summary without cutting words in half.
+ * If the text exceeds the limit, the result is truncated to the last full word
+ * that fits within the limit and an ellipsis is appended.
+ */
 export function summarize(text: string, limit = 100): string {
-  return text.length <= limit ? text : text.slice(0, limit) + '...';
+  if (text.length <= limit) return text;
+  const words = text.split(/\s+/);
+  let out = '';
+  for (const w of words) {
+    const candidate = out ? out + ' ' + w : w;
+    if (candidate.length > limit) break;
+    out = candidate;
+  }
+  return out + '…';
 }


### PR DESCRIPTION
## Summary
- improve EmergencePredictorAgent with linear regression trend prediction
- add word-aware summarization helper for GPTContextSummarizer
- mark related advanced ToDo entries as complete

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest --run packages/agents/EmergencePredictorAgent.test.ts`
- `npx vitest --run packages/gpt-bridges/GPTContextSummarizer.test.ts` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689c60632cb48322a731694210bfdfe4