### PR TITLE
feat: improve CREP trend analyzer

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1448,7 +1448,8 @@
     "commit": "Add CREPTrendAnalyzer",
     "path": "packages/crep-engine/CREPTrendAnalyzer.ts",
     "task": "Analyze historic CREP trends with AI",
-    "test": "packages/crep-engine/CREPTrendAnalyzer.test.ts"
+    "test": "packages/crep-engine/CREPTrendAnalyzer.test.ts",
+    "status": "done"
   },
   {
     "commit": "Implement CREPThresholdOptimizer",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1059,6 +1059,7 @@
   path: packages/crep-engine/CREPTrendAnalyzer.ts
   task: Analyze historic CREP trends with AI
   test: packages/crep-engine/CREPTrendAnalyzer.test.ts
+  status: done
 - commit: Implement CREPThresholdOptimizer
   path: packages/crep-engine/CREPThresholdOptimizer.ts
   task: Adapt CREP thresholds through learning

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -346,7 +346,7 @@
       "status": "done"
     },
     {
-      "commit": "meta:update-progress \u2013 mark memory governance done",
+      "commit": "meta:update-progress – mark memory governance done",
       "status": "done"
     },
     {
@@ -618,7 +618,7 @@
       "status": "done"
     },
     {
-      "commit": "Chat-Log Parser f\u00fcr Aufgaben",
+      "commit": "Chat-Log Parser für Aufgaben",
       "status": "done"
     },
     {
@@ -750,7 +750,7 @@
       "status": "done"
     },
     {
-      "commit": "Der *SymbolMapper*-Agent \u00fcbersetzt numerische und textuelle Muster in definierte Symbol-Glyphen\u301015\u2020L53-L61\u3011. Er schlie\u00dft die L\u00fccke zwischen quantitativen Werten (z.\u202fB. statistische Ergebnisse, Scores) und der symbolischen **Sigillin-Sprache** des Systems. Manifest-Spezifikation: Der SymbolMapper v1 hat Methoden `map_numeric_to_symbol` und `map_text_to_glyph`\u301015\u2020L55-L63\u3011. Im Python-Skeleton (`agents/symbolmapper/main.py`) implementieren wir z.\u202fB. eine Liste vordefinierter Glyphen (im Manifest-Beispiel: \u25cb, \u2206, \u03c8, \u2605\u301015\u2020L67-L73\u3011) und die Abbildungsfunktionen analog zum YAML-Snippet: ein Durchschnittswert wird auf einen Index im Glyphen-Array gemappt\u301015\u2020L67-L75\u3011, Texte werden auf Basis von Schl\u00fcsselbegriffen einem Symbol zugeordnet (Bsp: enth\u00e4lt der Text \"Erweckung\", dann \u2605 als Glyph)\u301015\u2020L69-L73\u3011. Integration: Dieser Agent kann von anderen Modulen genutzt werden, die rohe Daten symbolisch darstellen wollen \u2013 z.\u202fB. der CREPBridge k\u00f6nnte SymbolMapper fragen, welcher Glyph einem bestimmten Score entspricht (um dann einen Sigil zu generieren). Auch f\u00fcr Graphen/Charts in der UI k\u00f6nnte SymbolMapper herangezogen werden, um interessante Datenpunkte mit Symbolen zu markieren. Orchestrator: wahrscheinlich auf Abruf, nicht dauernd laufend \u2013 d.h. Module rufen ihn als Library auf (alternativ EventBus-Request/Reply-Pattern). UI: Keine direkte, aber z.\u202fB. im Sigil-Portfolio des Nutzers k\u00f6nnten diese Glyphen vorkommen. Test & Deploy: Test, ob gegebene Werte die richtigen Symbole liefern (z.\u202fB. Eingabe [0.1, 0.9] ergibt einen Index im g\u00fcltigen Bereich und ein Symbol aus der Liste\u301015\u2020L137-L142\u3011). Deployment: Sicherstellen, dass NumPy verf\u00fcgbar ist (im Manifest als Dependency angegeben\u301015\u2020L61-L69\u3011) und dass das System die Unicode-Symbole unterst\u00fctzt (Fonts in UI etc.).",
+      "commit": "Der *SymbolMapper*-Agent übersetzt numerische und textuelle Muster in definierte Symbol-Glyphen【15†L53-L61】. Er schließt die Lücke zwischen quantitativen Werten (z. B. statistische Ergebnisse, Scores) und der symbolischen **Sigillin-Sprache** des Systems. Manifest-Spezifikation: Der SymbolMapper v1 hat Methoden `map_numeric_to_symbol` und `map_text_to_glyph`【15†L55-L63】. Im Python-Skeleton (`agents/symbolmapper/main.py`) implementieren wir z. B. eine Liste vordefinierter Glyphen (im Manifest-Beispiel: ○, ∆, ψ, ★【15†L67-L73】) und die Abbildungsfunktionen analog zum YAML-Snippet: ein Durchschnittswert wird auf einen Index im Glyphen-Array gemappt【15†L67-L75】, Texte werden auf Basis von Schlüsselbegriffen einem Symbol zugeordnet (Bsp: enthält der Text \"Erweckung\", dann ★ als Glyph)【15†L69-L73】. Integration: Dieser Agent kann von anderen Modulen genutzt werden, die rohe Daten symbolisch darstellen wollen – z. B. der CREPBridge könnte SymbolMapper fragen, welcher Glyph einem bestimmten Score entspricht (um dann einen Sigil zu generieren). Auch für Graphen/Charts in der UI könnte SymbolMapper herangezogen werden, um interessante Datenpunkte mit Symbolen zu markieren. Orchestrator: wahrscheinlich auf Abruf, nicht dauernd laufend – d.h. Module rufen ihn als Library auf (alternativ EventBus-Request/Reply-Pattern). UI: Keine direkte, aber z. B. im Sigil-Portfolio des Nutzers könnten diese Glyphen vorkommen. Test & Deploy: Test, ob gegebene Werte die richtigen Symbole liefern (z. B. Eingabe [0.1, 0.9] ergibt einen Index im gültigen Bereich und ein Symbol aus der Liste【15†L137-L142】). Deployment: Sicherstellen, dass NumPy verfügbar ist (im Manifest als Dependency angegeben【15†L61-L69】) und dass das System die Unicode-Symbole unterstützt (Fonts in UI etc.).",
       "status": "done"
     },
     {
@@ -938,7 +938,7 @@
       "status": "done"
     },
     {
-      "commit": "Aktivit\u00e4tsdaten via Dispatcher laden",
+      "commit": "Aktivitätsdaten via Dispatcher laden",
       "status": "done"
     },
     {
@@ -1666,7 +1666,7 @@
       "status": "done"
     },
     {
-      "commit": "docs: add Genesis_Ver\u00f6ffentlichungsstrategie",
+      "commit": "docs: add Genesis_Veröffentlichungsstrategie",
       "status": "done"
     },
     {
@@ -1674,7 +1674,7 @@
       "status": "done"
     },
     {
-      "commit": "c & Manifest-Generator \u2013 Dokumentation auf Knopfdruck",
+      "commit": "c & Manifest-Generator – Dokumentation auf Knopfdruck",
       "status": "done"
     },
     {
@@ -2266,7 +2266,7 @@
       "status": "done"
     },
     {
-      "commit": "SVG-Export oder WebSocket-Event f\u00fcr UI",
+      "commit": "SVG-Export oder WebSocket-Event für UI",
       "status": "done"
     },
     {
@@ -3932,6 +3932,10 @@
     {
       "commit": "Research ArcticGravityWaves",
       "status": "done"
+    },
+    {
+      "commit": "Enhance CREPTrendAnalyzer with regression and classification",
+      "status": "done"
     }
   ],
   "completed": [
@@ -3967,67 +3971,67 @@
   "featureLog": [
     {
       "featureId": "open-ethik-dashboard",
-      "commit": "meta:implement-features \u2013 open-ethik-dashboard",
+      "commit": "meta:implement-features – open-ethik-dashboard",
       "status": "done"
     },
     {
       "featureId": "implicit-todos",
-      "commit": "meta:extract-features \u2013 implicit todo extraction",
+      "commit": "meta:extract-features – implicit todo extraction",
       "status": "done"
     },
     {
       "featureId": "zivilisations-sandboxen",
-      "commit": "meta:extract-features \u2013 Zivilisations-Sandboxen",
+      "commit": "meta:extract-features – Zivilisations-Sandboxen",
       "status": "done"
     },
     {
       "featureId": "climate-integration",
-      "commit": "meta:extract-features \u2013 climate integration",
+      "commit": "meta:extract-features – climate integration",
       "status": "done"
     },
     {
       "featureId": "keilschrift",
-      "commit": "meta:extract-features \u2013 keilschrift",
+      "commit": "meta:extract-features – keilschrift",
       "status": "done"
     },
     {
       "featureId": "grok-agent",
-      "commit": "meta:implement-features \u2013 grok agent skeleton",
+      "commit": "meta:implement-features – grok agent skeleton",
       "status": "done"
     },
     {
       "featureId": "shadow-integration",
-      "commit": "meta:extract-features \u2013 shadow integration",
+      "commit": "meta:extract-features – shadow integration",
       "status": "done"
     },
     {
       "featureId": "self-reflection",
-      "commit": "meta:extract-features \u2013 self reflection",
+      "commit": "meta:extract-features – self reflection",
       "status": "done"
     },
     {
       "featureId": "memory-governance",
-      "commit": "meta:extract-features \u2013 memory governance",
+      "commit": "meta:extract-features – memory governance",
       "status": "done"
     },
     {
       "featureId": "turing-tests",
-      "commit": "meta:extract-features \u2013 turing tests",
+      "commit": "meta:extract-features – turing tests",
       "status": "done"
     },
     {
       "featureId": "schwerewellen",
-      "commit": "meta:extract-features \u2013 schwerewellen",
+      "commit": "meta:extract-features – schwerewellen",
       "status": "done"
     },
     {
       "featureId": "anthropic-multiversum",
-      "commit": "meta:extract-features \u2013 anthropic multiversum",
+      "commit": "meta:extract-features – anthropic multiversum",
       "status": "done"
     },
     {
       "featureId": "memory-governance",
-      "commit": "meta:implement-features \u2013 memory governance service",
+      "commit": "meta:implement-features – memory governance service",
       "status": "done"
     },
     {

--- a/packages/crep-engine/CREPTrendAnalyzer.test.ts
+++ b/packages/crep-engine/CREPTrendAnalyzer.test.ts
@@ -1,5 +1,11 @@
-import { analyzeTrend } from './CREPTrendAnalyzer';
+import { analyzeTrend, classifyTrend } from './CREPTrendAnalyzer';
 
-test('computes linear trend', () => {
-  expect(analyzeTrend([1,2,3])).toBe(1);
+test('computes linear trend via regression', () => {
+  expect(analyzeTrend([1, 2, 3])).toBeCloseTo(1);
+});
+
+test('classifies trend direction', () => {
+  expect(classifyTrend([1, 2, 3])).toBe('upward');
+  expect(classifyTrend([3, 2, 1])).toBe('downward');
+  expect(classifyTrend([1, 1, 1.0001])).toBe('stable');
 });

--- a/packages/crep-engine/CREPTrendAnalyzer.ts
+++ b/packages/crep-engine/CREPTrendAnalyzer.ts
@@ -1,5 +1,28 @@
 export function analyzeTrend(values: number[]): number {
   if (values.length < 2) return 0;
-  const diff = values[values.length - 1] - values[0];
-  return diff / (values.length - 1);
+
+  const n = values.length;
+  const meanX = (n - 1) / 2;
+  const meanY = values.reduce((sum, v) => sum + v, 0) / n;
+
+  let numerator = 0;
+  let denominator = 0;
+  for (let i = 0; i < n; i++) {
+    const dx = i - meanX;
+    const dy = values[i] - meanY;
+    numerator += dx * dy;
+    denominator += dx * dx;
+  }
+
+  return denominator === 0 ? 0 : numerator / denominator;
+}
+
+export function classifyTrend(
+  values: number[],
+  epsilon = 1e-3
+): 'upward' | 'downward' | 'stable' {
+  const slope = analyzeTrend(values);
+  if (slope > epsilon) return 'upward';
+  if (slope < -epsilon) return 'downward';
+  return 'stable';
 }


### PR DESCRIPTION
## Summary
- enhance CREP trend analysis using linear regression and direction classification
- mark CREPTrendAnalyzer task complete in advanced ToDo lists and progress log

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright packages/crep-engine/CREPTrendAnalyzer.ts`
- `npx tsc packages/crep-engine/CREPTrendAnalyzer.ts --listEmittedFiles`
- `npx jest packages/crep-engine/CREPTrendAnalyzer.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689c66ac30288322af64a96e1da82103