### PR TITLE
feat: add presence indicator component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1479,9 +1479,10 @@
   },
   {
     "commit": "Add PresenceIndicator feature",
-    "path": "packages/collab-editor/PresenceIndicator.ts",
+    "path": "packages/collab-editor/PresenceIndicator.tsx",
     "task": "Show real-time user presence information",
-    "test": "packages/collab-editor/PresenceIndicator.test.ts"
+    "test": "packages/collab-editor/PresenceIndicator.test.ts",
+    "status": "done"
   },
   {
     "commit": "Implement EventPlaybackModule",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1081,9 +1081,10 @@
   test: packages/collab-editor/RealTimeCollaborationChat.test.ts
   status: done
 - commit: Add PresenceIndicator feature
-  path: packages/collab-editor/PresenceIndicator.ts
+  path: packages/collab-editor/PresenceIndicator.tsx
   task: Show real-time user presence information
   test: packages/collab-editor/PresenceIndicator.test.ts
+  status: done
 - commit: Implement EventPlaybackModule
   path: packages/event-bus/EventPlaybackModule.ts
   task: Record and replay event streams for debugging

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -4529,5 +4529,11 @@
   "metacommitTags": [
     "meta:extract-features",
     "meta:implement-features"
+  ],
+  "commits": [
+    {
+      "commit": "Add PresenceIndicator feature",
+      "status": "done"
+    }
   ]
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -48,3 +48,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Enhanced DesertTrackerAgent with optional UNCCD API integration and updated plugin configuration.
 - Added repository map summary script to list module counts for quick overview.
 - Scaffolded flood service microservice stub for global flood mapping feeds.
+- Implemented PresenceIndicator component for collaborative session awareness.

--- a/packages/collab-editor/PresenceIndicator.test.ts
+++ b/packages/collab-editor/PresenceIndicator.test.ts
@@ -1,8 +1,0 @@
-import { PresenceIndicator } from './PresenceIndicator';
-
-test('tracks join and leave', () => {
-  const p = new PresenceIndicator();
-  p.join('a');
-  p.leave('a');
-  expect(p.count()).toBe(0);
-});

--- a/packages/collab-editor/PresenceIndicator.test.tsx
+++ b/packages/collab-editor/PresenceIndicator.test.tsx
@@ -1,0 +1,14 @@
+import "@testing-library/jest-dom";
+import { render, screen } from '@testing-library/react';
+import { PresenceIndicator, PresenceUser } from './PresenceIndicator';
+
+test('shows active users', () => {
+  const users: PresenceUser[] = [
+    { id: '1', name: 'Alice', active: true },
+    { id: '2', name: 'Bob', active: false },
+  ];
+  render(<PresenceIndicator users={users} />);
+  expect(screen.getByText('Alice')).toBeInTheDocument();
+  expect(screen.getByText('Bob')).toBeInTheDocument();
+  expect(screen.getAllByTestId('indicator')).toHaveLength(2);
+});

--- a/packages/collab-editor/PresenceIndicator.ts
+++ b/packages/collab-editor/PresenceIndicator.ts
@@ -1,6 +1,0 @@
-export class PresenceIndicator {
-  private users = new Set<string>();
-  join(user: string) { this.users.add(user); }
-  leave(user: string) { this.users.delete(user); }
-  count() { return this.users.size; }
-}

--- a/packages/collab-editor/PresenceIndicator.tsx
+++ b/packages/collab-editor/PresenceIndicator.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export interface PresenceUser {
+  id: string;
+  name: string;
+  active?: boolean;
+}
+
+export interface PresenceIndicatorProps {
+  users: PresenceUser[];
+}
+
+/**
+ * Displays a list of users with a simple activity indicator.
+ */
+export function PresenceIndicator({ users }: PresenceIndicatorProps) {
+  return (
+    <ul>
+      {users.map((u) => (
+        <li key={u.id}>
+          <span
+            data-testid="indicator"
+            style={{ color: u.active ? 'green' : 'gray', marginRight: 4 }}
+          >
+            ●
+          </span>
+          {u.name}
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- add PresenceIndicator React component with basic activity styling
- test presence indicator rendering with Testing Library
- mark PresenceIndicator task complete in advanced progress and ToDo files

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest packages/collab-editor/PresenceIndicator.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689c7504545c832291195f3c83ba2bc1