### PR TITLE
feat: add json option to repository map summary

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-12, in der Zeit des Nacht.
+Am 2025-08-13, in der Zeit des Tag.
 
-Symbolphase: Reflexion (Fokus: P)
+Symbolphase: Aktivierung (Fokus: R)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12268,5 +12268,12 @@
     "task": "Simulate wave propagation in a null field using finite difference method",
     "test": "tests/nullfield_wave_test.py",
     "status": "done"
+  },
+  {
+    "commit": "Add JSON option to repository map summary",
+    "path": "scripts/repository-map-summary.ts",
+    "task": "Support --json flag for machine-readable module counts",
+    "test": "scripts/repository-map-summary.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12029,3 +12029,8 @@
   task: Find repositories referencing a given module in repository_map.yaml
   test: scripts/repository-map-find.test.ts
   status: done
+- commit: Add JSON option to repository map summary
+  path: scripts/repository-map-summary.ts
+  task: Support --json flag for machine-readable module counts
+  test: scripts/repository-map-summary.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add region profile endpoint",
+  "lastCommit": "Merge pull request #1186 from GenesisAeon/hwbjwk-codex/implement-features-from-advancedtodo.yaml",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -10,10 +10,6 @@
     {
       "commit": "Integrate finetune and review services in compose",
       "status": "todo"
-    },
-    {
-      "commit": "Scaffold economy_service microservice",
-      "status": "done"
     },
     {
       "commit": "Scaffold emissions_service microservice",
@@ -3936,6 +3932,46 @@
     {
       "commit": "Enhance CREPTrendAnalyzer with regression and classification",
       "status": "done"
+    },
+    {
+      "commit": "Implement EmergencePredictorAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Create AgentDependencyGraph module",
+      "status": "done"
+    },
+    {
+      "commit": "Add GPTContextSummarizer bridge",
+      "status": "done"
+    },
+    {
+      "commit": "Add CREPTrendAnalyzer",
+      "status": "done"
+    },
+    {
+      "commit": "Add PresenceIndicator feature",
+      "status": "done"
+    },
+    {
+      "commit": "Scaffold economy_service microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Add repository map finder script",
+      "status": "done"
+    },
+    {
+      "commit": "Add null field wave simulation",
+      "status": "done"
+    },
+    {
+      "commit": "Add JSON option to repository map summary",
+      "status": "done"
+    },
+    {
+      "commit": "ein einfaches Python-Programm schreiben, das die Wellenausbreitung im Nullfeld als Simulation darstellt",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4533,6 +4569,10 @@
   "commits": [
     {
       "commit": "Add PresenceIndicator feature",
+      "status": "done"
+    },
+    {
+      "commit": "Add JSON option to repository map summary",
       "status": "done"
     }
   ]

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -50,3 +50,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Scaffolded flood service microservice stub for global flood mapping feeds.
 - Implemented PresenceIndicator component for collaborative session awareness.
 - Scaffolded economy service microservice for basic inequality metrics.
+- Extended repository map summary script with JSON output option for automation.

--- a/scripts/repository-map-summary.test.ts
+++ b/scripts/repository-map-summary.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeRepositoryMap } from './repository-map-summary';
+
+describe('summarizeRepositoryMap', () => {
+  it('returns text summary by default', () => {
+    const result = summarizeRepositoryMap();
+    expect(result).toContain('aeon:');
+  });
+
+  it('returns JSON summary when json option is true', () => {
+    const result = summarizeRepositoryMap({ json: true }) as Record<string, number>;
+    expect(result.aeon).toBeGreaterThan(0);
+  });
+});

--- a/scripts/repository-map-summary.ts
+++ b/scripts/repository-map-summary.ts
@@ -12,18 +12,38 @@ import yaml from 'js-yaml';
 
 const file = path.join(__dirname, '../repositorypflege/repository_map.yaml');
 
-try {
+export interface SummaryOptions {
+  json?: boolean;
+}
+
+export function summarizeRepositoryMap(options: SummaryOptions = {}) {
   const raw = fs.readFileSync(file, 'utf8');
   const data = yaml.load(raw) as any;
 
   const items = Array.isArray(data.repository_map) ? data.repository_map : [];
+  const summary: Record<string, number> = {};
   items.forEach((item: any) => {
     const name = item.name || 'unnamed';
     const modules = Array.isArray(item.modules) ? item.modules.length : 0;
-    console.log(`${name}: ${modules} module(s)`);
+    summary[name] = modules;
   });
-} catch (err) {
-  console.error('Failed to read repository map:', err);
-  process.exit(1);
+
+  if (options.json) {
+    return summary;
+  }
+
+  return Object.entries(summary)
+    .map(([name, count]) => `${name}: ${count} module(s)`)
+    .join('\n');
+}
+
+if (require.main === module) {
+  const jsonFlag = process.argv.includes('--json');
+  const result = summarizeRepositoryMap({ json: jsonFlag });
+  if (jsonFlag) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(result);
+  }
 }
 


### PR DESCRIPTION
## Summary
- extend repository-map-summary script with machine-readable `--json` flag
- cover summary helper with vitest
- log new capability in advanced ToDo and progress trackers

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/repository-map-summary.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689c8c1b8e888322abf3bccbdee174e8