### PR TITLE
Add review microservice to NewsBot compose

### DIFF
--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11614,7 +11614,7 @@
   path: docker-compose.yml
   task: Add finetune and review service containers
   test: ""
-  status: todo
+  status: done
 - commit: Document NewsBot live cycle flow
   path: docs/newsbot/flows.md
   task: Describe NewsFetch -> ScriptGen -> TTS -> Avatar -> Stream

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -9,7 +9,7 @@
   "pendingTasks": [
     {
       "commit": "Integrate finetune and review services in compose",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Scaffold emissions_service microservice",

--- a/agents/review_checkpoint/Dockerfile
+++ b/agents/review_checkpoint/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY main.py /app/main.py
+
+RUN pip install --no-cache-dir fastapi uvicorn pydantic
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       - tts_service
       - avatar_renderer_service
       - streamer_service
+      - finetune_service
+      - review_service
 
   news_fetcher_service:
     build:
@@ -69,11 +71,16 @@ services:
       context: ./services/finetune
     ports:
       - "8106:8000"
+  review_service:
+    build:
+      context: ./agents/review_checkpoint
+    ports:
+      - "8107:8000"
   singularity_simulator_service:
     build:
       context: ./agents/singularity_simulator
     ports:
-      - "8107:8000"
+      - "8108:8000"
 
   # --- Open-source chat services ---
   gpt4all_service:

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -31,6 +31,7 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Integrated NewsBot services into docker-compose and pipeline configuration.
 
 - Added training controls to NewsBotPanel for collecting data and starting finetunes.
+- Integrated finetune and review services into docker-compose and orchestrator dependencies.
 
 - Added desertification tracker plugin and agent stub.
 - Added forest dynamics plugin and agent stub.


### PR DESCRIPTION
## Summary
- containerize review checkpoint agent
- wire finetune and review services into NewsBot compose
- update progress trackers and feedback

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false && echo 'tsc-ok'`
- `poetry run pytest agents/review_checkpoint/test_main.py` *(fails: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_689c9398d388832289d56111789ffa65