### PR TITLE
feat: add mitigation service microservice

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11782,7 +11782,7 @@
   {
     "commit": "Scaffold mitigation_service microservice",
     "path": "agents/news_climate/mitigation_service.py",
-    "status": "todo",
+    "status": "done",
     "task": "Gather climate mitigation program data",
     "test": "agents/news_climate/mitigation_service.test.py"
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11689,7 +11689,7 @@
   path: agents/news_climate/mitigation_service.py
   task: Gather climate mitigation program data
   test: agents/news_climate/mitigation_service.test.py
-  status: todo
+  status: done
 - commit: Create ClimateSocialPanel UI
   path: packages/unifiedmandala-ui/components/ClimateSocialPanel.tsx
   task: Display aggregated climate and social metrics on dashboard

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5,7 +5,7 @@
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented region profile REST endpoint and completed country/region model set.",
+  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub.",
   "pendingTasks": [
     {
       "commit": "Integrate finetune and review services in compose",
@@ -17,7 +17,7 @@
     },
     {
       "commit": "Scaffold mitigation_service microservice",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Create ClimateSocialPanel UI",

--- a/agents/news_climate/mitigation_service.py
+++ b/agents/news_climate/mitigation_service.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Placeholder microservice for climate mitigation program metrics."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class MitigationMetrics:
+    """Basic metrics describing climate mitigation programs.
+
+    Attributes:
+        emissions_reduced: Estimated emissions reduction in metric tons.
+        projects_active: Number of active mitigation projects.
+    """
+
+    emissions_reduced: float = 0.0
+    projects_active: int = 0
+
+
+def fetch_mitigation_metrics() -> MitigationMetrics:
+    """Fetch current mitigation metrics.
+
+    This stub returns zero values until real integrations are implemented.
+    """
+
+    return MitigationMetrics()

--- a/agents/news_climate/mitigation_service_test.py
+++ b/agents/news_climate/mitigation_service_test.py
@@ -1,0 +1,8 @@
+from agents.news_climate.mitigation_service import MitigationMetrics, fetch_mitigation_metrics
+
+
+def test_fetch_mitigation_metrics_returns_defaults() -> None:
+    metrics = fetch_mitigation_metrics()
+    assert isinstance(metrics, MitigationMetrics)
+    assert metrics.emissions_reduced == 0.0
+    assert metrics.projects_active == 0

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -52,3 +52,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented PresenceIndicator component for collaborative session awareness.
 - Scaffolded economy service microservice for basic inequality metrics.
 - Extended repository map summary script with JSON output option for automation.
+- Scaffolded mitigation service microservice for climate program metrics.


### PR DESCRIPTION
## Summary
- scaffold basic mitigation service microservice with default metrics
- add accompanying test and mark task done in progress trackers
- log update in feedbackcodex

## Testing
- `pytest agents/news_climate/mitigation_service_test.py -q`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689ca5fbbe0883229e34b786226bbb27