### PR TITLE
feat: add node-friendly utilities for sigillin-cli

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12275,5 +12275,12 @@
     "task": "Support --json flag for machine-readable module counts",
     "test": "scripts/repository-map-summary.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Fix sigillin-cli Node runtime",
+    "path": "packages/cli-tools/sigillin-cli.js",
+    "task": "Ensure CLI commands work without build using JS fallbacks",
+    "test": "packages/cli-tools/__tests__/sigillin-cli.list-open-tasks.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12034,3 +12034,8 @@
   task: Support --json flag for machine-readable module counts
   test: scripts/repository-map-summary.test.ts
   status: done
+- commit: Fix sigillin-cli Node runtime
+  path: packages/cli-tools/sigillin-cli.js
+  task: Ensure CLI commands work without build using JS fallbacks
+  test: packages/cli-tools/__tests__/sigillin-cli.list-open-tasks.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1186 from GenesisAeon/hwbjwk-codex/implement-features-from-advancedtodo.yaml",
+  "lastCommit": "feat: add js utilities for sigillin-cli",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -8,16 +8,8 @@
   "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub.",
   "pendingTasks": [
     {
-      "commit": "Integrate finetune and review services in compose",
-      "status": "done"
-    },
-    {
       "commit": "Scaffold emissions_service microservice",
       "status": "todo"
-    },
-    {
-      "commit": "Scaffold mitigation_service microservice",
-      "status": "done"
     },
     {
       "commit": "Create ClimateSocialPanel UI",
@@ -3972,6 +3964,18 @@
     {
       "commit": "ein einfaches Python-Programm schreiben, das die Wellenausbreitung im Nullfeld als Simulation darstellt",
       "status": "done"
+    },
+    {
+      "commit": "Scaffold mitigation_service microservice",
+      "status": "done"
+    },
+    {
+      "commit": "Fix sigillin-cli Node runtime",
+      "status": "done"
+    },
+    {
+      "commit": "Integrate finetune and review services in compose",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4573,6 +4577,10 @@
     },
     {
       "commit": "Add JSON option to repository map summary",
+      "status": "done"
+    },
+    {
+      "commit": "Fix sigillin-cli Node runtime",
       "status": "done"
     }
   ]

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -53,3 +53,5 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Scaffolded economy service microservice for basic inequality metrics.
 - Extended repository map summary script with JSON output option for automation.
 - Scaffolded mitigation service microservice for climate program metrics.
+
+- Enabled sigillin-cli commands to run without ts-node by adding JS fallbacks.

--- a/packages/cli-tools/OpenTaskLister.js
+++ b/packages/cli-tools/OpenTaskLister.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const YAML = require('yaml');
+
+function loadAdvancedTodo(file) {
+  try {
+    const data = fs.readFileSync(file, 'utf8');
+    const list = YAML.parse(data);
+    return Array.isArray(list) ? list : [];
+  } catch {
+    return [];
+  }
+}
+
+function getOpenTasks(file) {
+  return loadAdvancedTodo(file).filter(t => t.status === 'todo');
+}
+
+module.exports = { loadAdvancedTodo, getOpenTasks };

--- a/packages/cli-tools/__tests__/sigillin-cli.list-open-tasks.test.ts
+++ b/packages/cli-tools/__tests__/sigillin-cli.list-open-tasks.test.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+describe('list-open-tasks command', () => {
+  const tmpDir = path.join(__dirname, '__tmp_list__');
+  const todoFile = path.join(tmpDir, 'advancedToDo.yaml');
+
+  beforeAll(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(
+      todoFile,
+      '- commit: test\n  path: test.ts\n  task: sample task\n  status: todo\n'
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('outputs open tasks without ts-node', () => {
+    const cli = path.resolve(__dirname, '..', 'sigillin-cli.js');
+    const out = execSync(`node ${cli} list-open-tasks ${todoFile}`).toString();
+    expect(out).toContain('sample task');
+  });
+});

--- a/packages/genesis-sigillin-core/SigillinGenerator.js
+++ b/packages/genesis-sigillin-core/SigillinGenerator.js
@@ -1,0 +1,27 @@
+const Ajv = require('ajv');
+const addFormats = require('ajv-formats');
+const schema = require('./schemas/sigillin.schema.json');
+
+const ajv = new Ajv();
+addFormats(ajv);
+const validate = ajv.compile(schema);
+
+const SigillinGenerator = (id, type, status, creator, schema_version = '1.0.0') => {
+  const sigillin = {
+    schema_version,
+    id,
+    type,
+    status,
+    creator,
+    created_at: new Date().toISOString(),
+    related_sigils: [],
+    changes: [],
+  };
+  if (!validate(sigillin)) {
+    console.error(validate.errors);
+    throw new Error('Ungültiges Sigillin');
+  }
+  return sigillin;
+};
+
+module.exports = { SigillinGenerator };

--- a/packages/shared-utils/textFragmenter.js
+++ b/packages/shared-utils/textFragmenter.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+
+function splitText(text, maxLength = 1000) {
+  const chunks = [];
+  for (let i = 0; i < text.length; i += maxLength) {
+    chunks.push(text.slice(i, i + maxLength));
+  }
+  return chunks;
+}
+
+function splitFile(filePath, maxLength = 1000) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  return splitText(content, maxLength);
+}
+
+module.exports = { splitText, splitFile };


### PR DESCRIPTION
## Summary
- add CommonJS versions of text fragmenter, Sigillin generator, and open task lister
- enable sigillin-cli to list open tasks without ts-node and document progress
- record utility addition in advanced ToDo, progress, and feedback files

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `node packages/cli-tools/sigillin-cli.js list-open-tasks`
- `npx vitest run packages/cli-tools/__tests__/sigillin-cli.list-open-tasks.test.ts` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689cae0996ec8322848e35e4df18b075