### PR TITLE
feat(news-climate): add emissions service stub

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11775,7 +11775,7 @@
   {
     "commit": "Scaffold emissions_service microservice",
     "path": "agents/news_climate/emissions_service.py",
-    "status": "todo",
+    "status": "done",
     "task": "Stream CO2 and methane emission metrics",
     "test": "agents/news_climate/emissions_service.test.py"
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11684,7 +11684,7 @@
   path: agents/news_climate/emissions_service.py
   task: Stream CO2 and methane emission metrics
   test: agents/news_climate/emissions_service.test.py
-  status: todo
+  status: done
 - commit: Scaffold mitigation_service microservice
   path: agents/news_climate/mitigation_service.py
   task: Gather climate mitigation program data

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -9,7 +9,7 @@
   "pendingTasks": [
     {
       "commit": "Scaffold emissions_service microservice",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Create ClimateSocialPanel UI",

--- a/agents/news_climate/emissions_service.py
+++ b/agents/news_climate/emissions_service.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+
+"""Placeholder microservice for greenhouse gas emission metrics."""
+
+
+@dataclass
+class EmissionsMetrics:
+    """Basic metrics describing greenhouse gas emissions.
+
+    Attributes:
+        co2: Estimated CO2 emissions in metric tons.
+        methane: Estimated methane emissions in metric tons.
+    """
+
+    co2: float = 0.0
+    methane: float = 0.0
+
+
+def fetch_emissions_metrics() -> EmissionsMetrics:
+    """Fetch current emission metrics.
+
+    This stub returns zero values until real integrations are implemented.
+    """
+
+    return EmissionsMetrics()

--- a/agents/news_climate/emissions_service_test.py
+++ b/agents/news_climate/emissions_service_test.py
@@ -1,0 +1,8 @@
+from agents.news_climate.emissions_service import EmissionsMetrics, fetch_emissions_metrics
+
+
+def test_fetch_emissions_metrics_returns_defaults() -> None:
+    metrics = fetch_emissions_metrics()
+    assert isinstance(metrics, EmissionsMetrics)
+    assert metrics.co2 == 0.0
+    assert metrics.methane == 0.0

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -55,3 +55,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Scaffolded mitigation service microservice for climate program metrics.
 
 - Enabled sigillin-cli commands to run without ts-node by adding JS fallbacks.
+- Scaffolded emissions service microservice for CO2 and methane metrics.


### PR DESCRIPTION
## Summary
- scaffold emissions_service microservice and default metrics
- record new microservice in advanced ToDo and progress trackers
- leave feedback note about emissions service

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright agents/news_climate/emissions_service.py`
- `npx tsc -p tsconfig.json`
- `pytest agents/news_climate/emissions_service_test.py`


------
https://chatgpt.com/codex/tasks/task_e_689cba1d3a7c83228896f2e4b386b27a