### PR TITLE
feat: enhance GPT ethics supervisor filtering

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1412,7 +1412,8 @@
     "commit": "Introduce GPTEthicsSupervisor",
     "path": "packages/gpt-bridges/GPTEthicsSupervisor.ts",
     "task": "Check GPT answers for ethical consistency",
-    "test": "packages/gpt-bridges/GPTEthicsSupervisor.test.ts"
+    "test": "packages/gpt-bridges/GPTEthicsSupervisor.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add GPTSymbolInterpreter",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1037,6 +1037,7 @@
   path: packages/gpt-bridges/GPTEthicsSupervisor.ts
   task: Check GPT answers for ethical consistency
   test: packages/gpt-bridges/GPTEthicsSupervisor.test.ts
+  status: done
 - commit: Add GPTSymbolInterpreter
   path: packages/gpt-bridges/GPTSymbolInterpreter.ts
   task: Explain symbolic meanings to the user in real time

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,12 +1,16 @@
 {
-  "lastCommit": "feat: add js utilities for sigillin-cli",
+  "lastCommit": "feat: enhance GPT ethics supervisor filtering",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub.",
+  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks.",
   "pendingTasks": [
+    {
+      "commit": "Introduce GPTEthicsSupervisor",
+      "status": "done"
+    },
     {
       "commit": "Scaffold emissions_service microservice",
       "status": "done"

--- a/packages/gpt-bridges/GPTEthicsSupervisor.test.ts
+++ b/packages/gpt-bridges/GPTEthicsSupervisor.test.ts
@@ -1,6 +1,9 @@
 import { isEthical } from './GPTEthicsSupervisor';
 
-test('detects banned words', () => {
-  expect(isEthical('hello bad', ['bad'])).toBe(false);
-  expect(isEthical('hello', ['bad'])).toBe(true);
+test('detects banned words and patterns', () => {
+  expect(isEthical('hello BAD', { bannedWords: ['bad'] })).toBe(false);
+  expect(isEthical('hello', { bannedWords: ['bad'] })).toBe(true);
+  expect(
+    isEthical('promotion of violence', { bannedPatterns: [/violence/i] })
+  ).toBe(false);
 });

--- a/packages/gpt-bridges/GPTEthicsSupervisor.ts
+++ b/packages/gpt-bridges/GPTEthicsSupervisor.ts
@@ -1,3 +1,18 @@
-export function isEthical(text: string, banned: string[] = []): boolean {
-  return !banned.some(w => text.includes(w));
+export interface EthicsOptions {
+  /** Words that should not appear in the text */
+  bannedWords?: string[];
+  /** Regular expression patterns that flag unethical content */
+  bannedPatterns?: RegExp[];
+}
+
+export function isEthical(text: string, options: EthicsOptions = {}): boolean {
+  const { bannedWords = [], bannedPatterns = [] } = options;
+  const lower = text.toLowerCase();
+  if (bannedWords.some(w => lower.includes(w.toLowerCase()))) {
+    return false;
+  }
+  if (bannedPatterns.some(p => p.test(text))) {
+    return false;
+  }
+  return true;
 }

--- a/repositorypflege/repository_map.yaml
+++ b/repositorypflege/repository_map.yaml
@@ -87,4 +87,5 @@ gpt_bridges:
         - "AI = Werkzeug, nie Wille."
         - "Bewusstsein = fehlerhaft, aber lernend."
         - "Poetische Klarheit vor technischer Perfektion."
-
+  - gpt-ethics-supervisor.ts:
+      description: "Checks GPT answers for ethical consistency"


### PR DESCRIPTION
## Summary
- expand GPTEthicsSupervisor with options for banned words and regex patterns
- mark GPTEthicsSupervisor task complete and log progress updates
- document new GPT bridge in repository map

## Testing
- `npx pyright` *(fails: venvPath /workspace/unified-mandala/.venv is not a valid directory)*
- `npx tsc -p tsconfig.json`
- `npx jest packages/gpt-bridges/GPTEthicsSupervisor.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cf02d80f08322ac586201a7f0b140