### PR TITLE
feat: add SocialGood UI automation helpers

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1172,7 +1172,8 @@
     "commit": "Automate documentation, sigil generation, and TODO prioritization",
     "path": "apps/socialgood-ui",
     "task": "Automated docs, sigil generation, TODO ranking and conversation analytics",
-    "test": "apps/socialgood-ui/__tests__/automation.test.ts"
+    "test": "apps/socialgood-ui/__tests__/automation.test.ts",
+    "status": "done"
   },
   {
     "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part1.json - 4df8c73d-6df3-443c-a695-31458a2e1cf7",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -849,6 +849,7 @@
   path: apps/socialgood-ui
   task: Automated docs, sigil generation, TODO ranking and conversation analytics
   test: apps/socialgood-ui/__tests__/automation.test.ts
+  status: done
 - commit: TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part1.json -
     4df8c73d-6df3-443c-a695-31458a2e1cf7
   path: GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part1.json

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -4586,6 +4586,10 @@
     {
       "commit": "Fix sigillin-cli Node runtime",
       "status": "done"
+    },
+    {
+      "commit": "Add SocialGoodUI automation helpers",
+      "status": "done"
     }
   ]
 }

--- a/apps/socialgood-ui/__tests__/automation.test.ts
+++ b/apps/socialgood-ui/__tests__/automation.test.ts
@@ -1,0 +1,34 @@
+import {
+  prioritizeTodos,
+  generateDocumentation,
+  generateSigil,
+  analyzeConversations,
+} from '../automation';
+
+describe('automation helpers', () => {
+  test('prioritizeTodos sorts by priority descending', () => {
+    const todos = [
+      { task: 'b', priority: 1 },
+      { task: 'a', priority: 5 },
+    ];
+    const [first] = prioritizeTodos(todos);
+    expect(first.task).toBe('a');
+  });
+
+  test('generateDocumentation turns tasks into markdown', () => {
+    const doc = generateDocumentation(['alpha', 'beta']);
+    expect(doc).toBe('- alpha\n- beta');
+  });
+
+  test('generateSigil creates simple sigil', () => {
+    const sigil = generateSigil('hello world');
+    expect(sigil).toBe('H-E-L-L');
+  });
+
+  test('analyzeConversations returns stats', () => {
+    const stats = analyzeConversations(['hello world', 'hi']);
+    expect(stats.count).toBe(2);
+    expect(stats.averageLength).toBeCloseTo(1.5, 5);
+  });
+});
+

--- a/apps/socialgood-ui/automation.ts
+++ b/apps/socialgood-ui/automation.ts
@@ -1,0 +1,33 @@
+export interface Todo {
+  task: string;
+  priority: number;
+}
+
+export function prioritizeTodos(todos: Todo[]): Todo[] {
+  return [...todos].sort((a, b) => b.priority - a.priority);
+}
+
+export function generateDocumentation(tasks: string[]): string {
+  return tasks.map((t) => `- ${t}`).join('\n');
+}
+
+export function generateSigil(seed: string): string {
+  const compact = seed.replace(/\s+/g, '').toUpperCase();
+  return compact.slice(0, 4).split('').join('-');
+}
+
+export interface ConversationStats {
+  count: number;
+  averageLength: number;
+}
+
+export function analyzeConversations(conversations: string[]): ConversationStats {
+  const count = conversations.length;
+  const totalWords = conversations.reduce(
+    (sum, c) => sum + c.split(/\s+/).filter(Boolean).length,
+    0
+  );
+  const averageLength = count === 0 ? 0 : totalWords / count;
+  return { count, averageLength };
+}
+


### PR DESCRIPTION
## Summary
- add utility functions for TODO prioritization, documentation output, sigil generation and conversation analysis in SocialGood UI
- cover new automation helpers with unit tests
- record completion in advancedToDo and progress tracker

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest apps/socialgood-ui/__tests__/automation.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cf70a364083229a1558495e3ddf3a