### PR TITLE
feat: add ClimateSocialPanel UI

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11791,7 +11791,7 @@
   {
     "commit": "Create ClimateSocialPanel UI",
     "path": "packages/unifiedmandala-ui/components/ClimateSocialPanel.tsx",
-    "status": "todo",
+    "status": "done",
     "task": "Display aggregated climate and social metrics on dashboard",
     "test": "packages/unifiedmandala-ui/components/ClimateSocialPanel.test.tsx"
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11696,7 +11696,7 @@
   path: packages/unifiedmandala-ui/components/ClimateSocialPanel.tsx
   task: Display aggregated climate and social metrics on dashboard
   test: packages/unifiedmandala-ui/components/ClimateSocialPanel.test.tsx
-  status: todo
+  status: done
 - commit: Register climate news services in pipeline configuration
   path: pipeline_config.yaml
   task: Add sigillin_map and CREP thresholds for climate data pipeline

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: enhance GPT ethics supervisor filtering",
+  "lastCommit": "feat: add ClimateSocialPanel UI",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks.",
+  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics.",
   "pendingTasks": [
     {
       "commit": "Introduce GPTEthicsSupervisor",
@@ -17,7 +17,7 @@
     },
     {
       "commit": "Create ClimateSocialPanel UI",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Register climate news services in pipeline configuration",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -57,3 +57,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Enabled sigillin-cli commands to run without ts-node by adding JS fallbacks.
 - Scaffolded emissions service microservice for CO2 and methane metrics.
 - Defined Auto-Resonanz sigillin connecting core training and governance agents.
+- Implemented ClimateSocialPanel component to surface aggregated climate and social data on the dashboard.

--- a/packages/unifiedmandala-ui/components/ClimateSocialPanel.test.tsx
+++ b/packages/unifiedmandala-ui/components/ClimateSocialPanel.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ClimateSocialPanel from './ClimateSocialPanel';
+
+describe('ClimateSocialPanel', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      json: async () => ({ temperature: 1, socialIndex: 0.5 })
+    });
+  });
+
+  test('fetches data and renders heading', async () => {
+    render(<ClimateSocialPanel />);
+    expect(fetch).toHaveBeenCalledWith(
+      '/process',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(await screen.findByText(/Climate & Social Metrics/)).toBeInTheDocument();
+  });
+});

--- a/packages/unifiedmandala-ui/components/ClimateSocialPanel.tsx
+++ b/packages/unifiedmandala-ui/components/ClimateSocialPanel.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+
+/**
+ * ClimateSocialPanel fetches aggregated climate and social metrics
+ * from the `/process` endpoint and displays the raw response.
+ * The component was scaffolded from design fragments in
+ * `newadvancedconversations.json`.
+ */
+export default function ClimateSocialPanel() {
+  const [data, setData] = useState<any>(null);
+
+  useEffect(() => {
+    fetch('/process', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ task_type: 'climate_fetch', crep_score: 0.75 })
+    })
+      .then((r) => r.json())
+      .then((json) => setData(json))
+      .catch(() => setData(null));
+  }, []);
+
+  if (!data) {
+    return <div aria-label="ClimateSocialPanel">Loading...</div>;
+  }
+
+  return (
+    <div aria-label="ClimateSocialPanel">
+      <h2>Climate &amp; Social Metrics</h2>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add ClimateSocialPanel component for climate and social metrics
- mark ClimateSocialPanel task as complete in progress trackers
- log ClimateSocialPanel in feedback codex

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest packages/unifiedmandala-ui/components/ClimateSocialPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689d0230409883229f1ea607d3ffbd7f