### PR TITLE
Integrate climate news microservices into orchestrator pipeline and compose

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11798,14 +11798,14 @@
   {
     "commit": "Register climate news services in pipeline configuration",
     "path": "pipeline_config.yaml",
-    "status": "todo",
+    "status": "done",
     "task": "Add sigillin_map and CREP thresholds for climate data pipeline",
     "test": ""
   },
   {
     "commit": "Integrate climate news services into docker compose",
     "path": "docker-compose.yml",
-    "status": "todo",
+    "status": "done",
     "task": "Add climate data microservices and orchestrator containers",
     "test": ""
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11701,12 +11701,12 @@
   path: pipeline_config.yaml
   task: Add sigillin_map and CREP thresholds for climate data pipeline
   test: ""
-  status: todo
+  status: done
 - commit: Integrate climate news services into docker compose
   path: docker-compose.yml
   task: Add climate data microservices and orchestrator containers
   test: ""
-  status: todo
+  status: done
 - commit: Add global events plugin with positive progress services
   path: plugins/global-events.yaml
   task: Define global & positive progress event layer

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add ClimateSocialPanel UI",
+  "lastCommit": "feat: integrate climate news services",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -21,11 +21,11 @@
     },
     {
       "commit": "Register climate news services in pipeline configuration",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Integrate climate news services into docker compose",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Create GlobalEventsPanel UI",

--- a/agents/news_climate/climate_service.py
+++ b/agents/news_climate/climate_service.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from fastapi import FastAPI
+
 
 @dataclass
 class ClimateMetrics:
@@ -20,3 +22,19 @@ def fetch_metrics() -> ClimateMetrics:
     """
 
     return ClimateMetrics()
+
+
+app = FastAPI(title="Climate Service")
+
+
+@app.get("/metrics", response_model=ClimateMetrics)
+async def get_metrics() -> ClimateMetrics:
+    """Return climate metrics."""
+
+    return fetch_metrics()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/agents/news_climate/economy_service.py
+++ b/agents/news_climate/economy_service.py
@@ -1,6 +1,10 @@
-from dataclasses import dataclass
+from __future__ import annotations
 
 """Placeholder microservice for basic economic metrics."""
+
+from dataclasses import dataclass
+
+from fastapi import FastAPI
 
 
 @dataclass
@@ -26,3 +30,19 @@ def fetch_economy_metrics() -> EconomyMetrics:
     """
 
     return EconomyMetrics()
+
+
+app = FastAPI(title="Economy Service")
+
+
+@app.get("/metrics", response_model=EconomyMetrics)
+async def get_metrics() -> EconomyMetrics:
+    """Return economy metrics."""
+
+    return fetch_economy_metrics()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/agents/news_climate/emissions_service.py
+++ b/agents/news_climate/emissions_service.py
@@ -1,6 +1,10 @@
-from dataclasses import dataclass
+from __future__ import annotations
 
 """Placeholder microservice for greenhouse gas emission metrics."""
+
+from dataclasses import dataclass
+
+from fastapi import FastAPI
 
 
 @dataclass
@@ -23,3 +27,19 @@ def fetch_emissions_metrics() -> EmissionsMetrics:
     """
 
     return EmissionsMetrics()
+
+
+app = FastAPI(title="Emissions Service")
+
+
+@app.get("/metrics", response_model=EmissionsMetrics)
+async def get_metrics() -> EmissionsMetrics:
+    """Return emission metrics."""
+
+    return fetch_emissions_metrics()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/agents/news_climate/flood_service.py
+++ b/agents/news_climate/flood_service.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass
 
+from fastapi import FastAPI
+
 
 @dataclass
 class FloodMetrics:
@@ -21,3 +23,19 @@ def fetch_flood_metrics() -> FloodMetrics:
     """
 
     return FloodMetrics()
+
+
+app = FastAPI(title="Flood Service")
+
+
+@app.get("/metrics", response_model=FloodMetrics)
+async def get_metrics() -> FloodMetrics:
+    """Return flood metrics."""
+
+    return fetch_flood_metrics()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/agents/news_climate/forest_service.py
+++ b/agents/news_climate/forest_service.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from fastapi import FastAPI
+
 
 @dataclass
 class ForestMetrics:
@@ -25,4 +27,20 @@ def fetch_forest_metrics() -> ForestMetrics:
     """
 
     return ForestMetrics()
+
+
+app = FastAPI(title="Forest Service")
+
+
+@app.get("/metrics", response_model=ForestMetrics)
+async def get_metrics() -> ForestMetrics:
+    """Return forest metrics."""
+
+    return fetch_forest_metrics()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)
 

--- a/agents/news_climate/mitigation_service.py
+++ b/agents/news_climate/mitigation_service.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from fastapi import FastAPI
+
 
 @dataclass
 class MitigationMetrics:
@@ -25,3 +27,19 @@ def fetch_mitigation_metrics() -> MitigationMetrics:
     """
 
     return MitigationMetrics()
+
+
+app = FastAPI(title="Mitigation Service")
+
+
+@app.get("/metrics", response_model=MitigationMetrics)
+async def get_metrics() -> MitigationMetrics:
+    """Return mitigation metrics."""
+
+    return fetch_mitigation_metrics()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,3 +107,81 @@ services:
     image: ghcr.io/microsoft/autogen:latest
     ports:
       - "8205:80"
+
+  # --- Climate news microservices ---
+  climate_news_orchestrator:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: python agents/news_climate/orchestrator.py
+    volumes:
+      - .:/workspace/unified-mandala
+    ports:
+      - "8300:8000"
+    depends_on:
+      - climate_service
+      - forest_service
+      - flood_service
+      - economy_service
+      - emissions_service
+      - mitigation_service
+
+  climate_service:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: python agents/news_climate/climate_service.py
+    volumes:
+      - .:/workspace/unified-mandala
+    ports:
+      - "8301:8000"
+
+  forest_service:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: python agents/news_climate/forest_service.py
+    volumes:
+      - .:/workspace/unified-mandala
+    ports:
+      - "8302:8000"
+
+  flood_service:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: python agents/news_climate/flood_service.py
+    volumes:
+      - .:/workspace/unified-mandala
+    ports:
+      - "8303:8000"
+
+  economy_service:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: python agents/news_climate/economy_service.py
+    volumes:
+      - .:/workspace/unified-mandala
+    ports:
+      - "8304:8000"
+
+  emissions_service:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: python agents/news_climate/emissions_service.py
+    volumes:
+      - .:/workspace/unified-mandala
+    ports:
+      - "8305:8000"
+
+  mitigation_service:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: python agents/news_climate/mitigation_service.py
+    volumes:
+      - .:/workspace/unified-mandala
+    ports:
+      - "8306:8000"

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -58,3 +58,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Scaffolded emissions service microservice for CO2 and methane metrics.
 - Defined Auto-Resonanz sigillin connecting core training and governance agents.
 - Implemented ClimateSocialPanel component to surface aggregated climate and social data on the dashboard.
+- Registered climate news microservices in orchestrator pipeline configuration and docker-compose.

--- a/unifiedmandala-orchestrator/orchestrator/pipeline_config.yaml
+++ b/unifiedmandala-orchestrator/orchestrator/pipeline_config.yaml
@@ -19,6 +19,12 @@ sigillin_map:
   tech_events:      tech_service
   environment_events: environment_service
   global_events:    global_events_orchestrator
+  climate_metrics:  climate_service
+  forest_metrics:   forest_service
+  flood_metrics:    flood_service
+  economy_metrics:  economy_service
+  emissions_metrics: emissions_service
+  mitigation_metrics: mitigation_service
 
 crep_thresholds:
   gnn_service: 0.60
@@ -41,3 +47,9 @@ crep_thresholds:
   tech_service: 0.45
   environment_service: 0.45
   global_events_orchestrator: 0.50
+  climate_service: 0.40
+  forest_service: 0.40
+  flood_service: 0.40
+  economy_service: 0.45
+  emissions_service: 0.45
+  mitigation_service: 0.45


### PR DESCRIPTION
## Summary
- Add FastAPI endpoints for climate-related microservices and expose metrics routes
- Register climate microservices in orchestrator pipeline config and docker-compose
- Update advanced ToDo and progress trackers for completed climate service integration

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: venvPath .venv is not a valid directory)*
- `npx tsc -p tsconfig.json`
- `pytest agents/news_climate`


------
https://chatgpt.com/codex/tasks/task_e_689d0ea7373883228ef7f187f80971cc