### PR TITLE
feat: enhance GPTSymbolInterpreter

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1420,7 +1420,8 @@
     "commit": "Add GPTSymbolInterpreter",
     "path": "packages/gpt-bridges/GPTSymbolInterpreter.ts",
     "task": "Explain symbolic meanings to the user in real time",
-    "test": "packages/gpt-bridges/GPTSymbolInterpreter.test.ts"
+    "test": "packages/gpt-bridges/GPTSymbolInterpreter.test.ts",
+    "status": "done"
   },
   {
     "commit": "Create InteractiveSymbolzeitExplorer",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1043,6 +1043,7 @@
   path: packages/gpt-bridges/GPTSymbolInterpreter.ts
   task: Explain symbolic meanings to the user in real time
   test: packages/gpt-bridges/GPTSymbolInterpreter.test.ts
+  status: done
 - commit: Create InteractiveSymbolzeitExplorer
   path: packages/unifiedmandala-ui/components/InteractiveSymbolzeitExplorer.tsx
   task: Interactive exploration of past and future Symbolzeit

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -4590,6 +4590,10 @@
     {
       "commit": "Add SocialGoodUI automation helpers",
       "status": "done"
+    },
+    {
+      "commit": "Add GPTSymbolInterpreter async",
+      "status": "done"
     }
   ]
 }

--- a/packages/gpt-bridges/GPTSymbolInterpreter.test.ts
+++ b/packages/gpt-bridges/GPTSymbolInterpreter.test.ts
@@ -1,6 +1,18 @@
 import { interpret } from './GPTSymbolInterpreter';
 
-test('interprets known symbols', () => {
-  expect(interpret('🔥')).toBe('energy');
-  expect(interpret('❓')).toBe('unknown');
+test('interprets known symbols locally', async () => {
+  await expect(interpret('🔥')).resolves.toBe('energy');
+});
+
+test('fetches meaning for unknown symbols', async () => {
+  const mockFetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ meaning: 'mystery' }),
+    })
+  );
+
+  const res = await interpret('🔮', mockFetch as any);
+  expect(mockFetch).toHaveBeenCalled();
+  expect(res).toBe('mystery');
 });

--- a/packages/gpt-bridges/GPTSymbolInterpreter.ts
+++ b/packages/gpt-bridges/GPTSymbolInterpreter.ts
@@ -3,6 +3,35 @@ const mapping: Record<string, string> = {
   '💧': 'flow',
 };
 
-export function interpret(symbol: string): string {
-  return mapping[symbol] || 'unknown';
+/**
+ * Interpret a symbolic glyph. Known symbols are resolved locally while
+ * unknown symbols are sent to a GPT bridge which returns a textual meaning.
+ *
+ * The fetch implementation is injectable to keep the module testable without
+ * performing real network requests.
+ */
+export async function interpret(
+  symbol: string,
+  fetchImpl?: typeof fetch
+): Promise<string> {
+  if (mapping[symbol]) return mapping[symbol];
+
+  const endpoint =
+    process.env.GPT_SYMBOL_URL || 'http://localhost:3000/symbol-interpret';
+  const fn = fetchImpl || (globalThis as any).fetch;
+  try {
+    const res = await fn(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ symbol }),
+    });
+
+    if (!res.ok) return 'unknown';
+    const data = (await res.json()) as { meaning?: string };
+    return data.meaning || 'unknown';
+  } catch {
+    return 'unknown';
+  }
 }
+
+export { mapping };

--- a/repositorypflege/repository_map.yaml
+++ b/repositorypflege/repository_map.yaml
@@ -89,3 +89,5 @@ gpt_bridges:
         - "Poetische Klarheit vor technischer Perfektion."
   - gpt-ethics-supervisor.ts:
       description: "Checks GPT answers for ethical consistency"
+  - gpt-symbol-interpreter.ts:
+      description: "Explains symbolic meanings to the user in real time"


### PR DESCRIPTION
## Summary
- add async GPTSymbolInterpreter that queries configurable endpoint and falls back to local symbol map
- cover interpreter with fetch-mocking tests
- log progress for GPTSymbolInterpreter in advancedToDo and repository map

## Testing
- `npm test packages/gpt-bridges/GPTSymbolInterpreter.test.ts`
- `npx tsc -p tsconfig.json`
- `npx pyright` *(fails: FastAPI type issues)*

------
https://chatgpt.com/codex/tasks/task_e_689d1475246c8322af0f6e341e64aa11