### PR TITLE
feat(observability): enhance error reporting system

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1545,7 +1545,8 @@
     "commit": "Create ErrorReportingSystem",
     "path": "packages/observability/ErrorReportingSystem.ts",
     "task": "Collect and report runtime errors automatically",
-    "test": "packages/observability/ErrorReportingSystem.test.ts"
+    "test": "packages/observability/ErrorReportingSystem.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add CommunityPluginMarketplace",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1128,6 +1128,7 @@
   path: packages/observability/ErrorReportingSystem.ts
   task: Collect and report runtime errors automatically
   test: packages/observability/ErrorReportingSystem.test.ts
+  status: done
 - commit: Add CommunityPluginMarketplace
   path: packages/community/CommunityPluginMarketplace.ts
   task: Host and rate community plugins

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -4594,6 +4594,10 @@
     {
       "commit": "Add GPTSymbolInterpreter async",
       "status": "done"
+    },
+    {
+      "commit": "Create ErrorReportingSystem",
+      "status": "done"
     }
   ]
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -54,6 +54,8 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Extended repository map summary script with JSON output option for automation.
 - Scaffolded mitigation service microservice for climate program metrics.
 
+- Implemented enhanced ErrorReportingSystem with timestamped error reporting.
+
 - Enabled sigillin-cli commands to run without ts-node by adding JS fallbacks.
 - Scaffolded emissions service microservice for CO2 and methane metrics.
 - Defined Auto-Resonanz sigillin connecting core training and governance agents.

--- a/packages/observability/ErrorReportingSystem.test.ts
+++ b/packages/observability/ErrorReportingSystem.test.ts
@@ -1,7 +1,21 @@
 import { ErrorReportingSystem } from './ErrorReportingSystem';
+import { vi } from 'vitest';
 
-test('stores errors', () => {
+test('stores errors with timestamp', () => {
+  const s = new ErrorReportingSystem();
+  const err = new Error('x');
+  const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  s.report(err);
+  const errors = s.getErrors();
+  expect(errors).toHaveLength(1);
+  expect(errors[0].error).toBe(err);
+  expect(typeof errors[0].timestamp).toBe('number');
+  spy.mockRestore();
+});
+
+test('clears errors', () => {
   const s = new ErrorReportingSystem();
   s.report(new Error('x'));
-  expect(s.errors).toEqual(['x']);
+  s.clear();
+  expect(s.getErrors()).toHaveLength(0);
 });

--- a/packages/observability/ErrorReportingSystem.ts
+++ b/packages/observability/ErrorReportingSystem.ts
@@ -1,4 +1,21 @@
+export interface ErrorRecord {
+  error: Error;
+  timestamp: number;
+}
+
 export class ErrorReportingSystem {
-  errors: string[] = [];
-  report(e: Error) { this.errors.push(e.message); }
+  private records: ErrorRecord[] = [];
+
+  report(e: Error) {
+    console.error(e);
+    this.records.push({ error: e, timestamp: Date.now() });
+  }
+
+  getErrors(): ErrorRecord[] {
+    return this.records;
+  }
+
+  clear() {
+    this.records = [];
+  }
 }


### PR DESCRIPTION
## Summary
- expand ErrorReportingSystem to capture errors with timestamps and retrieval helpers
- record completion of ErrorReportingSystem task in advanced progress trackers and feedback codex

## Testing
- `npx pyright` *(fails: venvPath /workspace/unified-mandala/.venv is not a valid directory)*
- `npx tsc -p tsconfig.json --noEmit --pretty false`
- `npx vitest run packages/observability/ErrorReportingSystem.test.ts` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689d25e27ec48322b9ef5c49cc02da7c