### PR TITLE
feat(ui): add global events panel

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11851,7 +11851,7 @@
   {
     "commit": "Create GlobalEventsPanel UI",
     "path": "packages/unifiedmandala-ui/components/GlobalEventsPanel.tsx",
-    "status": "todo",
+    "status": "done",
     "task": "Display cosmic, crisis and positive events",
     "test": "packages/unifiedmandala-ui/components/GlobalEventsPanel.test.tsx"
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11740,7 +11740,7 @@
   path: packages/unifiedmandala-ui/components/GlobalEventsPanel.tsx
   task: Display cosmic, crisis and positive events
   test: packages/unifiedmandala-ui/components/GlobalEventsPanel.test.tsx
-  status: todo
+  status: done
 - commit: Register global events services in pipeline config
   path: pipeline_config.yaml
   task: Add sigillin_map and CREP thresholds for global events

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1198 from GenesisAeon/codex/implement-features-from-advancedtodo.yaml-qs3pws",
+  "lastCommit": "chore(progress): set commit reference",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -7,10 +7,6 @@
   "mergeConflicts": [],
   "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics.",
   "pendingTasks": [
-    {
-      "commit": "Create GlobalEventsPanel UI",
-      "status": "todo"
-    },
     {
       "commit": "Integrate global events services into compose",
       "status": "todo"
@@ -3995,6 +3991,10 @@
     },
     {
       "commit": "Define Auto-Resonanz sigillin",
+      "status": "done"
+    },
+    {
+      "commit": "Create GlobalEventsPanel UI",
       "status": "done"
     }
   ],

--- a/packages/unifiedmandala-ui/components/GlobalEventsPanel.test.tsx
+++ b/packages/unifiedmandala-ui/components/GlobalEventsPanel.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import GlobalEventsPanel from './GlobalEventsPanel';
+
+describe('GlobalEventsPanel', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      json: async () => ({ events: [] })
+    });
+  });
+
+  test('fetches events and renders heading', async () => {
+    render(<GlobalEventsPanel />);
+    expect(fetch).toHaveBeenCalledWith('/global-events');
+    expect(await screen.findByText(/Global Events/)).toBeInTheDocument();
+  });
+});

--- a/packages/unifiedmandala-ui/components/GlobalEventsPanel.tsx
+++ b/packages/unifiedmandala-ui/components/GlobalEventsPanel.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+
+/**
+ * GlobalEventsPanel fetches cosmic, crisis and positive events
+ * from the `/global-events` endpoint and displays the raw
+ * response. Inspired by design fragments in
+ * `newadvancedconversations.json`.
+ */
+export default function GlobalEventsPanel() {
+  const [data, setData] = useState<any>(null);
+
+  useEffect(() => {
+    fetch('/global-events')
+      .then((r) => r.json())
+      .then((json) => setData(json))
+      .catch(() => setData(null));
+  }, []);
+
+  if (!data) {
+    return <div aria-label="GlobalEventsPanel">Loading...</div>;
+  }
+
+  return (
+    <div aria-label="GlobalEventsPanel">
+      <h2>Global Events</h2>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add GlobalEventsPanel React component and test
- mark GlobalEventsPanel task complete in advancedToDo and progress tracker

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: FastAPI type errors)*
- `npx tsc -p tsconfig.json`
- `npx jest packages/unifiedmandala-ui/components/GlobalEventsPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689d35f9161c8322b874b386cc2fddea