### PR TITLE
feat: verify repository map module paths

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12288,5 +12288,12 @@
     "task": "Ensure CLI commands work without build using JS fallbacks",
     "test": "packages/cli-tools/__tests__/sigillin-cli.list-open-tasks.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Validate repository map module paths",
+    "path": "scripts/repository-map-check-modules.ts",
+    "task": "Verify modules listed in repository_map.yaml exist in filesystem",
+    "test": "scripts/repository-map-check-modules.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12045,3 +12045,8 @@
   task: Ensure CLI commands work without build using JS fallbacks
   test: packages/cli-tools/__tests__/sigillin-cli.list-open-tasks.test.ts
   status: done
+- commit: Validate repository map module paths
+  path: scripts/repository-map-check-modules.ts
+  task: Verify modules listed in repository_map.yaml exist in filesystem
+  test: scripts/repository-map-check-modules.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -4634,6 +4634,10 @@
     {
       "commit": "Integrate global events services into compose",
       "status": "done"
+    },
+    {
+      "commit": "Validate repository map module paths",
+      "status": "done"
     }
   ]
 }

--- a/scripts/repository-map-check-modules.test.ts
+++ b/scripts/repository-map-check-modules.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import yaml from 'js-yaml';
+import { findMissingModules } from './repository-map-check-modules';
+
+describe('findMissingModules', () => {
+  it('returns empty array when all modules exist', () => {
+    const tmp = path.join(os.tmpdir(), 'repo_map_valid.yaml');
+    const content = {
+      repository_map: [
+        { name: 'test', type: 't', role: 'r', modules: ['AGENTS.md'] },
+      ],
+    };
+    fs.writeFileSync(tmp, yaml.dump(content));
+    expect(findMissingModules(tmp)).toEqual([]);
+  });
+
+  it('lists missing modules', () => {
+    const tmp = path.join(os.tmpdir(), 'repo_map_missing.yaml');
+    const content = {
+      repository_map: [
+        { name: 'test', type: 't', role: 'r', modules: ['not_there.file'] },
+      ],
+    };
+    fs.writeFileSync(tmp, yaml.dump(content));
+    expect(findMissingModules(tmp)).toEqual(['not_there.file']);
+  });
+});

--- a/scripts/repository-map-check-modules.ts
+++ b/scripts/repository-map-check-modules.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env ts-node
+/**
+ * scripts/repository-map-check-modules.ts
+ *
+ * Utility to verify that module paths referenced in
+ * `repositorypflege/repository_map.yaml` exist in the repository.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+const repoRoot = path.join(__dirname, '..');
+const defaultFile = path.join(__dirname, '../repositorypflege/repository_map.yaml');
+
+export function findMissingModules(mapFile: string = defaultFile): string[] {
+  const raw = fs.readFileSync(mapFile, 'utf8');
+  const data = yaml.load(raw) as any;
+  const items = Array.isArray(data?.repository_map) ? data.repository_map : [];
+
+  const missing: string[] = [];
+  items.forEach((item: any) => {
+    const modules: string[] = Array.isArray(item.modules) ? item.modules : [];
+    modules.forEach((m) => {
+      const filePath = path.join(repoRoot, m);
+      if (!fs.existsSync(filePath)) {
+        missing.push(m);
+      }
+    });
+  });
+
+  return missing;
+}
+
+if (require.main === module) {
+  const missing = findMissingModules();
+  if (missing.length === 0) {
+    console.log('All modules exist');
+  } else {
+    console.error('Missing modules:');
+    missing.forEach((m) => console.error(m));
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add script to verify repository_map.yaml module paths exist in repository
- track repository map module validation in progress files
- cover script with vitest tests

## Testing
- `npx tsc scripts/repository-map-check-modules.ts scripts/repository-map-check-modules.test.ts --noEmit` *(failed: npm warn Unknown env config "http-proxy")*
- `npx pyright --venvpath /tmp` *(failed: npm warn Unknown env config "http-proxy")*
- `npx vitest run scripts/repository-map-check-modules.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689d407bfd8083228f42fae9fb41b22d