### PR TITLE
feat(ui): add InteractiveSymbolzeitExplorer component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1427,7 +1427,8 @@
     "commit": "Create InteractiveSymbolzeitExplorer",
     "path": "packages/unifiedmandala-ui/components/InteractiveSymbolzeitExplorer.tsx",
     "task": "Interactive exploration of past and future Symbolzeit",
-    "test": "packages/unifiedmandala-ui/components/InteractiveSymbolzeitExplorer.test.tsx"
+    "test": "packages/unifiedmandala-ui/components/InteractiveSymbolzeitExplorer.test.tsx",
+    "status": "done"
   },
   {
     "commit": "Implement SymbolzeitMLForecaster",

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat(compose): integrate global events services",
+  "lastCommit": "feat(ui): add InteractiveSymbolzeitExplorer component",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics.",
+  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI.",
   "pendingTasks": [
     {
       "commit": "Integrate global events services into compose",
@@ -4637,6 +4637,10 @@
     },
     {
       "commit": "Validate repository map module paths",
+      "status": "done"
+    },
+    {
+      "commit": "Add InteractiveSymbolzeitExplorer component",
       "status": "done"
     }
   ]

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -61,3 +61,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Defined Auto-Resonanz sigillin connecting core training and governance agents.
 - Implemented ClimateSocialPanel component to surface aggregated climate and social data on the dashboard.
 - Registered climate news microservices in orchestrator pipeline configuration and docker-compose.
+- Implemented InteractiveSymbolzeitExplorer component for navigating Symbolzeit timelines.

--- a/packages/unifiedmandala-ui/components/InteractiveSymbolzeitExplorer.test.tsx
+++ b/packages/unifiedmandala-ui/components/InteractiveSymbolzeitExplorer.test.tsx
@@ -1,8 +1,15 @@
-import { render, fireEvent } from '@testing-library/react';
-import { InteractiveSymbolzeitExplorer } from './InteractiveSymbolzeitExplorer';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import InteractiveSymbolzeitExplorer from './InteractiveSymbolzeitExplorer';
 
-test('increments symbolzeit', () => {
-  const { getByText, getByTestId } = render(<InteractiveSymbolzeitExplorer />);
-  fireEvent.click(getByText('next'));
-  expect(getByTestId('symbolzeit').textContent).toBe('1');
+test('explores past and future symbolzeit', () => {
+  const onChange = jest.fn();
+  render(<InteractiveSymbolzeitExplorer initial={0} onChange={onChange} />);
+  expect(screen.getByText('Symbolzeit: 0')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Future'));
+  expect(screen.getByText('Symbolzeit: 1')).toBeInTheDocument();
+  expect(onChange).toHaveBeenCalledWith(1);
+  fireEvent.click(screen.getByText('Past'));
+  expect(screen.getByText('Symbolzeit: 0')).toBeInTheDocument();
 });

--- a/packages/unifiedmandala-ui/components/InteractiveSymbolzeitExplorer.tsx
+++ b/packages/unifiedmandala-ui/components/InteractiveSymbolzeitExplorer.tsx
@@ -1,11 +1,25 @@
 import React, { useState } from 'react';
 
-export function InteractiveSymbolzeitExplorer() {
-  const [value, setValue] = useState(0);
+export interface InteractiveSymbolzeitExplorerProps {
+  initial?: number;
+  onChange?: (value: number) => void;
+}
+
+const InteractiveSymbolzeitExplorer: React.FC<InteractiveSymbolzeitExplorerProps> = ({ initial = 0, onChange }) => {
+  const [value, setValue] = useState(initial);
+
+  const update = (next: number) => {
+    setValue(next);
+    onChange?.(next);
+  };
+
   return (
-    <div>
-      <span data-testid="symbolzeit">{value}</span>
-      <button onClick={() => setValue(v => v + 1)}>next</button>
+    <div aria-label="symbolzeit-explorer">
+      <p>Symbolzeit: {value}</p>
+      <button onClick={() => update(value - 1)}>Past</button>
+      <button onClick={() => update(value + 1)}>Future</button>
     </div>
   );
-}
+};
+
+export default InteractiveSymbolzeitExplorer;

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -41,3 +41,4 @@ export { default as MandalaCanvas } from './components/MandalaCanvas';
 export { default as AIUI } from './components/AIUI';
 export { default as ArchiveMap } from './components/ArchiveMap';
 export { default as SigillinFractalVisualizer } from './components/SigillinFractalVisualizer';
+export { default as InteractiveSymbolzeitExplorer } from './components/InteractiveSymbolzeitExplorer';


### PR DESCRIPTION
## Summary
- add InteractiveSymbolzeitExplorer React component with past/future navigation
- expose component via unifiedmandala-ui index
- mark Symbolzeit explorer task as complete and log progress
- note new component in feedback codex

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx tsc -p tsconfig.json`
- `npx pyright` *(fails: Cannot access attribute "get" for class "FastAPI")*
- `pnpm test packages/unifiedmandala-ui/components/InteractiveSymbolzeitExplorer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689d4d18bd348322ad0ab0fe7facc957