### PR TITLE
feat(symbolzeit): add linear regression forecaster

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1434,7 +1434,8 @@
     "commit": "Implement SymbolzeitMLForecaster",
     "path": "packages/aeon-shell/SymbolzeitMLForecaster.ts",
     "task": "Predict Symbolzeit progression using ML",
-    "test": "packages/aeon-shell/SymbolzeitMLForecaster.test.ts"
+    "test": "packages/aeon-shell/SymbolzeitMLForecaster.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add InteractiveNarrativeEngine",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1052,6 +1052,7 @@
   path: packages/aeon-shell/SymbolzeitMLForecaster.ts
   task: Predict Symbolzeit progression using ML
   test: packages/aeon-shell/SymbolzeitMLForecaster.test.ts
+  status: done
 - commit: Add InteractiveNarrativeEngine
   path: packages/universum-simulationen/InteractiveNarrativeEngine.ts
   task: Allow users to build interactive narratives based on CREP

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat(ui): add ResonanceHistoryPanel",
+  "lastCommit": "feat(symbolzeit): add linear regression forecaster",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4008,6 +4008,10 @@
     {
       "commit": "Validate repository map module paths",
       "status": "done"
+    },
+    {
+      "commit": "Implement SymbolzeitMLForecaster",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4649,6 +4653,10 @@
     },
     {
       "commit": "Add InteractiveSymbolzeitExplorer component",
+      "status": "done"
+    },
+    {
+      "commit": "Implement SymbolzeitMLForecaster",
       "status": "done"
     }
   ]

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -63,3 +63,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Registered climate news microservices in orchestrator pipeline configuration and docker-compose.
 - Implemented InteractiveSymbolzeitExplorer component for navigating Symbolzeit timelines.
 - Added ResonanceHistoryPanel component for visualizing CREP, volume, and drift over time.
+- Enhanced SymbolzeitMLForecaster with linear regression training and forecasting utilities.

--- a/packages/aeon-shell/SymbolzeitMLForecaster.test.ts
+++ b/packages/aeon-shell/SymbolzeitMLForecaster.test.ts
@@ -1,5 +1,11 @@
-import { forecastSymbolzeit } from './SymbolzeitMLForecaster';
+import { SymbolzeitMLForecaster, forecastSymbolzeit } from './SymbolzeitMLForecaster';
 
-test('forecasts next symbolzeit', () => {
-  expect(forecastSymbolzeit(3)).toBe(4);
+test('forecasts next symbolzeit with helper', () => {
+  expect(forecastSymbolzeit([1, 2, 3])).toBeCloseTo(4);
+});
+
+test('forecasts next symbolzeit using class', () => {
+  const forecaster = new SymbolzeitMLForecaster();
+  forecaster.train([2, 4, 6]);
+  expect(forecaster.forecastNext()).toBeCloseTo(8);
 });

--- a/packages/aeon-shell/SymbolzeitMLForecaster.ts
+++ b/packages/aeon-shell/SymbolzeitMLForecaster.ts
@@ -1,3 +1,56 @@
-export function forecastSymbolzeit(current: number): number {
-  return current + 1;
+/**
+ * Basic Symbolzeit forecaster using linear regression over a numeric history.
+ *
+ * The model treats each entry in the history as a sequential time step and
+ * fits a simple y = ax + b line. The next Symbolzeit value is predicted by
+ * extrapolating this line.
+ */
+export class SymbolzeitMLForecaster {
+  private slope = 0;
+  private intercept = 0;
+  private length = 0;
+
+  /**
+     * Train the model using a sequence of Symbolzeit values.
+     * @param history Array of numeric Symbolzeit values ordered by time.
+     */
+  train(history: number[]): void {
+    this.length = history.length;
+    if (this.length === 0) {
+      this.slope = 0;
+      this.intercept = 0;
+      return;
+    }
+
+    const xMean = (this.length - 1) / 2;
+    const yMean = history.reduce((a, b) => a + b, 0) / this.length;
+
+    let num = 0;
+    let den = 0;
+    history.forEach((y, i) => {
+      const dx = i - xMean;
+      num += dx * (y - yMean);
+      den += dx * dx;
+    });
+    this.slope = den === 0 ? 0 : num / den;
+    this.intercept = yMean - this.slope * xMean;
+  }
+
+  /**
+     * Forecast the next Symbolzeit value.
+     */
+  forecastNext(): number {
+    const nextIndex = this.length;
+    return this.slope * nextIndex + this.intercept;
+  }
 }
+
+/**
+ * Convenience helper to forecast next Symbolzeit value from a history array.
+ */
+export function forecastSymbolzeit(history: number[]): number {
+  const forecaster = new SymbolzeitMLForecaster();
+  forecaster.train(history);
+  return forecaster.forecastNext();
+}
+


### PR DESCRIPTION
## Summary
- implement linear regression based SymbolzeitMLForecaster
- update tests and progress trackers
- document forecaster enhancement in feedback codex

## Testing
- `npx pyright` *(fails: Cannot access attribute "get" for FastAPI in news_climate services)*
- `npx tsc -p tsconfig.json`
- `pnpm test packages/aeon-shell/SymbolzeitMLForecaster.test.ts`
- `node scripts/parse-newadvanced-conversations.js TODO`


------
https://chatgpt.com/codex/tasks/task_e_689d5e1c89148322849d4d38824cd0f4