### PR TITLE
feat: add threshold alerts to performance monitor

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1543,7 +1543,8 @@
     "commit": "Add RealTimePerformanceMonitor",
     "path": "packages/observability/RealTimePerformanceMonitor.ts",
     "task": "Display system performance metrics live",
-    "test": "packages/observability/RealTimePerformanceMonitor.test.ts"
+    "test": "packages/observability/RealTimePerformanceMonitor.test.ts",
+    "status": "done"
   },
   {
     "commit": "Create ErrorReportingSystem",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1127,6 +1127,7 @@
   path: packages/observability/RealTimePerformanceMonitor.ts
   task: Display system performance metrics live
   test: packages/observability/RealTimePerformanceMonitor.test.ts
+  status: done
 - commit: Create ErrorReportingSystem
   path: packages/observability/ErrorReportingSystem.ts
   task: Collect and report runtime errors automatically

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "feat: add IoTSensorWidget component",
-  "fractalStep": "IoTSensorWidget implemented",
+  "lastCommit": "feat: add threshold alerts to RealTimePerformanceMonitor",
+  "fractalStep": "RealTimePerformanceMonitor extended",
   "openBranches": [
     "work"
   ],
@@ -4012,6 +4012,10 @@
     {
       "commit": "Create IoTSensorWidget component",
       "status": "done"
+    },
+    {
+      "commit": "Add RealTimePerformanceMonitor",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4662,6 +4666,11 @@
     {
       "commit": "Add Meta Tuner plugin and agent",
       "status": "done"
+    },
+    {
+      "commit": "Add threshold alerts to RealTimePerformanceMonitor",
+      "status": "done"
     }
   ]
 }
+

--- a/packages/observability/RealTimePerformanceMonitor.test.ts
+++ b/packages/observability/RealTimePerformanceMonitor.test.ts
@@ -4,4 +4,6 @@ test('computes average', () => {
   const m = new RealTimePerformanceMonitor();
   m.record(1); m.record(3);
   expect(m.average()).toBe(2);
+  expect(m.exceedsThreshold(1.5)).toBe(true);
+  expect(m.exceedsThreshold(2.5)).toBe(false);
 });

--- a/packages/observability/RealTimePerformanceMonitor.ts
+++ b/packages/observability/RealTimePerformanceMonitor.ts
@@ -4,4 +4,7 @@ export class RealTimePerformanceMonitor {
   average() {
     return this.metrics.length ? this.metrics.reduce((a,b)=>a+b,0)/this.metrics.length : 0;
   }
+  exceedsThreshold(threshold: number) {
+    return this.average() > threshold;
+  }
 }


### PR DESCRIPTION
## Summary
- extend real-time performance monitor with threshold checks
- mark monitoring task as complete and log progress

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: venvPath not valid)*
- `npx tsc -p tsconfig.json`
- `npx vitest run packages/observability/RealTimePerformanceMonitor.test.ts` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689db92328f48322867df241ac9b7bf0