### PR TITLE
feat: support multiple webhooks in HookTriggererAgent

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -8338,6 +8338,13 @@
     "status": "done"
   },
   {
+    "commit": "Extend HookTriggererAgent with multi webhook support",
+    "path": "packages/agents/HookTriggererAgent.ts",
+    "task": "Support task.urls array and log HTTP status",
+    "test": "packages/agents/__tests__/HookTriggererAgent.spec.ts",
+    "status": "done"
+  },
+  {
     "commit": "Validate conversation roles",
     "path": "scripts/validate-newadvanced-conversations.ts",
     "task": "Ensure conversation messages use allowed roles",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -9095,6 +9095,11 @@
   task: Add webhook POST trigger based on task.url
   test: packages/agents/__tests__/HookTriggererAgent.spec.ts
   status: done
+- commit: Extend HookTriggererAgent with multi webhook support
+  path: packages/agents/HookTriggererAgent.ts
+  task: Support task.urls array and log HTTP status
+  test: packages/agents/__tests__/HookTriggererAgent.spec.ts
+  status: done
 - commit: Validate conversation roles
   path: scripts/validate-newadvanced-conversations.ts
   task: Ensure conversation messages use allowed roles

--- a/advancedToDo_parts/advancedToDo.part6.json
+++ b/advancedToDo_parts/advancedToDo.part6.json
@@ -77,11 +77,11 @@
     "status": "planned"
   },
   {
-    "commit": "- **HookTriggererAgent (`HookTriggererAgent.ts`)**: Ein simpler Stub, der bei `handle()` lediglich ein Glocken-Emoji und den Task.id loggt【63†L3-L9】. Geplant ist wohl, Webhooks oder externe Hooks auszulösen. Potenzial: Hier könnte man REST-Calls an definierte Endpunkte einbauen (z.B. CI/CD Trigger, Slack Notifications etc.). Verbesserung: Implementierung echter Hook-Auslösung basierend auf Task-Details (evtl. URL im Task enthalten?).",
-    "path": "",
-    "task": "**HookTriggererAgent (`HookTriggererAgent.ts`)**: Ein simpler Stub, der bei `handle()` lediglich ein Glocken-Emoji und den Task.id loggt【63†L3-L9】. Geplant ist wohl, Webhooks oder externe Hooks auszulösen. Potenzial: Hier könnte man REST-Calls an definierte Endpunkte einbauen (z.B. CI/CD Trigger, Slack Notifications etc.). Verbesserung: Implementierung echter Hook-Auslösung basierend auf Task-Details (evtl. URL im Task enthalten?).",
-    "test": "",
-    "status": "planned"
+    "commit": "Extend HookTriggererAgent to trigger multiple webhooks and log responses",
+    "path": "packages/agents/HookTriggererAgent.ts",
+    "task": "Support array task.urls and log HTTP status for each hook",
+    "test": "packages/agents/__tests__/HookTriggererAgent.spec.ts",
+    "status": "done"
   },
   {
     "commit": "- There are **tools to process these logs**. For example, `scripts/parse-advanced-conversations.js` is used to parse new tasks from chat logs and update the to-do lists (`advancedToDo.json`) and progress tracking (`advancedprogress.json`)【29†L19-L22】. This indicates an automated pipeline where creative brainstorming with an AI is converted into actionable development tasks (ToDos) and their completion status.",

--- a/advancedToDo_parts/advancedToDo.part6.yaml
+++ b/advancedToDo_parts/advancedToDo.part6.yaml
@@ -103,23 +103,11 @@
     dem Datensatz zu filtern.
   test: ''
   status: planned
-- commit: >-
-    - **HookTriggererAgent (`HookTriggererAgent.ts`)**: Ein simpler Stub, der
-    bei `handle()` lediglich ein Glocken-Emoji und den Task.id loggt【63†L3-L9】.
-    Geplant ist wohl, Webhooks oder externe Hooks auszulösen. Potenzial: Hier
-    könnte man REST-Calls an definierte Endpunkte einbauen (z.B. CI/CD Trigger,
-    Slack Notifications etc.). Verbesserung: Implementierung echter
-    Hook-Auslösung basierend auf Task-Details (evtl. URL im Task enthalten?).
-  path: ''
-  task: >-
-    **HookTriggererAgent (`HookTriggererAgent.ts`)**: Ein simpler Stub, der bei
-    `handle()` lediglich ein Glocken-Emoji und den Task.id loggt【63†L3-L9】.
-    Geplant ist wohl, Webhooks oder externe Hooks auszulösen. Potenzial: Hier
-    könnte man REST-Calls an definierte Endpunkte einbauen (z.B. CI/CD Trigger,
-    Slack Notifications etc.). Verbesserung: Implementierung echter
-    Hook-Auslösung basierend auf Task-Details (evtl. URL im Task enthalten?).
-  test: ''
-  status: planned
+- commit: "Extend HookTriggererAgent to trigger multiple webhooks and log responses"
+  path: packages/agents/HookTriggererAgent.ts
+  task: "Support array task.urls and log HTTP status for each hook"
+  test: packages/agents/__tests__/HookTriggererAgent.spec.ts
+  status: done
 - commit: >-
     - There are **tools to process these logs**. For example,
     `scripts/parse-advanced-conversations.js` is used to parse new tasks from

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "feat: add threshold alerts to RealTimePerformanceMonitor",
-  "fractalStep": "RealTimePerformanceMonitor extended",
+  "lastCommit": "feat: support multiple webhooks in HookTriggererAgent",
+  "fractalStep": "HookTriggererAgent multi-webhook",
   "openBranches": [
     "work"
   ],
@@ -4669,6 +4669,10 @@
     },
     {
       "commit": "Add threshold alerts to RealTimePerformanceMonitor",
+      "status": "done"
+    },
+    {
+      "commit": "feat: support multiple webhooks in HookTriggererAgent",
       "status": "done"
     }
   ]

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -65,3 +65,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added ResonanceHistoryPanel component for visualizing CREP, volume, and drift over time.
 - Enhanced SymbolzeitMLForecaster with linear regression training and forecasting utilities.
 - Implemented IoTSensorWidget component to display realtime IoT sensor values.
+- Extended HookTriggererAgent to trigger multiple webhooks and report response statuses.

--- a/packages/agents/HookTriggererAgent.ts
+++ b/packages/agents/HookTriggererAgent.ts
@@ -10,18 +10,30 @@ export class HookTriggererAgent implements Agent {
   }
 
   async handle(task: Task): Promise<void> {
-    const url = (task as any).url;
-    if (url) {
+    const urls = Array.isArray((task as any).urls)
+      ? (task as any).urls
+      : (task as any).url
+      ? [(task as any).url]
+      : [];
+    const method = (task as any).method || 'POST';
+
+    for (const url of urls) {
       try {
-        await this.request(url, {
-          method: 'POST',
+        const res = await this.request(url, {
+          method,
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(task),
         });
+        if (!res.ok) {
+          console.error(
+            `HookTriggerer error for ${task.id} [${url}]: ${res.status}`
+          );
+        }
       } catch (err) {
-        console.error(`HookTriggerer error for ${task.id}:`, err);
+        console.error(`HookTriggerer error for ${task.id} [${url}]:`, err);
       }
     }
+
     console.log(`🔔 HookTriggerer → Trigger für ${task.id}`);
   }
 }

--- a/packages/agents/__tests__/HookTriggererAgent.spec.ts
+++ b/packages/agents/__tests__/HookTriggererAgent.spec.ts
@@ -20,4 +20,25 @@ describe('HookTriggererAgent', () => {
       expect.objectContaining({ method: 'POST' })
     );
   });
+
+  it('triggers multiple webhooks when urls array provided', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as any);
+    const agent = new HookTriggererAgent(fetchMock as any);
+    await agent.handle({
+      id: 'T-URLs',
+      description: '...',
+      urls: ['https://example.com/1', 'https://example.com/2'],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://example.com/1',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://example.com/2',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- allow HookTriggererAgent to trigger multiple webhook URLs and log HTTP status codes
- add dedicated tests for multi-webhook support
- document progress in advanced todo and progress tracking files

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: venvPath not valid)*
- `npx tsc -p tsconfig.json`
- `pnpm test:agents packages/agents/__tests__/HookTriggererAgent.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_689dc667a750832284ddac078e9f2bed