### PR TITLE
feat: add progress metrics and debug to nullfield wave

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11008,7 +11008,8 @@
     "commit": "eine Debugging-Phase einbauen, um falsche Werte oder ungewollte Endlosschleifen zu erkennen",
     "path": "",
     "task": "eine Debugging-Phase einbauen, um falsche Werte oder ungewollte Endlosschleifen zu erkennen",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "alternative Algorithmen für Kraftberechnungen und Partikelinteraktionen ausprobieren",
@@ -11038,7 +11039,8 @@
     "commit": "die Simulation so aufbauen, dass sie **Variablen für Fortschritt und mögliche Hürden** integriert",
     "path": "",
     "task": "die Simulation so aufbauen, dass sie **Variablen für Fortschritt und mögliche Hürden** integriert",
-    "test": ""
+    "test": "",
+    "status": "done"
   },
   {
     "commit": "die Gravitation als eine Strömungsreaktion im Nullfeld modellieren",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11100,6 +11100,7 @@
   task: eine Debugging-Phase einbauen, um falsche Werte oder ungewollte
     Endlosschleifen zu erkennen
   test: ""
+  status: done
 - commit: alternative Algorithmen für Kraftberechnungen und Partikelinteraktionen
     ausprobieren
   path: ""
@@ -11124,6 +11125,7 @@
   task: die Simulation so aufbauen, dass sie **Variablen für Fortschritt und
     mögliche Hürden** integriert
   test: ""
+  status: done
 - commit: die Gravitation als eine Strömungsreaktion im Nullfeld modellieren
   path: ""
   task: die Gravitation als eine Strömungsreaktion im Nullfeld modellieren

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1211 from GenesisAeon/codex/implement-features-from-advancedtodo.yaml-ebrje9",
+  "lastCommit": "Merge pull request #1212 from GenesisAeon/codex/implement-features-from-advancedtodo.yaml-y8rq64",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4024,6 +4024,14 @@
     {
       "commit": "Extend HookTriggererAgent with multi webhook support",
       "status": "done"
+    },
+    {
+      "commit": "eine Debugging-Phase einbauen, um falsche Werte oder ungewollte Endlosschleifen zu erkennen",
+      "status": "done"
+    },
+    {
+      "commit": "die Simulation so aufbauen, dass sie **Variablen für Fortschritt und mögliche Hürden** integriert",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4619,6 +4627,14 @@
     },
     {
       "commit": "Create AgentDependencyGraph module",
+      "status": "done"
+    },
+    {
+      "commit": "die Simulation so aufbauen, dass sie Variablen für Fortschritt und mögliche Hürden integriert",
+      "status": "done"
+    },
+    {
+      "commit": "eine Debugging-Phase einbauen, um falsche Werte oder ungewollte Endlosschleifen zu erkennen",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -68,3 +68,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Extended HookTriggererAgent to trigger multiple webhooks and report response statuses.
 - Implemented SigillinBlockchainIntegration with an in-memory ledger as a step toward on-chain Sigillin persistence.
 - Added contrastive training plugin and agent stub.
+- Integrated progress metrics and debugging safeguards into null field wave simulation.

--- a/simulations/nullfield_wave.py
+++ b/simulations/nullfield_wave.py
@@ -2,7 +2,16 @@
 import numpy as np  # type: ignore
 
 
-def simulate_nullfield_wave(length: float = 1.0, duration: float = 1.0, dx: float = 0.01, dt: float = 0.005, c: float = 1.0):
+def simulate_nullfield_wave(
+    length: float = 1.0,
+    duration: float = 1.0,
+    dx: float = 0.01,
+    dt: float = 0.005,
+    c: float = 1.0,
+    track_progress: bool = False,
+    debug: bool = False,
+    amplitude_limit: float = 10.0,
+):
     """Simulate a 1D wave equation on a 'null field'.
 
     Parameters
@@ -20,12 +29,15 @@ def simulate_nullfield_wave(length: float = 1.0, duration: float = 1.0, dx: floa
 
     Returns
     -------
-    np.ndarray
-        Array of shape (timesteps, points) representing the field over time.
+    np.ndarray or Tuple[np.ndarray, Dict[str, List[float]]]
+        Field values over time. If ``track_progress`` is True, a tuple of the
+        field array and a metrics dictionary is returned.
     """
     nx = int(length / dx) + 1
     nt = int(duration / dt) + 1
     u = np.zeros((nt, nx))
+
+    metrics = {"max_amplitude": [], "energy": []} if track_progress else None
 
     # initial condition: localized pulse in center
     mid = nx // 2
@@ -38,8 +50,24 @@ def simulate_nullfield_wave(length: float = 1.0, duration: float = 1.0, dx: floa
     coef = (c * dt / dx) ** 2
     for n in range(1, nt - 1):
         for i in range(1, nx - 1):
-            u[n + 1, i] = 2 * u[n, i] - u[n - 1, i] + coef * (u[n, i + 1] - 2 * u[n, i] + u[n, i - 1])
+            u[n + 1, i] = 2 * u[n, i] - u[n - 1, i] + coef * (
+                u[n, i + 1] - 2 * u[n, i] + u[n, i - 1]
+            )
 
+        if track_progress and metrics is not None:
+            max_amp = float(np.max(np.abs(u[n])))
+            energy = float(np.sum(u[n] ** 2))
+            metrics["max_amplitude"].append(max_amp)
+            metrics["energy"].append(energy)
+
+        if debug:
+            if np.isnan(u[n]).any() or np.isinf(u[n]).any() or (
+                track_progress and metrics is not None and metrics["max_amplitude"][-1] > amplitude_limit
+            ):
+                raise ValueError(f"Simulation diverged at step {n}")
+
+    if track_progress and metrics is not None:
+        return u, metrics
     return u
 
 

--- a/tests/nullfield_wave_test.py
+++ b/tests/nullfield_wave_test.py
@@ -15,3 +15,27 @@ def test_wave_propagates():
     peak_idx_initial = np.argmax(field[0])
     peak_idx_final = np.argmax(field[-1])
     assert peak_idx_final != peak_idx_initial
+
+
+def test_progress_metrics():
+    field, metrics = simulate_nullfield_wave(
+        length=1.0, duration=0.1, dx=0.1, dt=0.05, track_progress=True
+    )
+    # one entry per internal iteration (excluding boundaries)
+    assert len(metrics["max_amplitude"]) == field.shape[0] - 2
+    assert len(metrics["energy"]) == field.shape[0] - 2
+
+
+def test_debug_detection():
+    import pytest
+
+    with pytest.raises(ValueError):
+        simulate_nullfield_wave(
+            length=1.0,
+            duration=0.1,
+            dx=0.1,
+            dt=0.05,
+            debug=True,
+            amplitude_limit=0.1,
+            track_progress=True,
+        )


### PR DESCRIPTION
## Summary
- track max amplitude and energy in null field wave simulation
- raise error on NaNs or excessive amplitude to spot runaway waves
- document progress in advanced ToDo and feedback codex

## Testing
- `poetry install --with test`
- `pnpm install`
- `node scripts/parse-newadvanced-conversations.js TODO`
- `npx tsc -p tsconfig.json`
- `npx pyright simulations/nullfield_wave.py tests/nullfield_wave_test.py`
- `pytest tests/nullfield_wave_test.py`
- `npx pyright` *(fails: Cannot access attribute "get" for class "FastAPI" in agents/news_climate)*

------
https://chatgpt.com/codex/tasks/task_e_689de30b03cc8322ab0debe904af38a2