### PR TITLE
feat: add particle time dilation simulation

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2697,7 +2697,8 @@
     "commit": "feat: implement particle time-dilation module",
     "path": "packages/universum-simulationen/ParticleTimeDilation.ts",
     "task": "Simulate time dilation, energy conversion and gas formation",
-    "test": "packages/universum-simulationen/ParticleTimeDilation.test.ts"
+    "test": "packages/universum-simulationen/ParticleTimeDilation.test.ts",
+    "status": "done"
   },
   {
     "commit": "chore: scaffold Wissenschaftliche Versuche project",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4415,6 +4415,7 @@
   path: packages/universum-simulationen/ParticleTimeDilation.ts
   task: Simulate time dilation, energy conversion and gas formation
   test: packages/universum-simulationen/ParticleTimeDilation.test.ts
+  status: done
 - commit: "chore: scaffold Wissenschaftliche Versuche project"
   path: packages/wissenschaftliche-versuche
   task: Create WVH folder with module placeholders

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1212 from GenesisAeon/codex/implement-features-from-advancedtodo.yaml-y8rq64",
+  "lastCommit": "feat: add particle time dilation simulation",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4032,6 +4032,10 @@
     {
       "commit": "die Simulation so aufbauen, dass sie **Variablen für Fortschritt und mögliche Hürden** integriert",
       "status": "done"
+    },
+    {
+      "commit": "feat: implement particle time-dilation module",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4697,6 +4701,10 @@
     },
     {
       "commit": "feat: support multiple webhooks in HookTriggererAgent",
+      "status": "done"
+    },
+    {
+      "commit": "feat: implement particle time-dilation module",
       "status": "done"
     }
   ]

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -69,3 +69,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented SigillinBlockchainIntegration with an in-memory ledger as a step toward on-chain Sigillin persistence.
 - Added contrastive training plugin and agent stub.
 - Integrated progress metrics and debugging safeguards into null field wave simulation.
+- Implemented ParticleTimeDilation module simulating relativistic effects.

--- a/packages/universum-simulationen/ParticleTimeDilation.test.ts
+++ b/packages/universum-simulationen/ParticleTimeDilation.test.ts
@@ -1,0 +1,8 @@
+import { simulateParticleTimeDilation } from './ParticleTimeDilation';
+
+test('simulates relativistic particle behavior', () => {
+  const res = simulateParticleTimeDilation({ velocityFraction: 0.5, energy: 1e6 });
+  expect(res.timeFactor).toBeCloseTo(1.1547, 4);
+  expect(res.convertedMass).toBeCloseTo(1e6 / (299792458 ** 2));
+  expect(res.gasVolume).toBeGreaterThan(0);
+});

--- a/packages/universum-simulationen/ParticleTimeDilation.ts
+++ b/packages/universum-simulationen/ParticleTimeDilation.ts
@@ -1,0 +1,23 @@
+export interface ParticleTimeDilationParams {
+  velocityFraction: number; // velocity as fraction of speed of light (0-1)
+  energy: number; // energy in joules converted to mass
+}
+
+const SPEED_OF_LIGHT = 299792458; // m/s
+const AIR_DENSITY = 1.225; // kg/m^3 at sea level
+
+export interface ParticleTimeDilationResult {
+  timeFactor: number;
+  convertedMass: number;
+  gasVolume: number;
+}
+
+export function simulateParticleTimeDilation(
+  params: ParticleTimeDilationParams,
+): ParticleTimeDilationResult {
+  const v = params.velocityFraction * SPEED_OF_LIGHT;
+  const gamma = 1 / Math.sqrt(1 - (v * v) / (SPEED_OF_LIGHT * SPEED_OF_LIGHT));
+  const convertedMass = params.energy / (SPEED_OF_LIGHT * SPEED_OF_LIGHT);
+  const gasVolume = convertedMass / AIR_DENSITY;
+  return { timeFactor: gamma, convertedMass, gasVolume };
+}


### PR DESCRIPTION
## Summary
- add ParticleTimeDilation simulator for relativistic effects
- track completion in advanced progress files
- log implementation in feedback codex

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright` (fails: Cannot access attribute "get" for class "FastAPI")
- `npx tsc -p tsconfig.json`
- `npx vitest packages/universum-simulationen/ParticleTimeDilation.test.ts` (no test files found)

------
https://chatgpt.com/codex/tasks/task_e_689dee7c66e8832281b02da30ba38f60