### PR TITLE
feat: add mandala federation plugin

### DIFF
--- a/agents/federated_meta/main.test.ts
+++ b/agents/federated_meta/main.test.ts
@@ -1,0 +1,10 @@
+import assert from "assert";
+import { aggregateMetrics } from "./main";
+
+const aggregated = aggregateMetrics([
+  { instance: "alpha", count: 3 },
+  { instance: "beta", count: 5 },
+  { instance: "alpha", count: 2 }
+]);
+
+assert.deepStrictEqual(aggregated, { alpha: 5, beta: 5 });

--- a/agents/federated_meta/main.ts
+++ b/agents/federated_meta/main.ts
@@ -1,0 +1,21 @@
+/**
+ * FederatedMetaAgent utilities.
+ * Aggregates anonymous metrics from multiple Mandala instances.
+ */
+
+export interface Metric {
+  /** unique instance identifier */
+  instance: string;
+  /** metric count for the instance */
+  count: number;
+}
+
+/**
+ * Aggregate metrics counts per instance.
+ */
+export function aggregateMetrics(metrics: Metric[]): Record<string, number> {
+  return metrics.reduce<Record<string, number>>((acc, { instance, count }) => {
+    acc[instance] = (acc[instance] ?? 0) + count;
+    return acc;
+  }, {});
+}

--- a/plugins/mandala-global.yaml
+++ b/plugins/mandala-global.yaml
@@ -1,0 +1,7 @@
+id: mandala-global
+title: "Mandala Global Metrics"
+type: federation
+agent: FederatedMetaAgent
+entrypoint: agents/federated_meta/main.ts
+config:
+  sync_url: "https://example.com/metrics"

--- a/plugins/manifest.yaml
+++ b/plugins/manifest.yaml
@@ -24,3 +24,8 @@ plugins:
     component: "../plugins/meta-tuner.yaml"
     dataHook: ""
     story: ""
+  - name: mandala-global
+    version: "0.1.0"
+    component: "../plugins/mandala-global.yaml"
+    dataHook: ""
+    story: ""


### PR DESCRIPTION
## Summary
- add Mandala Global Metrics plugin
- introduce FederatedMetaAgent for aggregating instance metrics
- register mandala-global plugin in manifest

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx tsx agents/federated_meta/main.test.ts`
- `npx pyright` *(fails: FastAPI argument type errors)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689df68c0e508322957778acbc7cdd12