### PR TITLE
Add repository map duplicate checker

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12309,5 +12309,12 @@
     "task": "Verify modules listed in repository_map.yaml exist in filesystem",
     "test": "scripts/repository-map-check-modules.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add repository map duplicate checker",
+    "path": "scripts/repository-map-check-duplicates.ts",
+    "task": "Ensure repository_map.yaml has unique repository names and modules",
+    "test": "scripts/repository-map-check-duplicates.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12061,3 +12061,8 @@
   task: Verify modules listed in repository_map.yaml exist in filesystem
   test: scripts/repository-map-check-modules.test.ts
   status: done
+- commit: Add repository map duplicate checker
+  path: scripts/repository-map-check-duplicates.ts
+  task: Ensure repository and module names in repository_map.yaml are unique
+  test: scripts/repository-map-check-duplicates.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add particle time dilation simulation",
+  "lastCommit": "test: add repository map duplicate checker",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.",
+  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.",
   "pendingTasks": [
     {
       "commit": "Add mandala federation plugin and agent",
@@ -4036,6 +4036,10 @@
     {
       "commit": "feat: implement particle time-dilation module",
       "status": "done"
+    },
+    {
+      "commit": "Add repository map duplicate checker",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4640,6 +4644,10 @@
     {
       "commit": "eine Debugging-Phase einbauen, um falsche Werte oder ungewollte Endlosschleifen zu erkennen",
       "status": "done"
+    },
+    {
+      "commit": "Add repository map duplicate checker",
+      "status": "done"
     }
   ],
   "metacommitTags": [
@@ -4705,6 +4713,10 @@
     },
     {
       "commit": "feat: implement particle time-dilation module",
+      "status": "done"
+    },
+    {
+      "commit": "Add repository map duplicate checker",
       "status": "done"
     }
   ]

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -70,3 +70,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added contrastive training plugin and agent stub.
 - Integrated progress metrics and debugging safeguards into null field wave simulation.
 - Implemented ParticleTimeDilation module simulating relativistic effects.
+- Added repository map duplicate checker script to ensure unique repositories and modules.

--- a/scripts/repository-map-check-duplicates.test.ts
+++ b/scripts/repository-map-check-duplicates.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import yaml from 'js-yaml';
+import { findDuplicates } from './repository-map-check-duplicates';
+
+describe('findDuplicates', () => {
+  it('returns empty arrays when no duplicates', () => {
+    const tmp = path.join(os.tmpdir(), 'repo_map_unique.yaml');
+    const content = {
+      repository_map: [
+        { name: 'a', modules: ['m1', 'm2'] },
+        { name: 'b', modules: ['m3'] },
+      ],
+    };
+    fs.writeFileSync(tmp, yaml.dump(content));
+    expect(findDuplicates(tmp)).toEqual({ duplicateRepos: [], duplicateModules: [] });
+  });
+
+  it('detects duplicate repo names and modules', () => {
+    const tmp = path.join(os.tmpdir(), 'repo_map_dupe.yaml');
+    const content = {
+      repository_map: [
+        { name: 'a', modules: ['m1'] },
+        { name: 'a', modules: ['m1', 'm2'] },
+      ],
+    };
+    fs.writeFileSync(tmp, yaml.dump(content));
+    expect(findDuplicates(tmp)).toEqual({ duplicateRepos: ['a'], duplicateModules: ['m1'] });
+  });
+});

--- a/scripts/repository-map-check-duplicates.ts
+++ b/scripts/repository-map-check-duplicates.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env ts-node
+/**
+ * scripts/repository-map-check-duplicates.ts
+ *
+ * Utility to detect duplicate repository names and module paths in
+ * `repositorypflege/repository_map.yaml`.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+const defaultFile = path.join(__dirname, '../repositorypflege/repository_map.yaml');
+
+export interface DuplicateResult {
+  duplicateRepos: string[];
+  duplicateModules: string[];
+}
+
+export function findDuplicates(mapFile: string = defaultFile): DuplicateResult {
+  const raw = fs.readFileSync(mapFile, 'utf8');
+  const data = yaml.load(raw) as any;
+  const items = Array.isArray(data?.repository_map) ? data.repository_map : [];
+
+  const repoNames = new Map<string, number>();
+  const modulePaths = new Map<string, number>();
+
+  items.forEach((item: any) => {
+    const name = String(item.name);
+    repoNames.set(name, (repoNames.get(name) ?? 0) + 1);
+    const modules: string[] = Array.isArray(item.modules) ? item.modules : [];
+    modules.forEach((m) => {
+      modulePaths.set(m, (modulePaths.get(m) ?? 0) + 1);
+    });
+  });
+
+  const duplicateRepos = Array.from(repoNames.entries())
+    .filter(([, count]) => count > 1)
+    .map(([name]) => name);
+  const duplicateModules = Array.from(modulePaths.entries())
+    .filter(([, count]) => count > 1)
+    .map(([mod]) => mod);
+
+  return { duplicateRepos, duplicateModules };
+}
+
+if (require.main === module) {
+  const { duplicateRepos, duplicateModules } = findDuplicates();
+  if (duplicateRepos.length === 0 && duplicateModules.length === 0) {
+    console.log('No duplicates found');
+  } else {
+    if (duplicateRepos.length > 0) {
+      console.error('Duplicate repositories:');
+      duplicateRepos.forEach((r) => console.error(r));
+    }
+    if (duplicateModules.length > 0) {
+      console.error('Duplicate modules:');
+      duplicateModules.forEach((m) => console.error(m));
+    }
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- check repository_map.yaml for duplicate repository names and modules
- track duplicate checker in advanced TODO and progress files
- document new helper in feedback codex

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright` *(fails: Cannot access attribute "get" for FastAPI classes)*
- `npx vitest run scripts/repository-map-check-duplicates.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689df68c0e508322957778acbc7cdd12