### PR TITLE
feat: add impact map component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12047,7 +12047,7 @@
   {
     "commit": "Create ImpactMap component",
     "path": "packages/unifiedmandala-ui/components/ImpactMap.tsx",
-    "status": "todo",
+    "status": "done",
     "task": "Visualize societal impact metrics",
     "test": "packages/unifiedmandala-ui/components/ImpactMap.test.tsx"
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11881,7 +11881,7 @@
   path: packages/unifiedmandala-ui/components/ImpactMap.tsx
   task: Visualize societal impact metrics
   test: packages/unifiedmandala-ui/components/ImpactMap.test.tsx
-  status: todo
+  status: done
 - commit: Create EmergencePanel component
   path: packages/unifiedmandala-ui/components/EmergencePanel.tsx
   task: Display catalyst spark emergence data

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -61,7 +61,7 @@
     },
     {
       "commit": "Create ImpactMap component",
-      "status": "todo"
+      "status": "done"
     },
     {
       "commit": "Create EmergencePanel component",

--- a/packages/unifiedmandala-ui/components/ImpactMap.test.tsx
+++ b/packages/unifiedmandala-ui/components/ImpactMap.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ImpactMap from './ImpactMap';
+
+test('renders provided impact metrics', () => {
+  const metrics = [
+    { label: 'health', value: 80 },
+    { label: 'education', value: 90 },
+  ];
+  render(<ImpactMap metrics={metrics} />);
+  const list = screen.getByTestId('impact-map');
+  expect(list).toHaveTextContent('health: 80');
+  expect(list).toHaveTextContent('education: 90');
+});

--- a/packages/unifiedmandala-ui/components/ImpactMap.tsx
+++ b/packages/unifiedmandala-ui/components/ImpactMap.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface ImpactMetric {
+  /** Label describing the metric */
+  label: string;
+  /** Numeric value for the metric */
+  value: number;
+}
+
+interface ImpactMapProps {
+  /** Collection of societal impact metrics to display */
+  metrics: ImpactMetric[];
+}
+
+/**
+ * Renders a simple list of societal impact metrics.
+ * This acts as a placeholder visualizer that can later be
+ * extended into a full chart or map.
+ */
+const ImpactMap: React.FC<ImpactMapProps> = ({ metrics }) => {
+  return (
+    <ul data-testid="impact-map">
+      {metrics.map((m) => (
+        <li key={m.label}>
+          {m.label}: {m.value}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default ImpactMap;


### PR DESCRIPTION
## Summary
- add ImpactMap component with basic metric list visualization
- mark ImpactMap task as done in advanced todo and progress trackers

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: Cannot access attribute "get" for class "FastAPI" in agents/news_climate services)*
- `npx tsc -p tsconfig.json`
- `npx jest packages/unifiedmandala-ui/components/ImpactMap.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689dfe17e82483229f64ff8c5522bbc8