### PR TITLE
feat: enhance EventPlaybackModule filtering

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1494,7 +1494,8 @@
     "commit": "Implement EventPlaybackModule",
     "path": "packages/event-bus/EventPlaybackModule.ts",
     "task": "Record and replay event streams for debugging",
-    "test": "packages/event-bus/EventPlaybackModule.test.ts"
+    "test": "packages/event-bus/EventPlaybackModule.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add EventVisualizationDashboard",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1094,6 +1094,7 @@
   path: packages/event-bus/EventPlaybackModule.ts
   task: Record and replay event streams for debugging
   test: packages/event-bus/EventPlaybackModule.test.ts
+  status: done
 - commit: Add EventVisualizationDashboard
   path: packages/unifiedmandala-ui/components/EventVisualizationDashboard.tsx
   task: Visualize module communication in real time

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "test: add repository map duplicate checker",
+  "lastCommit": "chore: finalize progress sync",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -58,10 +58,6 @@
     {
       "commit": "Configure agents CI workflow for new agents",
       "status": "todo"
-    },
-    {
-      "commit": "Create ImpactMap component",
-      "status": "done"
     },
     {
       "commit": "Create EmergencePanel component",
@@ -4040,6 +4036,14 @@
     {
       "commit": "Add repository map duplicate checker",
       "status": "done"
+    },
+    {
+      "commit": "Implement EventPlaybackModule",
+      "status": "done"
+    },
+    {
+      "commit": "Create ImpactMap component",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4717,6 +4721,10 @@
     },
     {
       "commit": "Add repository map duplicate checker",
+      "status": "done"
+    },
+    {
+      "commit": "Enhance EventPlaybackModule with filtering",
       "status": "done"
     }
   ]

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -71,3 +71,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Integrated progress metrics and debugging safeguards into null field wave simulation.
 - Implemented ParticleTimeDilation module simulating relativistic effects.
 - Added repository map duplicate checker script to ensure unique repositories and modules.
+- Enhanced EventPlaybackModule with filtering and clear capabilities.

--- a/packages/event-bus/EventPlaybackModule.test.ts
+++ b/packages/event-bus/EventPlaybackModule.test.ts
@@ -1,7 +1,17 @@
 import { EventPlaybackModule } from './EventPlaybackModule';
 
-test('records and replays events', () => {
+test('records, filters and clears events', () => {
   const mod = new EventPlaybackModule();
-  mod.record({a:1});
-  expect(mod.playback()).toEqual([{a:1}]);
+  mod.record({ type: 'test', payload: { a: 1 } });
+  mod.record({ type: 'other', payload: { b: 2 } });
+
+  const all = mod.playback();
+  expect(all.length).toBe(2);
+  expect(all[0]).toHaveProperty('timestamp');
+
+  const filtered = mod.playback('test');
+  expect(filtered).toEqual([all[0]]);
+
+  mod.clear();
+  expect(mod.playback().length).toBe(0);
 });

--- a/packages/event-bus/EventPlaybackModule.ts
+++ b/packages/event-bus/EventPlaybackModule.ts
@@ -1,5 +1,23 @@
+export interface RecordedEvent<T = any> {
+  type: string;
+  payload: T;
+  timestamp: number;
+}
+
 export class EventPlaybackModule {
-  private events: any[] = [];
-  record(event: any) { this.events.push(event); }
-  playback() { return [...this.events]; }
+  private events: RecordedEvent[] = [];
+
+  record(event: Omit<RecordedEvent, 'timestamp'>): void {
+    this.events.push({ ...event, timestamp: Date.now() });
+  }
+
+  playback(type?: string): RecordedEvent[] {
+    return this.events
+      .filter(e => !type || e.type === type)
+      .map(e => ({ ...e }));
+  }
+
+  clear(): void {
+    this.events = [];
+  }
 }


### PR DESCRIPTION
## Summary
- add timestamped event recording with type filtering and clear support
- document EventPlaybackModule completion in todo and progress trackers
- note EventPlaybackModule enhancement in feedback codex

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npx pyright` *(fails: FastAPI attribute errors)*
- `npx jest packages/event-bus/EventPlaybackModule.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689e02039de08322a5db21a62fc16695