### PR TITLE
feat: repository map module listing utility

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12317,5 +12317,12 @@
     "task": "Ensure repository_map.yaml has unique repository names and modules",
     "test": "scripts/repository-map-check-duplicates.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add repository map list script",
+    "path": "scripts/repository-map-list.ts",
+    "task": "List repositories and modules from repository_map.yaml",
+    "test": "scripts/repository-map-list.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12067,3 +12067,8 @@
   task: Ensure repository and module names in repository_map.yaml are unique
   test: scripts/repository-map-check-duplicates.test.ts
   status: done
+- commit: Add repository map list script
+  path: scripts/repository-map-list.ts
+  task: List repositories and modules from repository_map.yaml
+  test: scripts/repository-map-list.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: finalize progress sync",
+  "lastCommit": "chore: sync progress tracker",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4044,6 +4044,10 @@
     {
       "commit": "Create ImpactMap component",
       "status": "done"
+    },
+    {
+      "commit": "Add repository map list script",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4725,6 +4729,10 @@
     },
     {
       "commit": "Enhance EventPlaybackModule with filtering",
+      "status": "done"
+    },
+    {
+      "commit": "Add repository map list script",
       "status": "done"
     }
   ]

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -72,3 +72,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented ParticleTimeDilation module simulating relativistic effects.
 - Added repository map duplicate checker script to ensure unique repositories and modules.
 - Enhanced EventPlaybackModule with filtering and clear capabilities.
+- Added repository map list script to enumerate modules per repository.

--- a/scripts/repository-map-list.test.ts
+++ b/scripts/repository-map-list.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { listRepositoryMap } from './repository-map-list';
+
+describe('listRepositoryMap', () => {
+  it('includes modules for aeon repository', () => {
+    const result = listRepositoryMap({ json: true }) as Record<string, string[]>;
+    expect(result.aeon).toContain('sigillin-validator.ts');
+  });
+});

--- a/scripts/repository-map-list.ts
+++ b/scripts/repository-map-list.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env ts-node
+/**
+ * scripts/repository-map-list.ts
+ *
+ * Utility to list all repositories and their modules from
+ * `repositorypflege/repository_map.yaml`.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+const file = path.join(__dirname, '../repositorypflege/repository_map.yaml');
+
+export interface ListOptions {
+  json?: boolean;
+}
+
+export function listRepositoryMap(options: ListOptions = {}) {
+  const raw = fs.readFileSync(file, 'utf8');
+  const data = yaml.load(raw) as any;
+
+  const items = Array.isArray((data as any).repository_map) ? (data as any).repository_map : [];
+  const result: Record<string, string[]> = {};
+
+  items.forEach((item: any) => {
+    const name = item.name || 'unnamed';
+    const modules = Array.isArray(item.modules) ? item.modules : [];
+    result[name] = modules.map((m: any) => String(m));
+  });
+
+  if (options.json) {
+    return result;
+  }
+
+  return Object.entries(result)
+    .map(([repo, mods]) => `${repo}:\n  - ${mods.join('\n  - ')}`)
+    .join('\n');
+}
+
+if (require.main === module) {
+  const jsonFlag = process.argv.includes('--json');
+  const output = listRepositoryMap({ json: jsonFlag });
+  if (jsonFlag) {
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    console.log(output);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add repository map list script to output modules per repository
- track new utility in advanced todo and progress files
- note addition in feedback codex

## Testing
- `npx pyright` *(fails: FastAPI attribute/type errors)*
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/repository-map-list.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689e066633f88322ad2b16aac3a4f9fe