### PR TITLE
feat: add branching narrative engine

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1441,7 +1441,8 @@
     "commit": "Add InteractiveNarrativeEngine",
     "path": "packages/universum-simulationen/InteractiveNarrativeEngine.ts",
     "task": "Allow users to build interactive narratives based on CREP",
-    "test": "packages/universum-simulationen/InteractiveNarrativeEngine.test.ts"
+    "test": "packages/universum-simulationen/InteractiveNarrativeEngine.test.ts",
+    "status": "done"
   },
   {
     "commit": "Introduce EmotionalResonanceSimulator",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1057,6 +1057,7 @@
   path: packages/universum-simulationen/InteractiveNarrativeEngine.ts
   task: Allow users to build interactive narratives based on CREP
   test: packages/universum-simulationen/InteractiveNarrativeEngine.test.ts
+  status: done
 - commit: Introduce EmotionalResonanceSimulator
   path: packages/universum-simulationen/EmotionalResonanceSimulator.ts
   task: Simulate emotional states via CREP and resonance values

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: sync progress tracker",
+  "lastCommit": "Merge pull request #1219 from GenesisAeon/codex/implement-features-from-advancedtodo.yaml-xigt6s",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4048,6 +4048,10 @@
     {
       "commit": "Add repository map list script",
       "status": "done"
+    },
+    {
+      "commit": "Add InteractiveNarrativeEngine",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4733,6 +4737,10 @@
     },
     {
       "commit": "Add repository map list script",
+      "status": "done"
+    },
+    {
+      "commit": "Enhance InteractiveNarrativeEngine with branching choices",
       "status": "done"
     }
   ]

--- a/packages/universum-simulationen/InteractiveNarrativeEngine.test.ts
+++ b/packages/universum-simulationen/InteractiveNarrativeEngine.test.ts
@@ -1,7 +1,11 @@
 import { InteractiveNarrativeEngine } from './InteractiveNarrativeEngine';
 
-test('records steps', () => {
+test('navigates branching choices', () => {
   const eng = new InteractiveNarrativeEngine();
-  eng.addStep('start');
-  expect(eng.getHistory()).toEqual(['start']);
+  eng.addStep('start', 'Start', { next: 'end' });
+  eng.addStep('end', 'The End');
+  eng.start('start');
+  eng.choose('next');
+  expect(eng.getHistory()).toEqual(['start', 'end']);
+  expect(eng.getCurrent()).toEqual({ id: 'end', text: 'The End', choices: {} });
 });

--- a/packages/universum-simulationen/InteractiveNarrativeEngine.ts
+++ b/packages/universum-simulationen/InteractiveNarrativeEngine.ts
@@ -1,9 +1,52 @@
+export interface NarrativeStep {
+  text: string;
+  /**
+   * Mapping of choice label to next step id.
+   */
+  choices: Record<string, string>;
+}
+
+/**
+ * Simple branching narrative engine.
+ * Steps can register choices leading to other steps.
+ */
 export class InteractiveNarrativeEngine {
-  private steps: string[] = [];
-  addStep(step: string) {
-    this.steps.push(step);
+  private steps: Record<string, NarrativeStep> = {};
+  private current?: string;
+  private history: string[] = [];
+
+  addStep(id: string, text: string, choices: Record<string, string> = {}) {
+    this.steps[id] = { text, choices };
   }
+
+  start(id: string) {
+    if (!this.steps[id]) {
+      throw new Error(`Unknown step: ${id}`);
+    }
+    this.current = id;
+    this.history = [id];
+  }
+
+  choose(option: string) {
+    if (!this.current) {
+      throw new Error('Narrative not started');
+    }
+    const step = this.steps[this.current];
+    const next = step.choices[option];
+    if (!next) {
+      throw new Error(`Invalid choice: ${option}`);
+    }
+    this.current = next;
+    this.history.push(next);
+  }
+
+  getCurrent() {
+    if (!this.current) return undefined;
+    const step = this.steps[this.current];
+    return { id: this.current, ...step };
+  }
+
   getHistory() {
-    return [...this.steps];
+    return [...this.history];
   }
 }


### PR DESCRIPTION
## Summary
- support branching choices in `InteractiveNarrativeEngine`
- test engine navigation across branches
- mark `InteractiveNarrativeEngine` task as complete in advanced trackers

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: FastAPI attribute errors)*
- `npx tsc -p tsconfig.json`
- `npx vitest packages/universum-simulationen/InteractiveNarrativeEngine.test.ts` *(no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689e0ac21d648322b8fe348eb2726ca2