### PR TITLE
feat: enhance emotional resonance simulation

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1448,7 +1448,8 @@
     "commit": "Introduce EmotionalResonanceSimulator",
     "path": "packages/universum-simulationen/EmotionalResonanceSimulator.ts",
     "task": "Simulate emotional states via CREP and resonance values",
-    "test": "packages/universum-simulationen/EmotionalResonanceSimulator.test.ts"
+    "test": "packages/universum-simulationen/EmotionalResonanceSimulator.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add CREPTrendAnalyzer",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1062,6 +1062,7 @@
   path: packages/universum-simulationen/EmotionalResonanceSimulator.ts
   task: Simulate emotional states via CREP and resonance values
   test: packages/universum-simulationen/EmotionalResonanceSimulator.test.ts
+  status: done
 - commit: Add CREPTrendAnalyzer
   path: packages/crep-engine/CREPTrendAnalyzer.ts
   task: Analyze historic CREP trends with AI

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1219 from GenesisAeon/codex/implement-features-from-advancedtodo.yaml-xigt6s",
+  "lastCommit": "feat: enhance emotional resonance simulation",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4052,6 +4052,10 @@
     {
       "commit": "Add InteractiveNarrativeEngine",
       "status": "done"
+    },
+    {
+      "commit": "Introduce EmotionalResonanceSimulator",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4741,6 +4745,10 @@
     },
     {
       "commit": "Enhance InteractiveNarrativeEngine with branching choices",
+      "status": "done"
+    },
+    {
+      "commit": "Introduce EmotionalResonanceSimulator",
       "status": "done"
     }
   ]

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -18,6 +18,7 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added agent backend switching in ChatPanel with service toolbar.
 - Implemented SingularitySimulatorPanel for interactive singularity simulations.
 - Added duplicate conversation title index tracking in validator.
+- Enhanced EmotionalResonanceSimulator to classify resonance states.
 - Added live suggestion badges to CREPVisualizer and synced progress files.
 - Implemented chat proxy route to forward /api/chat requests to configured services.
 - Exposed service avatars in PyramidVRMeetingRoom for interactive local/external agents.

--- a/packages/universum-simulationen/EmotionalResonanceSimulator.test.ts
+++ b/packages/universum-simulationen/EmotionalResonanceSimulator.test.ts
@@ -1,5 +1,12 @@
 import { simulateResonance } from './EmotionalResonanceSimulator';
 
-test('calculates average resonance', () => {
-  expect(simulateResonance([1,2,3])).toBe(2);
+test('calculates average resonance and positive state', () => {
+  const result = simulateResonance([0.6, 0.8, 1]);
+  expect(result.average).toBeCloseTo(0.8);
+  expect(result.state).toBe('positive');
+});
+
+test('detects negative resonance', () => {
+  const result = simulateResonance([-0.6, -0.8]);
+  expect(result.state).toBe('negative');
 });

--- a/packages/universum-simulationen/EmotionalResonanceSimulator.ts
+++ b/packages/universum-simulationen/EmotionalResonanceSimulator.ts
@@ -1,5 +1,28 @@
-export function simulateResonance(values: number[]): number {
-  if (values.length === 0) return 0;
-  const sum = values.reduce((a, b) => a + b, 0);
-  return sum / values.length;
+export interface ResonanceResult {
+  average: number;
+  state: 'positive' | 'neutral' | 'negative';
+}
+
+/**
+ * Calculate the average resonance value and classify it into a simple
+ * emotional state. Values greater than 0.5 are considered positive,
+ * values lower than -0.5 negative, the rest neutral.
+ */
+export function simulateResonance(values: number[]): ResonanceResult {
+  if (values.length === 0) {
+    return { average: 0, state: 'neutral' };
+  }
+
+  const average = values.reduce((a, b) => a + b, 0) / values.length;
+  let state: ResonanceResult['state'];
+
+  if (average > 0.5) {
+    state = 'positive';
+  } else if (average < -0.5) {
+    state = 'negative';
+  } else {
+    state = 'neutral';
+  }
+
+  return { average, state };
 }


### PR DESCRIPTION
## Summary
- expand EmotionalResonanceSimulator to classify average resonance into positive, neutral, or negative states
- mark EmotionalResonanceSimulator task as completed in advanced ToDo and progress files
- note enhancement in feedbackcodex

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright` *(fails: Cannot access attribute "get" for class "FastAPI" in agents/news_climate modules)*
- `npx tsc -p tsconfig.json --showConfig | head -n 20`
- `pnpm test packages/universum-simulationen/EmotionalResonanceSimulator.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689e135d2520832289d106e61ce850b4