### PR TITLE
feat: add sentiment agent container

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11959,7 +11959,7 @@
   {
     "commit": "Add Dockerfile and requirements for sentiment agent",
     "path": "agents/sentiment/Dockerfile",
-    "status": "todo",
+    "status": "done",
     "task": "Create Dockerfile and requirements for sentiment agent",
     "test": "agents/sentiment/main.test.py"
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11819,7 +11819,7 @@
   path: agents/sentiment/Dockerfile
   task: Create Dockerfile and requirements for sentiment agent
   test: agents/sentiment/main.test.py
-  status: todo
+  status: done
 - commit: Add Dockerfile and requirements for provenance agent
   path: agents/provenance/Dockerfile
   task: Create Dockerfile and requirements for provenance agent

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: enhance emotional resonance simulation",
+  "lastCommit": "feat: add sentiment agent container",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -17,10 +17,6 @@
     },
     {
       "commit": "Add Dockerfile and requirements for IoT sensor agent",
-      "status": "todo"
-    },
-    {
-      "commit": "Add Dockerfile and requirements for sentiment agent",
       "status": "todo"
     },
     {
@@ -4056,6 +4052,10 @@
     {
       "commit": "Introduce EmotionalResonanceSimulator",
       "status": "done"
+    },
+    {
+      "commit": "Add Dockerfile and requirements for sentiment agent",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4749,6 +4749,10 @@
     },
     {
       "commit": "Introduce EmotionalResonanceSimulator",
+      "status": "done"
+    },
+    {
+      "commit": "Add Dockerfile and requirements for sentiment agent",
       "status": "done"
     }
   ]

--- a/agents/sentiment/Dockerfile
+++ b/agents/sentiment/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+

--- a/agents/sentiment/__init__.py
+++ b/agents/sentiment/__init__.py
@@ -1,0 +1,2 @@
+"""Sentiment analysis agent package."""
+

--- a/agents/sentiment/main.py
+++ b/agents/sentiment/main.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Simple sentiment analysis agent.
+
+This FastAPI service exposes a minimal sentiment endpoint that
+computes a very naive sentiment score based on the presence of
+positive and negative keywords. It serves as a placeholder for
+more sophisticated models.
+"""
+
+from typing import Set
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="Sentiment Agent")
+
+POSITIVE: Set[str] = {"good", "great", "love", "excellent", "happy"}
+NEGATIVE: Set[str] = {"bad", "terrible", "hate", "poor", "sad"}
+
+
+class SentimentRequest(BaseModel):
+    text: str
+
+
+class SentimentResult(BaseModel):
+    score: float
+
+
+def compute_score(text: str) -> float:
+    """Return simple sentiment score in range [-1, 1]."""
+
+    words = [w.lower() for w in text.split()]
+    total = len(words) or 1
+    pos = sum(1 for w in words if w in POSITIVE)
+    neg = sum(1 for w in words if w in NEGATIVE)
+    return (pos - neg) / total
+
+
+@app.post("/analyze", response_model=SentimentResult)  # type: ignore[misc]
+async def analyze(req: SentimentRequest) -> SentimentResult:
+    """Analyze sentiment of the provided text."""
+
+    return SentimentResult(score=compute_score(req.text))
+

--- a/agents/sentiment/requirements.txt
+++ b/agents/sentiment/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+

--- a/agents/sentiment/test_main.py
+++ b/agents/sentiment/test_main.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+
+from agents.sentiment.main import app
+
+
+def test_analyze_positive_text() -> None:
+    client = TestClient(app)  # type: ignore[arg-type]
+    resp = client.post("/analyze", json={"text": "I love this great tool"})
+    assert resp.status_code == 200
+    assert resp.json()["score"] > 0
+
+
+def test_analyze_negative_text() -> None:
+    client = TestClient(app)  # type: ignore[arg-type]
+    resp = client.post("/analyze", json={"text": "This is a bad and terrible bug"})
+    assert resp.status_code == 200
+    assert resp.json()["score"] < 0
+

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -74,3 +74,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added repository map duplicate checker script to ensure unique repositories and modules.
 - Enhanced EventPlaybackModule with filtering and clear capabilities.
 - Added repository map list script to enumerate modules per repository.
+- Added sentiment analysis agent with container setup.


### PR DESCRIPTION
## Summary
- add simple keyword-based sentiment analysis agent with Docker container setup
- update advanced trackers to mark sentiment agent task complete
- note addition in feedbackcodex

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: venvPath .venv is not a valid directory)*
- `npx tsc -p tsconfig.json`
- `pytest agents/sentiment/test_main.py`

------
https://chatgpt.com/codex/tasks/task_e_689e19a97b148322b4d1e9444eaac5f9