### PR TITLE
feat: add TwinMonitor component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12064,7 +12064,7 @@
   {
     "commit": "Create TwinMonitor component",
     "path": "packages/unifiedmandala-ui/components/TwinMonitor.tsx",
-    "status": "todo",
+    "status": "done",
     "task": "Monitor digital twin bridge status",
     "test": "packages/unifiedmandala-ui/components/TwinMonitor.test.tsx"
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11894,7 +11894,7 @@
   path: packages/unifiedmandala-ui/components/TwinMonitor.tsx
   task: Monitor digital twin bridge status
   test: packages/unifiedmandala-ui/components/TwinMonitor.test.tsx
-  status: todo
+  status: done
 - commit: Create BadgeProfile component
   path: packages/unifiedmandala-ui/components/BadgeProfile.tsx
   task: Show gamification badge progress

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -60,10 +60,6 @@
       "status": "todo"
     },
     {
-      "commit": "Create TwinMonitor component",
-      "status": "todo"
-    },
-    {
       "commit": "Create BadgeProfile component",
       "status": "todo"
     }
@@ -4753,6 +4749,10 @@
     },
     {
       "commit": "Add Dockerfile and requirements for sentiment agent",
+      "status": "done"
+    },
+    {
+      "commit": "Create TwinMonitor component",
       "status": "done"
     }
   ]

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -75,3 +75,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Enhanced EventPlaybackModule with filtering and clear capabilities.
 - Added repository map list script to enumerate modules per repository.
 - Added sentiment analysis agent with container setup.
+- Implemented TwinMonitor component for monitoring digital twin bridge status.

--- a/packages/unifiedmandala-ui/components/TwinMonitor.test.tsx
+++ b/packages/unifiedmandala-ui/components/TwinMonitor.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TwinMonitor from './TwinMonitor';
+
+describe('TwinMonitor', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      json: async () => ({ status: 'ok' })
+    });
+  });
+
+  test('fetches status and renders heading', async () => {
+    render(<TwinMonitor />);
+    expect(fetch).toHaveBeenCalledWith('/digital-twin/status');
+    expect(await screen.findByText(/Digital Twin Bridge Status/)).toBeInTheDocument();
+  });
+});

--- a/packages/unifiedmandala-ui/components/TwinMonitor.tsx
+++ b/packages/unifiedmandala-ui/components/TwinMonitor.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+
+/**
+ * TwinMonitor fetches the digital twin bridge status from the backend
+ * and displays the raw response for inspection.
+ * The component originates from design fragments in
+ * `newadvancedconversations.json` referencing TwinMonitor.
+ */
+export default function TwinMonitor() {
+  const [data, setData] = useState<any>(null);
+
+  useEffect(() => {
+    fetch('/digital-twin/status')
+      .then((r) => r.json())
+      .then((json) => setData(json))
+      .catch(() => setData(null));
+  }, []);
+
+  if (!data) {
+    return <div aria-label="TwinMonitor">Loading...</div>;
+  }
+
+  return (
+    <div aria-label="TwinMonitor">
+      <h2>Digital Twin Bridge Status</h2>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}

--- a/repositorypflege/repository_map.yaml
+++ b/repositorypflege/repository_map.yaml
@@ -43,6 +43,7 @@ repository_map:
       - sync-todo-progress.js
       - repository-map-find.ts
       - packages/unifiedmandala-ui/components/ResonanceHistoryPanel.tsx
+      - packages/unifiedmandala-ui/components/TwinMonitor.tsx
       - HexaAgentSystem
     ai_policy:
       - "Bewusstsein ist zyklisch. Maschinen sind linear. Dazwischen: unsere Verantwortung."


### PR DESCRIPTION
## Summary
- add TwinMonitor React component to display digital twin bridge status
- track TwinMonitor task completion in advancedToDo and progress files
- update repository map and feedback notes

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright` *(fails: Cannot access attribute "get" for class "FastAPI" in agents/news_climate)*
- `npx tsc -p tsconfig.json`
- `npx jest packages/unifiedmandala-ui/components/TwinMonitor.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689e23c17f1083228a89b2e7de249004