### PR TITLE
feat: summarize sync-todo-progress

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12326,5 +12326,12 @@
     "task": "List repositories and modules from repository_map.yaml",
     "test": "scripts/repository-map-list.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add summary output to sync-todo-progress script",
+    "path": "scripts/sync-todo-progress.js",
+    "task": "Log counts of tasks synced into advancedprogress.json",
+    "test": "scripts/__tests__/sync-todo-progress.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12074,3 +12074,8 @@
   task: List repositories and modules from repository_map.yaml
   test: scripts/repository-map-list.test.ts
   status: done
+- commit: Add summary output to sync-todo-progress script
+  path: scripts/sync-todo-progress.js
+  task: Log counts of tasks synced into advancedprogress.json
+  test: scripts/__tests__/sync-todo-progress.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -4660,6 +4660,10 @@
     {
       "commit": "Add repository map duplicate checker",
       "status": "done"
+    },
+    {
+      "commit": "Add summary output to sync-todo-progress script",
+      "status": "done"
     }
   ],
   "metacommitTags": [
@@ -4757,6 +4761,10 @@
     },
     {
       "commit": "Filter conversations by keyword",
+      "status": "done"
+    },
+    {
+      "commit": "Add summary output to sync-todo-progress script",
       "status": "done"
     }
   ]

--- a/scripts/__tests__/sync-todo-progress.test.ts
+++ b/scripts/__tests__/sync-todo-progress.test.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { syncTodoProgress } from '../sync-todo-progress';
+
+test('syncTodoProgress reports counts and supports dry run', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sync-test-'));
+  const partsDir = path.join(tmp, 'parts');
+  fs.mkdirSync(partsDir);
+  const tasks = [
+    { commit: 'done task', status: 'done' },
+    { commit: 'pending task', status: 'open' }
+  ];
+  fs.writeFileSync(
+    path.join(partsDir, 'tasks.json'),
+    JSON.stringify(tasks, null, 2)
+  );
+  const progressFile = path.join(tmp, 'progress.json');
+  fs.writeFileSync(progressFile, JSON.stringify({ progress: [], pendingTasks: [] }, null, 2));
+
+  const dry = syncTodoProgress(partsDir, progressFile, [], { dryRun: true });
+  expect(dry.addedDone).toBe(1);
+  expect(dry.addedPending).toBe(1);
+  const afterDry = JSON.parse(fs.readFileSync(progressFile, 'utf8'));
+  expect(afterDry.progress).toHaveLength(0);
+
+  const run = syncTodoProgress(partsDir, progressFile);
+  expect(run.addedDone).toBe(1);
+  expect(run.addedPending).toBe(1);
+  const final = JSON.parse(fs.readFileSync(progressFile, 'utf8'));
+  expect(final.progress).toHaveLength(1);
+  expect(final.pendingTasks).toHaveLength(1);
+});

--- a/scripts/sync-todo-progress.d.ts
+++ b/scripts/sync-todo-progress.d.ts
@@ -1,0 +1,12 @@
+export interface SyncResult {
+  progress: any;
+  addedDone: number;
+  addedPending: number;
+}
+export function loadTasks(filePath: string): any;
+export function syncTodoProgress(
+  partsDir: string,
+  progressFile: string,
+  extraFiles?: string[],
+  options?: { dryRun?: boolean }
+): SyncResult;

--- a/scripts/sync-todo-progress.js
+++ b/scripts/sync-todo-progress.js
@@ -10,13 +10,17 @@ function loadTasks(filePath) {
   return [];
 }
 
-function syncTodoProgress(partsDir, progressFile, extraFiles = []) {
+function syncTodoProgress(partsDir, progressFile, extraFiles = [], options = {}) {
+  const { dryRun = false } = options;
   const progress = JSON.parse(fs.readFileSync(progressFile, 'utf8'));
   progress.progress = progress.progress || [];
   progress.pendingTasks = progress.pendingTasks || [];
 
   const doneSet = new Set(progress.progress.map(p => p.commit));
   const pendingSet = new Set(progress.pendingTasks.map(p => p.commit));
+
+  let addedDone = 0;
+  let addedPending = 0;
 
   const partFiles = fs
     .readdirSync(partsDir)
@@ -33,18 +37,22 @@ function syncTodoProgress(partsDir, progressFile, extraFiles = []) {
         if (!doneSet.has(task.commit)) {
           progress.progress.push({ commit: task.commit, status: 'done' });
           doneSet.add(task.commit);
+          addedDone++;
         }
       } else {
         if (!pendingSet.has(task.commit)) {
           progress.pendingTasks.push({ commit: task.commit, status: task.status || 'open' });
           pendingSet.add(task.commit);
+          addedPending++;
         }
       }
     });
   });
 
-  fs.writeFileSync(progressFile, JSON.stringify(progress, null, 2));
-  return progress;
+  if (!dryRun) {
+    fs.writeFileSync(progressFile, JSON.stringify(progress, null, 2));
+  }
+  return { progress, addedDone, addedPending };
 }
 
 if (require.main === module) {
@@ -54,8 +62,11 @@ if (require.main === module) {
     path.join(__dirname, '../advancedToDo.json'),
     path.join(__dirname, '../advancedToDo.yaml'),
   ];
-  syncTodoProgress(partsDir, progressFile, extra);
-  console.log('Synchronized ToDo parts with progress file');
+  const dryRun = process.argv.includes('--dry-run');
+  const { addedDone, addedPending } = syncTodoProgress(partsDir, progressFile, extra, { dryRun });
+  console.log(
+    `Synchronized ToDo parts with progress file (added ${addedDone} done, ${addedPending} pending)`
+  );
 }
 
 module.exports = { syncTodoProgress, loadTasks };


### PR DESCRIPTION
## Summary
- enhance sync-todo-progress with dry-run support and log summary counts
- track new capability in advanced todo and progress lists
- add unit test for sync-todo-progress reporting

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest scripts/__tests__/sync-todo-progress.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689e3d8caecc8322b144a464a275da78