### PR TITLE
feat: add EmergencePanel component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12060,7 +12060,7 @@
   {
     "commit": "Create EmergencePanel component",
     "path": "packages/unifiedmandala-ui/components/EmergencePanel.tsx",
-    "status": "todo",
+    "status": "done",
     "task": "Display catalyst spark emergence data",
     "test": "packages/unifiedmandala-ui/components/EmergencePanel.test.tsx"
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11892,7 +11892,7 @@
   path: packages/unifiedmandala-ui/components/EmergencePanel.tsx
   task: Display catalyst spark emergence data
   test: packages/unifiedmandala-ui/components/EmergencePanel.test.tsx
-  status: todo
+  status: done
 - commit: Create TwinMonitor component
   path: packages/unifiedmandala-ui/components/TwinMonitor.tsx
   task: Monitor digital twin bridge status

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Add Dockerfile and requirements for societal impact agent",
+  "lastCommit": "feat: add EmergencePanel component",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -29,10 +29,6 @@
     },
     {
       "commit": "Configure agents CI workflow for new agents",
-      "status": "todo"
-    },
-    {
-      "commit": "Create EmergencePanel component",
       "status": "todo"
     },
     {
@@ -4072,6 +4068,10 @@
     {
       "commit": "Add Dockerfile and requirements for societal impact agent",
       "status": "done"
+    },
+    {
+      "commit": "Create EmergencePanel component",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4691,6 +4691,10 @@
     "meta:implement-features"
   ],
   "commits": [
+    {
+      "commit": "Create EmergencePanel component",
+      "status": "done"
+    },
     {
       "commit": "Add PresenceIndicator feature",
       "status": "done"

--- a/packages/unifiedmandala-ui/components/EmergencePanel.test.tsx
+++ b/packages/unifiedmandala-ui/components/EmergencePanel.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import EmergencePanel, { CatalystSpark } from './EmergencePanel';
+
+test('renders catalyst sparks', () => {
+  const sparks: CatalystSpark[] = [
+    { description: 'spark-one', intensity: 0.7 },
+    { description: 'spark-two', intensity: 0.3 },
+  ];
+
+  render(<EmergencePanel sparks={sparks} />);
+  const panel = screen.getByTestId('emergence-panel');
+  expect(panel).toHaveTextContent('spark-one');
+  expect(panel).toHaveTextContent('70%');
+});

--- a/packages/unifiedmandala-ui/components/EmergencePanel.tsx
+++ b/packages/unifiedmandala-ui/components/EmergencePanel.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+/** Describes a catalyst spark emergence entry */
+export interface CatalystSpark {
+  /** Description of the catalyst spark */
+  description: string;
+  /** Intensity of the spark on a 0-1 scale */
+  intensity: number;
+}
+
+interface EmergencePanelProps {
+  /** List of catalyst sparks to render */
+  sparks: CatalystSpark[];
+}
+
+/**
+ * Displays catalyst spark emergence data in a simple list.
+ * Acts as a placeholder for future, richer visualizations.
+ */
+const EmergencePanel: React.FC<EmergencePanelProps> = ({ sparks }) => {
+  return (
+    <div data-testid="emergence-panel">
+      <h3>Emergence</h3>
+      <ul>
+        {sparks.map((spark, idx) => (
+          <li key={idx}>
+            {spark.description} – {(spark.intensity * 100).toFixed(0)}%
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default EmergencePanel;

--- a/repositorypflege/repository_map.yaml
+++ b/repositorypflege/repository_map.yaml
@@ -44,6 +44,7 @@ repository_map:
       - repository-map-find.ts
       - packages/unifiedmandala-ui/components/ResonanceHistoryPanel.tsx
       - packages/unifiedmandala-ui/components/TwinMonitor.tsx
+      - packages/unifiedmandala-ui/components/EmergencePanel.tsx
       - HexaAgentSystem
     ai_policy:
       - "Bewusstsein ist zyklisch. Maschinen sind linear. Dazwischen: unsere Verantwortung."


### PR DESCRIPTION
## Summary
- add EmergencePanel to visualise catalyst sparks
- track EmergencePanel completion in advanced TODO and progress files
- map EmergencePanel in repository map

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest packages/unifiedmandala-ui/components/EmergencePanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689eea02e38c832287184369daaae9c3