### PR TITLE
feat(agent): add catalyst agent container

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -11991,7 +11991,7 @@
   {
     "commit": "Add Dockerfile and requirements for catalyst agent",
     "path": "agents/catalyst/Dockerfile",
-    "status": "todo",
+    "status": "done",
     "task": "Create Dockerfile and requirements for catalyst agent",
     "test": "agents/catalyst/main.test.py"
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11843,7 +11843,7 @@
   path: agents/catalyst/Dockerfile
   task: Create Dockerfile and requirements for catalyst agent
   test: agents/catalyst/main.test.py
-  status: todo
+  status: done
 - commit: Add Dockerfile and requirements for digital twin agent
   path: agents/digital_twin/Dockerfile
   task: Create Dockerfile and requirements for digital twin agent

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,16 +1,12 @@
 {
-  "lastCommit": "feat(ui): add BadgeProfile component implementation and tests",
+  "lastCommit": "feat(agent): add catalyst agent container",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.",
+  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.",
   "pendingTasks": [
-    {
-      "commit": "Add Dockerfile and requirements for catalyst agent",
-      "status": "todo"
-    },
     {
       "commit": "Add Dockerfile and requirements for digital twin agent",
       "status": "todo"
@@ -33,6 +29,10 @@
     }
   ],
   "progress": [
+    {
+      "commit": "Add Dockerfile and requirements for catalyst agent",
+      "status": "done"
+    },
     {
       "commit": "Add Dockerfile and requirements for generative art agent",
       "status": "done"

--- a/agents/catalyst/Dockerfile
+++ b/agents/catalyst/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/agents/catalyst/__init__.py
+++ b/agents/catalyst/__init__.py
@@ -1,0 +1,1 @@
+"""Catalyst agent package."""

--- a/agents/catalyst/main.py
+++ b/agents/catalyst/main.py
@@ -1,0 +1,32 @@
+"""Catalyst agent service.
+
+This FastAPI microservice exposes a simple endpoint that
+computes a catalyst spark score based on the number of sparks
+and an energy factor.
+"""
+from __future__ import annotations
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="Catalyst Agent")
+
+
+class SparkRequest(BaseModel):
+    sparks: int = 0
+    energy: float = 0.0
+
+
+class SparkResult(BaseModel):
+    score: float
+
+
+def compute_score(data: SparkRequest) -> float:
+    """Compute a catalyst score."""
+    return data.sparks * data.energy
+
+
+@app.post("/spark", response_model=SparkResult)  # type: ignore[misc]
+async def spark(req: SparkRequest) -> SparkResult:
+    """Return the catalyst spark score."""
+    return SparkResult(score=compute_score(req))

--- a/agents/catalyst/requirements.txt
+++ b/agents/catalyst/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/agents/catalyst/test_main.py
+++ b/agents/catalyst/test_main.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+
+from agents.catalyst.main import app
+
+
+def test_spark_endpoint() -> None:
+    client = TestClient(app)  # type: ignore[arg-type]
+    resp = client.post("/spark", json={"sparks": 5, "energy": 2.0})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["score"] == 5 * 2.0


### PR DESCRIPTION
## Summary
- add catalyst FastAPI microservice with spark scoring endpoint
- include Dockerfile, requirements and tests for catalyst agent
- mark catalyst agent task as complete in advanced progress trackers

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pytest agents/catalyst/test_main.py`


------
https://chatgpt.com/codex/tasks/task_e_689f1197d4a483229478238341bff570