### PR TITLE
feat: register new agent plugins

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12014,7 +12014,7 @@
   {
     "commit": "Register new agents in plugins manifest",
     "path": "plugins/manifest.yaml",
-    "status": "todo",
+    "status": "done",
     "task": "Add plugin entries for new agents",
     "test": ""
   },

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11860,7 +11860,7 @@
   path: plugins/manifest.yaml
   task: Add plugin entries for new agents
   test: ""
-  status: todo
+  status: done
 - commit: Extend docker-compose with new agent services
   path: docker-compose.yml
   task: Add service definitions for new agents

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -16,10 +16,6 @@
       "status": "todo"
     },
     {
-      "commit": "Register new agents in plugins manifest",
-      "status": "todo"
-    },
-    {
       "commit": "Extend docker-compose with new agent services",
       "status": "todo"
     },
@@ -29,6 +25,10 @@
     }
   ],
   "progress": [
+    {
+      "commit": "Register new agents in plugins manifest",
+      "status": "done"
+    },
     {
       "commit": "Add Dockerfile and requirements for catalyst agent",
       "status": "done"

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -83,3 +83,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented EventVisualizationDashboard component for real-time event counts.
 - Added StyleAdapter utility to tailor responses to user language and style preferences.
 - Added deployment helper script for GhostShellAgent Lambda@Edge service.
+- Registered digital twin, gamification, generative art, and catalyst agents in plugin manifest and repository map.

--- a/plugins/manifest.yaml
+++ b/plugins/manifest.yaml
@@ -34,3 +34,23 @@ plugins:
     component: "../plugins/iot-sensor.yaml"
     dataHook: ""
     story: ""
+  - name: TwinMonitor
+    version: "0.1.0"
+    component: "../packages/unifiedmandala-ui/components/TwinMonitor"
+    dataHook: ""
+    story: ""
+  - name: BadgeProfile
+    version: "0.1.0"
+    component: "../packages/unifiedmandala-ui/components/BadgeProfile"
+    dataHook: ""
+    story: ""
+  - name: ArtGallery
+    version: "0.1.0"
+    component: "../packages/unifiedmandala-ui/components/ArtGallery"
+    dataHook: ""
+    story: ""
+  - name: EmergencePanel
+    version: "0.1.0"
+    component: "../packages/unifiedmandala-ui/components/EmergencePanel"
+    dataHook: ""
+    story: ""

--- a/repositorypflege/repository_map.yaml
+++ b/repositorypflege/repository_map.yaml
@@ -45,6 +45,8 @@ repository_map:
       - packages/unifiedmandala-ui/components/ResonanceHistoryPanel.tsx
       - packages/unifiedmandala-ui/components/TwinMonitor.tsx
       - packages/unifiedmandala-ui/components/EmergencePanel.tsx
+      - packages/unifiedmandala-ui/components/BadgeProfile.tsx
+      - packages/unifiedmandala-ui/components/ArtGallery.tsx
       - HexaAgentSystem
     ai_policy:
       - "Bewusstsein ist zyklisch. Maschinen sind linear. Dazwischen: unsere Verantwortung."


### PR DESCRIPTION
## Summary
- register TwinMonitor, BadgeProfile, ArtGallery, and EmergencePanel plugins
- track new plugin entries in repository map and ToDo progress
- log plugin registration in feedback codex

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_689f268e6fc48322b1bcc0876aeb0277