### PR TITLE
feat: add adaptive CREP threshold optimizer

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1463,7 +1463,8 @@
     "commit": "Implement CREPThresholdOptimizer",
     "path": "packages/crep-engine/CREPThresholdOptimizer.ts",
     "task": "Adapt CREP thresholds through learning",
-    "test": "packages/crep-engine/CREPThresholdOptimizer.test.ts"
+    "test": "packages/crep-engine/CREPThresholdOptimizer.test.ts",
+    "status": "done"
   },
   {
     "commit": "Integrate SigillinBlockchain storage",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1073,6 +1073,7 @@
   path: packages/crep-engine/CREPThresholdOptimizer.ts
   task: Adapt CREP thresholds through learning
   test: packages/crep-engine/CREPThresholdOptimizer.test.ts
+  status: done
 - commit: Integrate SigillinBlockchain storage
   path: packages/genesis-sigillin-core/SigillinBlockchainIntegration.ts
   task: Persist Sigillin metadata on a blockchain

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add GhostShell lambda-edge deployment",
+  "lastCommit": "feat: implement CREPThresholdOptimizer",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4083,6 +4083,10 @@
     },
     {
       "commit": "feat: add StyleAdapter utility",
+      "status": "done"
+    },
+    {
+      "commit": "Implement CREPThresholdOptimizer",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -84,3 +84,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added StyleAdapter utility to tailor responses to user language and style preferences.
 - Added deployment helper script for GhostShellAgent Lambda@Edge service.
 - Registered digital twin, gamification, generative art, and catalyst agents in plugin manifest and repository map.
+- Implemented adaptive CREPThresholdOptimizer for dynamic threshold learning.

--- a/packages/crep-engine/CREPThresholdOptimizer.test.ts
+++ b/packages/crep-engine/CREPThresholdOptimizer.test.ts
@@ -1,5 +1,10 @@
 import { optimizeThreshold } from './CREPThresholdOptimizer';
 
-test('optimizes towards average', () => {
-  expect(optimizeThreshold([2,4], 4)).toBe(3.5);
+test('moves threshold toward average using learning rate', () => {
+  expect(optimizeThreshold([0.8, 0.9], 0.5, 0.5)).toBeCloseTo(0.7, 5);
+});
+
+test('clamps threshold within bounds', () => {
+  expect(optimizeThreshold([2], 0.9, 0.5)).toBe(1);
+  expect(optimizeThreshold([-1], 0.1, 0.5)).toBe(0);
 });

--- a/packages/crep-engine/CREPThresholdOptimizer.ts
+++ b/packages/crep-engine/CREPThresholdOptimizer.ts
@@ -1,5 +1,10 @@
-export function optimizeThreshold(values: number[], current: number): number {
+export function optimizeThreshold(
+  values: number[],
+  current: number,
+  learningRate = 0.1
+): number {
   if (values.length === 0) return current;
-  const avg = values.reduce((a,b)=>a+b,0)/values.length;
-  return (current + avg) / 2;
+  const avg = values.reduce((a, b) => a + b, 0) / values.length;
+  const updated = current + (avg - current) * learningRate;
+  return Math.min(1, Math.max(0, updated));
 }


### PR DESCRIPTION
## Summary
- implement learning-rate-based CREPThresholdOptimizer with bounds
- test threshold adaptation and clamping
- mark task complete in ToDo and progress trackers

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: venvPath not valid; enumeration warning)*
- `npx tsc -p tsconfig.json` *(terminated; no output)*
- `npx jest packages/crep-engine/CREPThresholdOptimizer.test.ts` *(terminated; no output)*

------
https://chatgpt.com/codex/tasks/task_e_689fa3477d10832288a328024fcc0a4c