### PR TITLE
feat: add Nullfeld simulation and visualization modules

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2686,13 +2686,15 @@
     "commit": "Add NullfeldSimulation module",
     "path": "packages/universum-simulationen/NullfeldSimulation.ts",
     "task": "Implement NullfeldSimulation with gravitational forces, membrane curvature and energy conversion",
-    "test": "packages/universum-simulationen/NullfeldSimulation.test.ts"
+    "test": "packages/universum-simulationen/NullfeldSimulation.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add Nullfeld visualization components",
     "path": "packages/universum-simulationen/NullfeldVisualization.ts",
     "task": "Visualize membrane curvature, galaxy map and dark matter distribution",
-    "test": "packages/universum-simulationen/NullfeldVisualization.test.ts"
+    "test": "packages/universum-simulationen/NullfeldVisualization.test.ts",
+    "status": "done"
   },
   {
     "commit": "Integrate new GPT teams from Zukunft conversation",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4409,10 +4409,12 @@
   task: Implement NullfeldSimulation with gravitational forces, membrane curvature
     and energy conversion
   test: packages/universum-simulationen/NullfeldSimulation.test.ts
+  status: done
 - commit: Add Nullfeld visualization components
   path: packages/universum-simulationen/NullfeldVisualization.ts
   task: Visualize membrane curvature, galaxy map and dark matter distribution
   test: packages/universum-simulationen/NullfeldVisualization.test.ts
+  status: done
 - commit: Integrate new GPT teams from Zukunft conversation
   path: packages/agents
   task: Register PädagogikGPT, FutureTechScoutGPT, OptimizerGPT and StateMatterGPT

--- a/packages/universum-simulationen/NullfeldSimulation.test.ts
+++ b/packages/universum-simulationen/NullfeldSimulation.test.ts
@@ -1,14 +1,9 @@
-import { gravitationalForce, membraneCurvature, energyConversion, NullfeldParameters } from './NullfeldSimulation';
+import { simulateNullfeld } from './NullfeldSimulation';
 
-test('computes gravitational force', () => {
-  const params: NullfeldParameters = { mass1: 1, mass2: 2, distance: 3, membraneEnergy: 0 };
-  expect(gravitationalForce(params)).toBeCloseTo(6.674e-11 * 2 / 9);
-});
-
-test('computes membrane curvature', () => {
-  expect(membraneCurvature(10)).toBe(1);
-});
-
-test('converts energy', () => {
-  expect(energyConversion(100)).toBe(42);
+test('calculates forces, curvature effect and energy-mass conversion', () => {
+  const result = simulateNullfeld([1, 2], 0.5, 9e16);
+  const expectedForce = 6.674e-11 * 1 * 2;
+  expect(result.totalForce).toBeCloseTo(expectedForce);
+  expect(result.curvatureEffect).toBeCloseTo(expectedForce * 0.5);
+  expect(result.massFromEnergy).toBeCloseTo(1);
 });

--- a/packages/universum-simulationen/NullfeldSimulation.ts
+++ b/packages/universum-simulationen/NullfeldSimulation.ts
@@ -1,21 +1,27 @@
-export interface NullfeldParameters {
-  mass1: number;
-  mass2: number;
-  distance: number;
-  membraneEnergy: number;
+export interface NullfeldResult {
+  totalForce: number;
+  curvatureEffect: number;
+  massFromEnergy: number;
 }
 
-export function gravitationalForce({ mass1, mass2, distance }: NullfeldParameters): number {
-  const G = 6.674e-11;
-  return (G * mass1 * mass2) / (distance * distance);
-}
-
-export function membraneCurvature(energy: number): number {
-  const k = 0.1;
-  return k * energy;
-}
-
-export function energyConversion(energy: number): number {
-  const efficiency = 0.42;
-  return energy * efficiency;
+/**
+ * Simple null field simulation aggregating gravitational forces between masses,
+ * applying a curvature factor and converting supplied energy to mass via E=mc^2.
+ */
+export function simulateNullfeld(
+  masses: number[],
+  curvature: number,
+  energy: number
+): NullfeldResult {
+  const G = 6.674e-11; // gravitational constant simplified
+  let totalForce = 0;
+  for (let i = 0; i < masses.length; i++) {
+    for (let j = i + 1; j < masses.length; j++) {
+      totalForce += G * masses[i] * masses[j];
+    }
+  }
+  const curvatureEffect = totalForce * curvature;
+  const c2 = 9e16; // speed of light squared (approx)
+  const massFromEnergy = energy / c2;
+  return { totalForce, curvatureEffect, massFromEnergy };
 }

--- a/packages/universum-simulationen/NullfeldVisualization.test.ts
+++ b/packages/universum-simulationen/NullfeldVisualization.test.ts
@@ -1,13 +1,16 @@
-import { generateCurvatureMap, generateGalaxyMap, simulateDarkMatterDistribution } from './NullfeldVisualization';
+import { visualizeNullfeld } from './NullfeldVisualization';
 
-test('inverts curvature values', () => {
-  expect(generateCurvatureMap([1, -2])).toEqual([-1, 2]);
-});
-
-test('creates galaxy map identifiers', () => {
-  expect(generateGalaxyMap(2)).toEqual(['Galaxy-0', 'Galaxy-1']);
-});
-
-test('estimates dark matter distribution', () => {
-  expect(simulateDarkMatterDistribution(100)).toBeCloseTo(27);
+test('renders curvature, galaxies and dark matter', () => {
+  const viz = visualizeNullfeld({
+    curvature: [
+      [0.6, 0.1],
+      [0.2, 0.7],
+    ],
+    galaxies: [[1, 0]],
+    darkMatter: [
+      [0.1, 0.1],
+      [0.6, 0.2],
+    ],
+  });
+  expect(viz).toEqual(['^G', 'D^']);
 });

--- a/packages/universum-simulationen/NullfeldVisualization.ts
+++ b/packages/universum-simulationen/NullfeldVisualization.ts
@@ -1,12 +1,36 @@
-export function generateCurvatureMap(curvatures: number[]): number[] {
-  return curvatures.map(c => c * -1);
+export interface VisualizationInput {
+  curvature: number[][];
+  galaxies: Array<[number, number]>;
+  darkMatter: number[][];
 }
 
-export function generateGalaxyMap(count: number): string[] {
-  return Array.from({ length: count }, (_, i) => `Galaxy-${i}`);
-}
+/**
+ * Visualize curvature, galaxies and dark matter density on a simple grid.
+ * Galaxies override dark matter and curvature markers.
+ */
+export function visualizeNullfeld({
+  curvature,
+  galaxies,
+  darkMatter,
+}: VisualizationInput): string[] {
+  const height = curvature.length;
+  const width = curvature[0].length;
+  const galaxySet = new Set(galaxies.map(([x, y]) => `${x},${y}`));
 
-export function simulateDarkMatterDistribution(mass: number): number {
-  const darkMatterFraction = 0.27;
-  return mass * darkMatterFraction;
+  const rows: string[] = [];
+  for (let y = 0; y < height; y++) {
+    let row = '';
+    for (let x = 0; x < width; x++) {
+      const key = `${x},${y}`;
+      if (galaxySet.has(key)) {
+        row += 'G';
+      } else if (darkMatter[y][x] > 0.5) {
+        row += 'D';
+      } else {
+        row += curvature[y][x] > 0.5 ? '^' : '.';
+      }
+    }
+    rows.push(row);
+  }
+  return rows;
 }


### PR DESCRIPTION
## Summary
- simulate null field interactions with gravity, curvature, and energy conversion
- visualize curvature, galaxies, and dark matter on a simple grid
- mark Nullfeld simulation tasks as done in advanced ToDo lists

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json --diagnostics`
- `pnpm test packages/universum-simulationen/NullfeldSimulation.test.ts packages/universum-simulationen/NullfeldVisualization.test.ts`
- `node scripts/parse-newadvanced-conversations.js TODO`


------
https://chatgpt.com/codex/tasks/task_e_689fabd7e60083228b57fbe02a3d85a8