### PR TITLE
feat: add repository map graph exporter

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -4830,6 +4830,10 @@
     {
       "commit": "Add advancedToDo watcher script",
       "status": "done"
+    },
+    {
+      "commit": "Add repository map graph exporter",
+      "status": "done"
     }
   ],
   "fractalTodos": [

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -86,3 +86,5 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Registered digital twin, gamification, generative art, and catalyst agents in plugin manifest and repository map.
 - Implemented adaptive CREPThresholdOptimizer for dynamic threshold learning.
 - Added watcher script to monitor advancedToDo.json changes and log updates.
+
+- Added repository map graph exporter for visualizing repository relationships.

--- a/scripts/__tests__/repository-map-graph.test.ts
+++ b/scripts/__tests__/repository-map-graph.test.ts
@@ -1,0 +1,8 @@
+import { repositoryMapToDot } from '../repository-map-graph';
+
+test('generates graphviz dot from repository map', () => {
+  const dot = repositoryMapToDot();
+  expect(dot).toContain('digraph RepositoryMap');
+  expect(dot).toContain('"aeon"');
+  expect(dot).toContain('"codex-sync.sh"');
+});

--- a/scripts/repository-map-graph.ts
+++ b/scripts/repository-map-graph.ts
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+interface RepositoryEntry {
+  name: string;
+  modules?: string[];
+}
+
+export function repositoryMapToDot(mapPath = path.join(__dirname, '../repositorypflege/repository_map.yaml')): string {
+  const file = fs.readFileSync(mapPath, 'utf8');
+  const data = yaml.load(file) as { repository_map: RepositoryEntry[] };
+  const repos = data.repository_map || [];
+  const lines: string[] = ['digraph RepositoryMap {'];
+  for (const repo of repos) {
+    const modules = repo.modules || [];
+    for (const mod of modules) {
+      lines.push(`  "${repo.name}" -> "${mod}";`);
+    }
+  }
+  lines.push('}');
+  return lines.join('\n');
+}
+
+if (require.main === module) {
+  console.log(repositoryMapToDot());
+}


### PR DESCRIPTION
## Summary
- add script to convert repository_map.yaml into Graphviz DOT
- cover repository map exporter with unit test
- log new tool in advanced progress and feedback codex

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json --listFiles`
- `npx jest scripts/__tests__/repository-map-graph.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689fbc17e8a083229d6140d3367425df