### PR TITLE
feat: add energy-to-mass cooling to nullfield wave

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -10966,9 +10966,10 @@
   },
   {
     "commit": "den Mechanismus zur **Energieumwandlung und Abkühlung zu Masse** in der Simulation explizit umsetzen",
-    "path": "",
+    "path": "simulations/nullfield_wave.py",
     "task": "den Mechanismus zur **Energieumwandlung und Abkühlung zu Masse** in der Simulation explizit umsetzen",
-    "test": ""
+    "test": "tests/nullfield_wave_test.py",
+    "status": "done"
   },
   {
     "commit": "sie als eine **fundamentale Urkraft** betrachten",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -11070,10 +11070,11 @@
   test: ""
 - commit: den Mechanismus zur **Energieumwandlung und Abkühlung zu Masse** in der
     Simulation explizit umsetzen
-  path: ""
+  path: simulations/nullfield_wave.py
   task: den Mechanismus zur **Energieumwandlung und Abkühlung zu Masse** in der
     Simulation explizit umsetzen
-  test: ""
+  test: tests/nullfield_wave_test.py
+  status: done
 - commit: sie als eine **fundamentale Urkraft** betrachten
   path: ""
   task: sie als eine **fundamentale Urkraft** betrachten

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: implement CREPThresholdOptimizer",
+  "lastCommit": "feat: add energy-to-mass conversion in nullfield simulation",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4832,6 +4832,10 @@
     },
     {
       "commit": "Add repository map graph exporter",
+      "status": "done"
+    },
+    {
+      "commit": "Implement energy-to-mass cooling in nullfield simulation",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -88,3 +88,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added watcher script to monitor advancedToDo.json changes and log updates.
 
 - Added repository map graph exporter for visualizing repository relationships.
+- Implemented energy-to-mass conversion and cooling mechanics in null field wave simulation and updated progress trackers.

--- a/simulations/nullfield_wave.py
+++ b/simulations/nullfield_wave.py
@@ -11,6 +11,9 @@ def simulate_nullfield_wave(
     track_progress: bool = False,
     debug: bool = False,
     amplitude_limit: float = 10.0,
+    energy_to_mass: bool = False,
+    energy_to_mass_ratio: float = 0.1,
+    cooling_rate: float = 0.01,
 ):
     """Simulate a 1D wave equation on a 'null field'.
 
@@ -38,6 +41,7 @@ def simulate_nullfield_wave(
     u = np.zeros((nt, nx))
 
     metrics = {"max_amplitude": [], "energy": []} if track_progress else None
+    mass = 0.0
 
     # initial condition: localized pulse in center
     mid = nx // 2
@@ -54,11 +58,20 @@ def simulate_nullfield_wave(
                 u[n, i + 1] - 2 * u[n, i] + u[n, i - 1]
             )
 
+        if energy_to_mass:
+            energy = float(np.sum(u[n] ** 2))
+            converted = energy * energy_to_mass_ratio * cooling_rate
+            mass += converted
+            u[n] *= 1 - cooling_rate
+
         if track_progress and metrics is not None:
             max_amp = float(np.max(np.abs(u[n])))
             energy = float(np.sum(u[n] ** 2))
             metrics["max_amplitude"].append(max_amp)
             metrics["energy"].append(energy)
+            if energy_to_mass:
+                mass_metric = metrics.setdefault("mass", [])
+                mass_metric.append(mass)
 
         if debug:
             if np.isnan(u[n]).any() or np.isinf(u[n]).any() or (

--- a/tests/nullfield_wave_test.py
+++ b/tests/nullfield_wave_test.py
@@ -39,3 +39,18 @@ def test_debug_detection():
             amplitude_limit=0.1,
             track_progress=True,
         )
+
+
+def test_energy_to_mass_conversion():
+    field, metrics = simulate_nullfield_wave(
+        length=1.0,
+        duration=0.2,
+        dx=0.1,
+        dt=0.05,
+        track_progress=True,
+        energy_to_mass=True,
+        cooling_rate=0.2,
+    )
+    assert "mass" in metrics
+    assert metrics["mass"][-1] > 0
+    assert metrics["max_amplitude"][0] > metrics["max_amplitude"][-1]


### PR DESCRIPTION
## Summary
- simulate energy-to-mass conversion with cooling in null field wave
- verify mass accumulation and damping in simulation tests
- update todo and progress trackers

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pytest tests/nullfield_wave_test.py`


------
https://chatgpt.com/codex/tasks/task_e_689fca34ffac8322bb6cca5dff3ba0ed