### PR TITLE
feat: enhance CREP insight dashboard

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1526,7 +1526,8 @@
     "commit": "Introduce CREPInsightDashboard",
     "path": "packages/analytics/CREPInsightDashboard.tsx",
     "task": "Provide interactive CREP analytics",
-    "test": "packages/analytics/CREPInsightDashboard.test.tsx"
+    "test": "packages/analytics/CREPInsightDashboard.test.tsx",
+    "status": "done"
   },
   {
     "commit": "Add PredictiveAnalyticsAgent",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1120,6 +1120,7 @@
   path: packages/analytics/CREPInsightDashboard.tsx
   task: Provide interactive CREP analytics
   test: packages/analytics/CREPInsightDashboard.test.tsx
+  status: done
 - commit: Add PredictiveAnalyticsAgent
   path: packages/analytics/PredictiveAnalyticsAgent.ts
   task: Predict user interactions and events

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -4125,6 +4125,10 @@
     {
       "commit": "Add RealTimeCREPSonification",
       "status": "done"
+    },
+    {
+      "commit": "Introduce CREPInsightDashboard",
+      "status": "done"
     }
   ],
   "featureLog": [

--- a/packages/analytics/CREPInsightDashboard.test.tsx
+++ b/packages/analytics/CREPInsightDashboard.test.tsx
@@ -1,7 +1,10 @@
 import { render } from '@testing-library/react';
 import { CREPInsightDashboard } from './CREPInsightDashboard';
 
-test('shows score', () => {
+test('renders score, level, and bar width', () => {
   const { getByTestId } = render(<CREPInsightDashboard score={5} />);
   expect(getByTestId('score').textContent).toBe('5');
+  expect(getByTestId('level').textContent).toBe('medium');
+  expect((getByTestId('bar') as HTMLDivElement).style.width).toBe('50%');
 });
+

--- a/packages/analytics/CREPInsightDashboard.tsx
+++ b/packages/analytics/CREPInsightDashboard.tsx
@@ -1,5 +1,21 @@
 import React from 'react';
 
-export function CREPInsightDashboard({ score }: { score: number }) {
-  return <div data-testid="score">{score}</div>;
+export interface CREPInsightDashboardProps {
+  score: number;
 }
+
+export function CREPInsightDashboard({ score }: CREPInsightDashboardProps) {
+  const level = score >= 7 ? 'high' : score >= 4 ? 'medium' : 'low';
+  const percentage = Math.max(0, Math.min(10, score)) * 10;
+
+  return (
+    <div>
+      <div data-testid="score">{score}</div>
+      <div data-testid="level">{level}</div>
+      <div data-testid="bar-container" style={{ background: '#eee', width: '100%', height: '8px' }}>
+        <div data-testid="bar" style={{ background: '#3b82f6', width: `${percentage}%`, height: '100%' }} />
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- expand CREPInsightDashboard with visual score bar and qualitative level indicator
- track completion in advancedToDo and progress logs

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json --noEmit`
- `npx jest packages/analytics/CREPInsightDashboard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689fca34ffac8322bb6cca5dff3ba0ed