### PR TITLE
feat: sync implicit todos with progress

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7,6 +7,13 @@
     "status": "done"
   },
   {
+    "commit": "Include implicit TODOs in sync progress",
+    "path": "scripts/sync-todo-progress.js",
+    "task": "Sync implicit-todos.yaml with progress tracking",
+    "test": "scripts/__tests__/sync-todo-progress.test.ts",
+    "status": "done"
+  },
+  {
     "commit": "Integrate CREP SelfReflection filter into training data extractor",
     "path": "scripts/extract-training-data.ts",
     "task": "Filter extracted data through SelfReflectionAgent based on CREP scores",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3,6 +3,11 @@
   task: Replace placeholder with generated conversation summaries
   test: scripts/__tests__/extract-training-data.test.ts
   status: done
+- commit: Include implicit TODOs in sync progress
+  path: scripts/sync-todo-progress.js
+  task: Sync implicit-todos.yaml with progress tracking
+  test: scripts/__tests__/sync-todo-progress.test.ts
+  status: done
 - commit: Integrate CREP SelfReflection filter into training data extractor
   path: scripts/extract-training-data.ts
   task: Filter extracted data through SelfReflectionAgent based on CREP scores

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: implement CREPThresholdOptimizer",
+  "lastCommit": "Include implicit TODOs in sync progress",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.",
+  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.; Included implicit-todos.yaml in progress syncing.",
   "pendingTasks": [],
   "progress": [
     {
@@ -4832,6 +4832,10 @@
     },
     {
       "commit": "Add repository map graph exporter",
+      "status": "done"
+    },
+    {
+      "commit": "Include implicit TODOs in sync progress",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -88,3 +88,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added watcher script to monitor advancedToDo.json changes and log updates.
 
 - Added repository map graph exporter for visualizing repository relationships.
+- Improved sync-todo-progress to incorporate implicit TODOs from conversations for better progress tracking.

--- a/scripts/__tests__/sync-todo-progress.test.ts
+++ b/scripts/__tests__/sync-todo-progress.test.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import yaml from 'js-yaml';
+import { expect, test } from 'vitest';
 import { syncTodoProgress } from '../sync-todo-progress';
 
 test('syncTodoProgress reports counts and supports dry run', () => {
@@ -17,17 +19,25 @@ test('syncTodoProgress reports counts and supports dry run', () => {
   );
   const progressFile = path.join(tmp, 'progress.json');
   fs.writeFileSync(progressFile, JSON.stringify({ progress: [], pendingTasks: [] }, null, 2));
+  const extraFile = path.join(tmp, 'extra.yaml');
+  fs.writeFileSync(
+    extraFile,
+    yaml.dump([
+      { commit: 'extra done', status: 'done' },
+      { commit: 'extra pending' }
+    ]),
+  );
 
-  const dry = syncTodoProgress(partsDir, progressFile, [], { dryRun: true });
-  expect(dry.addedDone).toBe(1);
-  expect(dry.addedPending).toBe(1);
+  const dry = syncTodoProgress(partsDir, progressFile, [extraFile], { dryRun: true });
+  expect(dry.addedDone).toBe(2);
+  expect(dry.addedPending).toBe(2);
   const afterDry = JSON.parse(fs.readFileSync(progressFile, 'utf8'));
   expect(afterDry.progress).toHaveLength(0);
 
-  const run = syncTodoProgress(partsDir, progressFile);
-  expect(run.addedDone).toBe(1);
-  expect(run.addedPending).toBe(1);
+  const run = syncTodoProgress(partsDir, progressFile, [extraFile]);
+  expect(run.addedDone).toBe(2);
+  expect(run.addedPending).toBe(2);
   const final = JSON.parse(fs.readFileSync(progressFile, 'utf8'));
-  expect(final.progress).toHaveLength(1);
-  expect(final.pendingTasks).toHaveLength(1);
+  expect(final.progress).toHaveLength(2);
+  expect(final.pendingTasks).toHaveLength(2);
 });

--- a/scripts/sync-todo-progress.js
+++ b/scripts/sync-todo-progress.js
@@ -61,6 +61,7 @@ if (require.main === module) {
   const extra = [
     path.join(__dirname, '../advancedToDo.json'),
     path.join(__dirname, '../advancedToDo.yaml'),
+    path.join(__dirname, '../docs/sigils/implicit-todos.yaml'),
   ];
   const dryRun = process.argv.includes('--dry-run');
   const { addedDone, addedPending } = syncTodoProgress(partsDir, progressFile, extra, { dryRun });


### PR DESCRIPTION
## Summary
- include `docs/sigils/implicit-todos.yaml` in `sync-todo-progress` default sources
- test syncing with extra YAML tasks and vitest support
- track new feature in advanced ToDo lists and progress log

## Testing
- `node scripts/sync-todo-progress.js --dry-run`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx vitest run scripts/__tests__/sync-todo-progress.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689fca34ffac8322bb6cca5dff3ba0ed