### PR TITLE
feat: enhance predictive analytics agent

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,7 +1,7 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-15, in der Zeit des Morgen.
+Am 2025-08-16, in der Zeit des Morgen.
 
 Symbolphase: Initiation (Fokus: C)
 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1533,7 +1533,8 @@
     "commit": "Add PredictiveAnalyticsAgent",
     "path": "packages/analytics/PredictiveAnalyticsAgent.ts",
     "task": "Predict user interactions and events",
-    "test": "packages/analytics/PredictiveAnalyticsAgent.test.ts"
+    "test": "packages/analytics/PredictiveAnalyticsAgent.test.ts",
+    "status": "done"
   },
   {
     "commit": "Create PrivacyComplianceAgent",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1125,6 +1125,7 @@
   path: packages/analytics/PredictiveAnalyticsAgent.ts
   task: Predict user interactions and events
   test: packages/analytics/PredictiveAnalyticsAgent.test.ts
+  status: done
 - commit: Create PrivacyComplianceAgent
   path: packages/security/PrivacyComplianceAgent.ts
   task: Check data operations for privacy compliance

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add energy-to-mass conversion in nullfield simulation",
+  "lastCommit": "Merge pull request #1246 from GenesisAeon/codex/implement-features-from-advancedtodo.yaml-t69kje",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4086,6 +4086,38 @@
     },
     {
       "commit": "Implement CREPThresholdOptimizer",
+      "status": "done"
+    },
+    {
+      "commit": "Enhance PredictiveAnalyticsAgent with average delta prediction",
+      "status": "done"
+    },
+    {
+      "commit": "Introduce CREPInsightDashboard",
+      "status": "done"
+    },
+    {
+      "commit": "Add PredictiveAnalyticsAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Monitor tasks via polling on advancedToDo.json",
+      "status": "done"
+    },
+    {
+      "commit": "Add NullfeldSimulation module",
+      "status": "done"
+    },
+    {
+      "commit": "Add Nullfeld visualization components",
+      "status": "done"
+    },
+    {
+      "commit": "den Mechanismus zur **Energieumwandlung und Abkühlung zu Masse** in der Simulation explizit umsetzen",
+      "status": "done"
+    },
+    {
+      "commit": "Monitor advancedToDo tasks via polling",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -89,3 +89,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 
 - Added repository map graph exporter for visualizing repository relationships.
 - Implemented energy-to-mass conversion and cooling mechanics in null field wave simulation and updated progress trackers.
+- Enhanced PredictiveAnalyticsAgent with average delta prediction and synced progress files.

--- a/packages/analytics/PredictiveAnalyticsAgent.test.ts
+++ b/packages/analytics/PredictiveAnalyticsAgent.test.ts
@@ -1,6 +1,6 @@
 import { PredictiveAnalyticsAgent } from './PredictiveAnalyticsAgent';
 
-test('predicts last value', () => {
+test('predicts next value using average delta', () => {
   const agent = new PredictiveAnalyticsAgent();
-  expect(agent.predict([1,2,3])).toBe(3);
+  expect(agent.predict([1, 2, 3])).toBe(4);
 });

--- a/packages/analytics/PredictiveAnalyticsAgent.ts
+++ b/packages/analytics/PredictiveAnalyticsAgent.ts
@@ -1,5 +1,10 @@
 export class PredictiveAnalyticsAgent {
   predict(data: number[]): number {
-    return data.length ? data[data.length - 1] : 0;
+    if (data.length === 0) return 0;
+    if (data.length === 1) return data[0];
+
+    const deltas = data.slice(1).map((v, i) => v - data[i]);
+    const avgDelta = deltas.reduce((a, b) => a + b, 0) / deltas.length;
+    return data[data.length - 1] + avgDelta;
   }
 }


### PR DESCRIPTION
## Summary
- improve `PredictiveAnalyticsAgent` with average delta forecast
- mark predictive analytics task complete and sync progress trackers
- note analytics enhancement in feedback codex

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: venvPath ... is not a valid directory)*
- `npx tsc -p tsconfig.json`
- `npx jest packages/analytics/PredictiveAnalyticsAgent.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_689fd0e169188322b8cd0e1162f4b691