### PR TITLE
feat: add MasterGPTBridge orchestrator

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2721,7 +2721,8 @@
     "commit": "feat: add MasterGPTBridge orchestrator",
     "path": "packages/agents/MasterGPTBridge.ts",
     "task": "Orchestrate systems autonomously when captain absent",
-    "test": "packages/agents/__tests__/MasterGPTBridge.test.ts"
+    "test": "packages/agents/__tests__/MasterGPTBridge.test.ts",
+    "status": "done"
   },
   {
     "commit": "feat: integrate FutureTechFramework",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4437,6 +4437,7 @@
   path: packages/agents/MasterGPTBridge.ts
   task: Orchestrate systems autonomously when captain absent
   test: packages/agents/__tests__/MasterGPTBridge.test.ts
+  status: done
 - commit: "feat: integrate FutureTechFramework"
   path: packages/agents/FutureTechFramework.ts
   task: Launch Genesis FutureTech systems with orchestration

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add energy-to-mass conversion in nullfield simulation",
+  "lastCommit": "feat: add MasterGPTBridge orchestrator",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4086,6 +4086,10 @@
     },
     {
       "commit": "Implement CREPThresholdOptimizer",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add MasterGPTBridge orchestrator",
       "status": "done"
     }
   ],

--- a/packages/agents/MasterGPTBridge.ts
+++ b/packages/agents/MasterGPTBridge.ts
@@ -1,0 +1,17 @@
+export type OrchestrationTask = () => void;
+
+export class MasterGPTBridge {
+  private captainPresent = true;
+
+  setCaptainPresent(present: boolean) {
+    this.captainPresent = present;
+  }
+
+  orchestrate(task: OrchestrationTask): boolean {
+    if (!this.captainPresent) {
+      task();
+      return true;
+    }
+    return false;
+  }
+}

--- a/packages/agents/__tests__/MasterGPTBridge.test.ts
+++ b/packages/agents/__tests__/MasterGPTBridge.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { MasterGPTBridge } from '../MasterGPTBridge';
+
+describe('MasterGPTBridge', () => {
+  it('runs task when captain absent', () => {
+    const bridge = new MasterGPTBridge();
+    bridge.setCaptainPresent(false);
+    let executed = false;
+    bridge.orchestrate(() => { executed = true; });
+    expect(executed).toBe(true);
+  });
+
+  it('skips task when captain present', () => {
+    const bridge = new MasterGPTBridge();
+    bridge.setCaptainPresent(true);
+    let executed = false;
+    bridge.orchestrate(() => { executed = true; });
+    expect(executed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add MasterGPTBridge orchestrator agent with absence-aware task execution
- document completion in advancedToDo and progress trackers

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: workspace enumeration took too long)*
- `npx tsc -p tsconfig.json` *(no output before termination)*
- `npx vitest run packages/agents/__tests__/MasterGPTBridge.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689fd0e169188322b8cd0e1162f4b691