### PR TITLE
feat: add plugin rating

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1568,7 +1568,8 @@
     "commit": "Add CommunityPluginMarketplace",
     "path": "packages/community/CommunityPluginMarketplace.ts",
     "task": "Host and rate community plugins",
-    "test": "packages/community/CommunityPluginMarketplace.test.ts"
+    "test": "packages/community/CommunityPluginMarketplace.test.ts",
+    "status": "done"
   },
   {
     "commit": "Introduce PluginSecurityAuditor",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1150,6 +1150,7 @@
   path: packages/community/CommunityPluginMarketplace.ts
   task: Host and rate community plugins
   test: packages/community/CommunityPluginMarketplace.test.ts
+  status: done
 - commit: Introduce PluginSecurityAuditor
   path: packages/community/PluginSecurityAuditor.ts
   task: Audit community plugins before integration

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: enhance privacy compliance agent",
+  "lastCommit": "feat: add plugin rating",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4123,6 +4123,10 @@
     {
       "commit": "Create PrivacyComplianceAgent",
       "status": "done"
+    },
+    {
+      "commit": "Add CommunityPluginMarketplace",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4876,6 +4880,10 @@
     },
     {
       "commit": "Implement energy-to-mass cooling in nullfield simulation",
+      "status": "done"
+    },
+    {
+      "commit": "Add CommunityPluginMarketplace",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -91,3 +91,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented energy-to-mass conversion and cooling mechanics in null field wave simulation and updated progress trackers.
 - Enhanced PredictiveAnalyticsAgent with average delta prediction and synced progress files.
 - Improved PrivacyComplianceAgent with detailed violation reporting.
+- Enhanced CommunityPluginMarketplace with plugin rating support.

--- a/packages/community/CommunityPluginMarketplace.test.ts
+++ b/packages/community/CommunityPluginMarketplace.test.ts
@@ -1,7 +1,8 @@
 import { CommunityPluginMarketplace } from './CommunityPluginMarketplace';
 
-test('stores plugins', () => {
+test('rates plugins', () => {
   const m = new CommunityPluginMarketplace();
-  m.add('p');
-  expect(m.list()).toEqual(['p']);
+  m.add('p', 3);
+  m.rate('p', 5);
+  expect(m.list()).toEqual([{ name: 'p', rating: 5 }]);
 });

--- a/packages/community/CommunityPluginMarketplace.ts
+++ b/packages/community/CommunityPluginMarketplace.ts
@@ -1,5 +1,24 @@
+export interface PluginEntry {
+  name: string;
+  rating: number;
+}
+
 export class CommunityPluginMarketplace {
-  private plugins: string[] = [];
-  add(name: string) { this.plugins.push(name); }
-  list() { return [...this.plugins]; }
+  private plugins: PluginEntry[] = [];
+
+  add(name: string, rating = 0) {
+    this.plugins.push({ name, rating });
+  }
+
+  rate(name: string, rating: number) {
+    const plugin = this.plugins.find((p) => p.name === name);
+    if (!plugin) {
+      throw new Error(`Plugin ${name} not found`);
+    }
+    plugin.rating = rating;
+  }
+
+  list() {
+    return this.plugins.map((p) => ({ ...p }));
+  }
 }


### PR DESCRIPTION
## Summary
- add rating support to CommunityPluginMarketplace
- mark CommunityPluginMarketplace todo as done and sync progress
- note plugin rating in feedbackcodex

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/community/CommunityPluginMarketplace.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689fe5a5a9148322acb38bfca91e4d46