### PR TITLE
feat: add repository map export script

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -1,5 +1,12 @@
 [
   {
+    "commit": "Add repository map export script",
+    "path": "scripts/repository-map-export.ts",
+    "task": "Export repository_map.yaml to JSON",
+    "test": "scripts/repository-map-export.test.ts",
+    "status": "done"
+  },
+  {
     "commit": "Add summary generator to training data extraction",
     "path": "scripts/extract-training-data.ts",
     "task": "Replace placeholder with generated conversation summaries",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -1,3 +1,8 @@
+- commit: Add repository map export script
+  path: scripts/repository-map-export.ts
+  task: Export repository_map.yaml to JSON
+  test: scripts/repository-map-export.test.ts
+  status: done
 - commit: Add summary generator to training data extraction
   path: scripts/extract-training-data.ts
   task: Replace placeholder with generated conversation summaries

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: enhance privacy compliance agent",
+  "lastCommit": "feat: add repository map export script",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.",
+  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.; Added repository map export script.",
   "pendingTasks": [],
   "progress": [
     {
@@ -4123,6 +4123,10 @@
     {
       "commit": "Create PrivacyComplianceAgent",
       "status": "done"
+    },
+    {
+      "commit": "Add repository map export script",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4876,6 +4880,10 @@
     },
     {
       "commit": "Implement energy-to-mass cooling in nullfield simulation",
+      "status": "done"
+    },
+    {
+      "commit": "Add repository map export script",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -91,3 +91,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented energy-to-mass conversion and cooling mechanics in null field wave simulation and updated progress trackers.
 - Enhanced PredictiveAnalyticsAgent with average delta prediction and synced progress files.
 - Improved PrivacyComplianceAgent with detailed violation reporting.
+- Implemented repository map export script for YAML to JSON conversion.

--- a/repositorypflege/repository_map.yaml
+++ b/repositorypflege/repository_map.yaml
@@ -42,6 +42,7 @@ repository_map:
       - self-analyze.js
       - sync-todo-progress.js
       - repository-map-find.ts
+      - scripts/repository-map-export.ts
       - packages/unifiedmandala-ui/components/ResonanceHistoryPanel.tsx
       - packages/unifiedmandala-ui/components/TwinMonitor.tsx
       - packages/unifiedmandala-ui/components/EmergencePanel.tsx

--- a/scripts/repository-map-export.test.ts
+++ b/scripts/repository-map-export.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { exportRepositoryMap } from './repository-map-export';
+
+describe('exportRepositoryMap', () => {
+  it('returns repository map object', () => {
+    const data = exportRepositoryMap();
+    expect(data).toHaveProperty('repository_map');
+  });
+
+  it('writes JSON to file when outFile is provided', () => {
+    const tmp = path.join(os.tmpdir(), 'repo_map_export.json');
+    exportRepositoryMap(undefined, tmp);
+    const written = JSON.parse(fs.readFileSync(tmp, 'utf8'));
+    expect(written).toHaveProperty('repository_map');
+    fs.unlinkSync(tmp);
+  });
+});

--- a/scripts/repository-map-export.ts
+++ b/scripts/repository-map-export.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env ts-node
+/**
+ * scripts/repository-map-export.ts
+ *
+ * Utility to export `repositorypflege/repository_map.yaml` as JSON.
+ * When run directly, it prints the JSON or writes it to a file provided via `--out`.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+const defaultFile = path.join(__dirname, '../repositorypflege/repository_map.yaml');
+
+export function exportRepositoryMap(file: string = defaultFile, outFile?: string) {
+  const raw = fs.readFileSync(file, 'utf8');
+  const data = yaml.load(raw);
+  if (outFile) {
+    fs.writeFileSync(outFile, JSON.stringify(data, null, 2));
+  }
+  return data;
+}
+
+if (require.main === module) {
+  const fileArg = process.argv.find((arg) => arg.endsWith('.yaml'));
+  const outIndex = process.argv.indexOf('--out');
+  const outPath = outIndex !== -1 ? process.argv[outIndex + 1] : undefined;
+  const data = exportRepositoryMap(fileArg || defaultFile, outPath);
+  if (!outPath) {
+    console.log(JSON.stringify(data, null, 2));
+  }
+}


### PR DESCRIPTION
## Summary
- add script to export repository_map.yaml as JSON and support writing to file
- track repository map export task in advancedToDo and progress
- document repository map export in feedback codex and repository map modules

## Testing
- `npx pyright` *(fails: venvPath invalid)*
- `npx tsc -p tsconfig.json` *(no output, assumed pass)*
- `pnpm install`
- `poetry install --with test` *(interrupted after dependency install)*
- `npx vitest run scripts/repository-map-export.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689fe5a5a9148322acb38bfca91e4d46