### PR TITLE
feat: add repository map HTML exporter

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12348,5 +12348,12 @@
     "task": "Log counts of tasks synced into advancedprogress.json",
     "test": "scripts/__tests__/sync-todo-progress.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add repository map HTML exporter",
+    "path": "scripts/repository-map-html.ts",
+    "task": "Render repository_map.yaml as HTML table",
+    "test": "scripts/repository-map-html.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12096,3 +12096,8 @@
   task: Log counts of tasks synced into advancedprogress.json
   test: scripts/__tests__/sync-todo-progress.test.ts
   status: done
+- commit: Add repository map HTML exporter
+  path: scripts/repository-map-html.ts
+  task: Render repository_map.yaml as HTML table
+  test: scripts/repository-map-html.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -4885,6 +4885,10 @@
     {
       "commit": "Add CommunityPluginMarketplace",
       "status": "done"
+    },
+    {
+      "commit": "Add repository map HTML exporter",
+      "status": "done"
     }
   ],
   "fractalTodos": [

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -92,3 +92,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Enhanced PredictiveAnalyticsAgent with average delta prediction and synced progress files.
 - Improved PrivacyComplianceAgent with detailed violation reporting.
 - Enhanced CommunityPluginMarketplace with plugin rating support.
+- Added repository map HTML exporter for quick visual overview.

--- a/scripts/repository-map-html.test.ts
+++ b/scripts/repository-map-html.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { repositoryMapToHtml } from './repository-map-html';
+
+describe('repositoryMapToHtml', () => {
+  it('renders aeon repository and its modules', () => {
+    const html = repositoryMapToHtml();
+    expect(html).toContain('<td>aeon</td>');
+    expect(html).toContain('sigillin-validator.ts');
+    expect(html.trim().startsWith('<table>')).toBe(true);
+    expect(html.trim().endsWith('</table>')).toBe(true);
+  });
+});

--- a/scripts/repository-map-html.ts
+++ b/scripts/repository-map-html.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env ts-node
+/**
+ * scripts/repository-map-html.ts
+ *
+ * Render repositorypflege/repository_map.yaml as an HTML table.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+interface RepositoryEntry {
+  name: string;
+  modules?: string[];
+}
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function repositoryMapToHtml(mapPath = path.join(__dirname, '../repositorypflege/repository_map.yaml')): string {
+  const raw = fs.readFileSync(mapPath, 'utf8');
+  const data = yaml.load(raw) as { repository_map?: RepositoryEntry[] };
+  const repos = data.repository_map || [];
+
+  const rows = repos.map((repo) => {
+    const modules = (repo.modules || []).map((m) => escapeHtml(String(m))).join('<br>');
+    return `<tr><td>${escapeHtml(repo.name)}</td><td>${modules}</td></tr>`;
+  });
+
+  return [
+    '<table>',
+    '<thead><tr><th>Repository</th><th>Modules</th></tr></thead>',
+    '<tbody>',
+    ...rows,
+    '</tbody>',
+    '</table>',
+  ].join('\n');
+}
+
+if (require.main === module) {
+  console.log(repositoryMapToHtml());
+}


### PR DESCRIPTION
## Summary
- render repository_map.yaml as HTML table for quick visual reference
- document progress and feedback for repository map HTML exporter

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/repository-map-html.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689ff0652310832285f91ad1c5ea51fc