### PR TITLE
feat: list open advanced todos

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,12 +1,18 @@
 {
-  "lastCommit": "feat: add plugin rating",
+  "lastCommit": "feat: list open advanced todos",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
   "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.",
-  "pendingTasks": [],
+  "pendingTasks": [
+    "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part1.json - 4df8c73d-6df3-443c-a695-31458a2e1cf7",
+    "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129",
+    "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e",
+    "- und Progress-Dateien mit diesem Stand.",
+    "- und Progress-Dateien mit diesem Standpunkt, um Gedächtniskohärenz zu wahren."
+  ],
   "progress": [
     {
       "commit": "Add Dockerfile and requirements for digital twin agent",

--- a/repositorypflege/__tests__/list-open-advanced-todos.test.js
+++ b/repositorypflege/__tests__/list-open-advanced-todos.test.js
@@ -1,0 +1,11 @@
+const { listOpenAdvancedTodos } = require('../list-open-advanced-todos');
+
+test('lists open advanced todos', () => {
+  const todos = listOpenAdvancedTodos();
+  expect(Array.isArray(todos)).toBe(true);
+  expect(todos.length).toBeGreaterThan(0);
+  todos.forEach(todo => {
+    expect(todo).toHaveProperty('commit');
+    expect(todo).toHaveProperty('path');
+  });
+});

--- a/repositorypflege/list-open-advanced-todos.js
+++ b/repositorypflege/list-open-advanced-todos.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+
+function listOpenAdvancedTodos() {
+  const todoPath = path.resolve(__dirname, '..', 'advancedToDo.json');
+  const raw = fs.readFileSync(todoPath, 'utf-8');
+  const data = JSON.parse(raw);
+  return data.filter(item => item.status !== 'done')
+    .map(item => ({ commit: item.commit, path: item.path }));
+}
+
+if (require.main === module) {
+  const open = listOpenAdvancedTodos();
+  const display = open.slice(0, 5);
+  display.forEach(t => {
+    const commitText = (typeof t.commit === 'string' && t.commit.length > 120)
+      ? t.commit.slice(0, 117) + '...'
+      : t.commit;
+    console.log(`- ${commitText} (${t.path})`);
+  });
+  if (open.length > 5) {
+    console.log(`...and ${open.length - 5} more`);
+  }
+}
+
+module.exports = { listOpenAdvancedTodos };


### PR DESCRIPTION
## Summary
- add script to surface open tasks from advancedToDo
- track extracted tasks in advancedprogress
- cover listing logic with a minimal test

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false`
- `npx jest repositorypflege/__tests__/list-open-advanced-todos.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a023b9e07c8322bc54bfbc2cd97f11