### PR TITLE
Add repository map CSV exporter

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12348,5 +12348,12 @@
     "task": "Log counts of tasks synced into advancedprogress.json",
     "test": "scripts/__tests__/sync-todo-progress.test.ts",
     "status": "done"
+  },
+  {
+    "commit": "Add repository map CSV exporter",
+    "path": "scripts/repository-map-export-csv.ts",
+    "task": "Export repository_map.yaml entries to CSV listing repository-module pairs",
+    "test": "scripts/repository-map-export-csv.test.ts",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12096,3 +12096,8 @@
   task: Log counts of tasks synced into advancedprogress.json
   test: scripts/__tests__/sync-todo-progress.test.ts
   status: done
+- commit: Add repository map CSV exporter
+  path: scripts/repository-map-export-csv.ts
+  task: Export repository_map.yaml entries to CSV listing repository-module pairs
+  test: scripts/repository-map-export-csv.test.ts
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add plugin rating",
+  "lastCommit": "Merge pull request #1251 from GenesisAeon/codex/implement-features-from-advancedtodo.yaml-ezzbcp",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4127,6 +4127,10 @@
     {
       "commit": "Add CommunityPluginMarketplace",
       "status": "done"
+    },
+    {
+      "commit": "Add repository map CSV exporter",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4884,6 +4888,10 @@
     },
     {
       "commit": "Add CommunityPluginMarketplace",
+      "status": "done"
+    },
+    {
+      "commit": "Add repository map CSV exporter",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -92,3 +92,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Enhanced PredictiveAnalyticsAgent with average delta prediction and synced progress files.
 - Improved PrivacyComplianceAgent with detailed violation reporting.
 - Enhanced CommunityPluginMarketplace with plugin rating support.
+- Implemented repository map CSV exporter script for external analysis.

--- a/scripts/repository-map-export-csv.test.ts
+++ b/scripts/repository-map-export-csv.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { exportRepositoryMapCSV } from './repository-map-export-csv';
+
+describe('exportRepositoryMapCSV', () => {
+  it('generates CSV with header', () => {
+    const csv = exportRepositoryMapCSV();
+    const lines = csv.trim().split('\n');
+    expect(lines[0]).toBe('"repository","module"');
+    expect(lines.length).toBeGreaterThan(1);
+  });
+});

--- a/scripts/repository-map-export-csv.ts
+++ b/scripts/repository-map-export-csv.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env ts-node
+/**
+ * scripts/repository-map-export-csv.ts
+ *
+ * Export repository_map.yaml entries to CSV listing repository-module pairs.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+const file = path.join(__dirname, '../repositorypflege/repository_map.yaml');
+
+export function exportRepositoryMapCSV(): string {
+  const raw = fs.readFileSync(file, 'utf8');
+  const data = yaml.load(raw) as any;
+  const items = Array.isArray(data.repository_map) ? data.repository_map : [];
+  const rows: string[][] = [['repository', 'module']];
+
+  items.forEach((item: any) => {
+    const repo = item.name || '';
+    const modules = Array.isArray(item.modules) ? item.modules : [];
+    if (modules.length === 0) {
+      rows.push([repo, '']);
+    } else {
+      modules.forEach((m: any) => rows.push([repo, String(m)]));
+    }
+  });
+
+  return rows
+    .map((r) => r.map((v) => `"${String(v).replace(/"/g, '""')}"`).join(','))
+    .join('\n');
+}
+
+if (require.main === module) {
+  console.log(exportRepositoryMapCSV());
+}


### PR DESCRIPTION
## Summary
- add script to export repository_map.yaml contents as CSV
- record task completion in advanced ToDo and progress trackers
- document new exporter in feedback codex

## Testing
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx vitest run scripts/repository-map-export-csv.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a023b9e07c8322bc54bfbc2cd97f11