### PR TITLE
feat: sync advanced progress with open todos

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: list open advanced todos",
+  "lastCommit": "feat: sync advanced progress with open todos",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -7,13 +7,17 @@
   "mergeConflicts": [],
   "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.",
   "pendingTasks": [
-    "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part1.json - 4df8c73d-6df3-443c-a695-31458a2e1cf7",
-    "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129",
-    "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e",
-    "- und Progress-Dateien mit diesem Stand.",
-    "- und Progress-Dateien mit diesem Standpunkt, um Gedächtniskohärenz zu wahren."
+    "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part1.json - 4df8c73d-6df3-443c-a695-31458a2e1cf7 (GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part1.json)",
+    "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129 (GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json)",
+    "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e (GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json)",
+    "- und Progress-Dateien mit diesem Stand. ()",
+    "- und Progress-Dateien mit diesem Standpunkt, um Gedächtniskohärenz zu wahren. ()"
   ],
   "progress": [
+    {
+      "commit": "Add advanced progress sync script",
+      "status": "done"
+    },
     {
       "commit": "Add Dockerfile and requirements for digital twin agent",
       "status": "done"

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -92,3 +92,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Enhanced PredictiveAnalyticsAgent with average delta prediction and synced progress files.
 - Improved PrivacyComplianceAgent with detailed violation reporting.
 - Enhanced CommunityPluginMarketplace with plugin rating support.
+- Added script to sync advancedprogress pending tasks with open advanced todos.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "update:newadvanced-todo": "node scripts/update-newadvanced-todo.js",
     "update:fractal-todo": "node scripts/update-fractal-todo.js",
     "update:todo-sigil": "node scripts/update-todo-sigil.js",
+    "update:advanced-progress": "node repositorypflege/update-advanced-progress.js",
     "validate:todos": "node scripts/validate-implicit-todos.js",
     "validate:advancedtodo": "node scripts/validate-advancedtodo.js",
     "export:crep-docs": "node scripts/export-crep-docs.js",

--- a/repositorypflege/__tests__/update-advanced-progress.test.js
+++ b/repositorypflege/__tests__/update-advanced-progress.test.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+jest.mock('../list-open-advanced-todos', () => ({
+  listOpenAdvancedTodos: jest.fn()
+}));
+const { updateAdvancedProgress } = require('../update-advanced-progress');
+const { listOpenAdvancedTodos } = require('../list-open-advanced-todos');
+
+test('updates pendingTasks with limited todos', () => {
+  const tmp = path.join(__dirname, 'tmp-progress.json');
+  fs.writeFileSync(tmp, JSON.stringify({ pendingTasks: [] }, null, 2));
+
+  listOpenAdvancedTodos.mockReturnValue([
+    { commit: 'Task A', path: 'a' },
+    { commit: 'Task B', path: 'b' },
+    { commit: 'Task C', path: 'c' }
+  ]);
+
+  updateAdvancedProgress(2, tmp);
+  const updated = JSON.parse(fs.readFileSync(tmp, 'utf8'));
+  expect(updated.pendingTasks).toEqual([
+    'Task A (a)',
+    'Task B (b)'
+  ]);
+});

--- a/repositorypflege/update-advanced-progress.js
+++ b/repositorypflege/update-advanced-progress.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+const { listOpenAdvancedTodos } = require('./list-open-advanced-todos');
+
+function updateAdvancedProgress(limit = 5, progressFile) {
+  const progressPath = progressFile || path.resolve(__dirname, '..', 'advancedprogress.json');
+  const progress = JSON.parse(fs.readFileSync(progressPath, 'utf8'));
+  const todos = listOpenAdvancedTodos().slice(0, limit);
+  progress.pendingTasks = todos.map(t => `${t.commit} (${t.path})`);
+  fs.writeFileSync(progressPath, JSON.stringify(progress, null, 2));
+  console.log(`Synced ${todos.length} tasks to ${progressPath}`);
+}
+
+if (require.main === module) {
+  const limit = parseInt(process.argv[2], 10) || 5;
+  updateAdvancedProgress(limit);
+}
+
+module.exports = { updateAdvancedProgress };


### PR DESCRIPTION
## Summary
- add utility and package script to sync `advancedprogress.json` with open advanced todos
- record latest commit and tasks in `advancedprogress.json`
- note progress sync in `feedbackcodex`

## Testing
- `npx jest repositorypflege/__tests__/update-advanced-progress.test.js repositorypflege/__tests__/list-open-advanced-todos.test.js`
- `npx tsc -p tsconfig.json`
- `npx pyright`


------
https://chatgpt.com/codex/tasks/task_e_68a0490c880083228a83018db573ac8a