### PR TITLE
feat: add json output for open advanced todos

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: sync advanced progress with open todos",
+  "lastCommit": "feat: add json output to open advanced todos script",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -14,6 +14,10 @@
     "- und Progress-Dateien mit diesem Standpunkt, um Gedächtniskohärenz zu wahren. ()"
   ],
   "progress": [
+    {
+      "commit": "Add JSON output to open advanced todos script",
+      "status": "done"
+    },
     {
       "commit": "Add advanced progress sync script",
       "status": "done"

--- a/repositorypflege/__tests__/list-open-advanced-todos.test.js
+++ b/repositorypflege/__tests__/list-open-advanced-todos.test.js
@@ -1,11 +1,26 @@
+const { execSync } = require('child_process');
+const path = require('path');
 const { listOpenAdvancedTodos } = require('../list-open-advanced-todos');
 
 test('lists open advanced todos', () => {
   const todos = listOpenAdvancedTodos();
   expect(Array.isArray(todos)).toBe(true);
   expect(todos.length).toBeGreaterThan(0);
-  todos.forEach(todo => {
+  todos.forEach((todo) => {
     expect(todo).toHaveProperty('commit');
     expect(todo).toHaveProperty('path');
   });
+});
+
+test('respects limit parameter', () => {
+  const limited = listOpenAdvancedTodos(2);
+  expect(limited.length).toBe(2);
+});
+
+test('cli supports json output', () => {
+  const script = path.resolve(__dirname, '../list-open-advanced-todos.js');
+  const out = execSync(`node ${script} 1 --json`, { encoding: 'utf8' });
+  const parsed = JSON.parse(out);
+  expect(Array.isArray(parsed)).toBe(true);
+  expect(parsed.length).toBe(1);
 });

--- a/repositorypflege/list-open-advanced-todos.js
+++ b/repositorypflege/list-open-advanced-todos.js
@@ -1,25 +1,37 @@
 const fs = require('fs');
 const path = require('path');
 
-function listOpenAdvancedTodos() {
+function listOpenAdvancedTodos(limit = Infinity) {
   const todoPath = path.resolve(__dirname, '..', 'advancedToDo.json');
   const raw = fs.readFileSync(todoPath, 'utf-8');
   const data = JSON.parse(raw);
-  return data.filter(item => item.status !== 'done')
-    .map(item => ({ commit: item.commit, path: item.path }));
+  return data
+    .filter((item) => item.status !== 'done')
+    .slice(0, limit)
+    .map((item) => ({ commit: item.commit, path: item.path }));
 }
 
 if (require.main === module) {
-  const open = listOpenAdvancedTodos();
-  const display = open.slice(0, 5);
-  display.forEach(t => {
-    const commitText = (typeof t.commit === 'string' && t.commit.length > 120)
-      ? t.commit.slice(0, 117) + '...'
-      : t.commit;
-    console.log(`- ${commitText} (${t.path})`);
-  });
-  if (open.length > 5) {
-    console.log(`...and ${open.length - 5} more`);
+  const args = process.argv.slice(2);
+  const jsonFlag = args.includes('--json');
+  const limitArg = args.find((a) => /^\d+$/.test(a));
+  const limit = limitArg ? parseInt(limitArg, 10) : 5;
+  const todos = listOpenAdvancedTodos(limit);
+
+  if (jsonFlag) {
+    console.log(JSON.stringify(todos, null, 2));
+  } else {
+    todos.forEach((t) => {
+      const commitText =
+        typeof t.commit === 'string' && t.commit.length > 120
+          ? t.commit.slice(0, 117) + '...'
+          : t.commit;
+      console.log(`- ${commitText} (${t.path})`);
+    });
+    const remaining = listOpenAdvancedTodos().length - todos.length;
+    if (remaining > 0) {
+      console.log(`...and ${remaining} more`);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- extend list-open-advanced-todos script with limit param and JSON output option
- add tests for limit and JSON flag
- sync advancedprogress log

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright` *(fails: venvPath .venv not found)*
- `npx tsc -p tsconfig.json`
- `npx jest repositorypflege/__tests__/list-open-advanced-todos.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a04e2169b48322b10904752836a709