### PR TITLE
feat: aggregate advanced todos from yaml

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,18 +1,12 @@
 {
-  "lastCommit": "feat: sync advanced progress with open todos",
+  "lastCommit": "Merge pull request #1258 from GenesisAeon/codex/implement-features-from-advancedtodo.yaml-m6w00h",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
   "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.",
-  "pendingTasks": [
-    "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129 (GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json)",
-    "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e (GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json)",
-    "- und Progress-Dateien mit diesem Stand. ()",
-    "- und Progress-Dateien mit diesem Standpunkt, um Gedächtniskohärenz zu wahren. ()",
-    "Parser` – Liest ToDo-Listen aus Markdown-Dateien. ()"
-  ],
+  "pendingTasks": [],
   "progress": [
     {
       "commit": "Add advanced progress sync script",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -93,3 +93,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Improved PrivacyComplianceAgent with detailed violation reporting.
 - Enhanced CommunityPluginMarketplace with plugin rating support.
 - Added script to sync advancedprogress pending tasks with open advanced todos.
+- Extended list-open-advanced-todos to aggregate YAML and JSON tasks with dedicated tests.

--- a/repositorypflege/__tests__/list-open-advanced-todos.test.js
+++ b/repositorypflege/__tests__/list-open-advanced-todos.test.js
@@ -1,11 +1,26 @@
+const fs = require('fs');
+const path = require('path');
 const { listOpenAdvancedTodos } = require('../list-open-advanced-todos');
 
-test('lists open advanced todos', () => {
-  const todos = listOpenAdvancedTodos();
-  expect(Array.isArray(todos)).toBe(true);
-  expect(todos.length).toBeGreaterThan(0);
-  todos.forEach(todo => {
-    expect(todo).toHaveProperty('commit');
-    expect(todo).toHaveProperty('path');
-  });
+test('reads open todos from JSON and YAML', () => {
+  const tmpDir = fs.mkdtempSync(path.join(__dirname, 'tmp-'));
+  const jsonFile = path.join(tmpDir, 'advancedToDo.json');
+  const yamlFile = path.join(tmpDir, 'advancedToDo.yaml');
+
+  const jsonData = [
+    { commit: 'J task', path: 'a', status: 'todo' },
+    { commit: 'done', path: 'b', status: 'done' }
+  ];
+  fs.writeFileSync(jsonFile, JSON.stringify(jsonData, null, 2));
+
+  const yamlData = `- commit: Y task\n  path: c\n  status: todo\n- commit: finished\n  path: d\n  status: done\n`;
+  fs.writeFileSync(yamlFile, yamlData);
+
+  const result = listOpenAdvancedTodos(jsonFile, yamlFile);
+  expect(result).toEqual([
+    { commit: 'J task', path: 'a' },
+    { commit: 'Y task', path: 'c' }
+  ]);
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
 });

--- a/repositorypflege/list-open-advanced-todos.js
+++ b/repositorypflege/list-open-advanced-todos.js
@@ -1,11 +1,35 @@
 const fs = require('fs');
 const path = require('path');
+const yaml = require('js-yaml');
 
-function listOpenAdvancedTodos() {
-  const todoPath = path.resolve(__dirname, '..', 'advancedToDo.json');
-  const raw = fs.readFileSync(todoPath, 'utf-8');
-  const data = JSON.parse(raw);
-  return data.filter(item => item.status !== 'done')
+function listOpenAdvancedTodos(
+  jsonPath = path.resolve(__dirname, '..', 'advancedToDo.json'),
+  yamlPath = path.resolve(__dirname, '..', 'advancedToDo.yaml')
+) {
+  const items = [];
+
+  if (fs.existsSync(jsonPath)) {
+    try {
+      const rawJson = fs.readFileSync(jsonPath, 'utf-8');
+      const jsonData = JSON.parse(rawJson);
+      if (Array.isArray(jsonData)) items.push(...jsonData);
+    } catch {
+      // ignore parse errors
+    }
+  }
+
+  if (fs.existsSync(yamlPath)) {
+    try {
+      const rawYaml = fs.readFileSync(yamlPath, 'utf-8');
+      const yamlData = yaml.load(rawYaml);
+      if (Array.isArray(yamlData)) items.push(...yamlData);
+    } catch {
+      // ignore parse errors
+    }
+  }
+
+  return items
+    .filter(item => item.status !== 'done')
     .map(item => ({ commit: item.commit, path: item.path }));
 }
 


### PR DESCRIPTION
## Summary
- extend list-open-advanced-todos script to combine tasks from advancedToDo.yaml and advancedToDo.json
- add unit test for combined YAML and JSON todo parsing
- document enhancement in feedbackcodex

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json --noEmit`
- `npx jest repositorypflege/__tests__/list-open-advanced-todos.test.js repositorypflege/__tests__/update-advanced-progress.test.js`
- `pnpm install`
- `poetry install --with test`


------
https://chatgpt.com/codex/tasks/task_e_68a0565f179c83229781c9811a713d66