### PR TITLE
Add prod and enterprise pack tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14022,5 +14022,124 @@
     "task": "Configure ES2020 modules and ts-node options",
     "test": "",
     "status": "open"
+  },
+  {
+    "commit": "Add production docker compose file",
+    "path": "compose.prod.yml",
+    "task": "Provide dist-first multi-service builds with ts-node fallback",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Create generic Dockerfile for TypeScript services",
+    "path": "docker/Dockerfile.service",
+    "task": "Add multi-stage build template using SERVICE_ENTRY arg",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Configure NGINX reverse proxy for UM services",
+    "path": "config/nginx/mandala.conf",
+    "task": "Route REST and WebSocket paths for production",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Add Kong gateway configuration",
+    "path": "kong/kong.yml",
+    "task": "Define DB-less routes with CORS and rate limits",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Implement Ed25519 key generation script",
+    "path": "scripts/generate-ed25519.ts",
+    "task": "Write key pair to keys/ directory",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Add manifest signing script",
+    "path": "scripts/sign-manifest.ts",
+    "task": "Sign federation manifest with Ed25519 key",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Add manifest verification script",
+    "path": "scripts/verify-manifest.ts",
+    "task": "Verify signed manifest using public key",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Create verified federation registry service",
+    "path": "scripts/federation-registry-verified.ts",
+    "task": "Validate manifest signatures on register",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Implement SSO broker service",
+    "path": "scripts/sso-broker.ts",
+    "task": "Expose config and token exchange endpoints",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Generate systemd unit files script",
+    "path": "scripts/generate-systemd-units.ts",
+    "task": "Emit service units for production deployment",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Provide environment example",
+    "path": ".env.example",
+    "task": "Document core secrets and service ports",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Document production setup",
+    "path": "README-PROD.md",
+    "task": "Describe prod stack usage and security notes",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Add Keycloak OIDC dev bundle",
+    "path": "oidc/keycloak/docker-compose.yml",
+    "task": "Provide realm export and compose for local OIDC",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Add Kubernetes manifests with Kustomize overlays",
+    "path": "k8s/",
+    "task": "Include base and prod overlay with ingress and HPA",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Add monitoring configuration",
+    "path": "monitoring/",
+    "task": "Provide ServiceMonitor, alerts and Grafana dashboard",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Add Caddy TLS reverse proxy",
+    "path": "tls/caddy/Caddyfile",
+    "task": "Auto-configure HTTPS and WebSockets",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Add GitHub Actions workflow for Kubernetes deployment",
+    "path": ".github/workflows/deploy-k8s.yml",
+    "task": "Deploy base and prod manifests on tagged releases",
+    "test": "",
+    "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13294,3 +13294,88 @@
   task: Configure ES2020 modules and ts-node options
   test: ""
   status: open
+- commit: Add production docker compose file
+  path: compose.prod.yml
+  task: Provide dist-first multi-service builds with ts-node fallback
+  test: ""
+  status: open
+- commit: Create generic Dockerfile for TypeScript services
+  path: docker/Dockerfile.service
+  task: Add multi-stage build template using SERVICE_ENTRY arg
+  test: ""
+  status: open
+- commit: Configure NGINX reverse proxy for UM services
+  path: config/nginx/mandala.conf
+  task: Route REST and WebSocket paths for production
+  test: ""
+  status: open
+- commit: Add Kong gateway configuration
+  path: kong/kong.yml
+  task: Define DB-less routes with CORS and rate limits
+  test: ""
+  status: open
+- commit: Implement Ed25519 key generation script
+  path: scripts/generate-ed25519.ts
+  task: Write key pair to keys/ directory
+  test: ""
+  status: open
+- commit: Add manifest signing script
+  path: scripts/sign-manifest.ts
+  task: Sign federation manifest with Ed25519 key
+  test: ""
+  status: open
+- commit: Add manifest verification script
+  path: scripts/verify-manifest.ts
+  task: Verify signed manifest using public key
+  test: ""
+  status: open
+- commit: Create verified federation registry service
+  path: scripts/federation-registry-verified.ts
+  task: Validate manifest signatures on register
+  test: ""
+  status: open
+- commit: Implement SSO broker service
+  path: scripts/sso-broker.ts
+  task: Expose config and token exchange endpoints
+  test: ""
+  status: open
+- commit: Generate systemd unit files script
+  path: scripts/generate-systemd-units.ts
+  task: Emit service units for production deployment
+  test: ""
+  status: open
+- commit: Provide environment example
+  path: .env.example
+  task: Document core secrets and service ports
+  test: ""
+  status: open
+- commit: Document production setup
+  path: README-PROD.md
+  task: Describe prod stack usage and security notes
+  test: ""
+  status: open
+- commit: Add Keycloak OIDC dev bundle
+  path: oidc/keycloak/docker-compose.yml
+  task: Provide realm export and compose for local OIDC
+  test: ""
+  status: open
+- commit: Add Kubernetes manifests with Kustomize overlays
+  path: k8s/
+  task: Include base and prod overlay with ingress and HPA
+  test: ""
+  status: open
+- commit: Add monitoring configuration
+  path: monitoring/
+  task: Provide ServiceMonitor, alerts and Grafana dashboard
+  test: ""
+  status: open
+- commit: Add Caddy TLS reverse proxy
+  path: tls/caddy/Caddyfile
+  task: Auto-configure HTTPS and WebSockets
+  test: ""
+  status: open
+- commit: Add GitHub Actions workflow for Kubernetes deployment
+  path: .github/workflows/deploy-k8s.yml
+  task: Deploy base and prod manifests on tagged releases
+  test: ""
+  status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1271 from GenesisAeon/codex/create-repoconform-todos-in-json-and-yaml-pc5q80",
+  "lastCommit": "Merge pull request #1272 from GenesisAeon/codex/create-repok-compliant-todos-for-integration",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -961,6 +961,74 @@
     },
     {
       "commit": "Provide tsconfig for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add production docker compose file",
+      "status": "open"
+    },
+    {
+      "commit": "Create generic Dockerfile for TypeScript services",
+      "status": "open"
+    },
+    {
+      "commit": "Configure NGINX reverse proxy for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add Kong gateway configuration",
+      "status": "open"
+    },
+    {
+      "commit": "Implement Ed25519 key generation script",
+      "status": "open"
+    },
+    {
+      "commit": "Add manifest signing script",
+      "status": "open"
+    },
+    {
+      "commit": "Add manifest verification script",
+      "status": "open"
+    },
+    {
+      "commit": "Create verified federation registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Implement SSO broker service",
+      "status": "open"
+    },
+    {
+      "commit": "Generate systemd unit files script",
+      "status": "open"
+    },
+    {
+      "commit": "Provide environment example",
+      "status": "open"
+    },
+    {
+      "commit": "Document production setup",
+      "status": "open"
+    },
+    {
+      "commit": "Add Keycloak OIDC dev bundle",
+      "status": "open"
+    },
+    {
+      "commit": "Add Kubernetes manifests with Kustomize overlays",
+      "status": "open"
+    },
+    {
+      "commit": "Add monitoring configuration",
+      "status": "open"
+    },
+    {
+      "commit": "Add Caddy TLS reverse proxy",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitHub Actions workflow for Kubernetes deployment",
       "status": "open"
     }
   ],


### PR DESCRIPTION
## Summary
- track TODOs for production pack (docker compose, Dockerfile template, proxy configs, security scripts)
- add enterprise tasks for OIDC, Kubernetes, monitoring, TLS and CI/CD

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a0e85816448322a752b09b5023dfd3