### PR TITLE
Add advanced ToDo entries for Responses API and utopia planning

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-16, in der Zeit des Abend.
+Am 2025-08-16, in der Zeit des Nacht.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Reflexion (Fokus: P)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14449,8 +14449,7 @@
     "task": "Enforce cosign-signed images via Kyverno policy and helper script",
     "test": "./scripts/switch-cosign-enforce.sh",
     "status": "open"
-  }
-,
+  },
   {
     "commit": "Document EVC-guided worldview blueprint",
     "path": "worldview/mandala-worldview.yaml",
@@ -14498,6 +14497,48 @@
     "path": "validation/sanity_checks.py",
     "task": "Verify tree depth, duplicate nodes, and required fields",
     "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Document Reasoning-Effort and Responses API usage",
+    "path": "docs/guides/responses-api.md",
+    "task": "Explain Reasoning-Effort levels and demonstrate Responses API features for Mandala",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Document Mandala prompt patterns",
+    "path": "docs/prompts/mandala-patterns.md",
+    "task": "Describe planner-worker-verifier and other prompt recipes for CREP and Sigillin agents",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Integrate Utopie-to-Do adapter",
+    "path": "packages/utopie-adapter/",
+    "task": "Generate utopian Sigils and create CREP tasks via save_sigil and create_tasks",
+    "test": "packages/utopie-adapter/utopie_adapter.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Extend CREP metrics with hope activation",
+    "path": "packages/crep/metrics.ts",
+    "task": "Add hopeActivation field to CREP evaluation schema",
+    "test": "packages/crep/metrics.test.ts",
+    "status": "open"
+  },
+  {
+    "commit": "Compare tech vs society branches in Universe Tree",
+    "path": "sims/universe_tree_optimism.py",
+    "task": "Simulate and contrast tech- and society-optimistic branches for sustainable mobility",
+    "test": "",
+    "status": "open"
+  },
+  {
+    "commit": "Implement Consent Mesh for utopia packages",
+    "path": "packages/consent-mesh/utopie-consent.ts",
+    "task": "Collect community votes on utopia packages and feed results into task prioritization",
+    "test": "packages/consent-mesh/utopie-consent.test.ts",
     "status": "open"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13602,7 +13602,6 @@
   task: Enforce cosign-signed images via Kyverno policy and helper script
   test: ./scripts/switch-cosign-enforce.sh
   status: open
-
 - commit: Document EVC-guided worldview blueprint
   path: worldview/mandala-worldview.yaml
   task: Capture hypothesis, Emergence Viability Criteria, and CREP mapping
@@ -13637,4 +13636,38 @@
   path: validation/sanity_checks.py
   task: Verify tree depth, duplicate nodes, and required fields
   test: ""
+  status: open
+- commit: Document Reasoning-Effort and Responses API usage
+  path: docs/guides/responses-api.md
+  task: Explain Reasoning-Effort levels and demonstrate Responses API features for
+    Mandala
+  test: ""
+  status: open
+- commit: Document Mandala prompt patterns
+  path: docs/prompts/mandala-patterns.md
+  task: Describe planner-worker-verifier and other prompt recipes for CREP and
+    Sigillin agents
+  test: ""
+  status: open
+- commit: Integrate Utopie-to-Do adapter
+  path: packages/utopie-adapter/
+  task: Generate utopian Sigils and create CREP tasks via save_sigil and create_tasks
+  test: packages/utopie-adapter/utopie_adapter.test.ts
+  status: open
+- commit: Extend CREP metrics with hope activation
+  path: packages/crep/metrics.ts
+  task: Add hopeActivation field to CREP evaluation schema
+  test: packages/crep/metrics.test.ts
+  status: open
+- commit: Compare tech vs society branches in Universe Tree
+  path: sims/universe_tree_optimism.py
+  task: Simulate and contrast tech- and society-optimistic branches for
+    sustainable mobility
+  test: ""
+  status: open
+- commit: Implement Consent Mesh for utopia packages
+  path: packages/consent-mesh/utopie-consent.ts
+  task: Collect community votes on utopia packages and feed results into task
+    prioritization
+  test: packages/consent-mesh/utopie-consent.test.ts
   status: open

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: add security hardening tasks",
+  "lastCommit": "Add tasks for Responses API and utopia integration",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -1205,6 +1205,58 @@
     },
     {
       "commit": "Switch Kyverno verifyImages to enforce",
+      "status": "open"
+    },
+    {
+      "commit": "Document EVC-guided worldview blueprint",
+      "status": "open"
+    },
+    {
+      "commit": "Implement EPI scanning CLI",
+      "status": "open"
+    },
+    {
+      "commit": "Merge EPI with abundance dataset",
+      "status": "open"
+    },
+    {
+      "commit": "Add Universe Tree simulation",
+      "status": "open"
+    },
+    {
+      "commit": "Provide Universe Tree config",
+      "status": "open"
+    },
+    {
+      "commit": "Evaluate Universe Tree outputs",
+      "status": "open"
+    },
+    {
+      "commit": "Add Universe Tree sanity checks",
+      "status": "open"
+    },
+    {
+      "commit": "Document Reasoning-Effort and Responses API usage",
+      "status": "open"
+    },
+    {
+      "commit": "Document Mandala prompt patterns",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Utopie-to-Do adapter",
+      "status": "open"
+    },
+    {
+      "commit": "Extend CREP metrics with hope activation",
+      "status": "open"
+    },
+    {
+      "commit": "Compare tech vs society branches in Universe Tree",
+      "status": "open"
+    },
+    {
+      "commit": "Implement Consent Mesh for utopia packages",
       "status": "open"
     }
   ],


### PR DESCRIPTION
## Summary
- add documentation tasks for Reasoning-Effort and Responses API usage
- note Mandala prompt pattern write-ups
- schedule Utopie adapter, CREP hope activation, Universe Tree comparison and Consent Mesh work

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false --diagnostics`

------
https://chatgpt.com/codex/tasks/task_e_68a103eb49c88322a5f389750af2d341