### PR TITLE
feat: add run logger utilities

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12495,14 +12495,14 @@
     "path": "packages/shared-utils/jsonlLogger.ts",
     "task": "Write helper to stream simulation run metrics into JSONL logs",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add RunLogger utility",
     "path": "packages/shared-utils/runLogger.ts",
     "task": "Implement append-based JSONL run logging with run_id and reader",
     "test": "scripts/runlog-demo.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Integrate Sigil RAG search hooks",
@@ -12537,7 +12537,7 @@
     "path": "docs/hooks/RunLogger.md",
     "task": "Write guide for emitting and reading run logs",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Document Sigil RAG hooks",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12203,12 +12203,12 @@
   path: packages/shared-utils/jsonlLogger.ts
   task: Write helper to stream simulation run metrics into JSONL logs
   test: ""
-  status: open
+  status: done
 - commit: Add RunLogger utility
   path: packages/shared-utils/runLogger.ts
   task: Implement append-based JSONL run logging with run_id and reader
   test: scripts/runlog-demo.ts
-  status: open
+  status: done
 - commit: Integrate Sigil RAG search hooks
   path: packages/unifiedmandala-ui/components/SigilSearchPanel.tsx
   task: Provide hook and panel to search sigillin.jsonl via RAG index
@@ -12233,7 +12233,7 @@
   path: docs/hooks/RunLogger.md
   task: Write guide for emitting and reading run logs
   test: ""
-  status: open
+  status: done
 - commit: Document Sigil RAG hooks
   path: docs/hooks/RAG-Sigils.md
   task: Explain RAG index loading and search for sigils

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -89,11 +89,11 @@
     },
     {
       "commit": "Add JSONL logging utility for simulations",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add RunLogger utility",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Integrate Sigil RAG search hooks",
@@ -113,7 +113,7 @@
     },
     {
       "commit": "Document RunLogger usage",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Document Sigil RAG hooks",

--- a/docs/hooks/RunLogger.md
+++ b/docs/hooks/RunLogger.md
@@ -1,0 +1,21 @@
+# RunLogger
+
+The `RunLogger` utility writes simulation or workflow events to a JSON Lines file.
+Each run receives a unique `run_id`, allowing multiple runs to share the same log file.
+
+## Usage
+
+```ts
+import { RunLogger } from '../../packages/shared-utils/runLogger';
+
+const logger = new RunLogger('runlog.jsonl');
+logger.log('start');
+logger.log('metric', { loss: 0.123 });
+
+// read back entries
+const entries = RunLogger.read('runlog.jsonl');
+```
+
+## JSONL helper
+The logger uses `jsonlLogger` under the hood, which exposes `appendJsonl` and `readJsonl`
+functions for generic JSONL work.

--- a/packages/shared-utils/jsonlLogger.ts
+++ b/packages/shared-utils/jsonlLogger.ts
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Appends a JavaScript object as a JSON line to the given file.
+ * The directory is created if it does not yet exist.
+ */
+export function appendJsonl(filePath: string, obj: any) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.appendFileSync(filePath, JSON.stringify(obj) + '\n', 'utf8');
+}
+
+/**
+ * Reads a JSONL file and returns an array of parsed objects.
+ */
+export function readJsonl<T = any>(filePath: string): T[] {
+  if (!fs.existsSync(filePath)) return [];
+  const lines = fs
+    .readFileSync(filePath, 'utf8')
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean);
+  return lines.map(line => JSON.parse(line));
+}

--- a/packages/shared-utils/runLogger.ts
+++ b/packages/shared-utils/runLogger.ts
@@ -1,0 +1,36 @@
+import { appendJsonl, readJsonl } from './jsonlLogger';
+import { randomUUID } from 'crypto';
+
+export interface RunLogEntry<T = any> {
+  run_id: string;
+  timestamp: string;
+  event: string;
+  data?: T;
+}
+
+/**
+ * RunLogger provides append only JSONL based logging for simulation runs.
+ * Each entry is tagged with a run_id so multiple runs can share a log file.
+ */
+export class RunLogger {
+  constructor(private filePath: string, private runId: string = randomUUID()) {}
+
+  log(event: string, data?: any) {
+    const entry: RunLogEntry = {
+      run_id: this.runId,
+      timestamp: new Date().toISOString(),
+      event,
+      data,
+    };
+    appendJsonl(this.filePath, entry);
+    return entry;
+  }
+
+  get id() {
+    return this.runId;
+  }
+
+  static read(filePath: string): RunLogEntry[] {
+    return readJsonl<RunLogEntry>(filePath);
+  }
+}

--- a/scripts/runlog-demo.ts
+++ b/scripts/runlog-demo.ts
@@ -1,0 +1,14 @@
+import { RunLogger } from '../packages/shared-utils/runLogger';
+
+// Demo script showing how to emit and read run logs
+const logFile = 'runlog-demo.jsonl';
+const logger = new RunLogger(logFile);
+
+logger.log('start', { message: 'demo run started' });
+for (let i = 0; i < 3; i++) {
+  logger.log('step', { step: i });
+}
+logger.log('end');
+
+const entries = RunLogger.read(logFile);
+console.log('Run entries:', entries.filter(e => e.run_id === logger.id));


### PR DESCRIPTION
## Summary
- add JSONL logging helper and RunLogger class for simulation runs
- document RunLogger usage
- mark related advanced tasks as completed

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false --diagnostics`


------
https://chatgpt.com/codex/tasks/task_e_68a172c6777883229a8bb864bd8bf5b2