### PR TITLE
Track golden signals metrics

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12355,7 +12355,7 @@
     "path": "observability/golden-signals.ts",
     "task": "Collect p95 latency, success rate, queue depth and retries",
     "test": "observability/golden-signals.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Map CREP metrics to outcome KPIs",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12101,7 +12101,7 @@
   path: observability/golden-signals.ts
   task: Collect p95 latency, success rate, queue depth and retries
   test: observability/golden-signals.test.ts
-  status: open
+  status: done
 - commit: Map CREP metrics to outcome KPIs
   path: packages/pantheon/PantheonPortalAnalytics.ts
   task: Link coherence, resonance, emergence and poetics to task success analytics

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Add tasks for Responses API and utopia integration",
+  "lastCommit": "Track golden signals metrics",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -9,7 +9,7 @@
   "pendingTasks": [
     {
       "commit": "Track golden signals metrics",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Map CREP metrics to outcome KPIs",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -93,3 +93,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Improved PrivacyComplianceAgent with detailed violation reporting.
 - Enhanced CommunityPluginMarketplace with plugin rating support.
 - Added script to sync advancedprogress pending tasks with open advanced todos.
+- Implemented golden signals metrics collector for latency, success rate, queue depth, and retries.

--- a/observability/golden-signals.test.ts
+++ b/observability/golden-signals.test.ts
@@ -1,0 +1,18 @@
+import { calculateGoldenSignals } from './golden-signals';
+
+describe('calculateGoldenSignals', () => {
+  it('computes metrics from inputs', () => {
+    const latencies = [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000];
+    const metrics = calculateGoldenSignals(latencies, 90, 100, 5, 2);
+    expect(metrics.p95Latency).toBeCloseTo(955, 5);
+    expect(metrics.successRate).toBeCloseTo(0.9);
+    expect(metrics.queueDepth).toBe(5);
+    expect(metrics.retries).toBe(2);
+  });
+
+  it('handles empty inputs', () => {
+    const metrics = calculateGoldenSignals([], 0, 0, 0, 0);
+    expect(metrics.p95Latency).toBe(0);
+    expect(metrics.successRate).toBe(0);
+  });
+});

--- a/observability/golden-signals.ts
+++ b/observability/golden-signals.ts
@@ -1,0 +1,41 @@
+export interface GoldenSignalsMetrics {
+  p95Latency: number;
+  successRate: number;
+  queueDepth: number;
+  retries: number;
+}
+
+/**
+ * Calculate golden signal metrics.
+ * @param latencies array of request latencies in milliseconds
+ * @param successes number of successful requests
+ * @param totalRequests total number of requests attempted
+ * @param queueDepth current depth of the processing queue
+ * @param retries number of retry attempts performed
+ */
+export function calculateGoldenSignals(
+  latencies: number[],
+  successes: number,
+  totalRequests: number,
+  queueDepth: number,
+  retries: number
+): GoldenSignalsMetrics {
+  const sorted = [...latencies].sort((a, b) => a - b);
+  let p95Latency = 0;
+  if (sorted.length) {
+    const pos = 0.95 * (sorted.length - 1);
+    const lower = Math.floor(pos);
+    const upper = Math.ceil(pos);
+    const lowerVal = sorted[lower];
+    const upperVal = sorted[upper];
+    p95Latency =
+      lowerVal + (upperVal - lowerVal) * (pos - lower);
+  }
+  const successRate = totalRequests > 0 ? successes / totalRequests : 0;
+  return {
+    p95Latency,
+    successRate,
+    queueDepth,
+    retries,
+  };
+}


### PR DESCRIPTION
## Summary
- add golden signals metrics collector with p95 latency, success rate, queue depth, and retry tracking
- mark corresponding advanced tasks as complete and sync progress
- note implementation in feedback codex

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest observability/golden-signals.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a18fe1cdb08322b738f919cf689e71