### PR TITLE
Map CREP metrics to KPIs and add simulation templates

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12362,7 +12362,7 @@
     "path": "packages/pantheon/PantheonPortalAnalytics.ts",
     "task": "Link coherence, resonance, emergence and poetics to task success analytics",
     "test": "packages/pantheon/PantheonPortalAnalytics.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add one-click workflow launcher",
@@ -12481,14 +12481,14 @@
     "path": "data/simulations/scenarios",
     "task": "Provide initial universe and multiverse scenario YAMLs for GPT-5 testing",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create historic sandbox scenario templates",
     "path": "data/sandboxes/historic",
     "task": "Define initial civilization simulation scenarios with source references",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add JSONL logging utility for simulations",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12106,7 +12106,7 @@
   path: packages/pantheon/PantheonPortalAnalytics.ts
   task: Link coherence, resonance, emergence and poetics to task success analytics
   test: packages/pantheon/PantheonPortalAnalytics.test.ts
-  status: open
+  status: done
 - commit: Add one-click workflow launcher
   path: packages/unifiedmandala-ui/components/WorkflowLauncher.tsx
   task: Provide button to trigger Sigillin jobs without intermediate screens
@@ -12193,12 +12193,12 @@
   path: data/simulations/scenarios
   task: Provide initial universe and multiverse scenario YAMLs for GPT-5 testing
   test: ""
-  status: open
+  status: done
 - commit: Create historic sandbox scenario templates
   path: data/sandboxes/historic
   task: Define initial civilization simulation scenarios with source references
   test: ""
-  status: open
+  status: done
 - commit: Add JSONL logging utility for simulations
   path: packages/shared-utils/jsonlLogger.ts
   task: Write helper to stream simulation run metrics into JSONL logs

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Track golden signals metrics",
+  "lastCommit": "Create historic sandbox scenario templates",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -13,7 +13,7 @@
     },
     {
       "commit": "Map CREP metrics to outcome KPIs",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add one-click workflow launcher",
@@ -81,11 +81,11 @@
     },
     {
       "commit": "Create simulation scenario starter templates",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Create historic sandbox scenario templates",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add JSONL logging utility for simulations",

--- a/data/sandboxes/historic/ancient-egypt.yaml
+++ b/data/sandboxes/historic/ancient-egypt.yaml
@@ -1,0 +1,5 @@
+title: Ancient Egypt Civilization Sandbox
+era: "3000 BCE"
+focus: Socio-economic development along the Nile
+references:
+  - Brewer, Egyptology 2001

--- a/data/sandboxes/historic/industrial-revolution.yaml
+++ b/data/sandboxes/historic/industrial-revolution.yaml
@@ -1,0 +1,5 @@
+title: Industrial Revolution Sandbox
+era: "18th Century"
+focus: Urbanization and technological change in Europe
+references:
+  - Landes, The Unbound Prometheus, 1969

--- a/data/simulations/scenarios/multiverse.yaml
+++ b/data/simulations/scenarios/multiverse.yaml
@@ -1,0 +1,6 @@
+title: Basic Multiverse Simulation
+description: Template exploring parallel universes with divergent constants.
+parameters:
+  universes: 3
+  base_seed: 42
+  timesteps: 500

--- a/data/simulations/scenarios/universe.yaml
+++ b/data/simulations/scenarios/universe.yaml
@@ -1,0 +1,6 @@
+title: Basic Universe Simulation
+description: Starter template for single universe evolution used in GPT-5 tests.
+parameters:
+  dimensions: 3
+  initial_energy: 1000000
+  timesteps: 1000

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -94,3 +94,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Enhanced CommunityPluginMarketplace with plugin rating support.
 - Added script to sync advancedprogress pending tasks with open advanced todos.
 - Implemented golden signals metrics collector for latency, success rate, queue depth, and retries.
+- Added starter simulation templates and linked CREP metrics to outcome KPIs.

--- a/packages/pantheon/PantheonPortalAnalytics.test.ts
+++ b/packages/pantheon/PantheonPortalAnalytics.test.ts
@@ -9,6 +9,22 @@ describe('PantheonPortalAnalytics', () => {
     analytics.recordEvent('open');
     analytics.recordEvent('open');
     analytics.recordEvent('close');
-    expect(analytics.getStats()).toEqual({ visits: 2, events: { open: 2, close: 1 } });
+    expect(analytics.getStats()).toEqual({
+      visits: 2,
+      events: { open: 2, close: 1 },
+      outcomeKPIs: { coherence: 0, resonance: 0, emergence: 0, poetics: 0 },
+    });
+  });
+
+  it('maps CREP metrics to outcome KPIs', () => {
+    const analytics = new PantheonPortalAnalytics();
+    analytics.recordCREP({ coherence: 0.5, resonance: 0.6, emergence: 0.7, poetics: 0.8 });
+    analytics.recordCREP({ coherence: 1, resonance: 0.4, emergence: 0.9, poetics: 0.2 });
+    expect(analytics.getStats().outcomeKPIs).toEqual({
+      coherence: 0.75,
+      resonance: 0.5,
+      emergence: 0.8,
+      poetics: 0.5,
+    });
   });
 });

--- a/packages/pantheon/PantheonPortalAnalytics.ts
+++ b/packages/pantheon/PantheonPortalAnalytics.ts
@@ -1,6 +1,13 @@
 export class PantheonPortalAnalytics {
   private visits = 0;
   private events: Record<string, number> = {};
+  private crepTotals = {
+    coherence: 0,
+    resonance: 0,
+    emergence: 0,
+    poetics: 0,
+  };
+  private crepCount = 0;
 
   recordVisit() {
     this.visits += 1;
@@ -10,7 +17,36 @@ export class PantheonPortalAnalytics {
     this.events[name] = (this.events[name] || 0) + 1;
   }
 
+  recordCREP(metrics: {
+    coherence: number;
+    resonance: number;
+    emergence: number;
+    poetics: number;
+  }) {
+    this.crepTotals.coherence += metrics.coherence;
+    this.crepTotals.resonance += metrics.resonance;
+    this.crepTotals.emergence += metrics.emergence;
+    this.crepTotals.poetics += metrics.poetics;
+    this.crepCount += 1;
+  }
+
+  private getOutcomeKPIs() {
+    if (this.crepCount === 0) {
+      return { ...this.crepTotals };
+    }
+    return {
+      coherence: this.crepTotals.coherence / this.crepCount,
+      resonance: this.crepTotals.resonance / this.crepCount,
+      emergence: this.crepTotals.emergence / this.crepCount,
+      poetics: this.crepTotals.poetics / this.crepCount,
+    };
+  }
+
   getStats() {
-    return { visits: this.visits, events: { ...this.events } };
+    return {
+      visits: this.visits,
+      events: { ...this.events },
+      outcomeKPIs: this.getOutcomeKPIs(),
+    };
   }
 }


### PR DESCRIPTION
## Summary
- extend PantheonPortalAnalytics with CREP KPI tracking and expose averages
- add universe, multiverse, and historic sandbox scenario templates
- mark completed tasks in advancedToDo and progress trackers

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` (fails: venvPath not valid)
- `npx tsc -p tsconfig.json` (terminated: process did not finish)

------
https://chatgpt.com/codex/tasks/task_e_68a19763ecac8322bc52b58ae8935047