### PR TITLE
docs: add Mandala prompt patterns

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14511,7 +14511,7 @@
     "path": "docs/prompts/mandala-patterns.md",
     "task": "Describe planner-worker-verifier and other prompt recipes for CREP and Sigillin agents",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Integrate Utopie-to-Do adapter",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13648,7 +13648,7 @@
   task: Describe planner-worker-verifier and other prompt recipes for CREP and
     Sigillin agents
   test: ""
-  status: open
+  status: done
 - commit: Integrate Utopie-to-Do adapter
   path: packages/utopie-adapter/
   task: Generate utopian Sigils and create CREP tasks via save_sigil and create_tasks

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Create historic sandbox scenario templates",
+  "lastCommit": "Document Mandala prompt patterns",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.",
+  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.; Documented Mandala prompt patterns",
   "pendingTasks": [
     {
       "commit": "Track golden signals metrics",
@@ -1241,7 +1241,7 @@
     },
     {
       "commit": "Document Mandala prompt patterns",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Integrate Utopie-to-Do adapter",

--- a/docs/prompts/mandala-patterns.md
+++ b/docs/prompts/mandala-patterns.md
@@ -1,0 +1,33 @@
+# Mandala Prompt Patterns
+
+This guide collects resonant prompt recipes used throughout the Mandala project. These patterns help agents coordinate when solving complex tasks under the CREP (Context, Resonance, Emergence, Purpose) framework.
+
+## Planner–Worker–Verifier
+
+**Planner** prompts outline goals and context. They break a challenge into actionable steps.
+
+```
+You are the Planner. Given the user's aim, draft a step-by-step plan. Consider CREP metrics and reference relevant Sigillin.
+```
+
+**Worker** prompts execute each step, grounding responses in repository data or Sigillin instructions.
+
+```
+You are the Worker. Follow the plan step {n}. Use available modules and cite sources when possible.
+```
+
+**Verifier** prompts review outputs and ensure they satisfy CREP thresholds and repository conventions.
+
+```
+You are the Verifier. Check the Worker response for accuracy, style, and resonance. If issues arise, suggest corrections.
+```
+
+## Resonant Reflection
+
+After each Planner–Worker–Verifier cycle, a short reflection prompt can reinforce learning and maintain coherence:
+
+```
+Reflect on the last cycle. Did the response advance the purpose with sufficient resonance? Note any follow-up tasks.
+```
+
+These patterns emerged from analysis of the `newadvancedconversations` dataset and continue to evolve as the Mandala grows. Contributions and refinements are welcome.

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -95,3 +95,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added script to sync advancedprogress pending tasks with open advanced todos.
 - Implemented golden signals metrics collector for latency, success rate, queue depth, and retries.
 - Added starter simulation templates and linked CREP metrics to outcome KPIs.
+- Documented Mandala prompt patterns and synced progress files.


### PR DESCRIPTION
## Summary
- document planner-worker-verifier prompt recipe and reflection loop
- mark Mandala prompt pattern task complete in advanced tracker
- log work in feedbackcodex for future resonance

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a19d97bcfc8322911de871ded6dc27