### PR TITLE
docs: add Responses API guide

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14504,7 +14504,7 @@
     "path": "docs/guides/responses-api.md",
     "task": "Explain Reasoning-Effort levels and demonstrate Responses API features for Mandala",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Document Mandala prompt patterns",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13642,7 +13642,7 @@
   task: Explain Reasoning-Effort levels and demonstrate Responses API features for
     Mandala
   test: ""
-  status: open
+  status: done
 - commit: Document Mandala prompt patterns
   path: docs/prompts/mandala-patterns.md
   task: Describe planner-worker-verifier and other prompt recipes for CREP and

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1237,7 +1237,7 @@
     },
     {
       "commit": "Document Reasoning-Effort and Responses API usage",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Document Mandala prompt patterns",

--- a/docs/guides/responses-api.md
+++ b/docs/guides/responses-api.md
@@ -1,0 +1,34 @@
+# Responses API and Reasoning-Effort
+
+The Mandala Responses API allows agents and tools to request answers while specifying how much reasoning effort the model should invest.
+
+## Reasoning-Effort Levels
+- **low**: quick heuristic reasoning for lightweight queries.
+- **medium**: balanced depth and speed for everyday tasks.
+- **high**: thorough analysis for complex or safety-critical decisions.
+
+## Example Usage
+
+```ts
+import { ResponsesClient } from '@unifiedmandala/responses';
+
+const client = new ResponsesClient({ baseUrl: 'http://localhost:8080' });
+
+const result = await client.ask({
+  prompt: 'Explain the CREP framework',
+  reasoning_effort: 'medium'
+});
+
+console.log(result.answer);
+console.log(result.citations);
+```
+
+For shell based workflows the same endpoint can be called with `curl`:
+
+```bash
+curl -X POST http://localhost:8080/ask \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt":"Explain the CREP framework","reasoning_effort":"high"}'
+```
+
+The server responds with an `answer` field and, when available, a list of `citations`. Adjust the `reasoning_effort` parameter to trade between speed and depth.

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -96,3 +96,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented golden signals metrics collector for latency, success rate, queue depth, and retries.
 - Added starter simulation templates and linked CREP metrics to outcome KPIs.
 - Documented Mandala prompt patterns and synced progress files.
+- Documented Responses API usage and reasoning-effort levels.


### PR DESCRIPTION
## Summary
- document Reasoning-Effort levels and sample usage of the Responses API
- mark Responses API documentation task as complete in advanced todos and progress tracker
- note the update in feedbackcodex

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json` *(hangs, aborted after no output)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a4ed2aa88322900e6e0afe01e5d2