### PR TITLE
docs: document EVC worldview blueprint

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14455,7 +14455,7 @@
     "path": "worldview/mandala-worldview.yaml",
     "task": "Capture hypothesis, Emergence Viability Criteria, and CREP mapping",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement EPI scanning CLI",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13606,7 +13606,7 @@
   path: worldview/mandala-worldview.yaml
   task: Capture hypothesis, Emergence Viability Criteria, and CREP mapping
   test: ""
-  status: open
+  status: done
 - commit: Implement EPI scanning CLI
   path: analysis/epi_scan.py
   task: Calculate Emergence Potential Index and generate heatmap overlays

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Implement RAG Chunker",
+  "lastCommit": "Document EVC-guided worldview blueprint",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4144,6 +4144,10 @@
     },
     {
       "commit": "Implement RAG Chunker",
+      "status": "done"
+    },
+    {
+      "commit": "Document EVC-guided worldview blueprint",
       "status": "done"
     }
   ],

--- a/worldview/mandala-worldview.yaml
+++ b/worldview/mandala-worldview.yaml
@@ -1,0 +1,12 @@
+hypothesis: |
+  The Mandala worldview models knowledge as interconnected layers.
+  It aligns emergent behavior with ethical resonance to guide decisions.
+evC:
+  - balance_of_forces: Evaluate harmony among system actors.
+  - sustainability_thresholds: Track resource cycles and regeneration.
+  - adaptive_learning: Encourage iterative reflection and growth.
+crep_mapping:
+  - metric: hopeActivation
+    description: Quantifies aspirational impact within CREP evaluations.
+  - metric: depth
+    description: Measures contextual richness and symbolic depth.


### PR DESCRIPTION
## Summary
- capture Mandala worldview blueprint with EVC and CREP mapping
- mark worldview blueprint task complete in advanced ToDo files
- log progress update in advancedprogress

## Testing
- `npx pyright` *(fails: venvPath /workspace/unified-mandala/.venv is not a valid directory)*
- `npx tsc -p tsconfig.json`
- `node repositorypflege/update-advanced-progress.js 5`

------
https://chatgpt.com/codex/tasks/task_e_68a1cdcb435c83229fc959ff609f7eff