### PR TITLE
feat: add PII redactor utility

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12949,8 +12949,8 @@
     "commit": "Implement PIIRedactor utility",
     "path": "packages/security/PIIRedactor.ts",
     "task": "Mask phone numbers, emails and card numbers in text",
-    "test": "",
-    "status": "open"
+    "test": "packages/security/PIIRedactor.test.ts",
+    "status": "done"
   },
   {
     "commit": "Create ResearchHub UI",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12527,8 +12527,8 @@
 - commit: Implement PIIRedactor utility
   path: packages/security/PIIRedactor.ts
   task: Mask phone numbers, emails and card numbers in text
-  test: ""
-  status: open
+  test: packages/security/PIIRedactor.test.ts
+  status: done
 - commit: Create ResearchHub UI
   path: packages/unifiedmandala-ui/components/ResearchHub.tsx
   task: Provide entry point for research agents and flags

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Document EVC-guided worldview blueprint",
+  "lastCommit": "Implement PIIRedactor utility",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4148,6 +4148,10 @@
     },
     {
       "commit": "Document EVC-guided worldview blueprint",
+      "status": "done"
+    },
+    {
+      "commit": "Implement PIIRedactor utility",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -97,3 +97,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added starter simulation templates and linked CREP metrics to outcome KPIs.
 - Documented Mandala prompt patterns and synced progress files.
 - Documented Responses API usage and reasoning-effort levels.
+- Added PIIRedactor utility to mask emails, phone numbers, and card numbers.

--- a/packages/security/PIIRedactor.test.ts
+++ b/packages/security/PIIRedactor.test.ts
@@ -1,0 +1,23 @@
+import { PIIRedactor } from './PIIRedactor';
+
+describe('PIIRedactor', () => {
+  it('redacts emails', () => {
+    const input = 'Contact me at test@example.com';
+    expect(PIIRedactor.redact(input)).toBe('Contact me at [REDACTED_EMAIL]');
+  });
+
+  it('redacts phone numbers', () => {
+    const input = 'Call me at +1 555-123-4567 tomorrow';
+    expect(PIIRedactor.redact(input)).toBe('Call me at [REDACTED_PHONE] tomorrow');
+  });
+
+  it('redacts credit card numbers', () => {
+    const input = 'Use card 4111 1111 1111 1111 for payment';
+    expect(PIIRedactor.redact(input)).toBe('Use card [REDACTED_CARD] for payment');
+  });
+
+  it('leaves other text unchanged', () => {
+    const input = 'No sensitive data here';
+    expect(PIIRedactor.redact(input)).toBe(input);
+  });
+});

--- a/packages/security/PIIRedactor.ts
+++ b/packages/security/PIIRedactor.ts
@@ -1,0 +1,14 @@
+export class PIIRedactor {
+  private static email = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+  private static phone = /(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?){2}\d{4}/g;
+  private static card = /\b(?:\d[ -]*?){13,16}\b/g;
+
+  static redact(text: string): string {
+    return text
+      .replace(this.email, '[REDACTED_EMAIL]')
+      .replace(this.phone, '[REDACTED_PHONE]')
+      .replace(this.card, '[REDACTED_CARD]');
+  }
+}
+
+export default PIIRedactor;


### PR DESCRIPTION
## Summary
- implement `PIIRedactor` to mask emails, phone numbers, and credit cards
- mark PIIRedactor task as complete in advanced progress trackers
- jot down note in feedback codex

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest packages/security/PIIRedactor.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a1e6bd9cc88322935ea3da9f19b784