### PR TITLE
Add personhood consent guard

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13153,7 +13153,7 @@
     "path": "tests/personhood.guard.test.ts",
     "task": "Verify consent requirement for PII research",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement RAG Chunker",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12673,7 +12673,7 @@
   path: tests/personhood.guard.test.ts
   task: Verify consent requirement for PII research
   test: ""
-  status: open
+  status: done
 - commit: Implement RAG Chunker
   path: packages/rag/Chunker.ts
   task: Split documents into overlapping token chunks

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -4153,6 +4153,10 @@
     {
       "commit": "Implement PIIRedactor utility",
       "status": "done"
+    },
+    {
+      "commit": "Add personhood guard test",
+      "status": "done"
     }
   ],
   "completed": [

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -98,3 +98,5 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Documented Mandala prompt patterns and synced progress files.
 - Documented Responses API usage and reasoning-effort levels.
 - Added PIIRedactor utility to mask emails, phone numbers, and card numbers.
+
+- Added basic personhood consent guard with tests enforcing consent requirement.

--- a/packages/personhood/ConsentRegistry.ts
+++ b/packages/personhood/ConsentRegistry.ts
@@ -1,0 +1,15 @@
+export class ConsentRegistry {
+  private static consentMap = new Map<string, boolean>();
+
+  static grant(personId: string) {
+    this.consentMap.set(personId, true);
+  }
+
+  static revoke(personId: string) {
+    this.consentMap.delete(personId);
+  }
+
+  static hasConsent(personId: string): boolean {
+    return this.consentMap.get(personId) === true;
+  }
+}

--- a/packages/personhood/PolicyGuard.ts
+++ b/packages/personhood/PolicyGuard.ts
@@ -1,0 +1,7 @@
+import { ConsentRegistry } from './ConsentRegistry';
+
+export function requireConsent(personId: string): void {
+  if (!ConsentRegistry.hasConsent(personId)) {
+    throw new Error(`Consent required for PII research: ${personId}`);
+  }
+}

--- a/tests/personhood.guard.test.ts
+++ b/tests/personhood.guard.test.ts
@@ -1,0 +1,13 @@
+import { ConsentRegistry } from '../packages/personhood/ConsentRegistry';
+import { requireConsent } from '../packages/personhood/PolicyGuard';
+
+describe('Personhood Policy Guard', () => {
+  test('throws when consent missing', () => {
+    expect(() => requireConsent('user1')).toThrow('Consent required');
+  });
+
+  test('allows when consent granted', () => {
+    ConsentRegistry.grant('user2');
+    expect(() => requireConsent('user2')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add in-memory consent registry and policy guard
- cover personhood consent guard with basic tests
- mark personhood guard task as completed in progress trackers

## Testing
- `pnpm install` *(fails: pnpm not found)*
- `poetry install --with test` *(fails: command not found)*
- `npx pyright` *(fails: command not found)*
- `npx tsc -p tsconfig.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2317777e0832285b4b879b733894d