### PR TITLE
docs: add voice intent cheat sheet

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12460,7 +12460,7 @@
     "path": "voice_intents.yaml",
     "task": "Document voice intents and trigger mappings for aeon.sh, Sigillin loader and ToDo parser",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement voice note to advancedToDo pipeline",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12177,7 +12177,7 @@
   task: Document voice intents and trigger mappings for aeon.sh, Sigillin loader
     and ToDo parser
   test: ""
-  status: open
+  status: done
 - commit: Implement voice note to advancedToDo pipeline
   path: scripts/parse-advanced-conversations.js
   task: Convert voice notes into advancedToDo entries using

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Implement PIIRedactor utility",
+  "lastCommit": "Add voice intent cheat sheet and YAML mapping",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4156,6 +4156,10 @@
     },
     {
       "commit": "Add personhood guard test",
+      "status": "done"
+    },
+    {
+      "commit": "Add voice intent cheat sheet and YAML mapping",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -100,3 +100,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added PIIRedactor utility to mask emails, phone numbers, and card numbers.
 
 - Added basic personhood consent guard with tests enforcing consent requirement.
+- Added voice intent cheat sheet for aeon.sh, Sigillin loader and ToDo parser.

--- a/voice_intents.yaml
+++ b/voice_intents.yaml
@@ -1,0 +1,11 @@
+# Cheat sheet for voice intents and their command mappings
+intents:
+  - intent: "open workflow"
+    command: "aeon.sh workflow open"
+    description: "Launches the workflow launcher in the shell"
+  - intent: "load sigil"
+    command: "sigillin load <name>"
+    description: "Loads a Sigillin file into the active context"
+  - intent: "add task"
+    command: "todo add <task>"
+    description: "Appends a new item to the advanced ToDo list"


### PR DESCRIPTION
## Summary
- document voice command mappings in `voice_intents.yaml`
- mark voice intent todo as complete in advanced trackers
- log the addition in `feedbackcodex.md`

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a24176535c83229124ad686bb68de0