### PR TITLE
feat: expand SymbolMapper for numpy

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Add voice intent cheat sheet and YAML mapping",
+  "lastCommit": "Enhance SymbolMapper with NumPy support",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.; Documented Mandala prompt patterns; Implemented RAG Chunker for document tokenization",
+  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.; Documented Mandala prompt patterns; Implemented RAG Chunker for document tokenization; Extended SymbolMapper to accept NumPy arrays",
   "pendingTasks": [
     "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129 (GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json)",
     "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e (GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json)",
@@ -4160,6 +4160,10 @@
     },
     {
       "commit": "Add voice intent cheat sheet and YAML mapping",
+      "status": "done"
+    },
+    {
+      "commit": "Enhance SymbolMapper to handle NumPy arrays",
       "status": "done"
     }
   ],

--- a/agents/symbolmapper/main.py
+++ b/agents/symbolmapper/main.py
@@ -8,7 +8,12 @@ Sigillin symbolism used throughout the project.
 """
 
 from dataclasses import dataclass, field
-from typing import Iterable, List, Dict
+from typing import Iterable, List, Dict, Any
+
+try:  # Optional dependency used for array support
+    import numpy as np
+except Exception:  # pragma: no cover - numpy not available
+    np = None  # type: ignore
 
 GLYPHS: List[str] = ["○", "∆", "ψ", "★"]
 KEYWORDS: Dict[str, str] = {
@@ -19,18 +24,26 @@ KEYWORDS: Dict[str, str] = {
 }
 
 
-def map_numeric_to_symbol(values: Iterable[float]) -> str:
-    """Map a sequence of numeric values to a glyph.
+def map_numeric_to_symbol(values: Iterable[float] | Any) -> str:
+    """Map numeric inputs to a glyph.
 
-    The mean of the values is scaled to the index of the ``GLYPHS`` list.
-    Values outside the 0..1 range are clamped.
+    Accepts any iterable of floats or a :class:`numpy.ndarray`. The values are
+    clipped to ``0..1`` before calculating the mean that determines the glyph
+    index.
     """
 
-    vals = list(values)
-    if not vals:
-        raise ValueError("values must not be empty")
-    mean = sum(vals) / len(vals)
-    mean = max(0.0, min(1.0, mean))
+    if np is not None and hasattr(values, "__array__"):
+        arr = np.array(values, dtype=float)  # type: ignore[attr-defined]
+        if arr.size == 0:
+            raise ValueError("values must not be empty")
+        arr = np.clip(arr, 0.0, 1.0)  # type: ignore[attr-defined]
+        mean = float(arr.mean())
+    else:
+        vals = list(values)  # type: ignore[arg-type]
+        if not vals:
+            raise ValueError("values must not be empty")
+        vals = [max(0.0, min(1.0, v)) for v in vals]
+        mean = sum(vals) / len(vals)
     idx = min(int(mean * len(GLYPHS)), len(GLYPHS) - 1)
     return GLYPHS[idx]
 

--- a/agents/symbolmapper/test_main.py
+++ b/agents/symbolmapper/test_main.py
@@ -1,10 +1,16 @@
 import pytest
+import numpy as np
 from .main import map_numeric_to_symbol, map_text_to_glyph, SymbolMapper
 
 
 def test_map_numeric_to_symbol_basic():
     assert map_numeric_to_symbol([0.1, 0.9]) == "ψ"
     assert map_numeric_to_symbol([1.0]) == "★"
+
+
+def test_map_numeric_to_symbol_numpy():
+    arr = np.array([0.1, 0.9])  # type: ignore[attr-defined]
+    assert map_numeric_to_symbol(arr) == "ψ"
 
 
 def test_map_numeric_to_symbol_empty():

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -101,3 +101,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 
 - Added basic personhood consent guard with tests enforcing consent requirement.
 - Added voice intent cheat sheet for aeon.sh, Sigillin loader and ToDo parser.
+- Enhanced SymbolMapper to support NumPy arrays.


### PR DESCRIPTION
## Summary
- allow SymbolMapper to accept numpy arrays by detecting array-like inputs and clamping values
- cover numpy usage in SymbolMapper tests
- record progress and feedback for the new feature

## Testing
- `pnpm install`
- `poetry install --with test`
- `pytest agents/symbolmapper/test_main.py`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a252aee4188322b486ed343b9b16a9