### PR TITLE
feat: add LocalHasher and OpenAIEmbedder

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13167,7 +13167,7 @@
     "path": "packages/rag/Embedder.ts",
     "task": "Provide embedding implementations with fallback local hasher",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create VectorStore",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12683,7 +12683,7 @@
   path: packages/rag/Embedder.ts
   task: Provide embedding implementations with fallback local hasher
   test: ""
-  status: open
+  status: done
 - commit: Create VectorStore
   path: packages/rag/VectorStore.ts
   task: Persist vectors on disk and support cosine search

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Enhance SymbolMapper with NumPy support",
+  "lastCommit": "Add LocalHasher and OpenAIEmbedder",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4164,6 +4164,10 @@
     },
     {
       "commit": "Enhance SymbolMapper to handle NumPy arrays",
+      "status": "done"
+    },
+    {
+      "commit": "Add LocalHasher and OpenAIEmbedder",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -102,3 +102,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added basic personhood consent guard with tests enforcing consent requirement.
 - Added voice intent cheat sheet for aeon.sh, Sigillin loader and ToDo parser.
 - Enhanced SymbolMapper to support NumPy arrays.
+\n- Added LocalHasher and OpenAIEmbedder with fallback to expand RAG capabilities.

--- a/packages/rag/Embedder.ts
+++ b/packages/rag/Embedder.ts
@@ -1,0 +1,75 @@
+import crypto from 'crypto';
+
+export interface Embedder {
+  /**
+   * Generate a vector embedding for the given text.
+   */
+  embed(text: string): Promise<number[]>;
+}
+
+/**
+ * LocalHasher provides a deterministic embedding based on SHA256 hashing.
+ * Useful as a lightweight fallback when no external embedding service is
+ * available.
+ */
+export class LocalHasher implements Embedder {
+  constructor(private dimensions = 256) {}
+
+  async embed(text: string): Promise<number[]> {
+    const hash = crypto.createHash('sha256').update(text).digest();
+    const vector: number[] = [];
+    for (let i = 0; i < this.dimensions; i++) {
+      vector[i] = hash[i % hash.length] / 255;
+    }
+    return vector;
+  }
+}
+
+/**
+ * OpenAIEmbedder calls the OpenAI embeddings API. If no API key is set or the
+ * request fails it throws, allowing callers to fallback to LocalHasher.
+ */
+export class OpenAIEmbedder implements Embedder {
+  constructor(private apiKey = process.env.OPENAI_API_KEY) {}
+
+  async embed(text: string): Promise<number[]> {
+    if (!this.apiKey) throw new Error('Missing OPENAI_API_KEY');
+    const res = await fetch('https://api.openai.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'text-embedding-3-small',
+        input: text,
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`OpenAI API error: ${res.status}`);
+    }
+    const json: any = await res.json();
+    const embedding = json?.data?.[0]?.embedding;
+    if (!Array.isArray(embedding)) {
+      throw new Error('Invalid embedding response');
+    }
+    return embedding.map((v: number) => Number(v));
+  }
+}
+
+/**
+ * Helper to create an embedder with automatic fallback to LocalHasher.
+ */
+export function createEmbedder(): Embedder {
+  const local = new LocalHasher();
+  const openai = new OpenAIEmbedder();
+  return {
+    async embed(text: string) {
+      try {
+        return await openai.embed(text);
+      } catch {
+        return await local.embed(text);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- implement LocalHasher and OpenAIEmbedder with automatic fallback for RAG
- mark embedder task complete in advanced ToDo lists and progress tracker
- note embedder addition in feedback codex

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a2588c93648322b34a0cd2efcb6c62