### PR TITLE
Add Mandala transparency policy block

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - Sozialaktionen anstoßen: `node scripts/trigger-socialgood-workflow.js` (parst ToDos und startet SocialGood-Matching) oder `node scripts/run-parsing-socialgood.js` (lokales Parsing & Matching)
 - MemoryManager verschiebt abgelaufene Einträge automatisch von `daily` zu `weekly` und `longterm`.
 
+## 🔍 Mandala Transparency
+
+Transparenz ist ein zentraler Wert des UnifiedMandala.
+Dieses Repository bietet klare Einblicke in Entwicklungsentscheidungen, offene Aufgaben und ethische Richtlinien.
+Siehe [AI_POLICY.md](AI_POLICY.md) und [advancedprogress.json](advancedprogress.json) für fortlaufend nachvollziehbare Zustände.
+
 ## 🚀 Features
 
 - [**CREP-Systematik**](docs/crep/overview.md) – Coherence, Resonance, Emergence, Poetics

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14540,5 +14540,12 @@
     "task": "Collect community votes on utopia packages and feed results into task prioritization",
     "test": "packages/consent-mesh/utopie-consent.test.ts",
     "status": "open"
+  },
+  {
+    "commit": "Add Mandala transparency policy block",
+    "path": "README.md",
+    "task": "Document transparency principles in README",
+    "test": "",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13671,3 +13671,8 @@
     prioritization
   test: packages/consent-mesh/utopie-consent.test.ts
   status: open
+- commit: Add Mandala transparency policy block
+  path: README.md
+  task: Document transparency principles in README
+  test: ""
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Add LocalHasher and OpenAIEmbedder",
+  "lastCommit": "Add Mandala transparency policy block",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4168,6 +4168,10 @@
     },
     {
       "commit": "Add LocalHasher and OpenAIEmbedder",
+      "status": "done"
+    },
+    {
+      "commit": "Add Mandala transparency policy block",
       "status": "done"
     }
   ],


### PR DESCRIPTION
## Summary
- add Mandala Transparency section to clarify ethical and development insight links
- mark transparency feature as complete in advanced ToDo and progress trackers

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test` *(fails: Vitest cannot be imported in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68a266ff80d08322b9ed4dd2e97c85cc