### PR TITLE
feat: add disk-backed vector store

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13174,7 +13174,7 @@
     "path": "packages/rag/VectorStore.ts",
     "task": "Persist vectors on disk and support cosine search",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create DocStore",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12688,7 +12688,7 @@
   path: packages/rag/VectorStore.ts
   task: Persist vectors on disk and support cosine search
   test: ""
-  status: open
+  status: done
 - commit: Create DocStore
   path: packages/rag/DocStore.ts
   task: Track provenance and tombstone documents

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Add Mandala transparency policy block",
+  "lastCommit": "Create VectorStore",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.; Documented Mandala prompt patterns; Implemented RAG Chunker for document tokenization; Extended SymbolMapper to accept NumPy arrays",
+  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.; Documented Mandala prompt patterns; Implemented RAG Chunker for document tokenization; Extended SymbolMapper to accept NumPy arrays; Added VectorStore for RAG.",
   "pendingTasks": [
     "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129 (GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json)",
     "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e (GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json)",
@@ -4172,6 +4172,10 @@
     },
     {
       "commit": "Add Mandala transparency policy block",
+      "status": "done"
+    },
+    {
+      "commit": "Create VectorStore",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -103,3 +103,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added voice intent cheat sheet for aeon.sh, Sigillin loader and ToDo parser.
 - Enhanced SymbolMapper to support NumPy arrays.
 \n- Added LocalHasher and OpenAIEmbedder with fallback to expand RAG capabilities.
+- Implemented VectorStore for RAG with cosine search and persistence.

--- a/packages/rag/VectorStore.test.ts
+++ b/packages/rag/VectorStore.test.ts
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+import { VectorStore } from './VectorStore';
+
+describe('VectorStore', () => {
+  const tmpDir = path.join(__dirname, '__test__');
+  const file = path.join(tmpDir, 'vectors.json');
+
+  beforeEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('persists vectors and retrieves nearest by cosine similarity', () => {
+    const store = new VectorStore(file);
+    store.add('a', [1, 0]);
+    store.add('b', [0, 1]);
+
+    const results = store.search([0.9, 0.1], 1);
+    expect(results[0].id).toBe('a');
+
+    const reloaded = new VectorStore(file);
+    const again = reloaded.search([0, 0.8], 1);
+    expect(again[0].id).toBe('b');
+  });
+});

--- a/packages/rag/VectorStore.ts
+++ b/packages/rag/VectorStore.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface VectorRecord {
+  id: string;
+  vector: number[];
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  const dot = a.reduce((sum, val, i) => sum + val * (b[i] || 0), 0);
+  const magA = Math.sqrt(a.reduce((sum, val) => sum + val * val, 0));
+  const magB = Math.sqrt(b.reduce((sum, val) => sum + val * val, 0));
+  if (magA === 0 || magB === 0) return 0;
+  return dot / (magA * magB);
+}
+
+export class VectorStore {
+  private records: VectorRecord[] = [];
+
+  constructor(private filePath: string) {
+    if (fs.existsSync(filePath)) {
+      try {
+        const json = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        this.records = Array.isArray(json.records) ? json.records : [];
+      } catch {
+        this.records = [];
+      }
+    }
+  }
+
+  add(id: string, vector: number[]): void {
+    this.records.push({ id, vector });
+    this.save();
+  }
+
+  search(query: number[], k = 5): { id: string; score: number }[] {
+    return this.records
+      .map((r) => ({ id: r.id, score: cosineSimilarity(query, r.vector) }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, k);
+  }
+
+  private save(): void {
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    fs.writeFileSync(
+      this.filePath,
+      JSON.stringify({ records: this.records }, null, 2)
+    );
+  }
+}
+
+export default VectorStore;


### PR DESCRIPTION
## Summary
- add simple VectorStore that saves vectors on disk and performs cosine search
- mark VectorStore task complete in advanced TODO and progress files
- log VectorStore implementation feedback

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/rag/VectorStore.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a2d562f4dc8322adb38c1f3edad703