### PR TITLE
feat: add RAG DocStore

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13181,7 +13181,7 @@
     "path": "packages/rag/DocStore.ts",
     "task": "Track provenance and tombstone documents",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add AnswerComposer",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12693,7 +12693,7 @@
   path: packages/rag/DocStore.ts
   task: Track provenance and tombstone documents
   test: ""
-  status: open
+  status: done
 - commit: Add AnswerComposer
   path: packages/rag/AnswerComposer.ts
   task: Generate answers with citations using ModelRouter

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Adjust text fragmenter for gpt-5 context",
+  "lastCommit": "Create DocStore",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4938,6 +4938,10 @@
     },
     {
       "commit": "Adjust text fragmenter for gpt-5 context",
+      "status": "done"
+    },
+    {
+      "commit": "Create DocStore",
       "status": "done"
     }
   ],

--- a/packages/rag/DocStore.test.ts
+++ b/packages/rag/DocStore.test.ts
@@ -1,0 +1,28 @@
+import fs from 'fs';
+import path from 'path';
+import { DocStore } from './DocStore';
+
+describe('DocStore', () => {
+  const tmpDir = path.join(__dirname, '__test__');
+  const file = path.join(tmpDir, 'docs.json');
+
+  beforeEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('stores documents and marks tombstones', () => {
+    const store = new DocStore(file);
+    store.add({ id: '1', text: 'hello', source: 'test' });
+
+    let doc = store.get('1');
+    expect(doc?.text).toBe('hello');
+    expect(store.list().length).toBe(1);
+
+    store.tombstone('1');
+    expect(store.get('1')).toBeUndefined();
+    expect(store.list().length).toBe(0);
+
+    const reloaded = new DocStore(file);
+    expect(reloaded.get('1')).toBeUndefined();
+  });
+});

--- a/packages/rag/DocStore.ts
+++ b/packages/rag/DocStore.ts
@@ -1,0 +1,61 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface DocRecord {
+  id: string;
+  text: string;
+  source?: string;
+  tombstoned?: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/**
+ * Simple document store with provenance tracking and tombstoning.
+ * Persists records as JSON on disk.
+ */
+export class DocStore {
+  private docs: DocRecord[] = [];
+
+  constructor(private filePath: string) {
+    if (fs.existsSync(filePath)) {
+      try {
+        const json = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        this.docs = Array.isArray(json.docs) ? json.docs : [];
+      } catch {
+        this.docs = [];
+      }
+    }
+  }
+
+  add(record: Omit<DocRecord, 'createdAt' | 'updatedAt' | 'tombstoned'>): void {
+    const now = Date.now();
+    this.docs.push({ ...record, createdAt: now, updatedAt: now });
+    this.save();
+  }
+
+  get(id: string): DocRecord | undefined {
+    const rec = this.docs.find((d) => d.id === id && !d.tombstoned);
+    return rec ? { ...rec } : undefined;
+  }
+
+  list(): DocRecord[] {
+    return this.docs.filter((d) => !d.tombstoned).map((d) => ({ ...d }));
+  }
+
+  tombstone(id: string): void {
+    const rec = this.docs.find((d) => d.id === id);
+    if (rec) {
+      rec.tombstoned = true;
+      rec.updatedAt = Date.now();
+      this.save();
+    }
+  }
+
+  private save(): void {
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    fs.writeFileSync(this.filePath, JSON.stringify({ docs: this.docs }, null, 2));
+  }
+}
+
+export default DocStore;


### PR DESCRIPTION
## Summary
- implement DocStore for RAG package with provenance tracking and tombstone support
- mark DocStore task complete in advancedToDo manifests and progress log

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false --listEmittedFiles`
- `npx jest packages/rag/DocStore.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a2df21c9f08322aeb9f8f25cf492b2