### PR TITLE
feat: add personhood router hook

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13132,7 +13132,7 @@
     "path": "packages/gpt-bridges/router/withPersonhood.ts",
     "task": "Wrap tools or models with policy checks and audit",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Update agent permissions",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12658,7 +12658,7 @@
   path: packages/gpt-bridges/router/withPersonhood.ts
   task: Wrap tools or models with policy checks and audit
   test: ""
-  status: open
+  status: done
 - commit: Update agent permissions
   path: governance/permissions.yaml
   task: Allow personhood-agent and autotuning-agent tools and models

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Create DocStore",
+  "lastCommit": "Add withPersonhood router hook",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4177,6 +4177,10 @@
     {
       "commit": "Create VectorStore",
       "status": "done"
+    },
+    {
+      "commit": "Add withPersonhood router hook",
+      "status": "done"
     }
   ],
   "completed": [
@@ -4218,6 +4222,10 @@
     },
     {
       "commit": "Introduce CREPInsightDashboard",
+      "status": "done"
+    },
+    {
+      "commit": "Add withPersonhood router hook",
       "status": "done"
     }
   ],

--- a/packages/gpt-bridges/router/withPersonhood.test.ts
+++ b/packages/gpt-bridges/router/withPersonhood.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { withPersonhood } from './withPersonhood';
+import { ConsentRegistry } from '../../personhood/ConsentRegistry';
+import { GPTEventHub } from '../GPTEventHub';
+
+describe('withPersonhood', () => {
+  const personId = 'alice';
+
+  beforeEach(() => {
+    ConsentRegistry.revoke(personId);
+  });
+
+  it('throws when consent is missing', () => {
+    const wrapped = withPersonhood(() => 'ok', personId);
+    expect(() => wrapped()).toThrow(/Consent required/);
+  });
+
+  it('runs handler and emits audit event when consent granted', () => {
+    ConsentRegistry.grant(personId);
+    let event: any = null;
+    const handler = (e: any) => {
+      event = e;
+    };
+    GPTEventHub.on('personhood-check', handler);
+    const wrapped = withPersonhood((n: number) => n + 1, personId);
+    const result = wrapped(1);
+    expect(result).toBe(2);
+    expect(event).toEqual({ personId, tool: 'anonymous' });
+    GPTEventHub.off('personhood-check', handler);
+  });
+});

--- a/packages/gpt-bridges/router/withPersonhood.ts
+++ b/packages/gpt-bridges/router/withPersonhood.ts
@@ -1,0 +1,20 @@
+import { requireConsent } from '../../personhood/PolicyGuard';
+import { GPTEventHub } from '../GPTEventHub';
+
+/**
+ * Wraps a handler with a personhood consent check and audit emission.
+ * Throws if consent is missing and emits a `personhood-check` event.
+ */
+export function withPersonhood<T extends (...args: any[]) => any>(
+  handler: T,
+  personId: string
+): (...args: Parameters<T>) => ReturnType<T> {
+  return (...args: Parameters<T>): ReturnType<T> => {
+    requireConsent(personId);
+    GPTEventHub.emit('personhood-check', {
+      personId,
+      tool: handler.name || 'anonymous',
+    });
+    return handler(...args);
+  };
+}


### PR DESCRIPTION
## Summary
- add `withPersonhood` router utility to audit and enforce consent before model or tool use
- track personhood hook task in advanced progress files

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run packages/gpt-bridges/router/withPersonhood.test.ts` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e66c2a1483229289ac5765ca4e84