### PR TITLE
feat(rag): add answer composer with citation support

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13188,7 +13188,7 @@
     "path": "packages/rag/AnswerComposer.ts",
     "task": "Generate answers with citations using ModelRouter",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement RAGPipeline",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12698,7 +12698,7 @@
   path: packages/rag/AnswerComposer.ts
   task: Generate answers with citations using ModelRouter
   test: ""
-  status: open
+  status: done
 - commit: Implement RAGPipeline
   path: packages/rag/RAGPipeline.ts
   task: Index and query documents with personhood guard and audit

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Add withPersonhood router hook",
+  "lastCommit": "Add AnswerComposer",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4950,6 +4950,11 @@
     },
     {
       "commit": "Create DocStore",
+      "status": "done"
+    }
+    ,
+    {
+      "commit": "Add AnswerComposer",
       "status": "done"
     }
   ],

--- a/packages/rag/AnswerComposer.test.ts
+++ b/packages/rag/AnswerComposer.test.ts
@@ -1,0 +1,19 @@
+import { AnswerComposer, ModelRouter } from './AnswerComposer';
+import { DocRecord } from './DocStore';
+
+describe('AnswerComposer', () => {
+  it('generates answer and returns citations', async () => {
+    const router: ModelRouter = {
+      async generate(prompt: string) {
+        expect(prompt).toContain('Question: What?');
+        return 'Because [1]';
+      },
+    };
+    const docs: DocRecord[] = [{ id: 'doc1', text: 'fact', source: 'src' , createdAt: 0, updatedAt: 0}];
+    const composer = new AnswerComposer(router);
+    const res = await composer.compose('What?', docs);
+    expect(res.answer).toBe('Because [1]');
+    expect(res.citations[0].id).toBe('doc1');
+    expect(res.citations[0].source).toBe('src');
+  });
+});

--- a/packages/rag/AnswerComposer.ts
+++ b/packages/rag/AnswerComposer.ts
@@ -1,0 +1,38 @@
+import { DocRecord } from './DocStore';
+
+export interface ModelRouter {
+  /**
+   * Generate a response for the given prompt.
+   */
+  generate(prompt: string): Promise<string>;
+}
+
+export interface Citation {
+  id: string;
+  source?: string;
+}
+
+export interface AnswerResult {
+  answer: string;
+  citations: Citation[];
+}
+
+/**
+ * AnswerComposer generates answers for a query using a ModelRouter and
+ * attaches simple citation references for the provided documents.
+ */
+export class AnswerComposer {
+  constructor(private router: ModelRouter) {}
+
+  async compose(question: string, docs: DocRecord[]): Promise<AnswerResult> {
+    const contextLines = docs
+      .map((d, i) => `[${i + 1}] ${d.text}`)
+      .join('\n');
+    const prompt = `${contextLines}\n\nQuestion: ${question}\nAnswer:`;
+    const answer = await this.router.generate(prompt);
+    const citations = docs.map((d) => ({ id: d.id, source: d.source }));
+    return { answer, citations };
+  }
+}
+
+export default AnswerComposer;


### PR DESCRIPTION
## Summary
- implement AnswerComposer to generate model answers with simple citations
- cover AnswerComposer with unit test
- mark AnswerComposer task as complete in advanced ToDo and progress tracking

## Testing
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx jest packages/rag/AnswerComposer.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a2ec1c628c8322a55fd45c22c89aa0