### PR TITLE
feat: add workflow launcher component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12369,7 +12369,7 @@
     "path": "packages/unifiedmandala-ui/components/WorkflowLauncher.tsx",
     "task": "Provide button to trigger Sigillin jobs without intermediate screens",
     "test": "packages/unifiedmandala-ui/components/WorkflowLauncher.test.tsx",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Revise pitch docs with outcome focused demos",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12111,7 +12111,7 @@
   path: packages/unifiedmandala-ui/components/WorkflowLauncher.tsx
   task: Provide button to trigger Sigillin jobs without intermediate screens
   test: packages/unifiedmandala-ui/components/WorkflowLauncher.test.tsx
-  status: open
+  status: done
 - commit: Revise pitch docs with outcome focused demos
   path: docs/pitch/impact-demos.md
   task: Include two short GIFs demonstrating outcome over screentime

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "docs: add impact demos and extend voice intents",
+  "lastCommit": "feat: add workflow launcher component",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -7,10 +7,6 @@
   "mergeConflicts": [],
   "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.; Documented Mandala prompt patterns; Implemented RAG Chunker for document tokenization; Extended SymbolMapper to accept NumPy arrays; Added VectorStore for RAG.",
   "pendingTasks": [
-    {
-      "commit": "Add one-click workflow launcher",
-      "status": "open"
-    },
     {
       "commit": "Add gpt-5 ModelMatrix and routing",
       "status": "open"
@@ -5395,6 +5391,10 @@
     },
     {
       "commit": "Document Mandala prompt patterns",
+      "status": "done"
+    },
+    {
+      "commit": "Add one-click workflow launcher",
       "status": "done"
     }
   ],

--- a/packages/unifiedmandala-ui/components/WorkflowLauncher.test.tsx
+++ b/packages/unifiedmandala-ui/components/WorkflowLauncher.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import WorkflowLauncher from './WorkflowLauncher';
+
+test('triggers workflow via POST', async () => {
+  const fetchMock = jest.fn().mockResolvedValue({ ok: true });
+  // @ts-ignore
+  global.fetch = fetchMock;
+  render(<WorkflowLauncher endpoint="/api/test" />);
+  const btn = screen.getByLabelText('launch-workflow');
+  fireEvent.click(btn);
+  expect(fetchMock).toHaveBeenCalledWith('/api/test', { method: 'POST' });
+  expect(btn).toBeDisabled();
+  await waitFor(() => expect(btn).not.toBeDisabled());
+});

--- a/packages/unifiedmandala-ui/components/WorkflowLauncher.tsx
+++ b/packages/unifiedmandala-ui/components/WorkflowLauncher.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+
+export interface WorkflowLauncherProps {
+  endpoint?: string;
+  label?: string;
+  onLaunch?: (success: boolean) => void;
+}
+
+const WorkflowLauncher: React.FC<WorkflowLauncherProps> = ({
+  endpoint = '/api/sigillin/workflow',
+  label = 'Launch Sigillin Workflow',
+  onLaunch,
+}) => {
+  const [loading, setLoading] = useState(false);
+
+  const launch = async () => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      const res = await fetch(endpoint, { method: 'POST' });
+      onLaunch?.(res.ok);
+    } catch {
+      onLaunch?.(false);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <button aria-label="launch-workflow" onClick={launch} disabled={loading}>
+      {loading ? 'Launching...' : label}
+    </button>
+  );
+};
+
+export default WorkflowLauncher;
+


### PR DESCRIPTION
## Summary
- add `WorkflowLauncher` React component for one-click Sigillin jobs
- test POST workflow trigger with new component test
- mark workflow launcher task as done and sync advanced progress tracker

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json && echo tsc_done`
- `npx jest packages/unifiedmandala-ui/components/WorkflowLauncher.test.tsx repositorypflege/__tests__/list-open-advanced-todos.test.js repositorypflege/__tests__/update-advanced-progress.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a2f72447dc8322b2a2f94086717760