### PR TITLE
docs: document vector index env variable

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12558,7 +12558,7 @@
     "path": "docs/snippets/ENV_VECTOR_INDEX.md",
     "task": "Provide VECTOR_INDEX_URL environment variable example",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add AgentWorkflowEngine",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12248,7 +12248,7 @@
   path: docs/snippets/ENV_VECTOR_INDEX.md
   task: Provide VECTOR_INDEX_URL environment variable example
   test: ""
-  status: open
+  status: done
 - commit: Add AgentWorkflowEngine
   path: packages/agents/AgentWorkflowEngine.ts
   task: Load agents.yaml and emit lifecycle events with status snapshot

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -80,10 +80,6 @@
       "status": "open"
     },
     {
-      "commit": "Document vector index env snippet",
-      "status": "open"
-    },
-    {
       "commit": "Add AgentWorkflowEngine",
       "status": "open"
     },
@@ -5441,6 +5437,10 @@
     },
     {
       "commit": "Add withPersonhood router hook",
+      "status": "done"
+    },
+    {
+      "commit": "Document vector index env snippet",
       "status": "done"
     }
   ],

--- a/docs/snippets/ENV_VECTOR_INDEX.md
+++ b/docs/snippets/ENV_VECTOR_INDEX.md
@@ -1,0 +1,12 @@
+# VECTOR_INDEX_URL
+
+The `VECTOR_INDEX_URL` environment variable specifies the endpoint of the vector index service.
+Use it to direct ingestion and search scripts to the correct API.
+
+```bash
+# example: local development
+export VECTOR_INDEX_URL="http://localhost:9000"
+```
+
+Add this variable to your shell profile or `.env` file before running scripts like
+`ingest-sigils-to-vector-index.ts` or other RAG utilities.

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -104,3 +104,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Enhanced SymbolMapper to support NumPy arrays.
 \n- Added LocalHasher and OpenAIEmbedder with fallback to expand RAG capabilities.
 - Implemented VectorStore for RAG with cosine search and persistence.
+- Documented VECTOR_INDEX_URL snippet for vector index configuration.


### PR DESCRIPTION
## Summary
- document VECTOR_INDEX_URL usage for vector index scripts
- update advanced ToDo and progress trackers
- leave feedback about env snippet addition

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: workspace enumeration too large)*
- `npx tsc -p tsconfig.json` *(fails: command did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fd28aad8832284d64682fdec054b