### PR TITLE
feat: add rag index CLI

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13202,7 +13202,7 @@
     "path": "scripts/rag-index.ts",
     "task": "Index files into RAG store via CLI",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add rag-query CLI",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12708,7 +12708,7 @@
   path: scripts/rag-index.ts
   task: Index files into RAG store via CLI
   test: ""
-  status: open
+  status: done
 - commit: Add rag-query CLI
   path: scripts/rag-query.ts
   task: Query RAG index from command line

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -413,7 +413,7 @@
     },
     {
       "commit": "Add rag-index CLI",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add rag-query CLI",

--- a/scripts/rag-index.ts
+++ b/scripts/rag-index.ts
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import path from 'path';
+import { chunkText } from '../packages/rag/Chunker';
+import { createEmbedder } from '../packages/rag/Embedder';
+import { VectorStore } from '../packages/rag/VectorStore';
+import { DocStore } from '../packages/rag/DocStore';
+
+const STORE_DIR = process.env.RAG_STORE_DIR || path.join('data', 'rag');
+const VECTOR_PATH = path.join(STORE_DIR, 'vectors.json');
+const DOC_PATH = path.join(STORE_DIR, 'docs.json');
+
+async function indexFile(file: string) {
+  const text = fs.readFileSync(file, 'utf8');
+  const docId = path.basename(file);
+  const docStore = new DocStore(DOC_PATH);
+  docStore.add({ id: docId, text, source: file });
+
+  const chunks = chunkText(text, 200, 20);
+  const embedder = createEmbedder();
+  const vectorStore = new VectorStore(VECTOR_PATH);
+
+  for (let i = 0; i < chunks.length; i++) {
+    const vec = await embedder.embed(chunks[i].text);
+    vectorStore.add(`${docId}-${i}`, vec);
+  }
+  console.log(`Indexed ${chunks.length} chunks from ${file}`);
+}
+
+async function main() {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    console.error('Usage: ts-node scripts/rag-index.ts <file ...>');
+    process.exit(1);
+  }
+  for (const f of files) {
+    await indexFile(f);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+


### PR DESCRIPTION
## Summary
- add rag-index CLI to build local RAG stores
- track rag-index task completion in advanced todo files

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx ts-node scripts/rag-index.ts README.md`


------
https://chatgpt.com/codex/tasks/task_e_68a3062e726483228368a7d52a5ba006