### PR TITLE
feat: add todo filtering options

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -9,9 +9,9 @@
   "pendingTasks": [
     "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129 (GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json)",
     "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e (GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json)",
-    "- und Progress-Dateien mit diesem Stand. ()",
-    "- und Progress-Dateien mit diesem Standpunkt, um Gedächtniskohärenz zu wahren. ()",
-    "Parser` – Liest ToDo-Listen aus Markdown-Dateien. ()"
+    "Integrate new GPT teams from Zukunft conversation (packages/agents)",
+    "chore: scaffold Wissenschaftliche Versuche project (packages/wissenschaftliche-versuche)",
+    "feat: add MasterGPTBridge orchestrator (packages/agents/MasterGPTBridge.ts)"
   ],
   "progress": [
     {

--- a/repositorypflege/__tests__/list-open-advanced-todos.test.js
+++ b/repositorypflege/__tests__/list-open-advanced-todos.test.js
@@ -1,11 +1,19 @@
+const fs = require('fs');
+const path = require('path');
 const { listOpenAdvancedTodos } = require('../list-open-advanced-todos');
 
-test('lists open advanced todos', () => {
-  const todos = listOpenAdvancedTodos();
-  expect(Array.isArray(todos)).toBe(true);
-  expect(todos.length).toBeGreaterThan(0);
-  todos.forEach(todo => {
-    expect(todo).toHaveProperty('commit');
-    expect(todo).toHaveProperty('path');
-  });
+test('lists and filters open advanced todos', () => {
+  const tmp = path.join(__dirname, 'tmp-advancedToDo.json');
+  const sample = [
+    { commit: 'Task A', path: 'a', status: 'open' },
+    { commit: 'Task B', path: 'b', status: 'done' },
+    { commit: '', path: 'c', status: 'open' },
+    { commit: 'Test C', path: 'c', status: 'open' }
+  ];
+  fs.writeFileSync(tmp, JSON.stringify(sample, null, 2));
+
+  const todos = listOpenAdvancedTodos('Test', tmp);
+  expect(todos).toEqual([{ commit: 'Test C', path: 'c' }]);
+
+  fs.unlinkSync(tmp);
 });

--- a/repositorypflege/list-open-advanced-todos.js
+++ b/repositorypflege/list-open-advanced-todos.js
@@ -1,25 +1,37 @@
 const fs = require('fs');
 const path = require('path');
 
-function listOpenAdvancedTodos() {
-  const todoPath = path.resolve(__dirname, '..', 'advancedToDo.json');
-  const raw = fs.readFileSync(todoPath, 'utf-8');
+function listOpenAdvancedTodos(pattern, todoPath) {
+  const file = todoPath || path.resolve(__dirname, '..', 'advancedToDo.json');
+  const raw = fs.readFileSync(file, 'utf-8');
   const data = JSON.parse(raw);
-  return data.filter(item => item.status !== 'done')
-    .map(item => ({ commit: item.commit, path: item.path }));
+  const regex = pattern ? new RegExp(pattern, 'i') : null;
+  return data
+    .filter(
+      (item) =>
+        item.status !== 'done' &&
+        item.commit &&
+        item.path &&
+        (!regex || regex.test(item.commit) || regex.test(item.path))
+    )
+    .map((item) => ({ commit: item.commit, path: item.path }));
 }
 
 if (require.main === module) {
-  const open = listOpenAdvancedTodos();
-  const display = open.slice(0, 5);
-  display.forEach(t => {
-    const commitText = (typeof t.commit === 'string' && t.commit.length > 120)
-      ? t.commit.slice(0, 117) + '...'
-      : t.commit;
+  const limit = parseInt(process.argv[2], 10) || 5;
+  const grepIndex = process.argv.indexOf('--grep');
+  const pattern = grepIndex >= 0 ? process.argv[grepIndex + 1] : undefined;
+  const open = listOpenAdvancedTodos(pattern);
+  const display = open.slice(0, limit);
+  display.forEach((t) => {
+    const commitText =
+      typeof t.commit === 'string' && t.commit.length > 120
+        ? t.commit.slice(0, 117) + '...'
+        : t.commit;
     console.log(`- ${commitText} (${t.path})`);
   });
-  if (open.length > 5) {
-    console.log(`...and ${open.length - 5} more`);
+  if (open.length > limit) {
+    console.log(`...and ${open.length - limit} more`);
   }
 }
 

--- a/repositorypflege/update-advanced-progress.js
+++ b/repositorypflege/update-advanced-progress.js
@@ -2,18 +2,20 @@ const fs = require('fs');
 const path = require('path');
 const { listOpenAdvancedTodos } = require('./list-open-advanced-todos');
 
-function updateAdvancedProgress(limit = 5, progressFile) {
+function updateAdvancedProgress(limit = 5, progressFile, pattern) {
   const progressPath = progressFile || path.resolve(__dirname, '..', 'advancedprogress.json');
   const progress = JSON.parse(fs.readFileSync(progressPath, 'utf8'));
-  const todos = listOpenAdvancedTodos().slice(0, limit);
-  progress.pendingTasks = todos.map(t => `${t.commit} (${t.path})`);
+  const todos = listOpenAdvancedTodos(pattern).slice(0, limit);
+  progress.pendingTasks = todos.map((t) => `${t.commit} (${t.path})`);
   fs.writeFileSync(progressPath, JSON.stringify(progress, null, 2));
   console.log(`Synced ${todos.length} tasks to ${progressPath}`);
 }
 
 if (require.main === module) {
   const limit = parseInt(process.argv[2], 10) || 5;
-  updateAdvancedProgress(limit);
+  const grepIndex = process.argv.indexOf('--grep');
+  const pattern = grepIndex >= 0 ? process.argv[grepIndex + 1] : undefined;
+  updateAdvancedProgress(limit, undefined, pattern);
 }
 
 module.exports = { updateAdvancedProgress };


### PR DESCRIPTION
## Summary
- add pattern filtering and input validation to list-open-advanced-todos script
- extend update-advanced-progress script with grep option
- add tests for advanced todo filtering

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx jest repositorypflege/__tests__/list-open-advanced-todos.test.js repositorypflege/__tests__/update-advanced-progress.test.js`
- `npx pyright`
- `npx tsc -p tsconfig.json && echo 'tsc completed'`


------
https://chatgpt.com/codex/tasks/task_e_68a323df8b58832288890bb4d1ce8bff