### PR TITLE
feat: add code agent RAG tasks

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-18, in der Zeit des Morgen.
+Am 2025-08-18, in der Zeit des Tag.
 
-Symbolphase: Initiation (Fokus: C)
+Symbolphase: Aktivierung (Fokus: R)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13146,7 +13146,7 @@
     "path": "code-agent-tasks.yaml",
     "task": "Add setup and API start commands for new modules",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add personhood guard test",
@@ -13244,7 +13244,7 @@
     "path": "code-agent-tasks.yaml",
     "task": "Add rag.api, rag.index.demo and rag.query.demo commands",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement DatasetRegistry",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12668,7 +12668,7 @@
   path: code-agent-tasks.yaml
   task: Add setup and API start commands for new modules
   test: ""
-  status: open
+  status: done
 - commit: Add personhood guard test
   path: tests/personhood.guard.test.ts
   task: Verify consent requirement for PII research
@@ -12738,7 +12738,7 @@
   path: code-agent-tasks.yaml
   task: Add rag.api, rag.index.demo and rag.query.demo commands
   test: ""
-  status: open
+  status: done
 - commit: Implement DatasetRegistry
   path: packages/datasets/DatasetRegistry.ts
   task: Register datasets, versions, splits and artifacts with personhood checks

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add rag-query CLI",
+  "lastCommit": "feat: add code agent RAG tasks",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -7,11 +7,1150 @@
   "mergeConflicts": [],
   "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.; Documented Mandala prompt patterns; Implemented RAG Chunker for document tokenization; Extended SymbolMapper to accept NumPy arrays; Added VectorStore for RAG.",
   "pendingTasks": [
-    "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129 (GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json)",
-    "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e (GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json)",
-    "Integrate new GPT teams from Zukunft conversation (packages/agents)",
-    "chore: scaffold Wissenschaftliche Versuche project (packages/wissenschaftliche-versuche)",
-    "feat: add MasterGPTBridge orchestrator (packages/agents/MasterGPTBridge.ts)"
+    {
+      "commit": "Add gpt-5 ModelMatrix and routing",
+      "status": "open"
+    },
+    {
+      "commit": "Declare gpt-5 capabilities for agents",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce ToolAdapter for unified tool calling",
+      "status": "open"
+    },
+    {
+      "commit": "Add gpt-5 QA script and Fourier logging",
+      "status": "open"
+    },
+    {
+      "commit": "Tune ethics policy for gpt-5",
+      "status": "open"
+    },
+    {
+      "commit": "Configure gpt-5 KEDA scaler and budget guard",
+      "status": "open"
+    },
+    {
+      "commit": "Expose gpt-5 metrics in admin panel",
+      "status": "open"
+    },
+    {
+      "commit": "Enable gpt-5 filter in MandalaNetworkView",
+      "status": "open"
+    },
+    {
+      "commit": "Switch OpenAI provider to responses API",
+      "status": "open"
+    },
+    {
+      "commit": "Add gpt-5 smoke test suite",
+      "status": "open"
+    },
+    {
+      "commit": "Implement voice note to advancedToDo pipeline",
+      "status": "open"
+    },
+    {
+      "commit": "Generate sigillin JSONL index",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Sigil RAG search hooks",
+      "status": "open"
+    },
+    {
+      "commit": "Expose Sigil search API",
+      "status": "open"
+    },
+    {
+      "commit": "Add Mandala Sigil link bridge",
+      "status": "open"
+    },
+    {
+      "commit": "Implement vector index ingest script",
+      "status": "open"
+    },
+    {
+      "commit": "Document Sigil RAG hooks",
+      "status": "open"
+    },
+    {
+      "commit": "Add runlog archive workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Add AgentWorkflowEngine",
+      "status": "open"
+    },
+    {
+      "commit": "Create agent registry file",
+      "status": "open"
+    },
+    {
+      "commit": "Add event bus subjects and LocalEventBus",
+      "status": "open"
+    },
+    {
+      "commit": "Provide system start script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement model router and providers",
+      "status": "open"
+    },
+    {
+      "commit": "Add open-source model provider interfaces",
+      "status": "open"
+    },
+    {
+      "commit": "Expose agent status API",
+      "status": "open"
+    },
+    {
+      "commit": "Expose agent status in UI",
+      "status": "open"
+    },
+    {
+      "commit": "Document agent workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Document open source model setup",
+      "status": "open"
+    },
+    {
+      "commit": "Provide model env snippet",
+      "status": "open"
+    },
+    {
+      "commit": "Document system start workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Add agent workflow CI check",
+      "status": "open"
+    },
+    {
+      "commit": "Extend NatsEventBus with auth options",
+      "status": "open"
+    },
+    {
+      "commit": "Bridge LocalEventBus with NATS",
+      "status": "open"
+    },
+    {
+      "commit": "Add NATS bridge start script",
+      "status": "open"
+    },
+    {
+      "commit": "Provide NATS env snippet",
+      "status": "open"
+    },
+    {
+      "commit": "Implement ToolRegistry",
+      "status": "open"
+    },
+    {
+      "commit": "Add chatWithTools helper",
+      "status": "open"
+    },
+    {
+      "commit": "Create tool-calling demo script",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce AgentHeartbeat class",
+      "status": "open"
+    },
+    {
+      "commit": "Expose agent health API",
+      "status": "open"
+    },
+    {
+      "commit": "Add AgentHealthPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Add JetStreamBus for persistent events",
+      "status": "open"
+    },
+    {
+      "commit": "Create JetStream setup script",
+      "status": "open"
+    },
+    {
+      "commit": "Create JetStream replay script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement OpenAIProvider with Responses API fallback",
+      "status": "open"
+    },
+    {
+      "commit": "Validate tool arguments with AJV",
+      "status": "open"
+    },
+    {
+      "commit": "Add PolicyEnforcer for governance",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce HmacSigner for event envelopes",
+      "status": "open"
+    },
+    {
+      "commit": "Start metrics server script",
+      "status": "open"
+    },
+    {
+      "commit": "Provide KEDA autoscaling template",
+      "status": "open"
+    },
+    {
+      "commit": "Add BudgetGuard utility",
+      "status": "open"
+    },
+    {
+      "commit": "Add ToolRegistry tests",
+      "status": "open"
+    },
+    {
+      "commit": "Document MaxBundle runbook",
+      "status": "open"
+    },
+    {
+      "commit": "Extend event subjects for agent health and errors",
+      "status": "open"
+    },
+    {
+      "commit": "Implement WebSocketHub for live events",
+      "status": "open"
+    },
+    {
+      "commit": "Add ws-start bridge script",
+      "status": "open"
+    },
+    {
+      "commit": "Create live event React hook",
+      "status": "open"
+    },
+    {
+      "commit": "Add EventStreamPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Implement JetStreamKV wrapper",
+      "status": "open"
+    },
+    {
+      "commit": "Implement JetStreamObjectStore",
+      "status": "open"
+    },
+    {
+      "commit": "Load tools from YAML specs",
+      "status": "open"
+    },
+    {
+      "commit": "Provide sigil search tool spec",
+      "status": "open"
+    },
+    {
+      "commit": "Add sigil search tool handler",
+      "status": "open"
+    },
+    {
+      "commit": "Define diverse research agents",
+      "status": "open"
+    },
+    {
+      "commit": "Write reproducibility protocol",
+      "status": "open"
+    },
+    {
+      "commit": "Write dataset provenance protocol",
+      "status": "open"
+    },
+    {
+      "commit": "Write CREP research protocol",
+      "status": "open"
+    },
+    {
+      "commit": "Write research safety guidelines",
+      "status": "open"
+    },
+    {
+      "commit": "Create PipelineOrchestrator",
+      "status": "open"
+    },
+    {
+      "commit": "Add universe pulse pipeline",
+      "status": "open"
+    },
+    {
+      "commit": "Add UniversePulse E2E demo",
+      "status": "open"
+    },
+    {
+      "commit": "Provide Prometheus scrape config",
+      "status": "open"
+    },
+    {
+      "commit": "Add Grafana mini dashboard",
+      "status": "open"
+    },
+    {
+      "commit": "Create ResearchHub UI",
+      "status": "open"
+    },
+    {
+      "commit": "Implement FeatureFlags service",
+      "status": "open"
+    },
+    {
+      "commit": "Seed feature flags script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement ExperimentRegistry",
+      "status": "open"
+    },
+    {
+      "commit": "Add experiment sample script",
+      "status": "open"
+    },
+    {
+      "commit": "Add Personhood Protocol documentation",
+      "status": "open"
+    },
+    {
+      "commit": "Create personhood policy config",
+      "status": "open"
+    },
+    {
+      "commit": "Implement ConsentRegistry",
+      "status": "open"
+    },
+    {
+      "commit": "Implement AuditTrail",
+      "status": "open"
+    },
+    {
+      "commit": "Add RefusalEngine",
+      "status": "open"
+    },
+    {
+      "commit": "Implement PolicyGuard",
+      "status": "open"
+    },
+    {
+      "commit": "Implement flags API",
+      "status": "open"
+    },
+    {
+      "commit": "Add FeatureFlagsPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Implement experiments API",
+      "status": "open"
+    },
+    {
+      "commit": "Add ExperimentBoard component",
+      "status": "open"
+    },
+    {
+      "commit": "Add provenance card type",
+      "status": "open"
+    },
+    {
+      "commit": "Implement PDF ingest",
+      "status": "open"
+    },
+    {
+      "commit": "Implement GeoTIFF ingest",
+      "status": "open"
+    },
+    {
+      "commit": "Implement VCF ingest",
+      "status": "open"
+    },
+    {
+      "commit": "Add ingest demo script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement ReviewerQueue",
+      "status": "open"
+    },
+    {
+      "commit": "Add reviewer API",
+      "status": "open"
+    },
+    {
+      "commit": "Add AutoTuningAgent",
+      "status": "open"
+    },
+    {
+      "commit": "Implement SecureAggregator",
+      "status": "open"
+    },
+    {
+      "commit": "Add federated API",
+      "status": "open"
+    },
+    {
+      "commit": "Update agent permissions",
+      "status": "open"
+    },
+    {
+      "commit": "Implement RAGPipeline",
+      "status": "open"
+    },
+    {
+      "commit": "Add rag-api server",
+      "status": "open"
+    },
+    {
+      "commit": "Add ReviewerPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Add RAGSearchPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Add RAG smoke test",
+      "status": "open"
+    },
+    {
+      "commit": "Implement DatasetRegistry",
+      "status": "open"
+    },
+    {
+      "commit": "Add dataset API",
+      "status": "open"
+    },
+    {
+      "commit": "Add CitationIndex",
+      "status": "open"
+    },
+    {
+      "commit": "Add RAG citation demo script",
+      "status": "open"
+    },
+    {
+      "commit": "Add RAG API deployment",
+      "status": "open"
+    },
+    {
+      "commit": "Add flags, experiments and reviewer deployments",
+      "status": "open"
+    },
+    {
+      "commit": "Add optional KEDA scaler",
+      "status": "open"
+    },
+    {
+      "commit": "Add dataset registry test",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for dataset and k8s",
+      "status": "open"
+    },
+    {
+      "commit": "Add Realtime StreamProtocol definitions",
+      "status": "open"
+    },
+    {
+      "commit": "Implement ResearchHubWS server",
+      "status": "open"
+    },
+    {
+      "commit": "Create realtime hub HTTP bridge script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement annotations KV store",
+      "status": "open"
+    },
+    {
+      "commit": "Add annotations API with broadcast",
+      "status": "open"
+    },
+    {
+      "commit": "Add ReviewerHotkeys UI hook",
+      "status": "open"
+    },
+    {
+      "commit": "Implement HMAC signed URLs",
+      "status": "open"
+    },
+    {
+      "commit": "Create share API server",
+      "status": "open"
+    },
+    {
+      "commit": "Add RealtimeResearchHub UI component",
+      "status": "open"
+    },
+    {
+      "commit": "Add AnnotationsPanel UI component",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for realtime APIs",
+      "status": "open"
+    },
+    {
+      "commit": "Add signed URL test",
+      "status": "open"
+    },
+    {
+      "commit": "Add realtime flow smoke test",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows dev scripts and cross-env support",
+      "status": "open"
+    },
+    {
+      "commit": "Create Windows start-all PowerShell script",
+      "status": "open"
+    },
+    {
+      "commit": "Add OS Bridge capability policy",
+      "status": "open"
+    },
+    {
+      "commit": "Implement CapabilityGuard for OS Bridge",
+      "status": "open"
+    },
+    {
+      "commit": "Add WindowsPS helper",
+      "status": "open"
+    },
+    {
+      "commit": "Implement OS Bridge API",
+      "status": "open"
+    },
+    {
+      "commit": "Add OSControlPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Create DesktopAutomationAgent",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows UIA and hotkey tools",
+      "status": "open"
+    },
+    {
+      "commit": "Add voice and screen control API",
+      "status": "open"
+    },
+    {
+      "commit": "Extend OS Bridge API with UIA and screen routes",
+      "status": "open"
+    },
+    {
+      "commit": "Add VoicePanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Add ScreenCapturePanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows tools build script and package entries",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for Windows OS bridge",
+      "status": "open"
+    },
+    {
+      "commit": "Add UIA screen redaction tool",
+      "status": "open"
+    },
+    {
+      "commit": "Add WinUI tree inspector utility",
+      "status": "open"
+    },
+    {
+      "commit": "Add AutoHotkey hook scripts",
+      "status": "open"
+    },
+    {
+      "commit": "Add desktop recorder tool",
+      "status": "open"
+    },
+    {
+      "commit": "Implement UIMacroSynth agent",
+      "status": "open"
+    },
+    {
+      "commit": "Add PII regex patterns module",
+      "status": "open"
+    },
+    {
+      "commit": "Add image redactor utility",
+      "status": "open"
+    },
+    {
+      "commit": "Implement redaction API service",
+      "status": "open"
+    },
+    {
+      "commit": "Add AutoHotkey template script",
+      "status": "open"
+    },
+    {
+      "commit": "Create AutoHotkey macro compiler",
+      "status": "open"
+    },
+    {
+      "commit": "Add AutoHotkey runner script",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce macro DSL validator",
+      "status": "open"
+    },
+    {
+      "commit": "Add macro execution script",
+      "status": "open"
+    },
+    {
+      "commit": "Add session log utility",
+      "status": "open"
+    },
+    {
+      "commit": "Add macro replay script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement desktop recorder API",
+      "status": "open"
+    },
+    {
+      "commit": "Create MacroEditor component",
+      "status": "open"
+    },
+    {
+      "commit": "Create RedactionPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Define role permissions map",
+      "status": "open"
+    },
+    {
+      "commit": "Extend capability policy for UI consent",
+      "status": "open"
+    },
+    {
+      "commit": "Add topology index registry",
+      "status": "open"
+    },
+    {
+      "commit": "Implement admin API gateway",
+      "status": "open"
+    },
+    {
+      "commit": "Create admin console app",
+      "status": "open"
+    },
+    {
+      "commit": "Add AI peer connector module",
+      "status": "open"
+    },
+    {
+      "commit": "Implement admin peers API",
+      "status": "open"
+    },
+    {
+      "commit": "Create spaces management module",
+      "status": "open"
+    },
+    {
+      "commit": "Implement commons API",
+      "status": "open"
+    },
+    {
+      "commit": "Add commons presence websocket",
+      "status": "open"
+    },
+    {
+      "commit": "Create commons hub app",
+      "status": "open"
+    },
+    {
+      "commit": "Add system overview widget",
+      "status": "open"
+    },
+    {
+      "commit": "Add capability graph widget",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce task router module",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for admin and commons modules",
+      "status": "open"
+    },
+    {
+      "commit": "Add ContributionEvent schema",
+      "status": "open"
+    },
+    {
+      "commit": "Add PluginManifest schema",
+      "status": "open"
+    },
+    {
+      "commit": "Add AIPeerHandshake protocol",
+      "status": "open"
+    },
+    {
+      "commit": "Create CoIntel orchestrator service",
+      "status": "open"
+    },
+    {
+      "commit": "Implement collab websocket server",
+      "status": "open"
+    },
+    {
+      "commit": "Add CreditLedger module",
+      "status": "open"
+    },
+    {
+      "commit": "Add AttributionIndex module",
+      "status": "open"
+    },
+    {
+      "commit": "Add Provenance hashing utilities",
+      "status": "open"
+    },
+    {
+      "commit": "Create peer handshake service",
+      "status": "open"
+    },
+    {
+      "commit": "Add setup wizard script",
+      "status": "open"
+    },
+    {
+      "commit": "Create CoauthorCanvas component",
+      "status": "open"
+    },
+    {
+      "commit": "Create TaskBoard component",
+      "status": "open"
+    },
+    {
+      "commit": "Add ConsentTimeline component",
+      "status": "open"
+    },
+    {
+      "commit": "Add PeerManager component",
+      "status": "open"
+    },
+    {
+      "commit": "Add ModelRouterEditor component",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce Tenant and Instance types",
+      "status": "open"
+    },
+    {
+      "commit": "Add RBAC permission helper",
+      "status": "open"
+    },
+    {
+      "commit": "Create identity API service",
+      "status": "open"
+    },
+    {
+      "commit": "Define UI templates",
+      "status": "open"
+    },
+    {
+      "commit": "Create instance registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Add ACL API service",
+      "status": "open"
+    },
+    {
+      "commit": "Create InitialAdminPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Define federation manifest type",
+      "status": "open"
+    },
+    {
+      "commit": "Create federation registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Create federation bridge websocket",
+      "status": "open"
+    },
+    {
+      "commit": "Add collab federation bridge script",
+      "status": "open"
+    },
+    {
+      "commit": "Create GlobalMandalaGraph component",
+      "status": "open"
+    },
+    {
+      "commit": "Add unified AppShell",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for Co-Intelligence services",
+      "status": "open"
+    },
+    {
+      "commit": "Append identity and federation services to code agent tasks",
+      "status": "open"
+    },
+    {
+      "commit": "Add OIDC stub service",
+      "status": "open"
+    },
+    {
+      "commit": "Add UI switchboard service",
+      "status": "open"
+    },
+    {
+      "commit": "Add policy lint script",
+      "status": "open"
+    },
+    {
+      "commit": "Add compose override for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows stack start script",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows services installer",
+      "status": "open"
+    },
+    {
+      "commit": "Add UM integration GitHub workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Document UM integration guide",
+      "status": "open"
+    },
+    {
+      "commit": "Add integration copier script",
+      "status": "open"
+    },
+    {
+      "commit": "Expose UM service scripts in package.json",
+      "status": "open"
+    },
+    {
+      "commit": "Provide tsconfig for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add production docker compose file",
+      "status": "open"
+    },
+    {
+      "commit": "Create generic Dockerfile for TypeScript services",
+      "status": "open"
+    },
+    {
+      "commit": "Configure NGINX reverse proxy for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add Kong gateway configuration",
+      "status": "open"
+    },
+    {
+      "commit": "Implement Ed25519 key generation script",
+      "status": "open"
+    },
+    {
+      "commit": "Add manifest signing script",
+      "status": "open"
+    },
+    {
+      "commit": "Add manifest verification script",
+      "status": "open"
+    },
+    {
+      "commit": "Create verified federation registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Implement SSO broker service",
+      "status": "open"
+    },
+    {
+      "commit": "Generate systemd unit files script",
+      "status": "open"
+    },
+    {
+      "commit": "Provide environment example",
+      "status": "open"
+    },
+    {
+      "commit": "Document production setup",
+      "status": "open"
+    },
+    {
+      "commit": "Add Keycloak OIDC dev bundle",
+      "status": "open"
+    },
+    {
+      "commit": "Add Kubernetes manifests with Kustomize overlays",
+      "status": "open"
+    },
+    {
+      "commit": "Add monitoring configuration",
+      "status": "open"
+    },
+    {
+      "commit": "Add Caddy TLS reverse proxy",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitHub Actions workflow for Kubernetes deployment",
+      "status": "open"
+    },
+    {
+      "commit": "Add Helm OIDC bundle",
+      "status": "open"
+    },
+    {
+      "commit": "Add Traefik mTLS ingress",
+      "status": "open"
+    },
+    {
+      "commit": "Add SLO monitoring pack",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps manifests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Add Go OIDC quickstart",
+      "status": "open"
+    },
+    {
+      "commit": "Add Keycloak auto-import helmfile",
+      "status": "open"
+    },
+    {
+      "commit": "Add Cloudflare DNS01 ClusterIssuer",
+      "status": "open"
+    },
+    {
+      "commit": "Add Argo Rollouts canary stack",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps app factory script",
+      "status": "open"
+    },
+    {
+      "commit": "Add Observability++ stack",
+      "status": "open"
+    },
+    {
+      "commit": "Add secret management examples",
+      "status": "open"
+    },
+    {
+      "commit": "Add NetworkPolicy templates",
+      "status": "open"
+    },
+    {
+      "commit": "Add blue/green rollouts with Slack alerts",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps golden path template",
+      "status": "open"
+    },
+    {
+      "commit": "Add one-click cluster bootstrap",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Vault CSI for secret file mounts",
+      "status": "open"
+    },
+    {
+      "commit": "Add ServiceMap-based NetworkPolicy generator",
+      "status": "open"
+    },
+    {
+      "commit": "Set up Cypress UI smoke tests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Set up k6 API smoke tests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Configure promotion gates for rollouts",
+      "status": "open"
+    },
+    {
+      "commit": "Deploy gate-controller for E2E gating",
+      "status": "open"
+    },
+    {
+      "commit": "Add Playwright synthetics with OTel",
+      "status": "open"
+    },
+    {
+      "commit": "Provide RUM OTel web snippet",
+      "status": "open"
+    },
+    {
+      "commit": "Implement multi-signal quorum gates",
+      "status": "open"
+    },
+    {
+      "commit": "Add Terraform synthetics and alerting",
+      "status": "open"
+    },
+    {
+      "commit": "Enable auto-rollback on SLO violation",
+      "status": "open"
+    },
+    {
+      "commit": "Schedule weekly SLO and error budget reports",
+      "status": "open"
+    },
+    {
+      "commit": "Support multi-tenant E2E gates",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows E2E workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Track SLO budget consumption",
+      "status": "open"
+    },
+    {
+      "commit": "Capture debug snapshots on aborted rollouts",
+      "status": "open"
+    },
+    {
+      "commit": "Provide tenant admin API and UI",
+      "status": "open"
+    },
+    {
+      "commit": "Automate image builds and Kustomize validation",
+      "status": "open"
+    },
+    {
+      "commit": "Bootstrap GitOps root application",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce multi-cluster ApplicationSet and security policies",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Kyverno policies with Gatekeeper audit layer",
+      "status": "open"
+    },
+    {
+      "commit": "Apply Cilium default-deny and service allow policies",
+      "status": "open"
+    },
+    {
+      "commit": "Deploy Falco with RBAC-abuse rules and Slack alerts",
+      "status": "open"
+    },
+    {
+      "commit": "Wire OpenTelemetry collector to Tempo and Loki",
+      "status": "open"
+    },
+    {
+      "commit": "Add unified security Grafana dashboard",
+      "status": "open"
+    },
+    {
+      "commit": "Add Red Team Day exercise scripts",
+      "status": "open"
+    },
+    {
+      "commit": "Enable Alertmanager night mode routing",
+      "status": "open"
+    },
+    {
+      "commit": "Define per-namespace Cilium FQDN allowlists",
+      "status": "open"
+    },
+    {
+      "commit": "Switch Kyverno verifyImages to enforce",
+      "status": "open"
+    },
+    {
+      "commit": "Implement EPI scanning CLI",
+      "status": "open"
+    },
+    {
+      "commit": "Merge EPI with abundance dataset",
+      "status": "open"
+    },
+    {
+      "commit": "Add Universe Tree simulation",
+      "status": "open"
+    },
+    {
+      "commit": "Provide Universe Tree config",
+      "status": "open"
+    },
+    {
+      "commit": "Evaluate Universe Tree outputs",
+      "status": "open"
+    },
+    {
+      "commit": "Add Universe Tree sanity checks",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Utopie-to-Do adapter",
+      "status": "open"
+    },
+    {
+      "commit": "Extend CREP metrics with hope activation",
+      "status": "open"
+    },
+    {
+      "commit": "Compare tech vs society branches in Universe Tree",
+      "status": "open"
+    },
+    {
+      "commit": "Implement Consent Mesh for utopia packages",
+      "status": "open"
+    }
   ],
   "progress": [
     {
@@ -4236,6 +5375,30 @@
     },
     {
       "commit": "Add one-click workflow launcher",
+      "status": "done"
+    },
+    {
+      "commit": "Add code agent RAG tasks",
+      "status": "done"
+    },
+    {
+      "commit": "Document vector index env snippet",
+      "status": "done"
+    },
+    {
+      "commit": "Extend code agent tasks for Wave 2",
+      "status": "done"
+    },
+    {
+      "commit": "Add rag-index CLI",
+      "status": "done"
+    },
+    {
+      "commit": "Add rag-query CLI",
+      "status": "done"
+    },
+    {
+      "commit": "Extend code agent tasks for RAG",
       "status": "done"
     }
   ],

--- a/code-agent-tasks.yaml
+++ b/code-agent-tasks.yaml
@@ -1,0 +1,28 @@
+version: 2
+tasks:
+  - id: env.setup
+    run:
+      - pnpm add -D ts-node yaml node-fetch nats ws ajv micromatch
+    verify:
+      - node -v
+      - pnpm -v
+  - id: bus.jetstream.setup
+    env: [NATS_URL]
+    run:
+      - npx ts-node scripts/js-setup.ts
+    verify:
+      - echo "JetStream ready"
+  - id: deps.wave2
+    run:
+      - pnpm install
+  - id: rag.api
+    run:
+      - npx ts-node scripts/rag-api.ts
+    verify:
+      - curl -f http://localhost:4010/health || echo "API not responding"
+  - id: rag.index.demo
+    run:
+      - npx ts-node scripts/rag-index.ts docs
+  - id: rag.query.demo
+    run:
+      - npx ts-node scripts/rag-query.ts "What is Mandala?"

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -105,3 +105,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 \n- Added LocalHasher and OpenAIEmbedder with fallback to expand RAG capabilities.
 - Implemented VectorStore for RAG with cosine search and persistence.
 - Documented VECTOR_INDEX_URL snippet for vector index configuration.
+- Added initial RAG tasks to code-agent workflow for Wave 2.


### PR DESCRIPTION
## Summary
- add code-agent-tasks.yaml with Wave 2 and RAG commands
- mark corresponding advanced ToDo items as done and sync progress
- note RAG task integration in feedback codex

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a3389eda8483228c76771ca7385244