### PR TITLE
feat(event-bus): add LocalEventBus and sync progress

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12580,7 +12580,7 @@
     "path": "packages/event-bus/subjects.ts",
     "task": "Define versioned event names and simple local bus",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Provide system start script",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12264,7 +12264,7 @@
   path: packages/event-bus/subjects.ts
   task: Define versioned event names and simple local bus
   test: ""
-  status: open
+  status: done
 - commit: Provide system start script
   path: scripts/system-start.ts
   task: Initialize agents and log lifecycle events with dry-run option

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add BinaryExistenceMatrix simulation",
+  "lastCommit": "feat(event-bus): add LocalEventBus",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -81,10 +81,6 @@
     },
     {
       "commit": "Create agent registry file",
-      "status": "open"
-    },
-    {
-      "commit": "Add event bus subjects and LocalEventBus",
       "status": "open"
     },
     {
@@ -5404,6 +5400,10 @@
     {
       "commit": "Declare gpt-5 capabilities for agents",
       "status": "done"
+    },
+    {
+      "commit": "Add event bus subjects and LocalEventBus",
+      "status": "done"
     }
   ],
   "completed": [
@@ -6181,6 +6181,10 @@
     },
     {
       "commit": "Add AnswerComposer",
+      "status": "done"
+    },
+    {
+      "commit": "Add event bus subjects and LocalEventBus",
       "status": "done"
     },
     {

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -107,3 +107,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Documented VECTOR_INDEX_URL snippet for vector index configuration.
 - Added initial RAG tasks to code-agent workflow for Wave 2.
 - Declared gpt-5 capabilities for core agents.
+- Introduced LocalEventBus with versioned subjects for lightweight event handling.

--- a/packages/event-bus/LocalEventBus.test.ts
+++ b/packages/event-bus/LocalEventBus.test.ts
@@ -1,0 +1,20 @@
+import { LocalEventBus } from './LocalEventBus';
+import { Subjects } from './subjects';
+
+describe('LocalEventBus', () => {
+  it('publishes and subscribes to events', () => {
+    const bus = new LocalEventBus();
+    const handler = jest.fn();
+    const unsubscribe = bus.subscribe(Subjects.CREP_UPDATE, handler);
+    const payload = { value: 42 };
+
+    bus.publish(Subjects.CREP_UPDATE, payload);
+    expect(handler).toHaveBeenCalledWith(payload);
+
+    // ensure unsubscribe stops receiving events
+    unsubscribe();
+    bus.publish(Subjects.CREP_UPDATE, { value: 7 });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/packages/event-bus/LocalEventBus.ts
+++ b/packages/event-bus/LocalEventBus.ts
@@ -1,0 +1,40 @@
+import { EventEmitter } from 'events';
+import { Subjects } from './subjects';
+
+/**
+ * LocalEventBus provides an in-memory event bus implementation used for
+ * lightweight testing or environments where a full message broker is not
+ * required. It mirrors the publish/subscribe API of NatsEventBus but relies on
+ * Node's EventEmitter under the hood.
+ */
+export class LocalEventBus {
+  private emitter = new EventEmitter();
+
+  /**
+     * Publish a payload to a subject.
+     * @param subject The event subject.
+     * @param payload Data to emit.
+     */
+  publish(subject: Subjects, payload: unknown): void {
+    this.emitter.emit(subject, payload);
+  }
+
+  /**
+     * Subscribe to a subject.
+     * @param subject The event subject.
+     * @param handler Callback invoked with the payload.
+     * @returns Function to unsubscribe.
+     */
+  subscribe(subject: Subjects, handler: (data: unknown) => void): () => void {
+    this.emitter.on(subject, handler);
+    return () => this.emitter.off(subject, handler);
+  }
+
+  /**
+     * Remove all listeners and reset the bus.
+     */
+  close(): void {
+    this.emitter.removeAllListeners();
+  }
+}
+

--- a/packages/event-bus/index.ts
+++ b/packages/event-bus/index.ts
@@ -1,2 +1,3 @@
 export * from './NatsEventBus';
+export * from './LocalEventBus';
 export * from './subjects';

--- a/packages/event-bus/subjects.ts
+++ b/packages/event-bus/subjects.ts
@@ -1,4 +1,13 @@
 export enum Subjects {
-  CREP_UPDATE = 'crep.update',
-  AGENT_HEARTBEAT = 'agent.heartbeat',
+  /**
+   * Emitted when CREP metrics change.
+   * The `v1` prefix allows future event versioning without breaking
+   * existing listeners.
+   */
+  CREP_UPDATE = 'v1.crep.update',
+  /**
+   * Heartbeat events emitted by agents to signal liveness.
+   * Versioned for forward compatibility.
+   */
+  AGENT_HEARTBEAT = 'v1.agent.heartbeat',
 }


### PR DESCRIPTION
## Summary
- add LocalEventBus for in-memory publish/subscribe
- version event bus subjects for forward compatibility
- mark event bus task complete in advancedToDo and progress tracking

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright -p pyrightconfig.json` *(fails: venvPath is not a valid directory)*
- `npx tsc -p tsconfig.json`
- `pnpm test packages/event-bus/LocalEventBus.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a34ffba31483229dd4d877fe3cf7f7