### PR TITLE
feat(ui): add reviewer and RAG search panels

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13224,14 +13224,14 @@
     "path": "packages/unifiedmandala-ui/components/ReviewerPanel.tsx",
     "task": "Enqueue and decide review items via API",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add RAGSearchPanel component",
     "path": "packages/unifiedmandala-ui/components/RAGSearchPanel.tsx",
     "task": "Provide retrieval and ask UI for RAG API",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add RAG smoke test",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12724,12 +12724,12 @@
   path: packages/unifiedmandala-ui/components/ReviewerPanel.tsx
   task: Enqueue and decide review items via API
   test: ""
-  status: open
+  status: done
 - commit: Add RAGSearchPanel component
   path: packages/unifiedmandala-ui/components/RAGSearchPanel.tsx
   task: Provide retrieval and ask UI for RAG API
   test: ""
-  status: open
+  status: done
 - commit: Add RAG smoke test
   path: tests/rag.flow.test.ts
   task: Verify indexing and querying of RAG pipeline

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5067,6 +5067,14 @@
     {
       "commit": "feat: add BinaryExistenceMatrix simulation",
       "status": "done"
+    },
+    {
+      "commit": "Add ReviewerPanel component",
+      "status": "done"
+    },
+    {
+      "commit": "Add RAGSearchPanel component",
+      "status": "done"
     }
   ],
   "fractalTodos": [

--- a/packages/unifiedmandala-ui/components/RAGSearchPanel.test.tsx
+++ b/packages/unifiedmandala-ui/components/RAGSearchPanel.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import RAGSearchPanel from './RAGSearchPanel';
+
+describe('RAGSearchPanel', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn().mockResolvedValue({ json: async () => ({ hits: [] }) });
+  });
+
+  test('executes search request', () => {
+    render(<RAGSearchPanel />);
+    fireEvent.change(screen.getByPlaceholderText('Search'), { target: { value: 'test' } });
+    fireEvent.click(screen.getByText('Search'));
+    expect(fetch).toHaveBeenCalledWith('/rag/search?q=test');
+  });
+});

--- a/packages/unifiedmandala-ui/components/RAGSearchPanel.tsx
+++ b/packages/unifiedmandala-ui/components/RAGSearchPanel.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+
+/**
+ * RAGSearchPanel provides a minimal UI to query the RAG API.
+ * Suggestions originate from `newadvancedconversations.json`.
+ */
+export default function RAGSearchPanel() {
+  const [query, setQuery] = useState('');
+  const [result, setResult] = useState<any>(null);
+
+  const search = () => {
+    fetch(`/rag/search?q=${encodeURIComponent(query)}`)
+      .then((r) => r.json())
+      .then((json) => setResult(json))
+      .catch(() => setResult(null));
+  };
+
+  return (
+    <div aria-label="RAGSearchPanel">
+      <input
+        placeholder="Search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <button onClick={search}>Search</button>
+      {result && <pre>{JSON.stringify(result, null, 2)}</pre>}
+    </div>
+  );
+}

--- a/packages/unifiedmandala-ui/components/ReviewerPanel.test.tsx
+++ b/packages/unifiedmandala-ui/components/ReviewerPanel.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ReviewerPanel from './ReviewerPanel';
+
+describe('ReviewerPanel', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ json: async () => ({ items: [{ id: '1', text: 'Test' }] }) })
+      .mockResolvedValueOnce({});
+  });
+
+  test('loads items and sends decision', async () => {
+    render(<ReviewerPanel />);
+    expect(fetch).toHaveBeenCalledWith('/review/items');
+    const approve = await screen.findByText('Approve');
+    fireEvent.click(approve);
+    expect(fetch).toHaveBeenCalledWith(
+      '/review/decision',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+});

--- a/packages/unifiedmandala-ui/components/ReviewerPanel.tsx
+++ b/packages/unifiedmandala-ui/components/ReviewerPanel.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+
+interface ReviewItem {
+  id: string;
+  text: string;
+}
+
+/**
+ * ReviewerPanel fetches review items and allows approving or rejecting them
+ * via simple API calls. Derived from guidance in `newadvancedconversations.json`.
+ */
+export default function ReviewerPanel() {
+  const [items, setItems] = useState<ReviewItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/review/items')
+      .then((r) => r.json())
+      .then((json) => {
+        setItems(json.items || []);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  const decide = (id: string, decision: 'approve' | 'reject') => {
+    fetch('/review/decision', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, decision })
+    }).then(() => setItems((prev) => prev.filter((i) => i.id !== id)));
+  };
+
+  if (loading) {
+    return <div aria-label="ReviewerPanel">Loading...</div>;
+  }
+  if (items.length === 0) {
+    return <div aria-label="ReviewerPanel">No review items</div>;
+  }
+
+  return (
+    <div aria-label="ReviewerPanel">
+      <ul>
+        {items.map((item) => (
+          <li key={item.id}>
+            {item.text}
+            <button onClick={() => decide(item.id, 'approve')}>Approve</button>
+            <button onClick={() => decide(item.id, 'reject')}>Reject</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add ReviewerPanel to manage review items with approve/reject actions
- add RAGSearchPanel for querying retrieval-augmented API
- track completion in advanced todo and progress files

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false --diagnostics`
- `npx vitest packages/unifiedmandala-ui/components/ReviewerPanel.test.tsx packages/unifiedmandala-ui/components/RAGSearchPanel.test.tsx` *(failed: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a37d7b9bf08322a8ece3ac8a4e0a80