### PR TITLE
chore: add runlog archive workflow

### DIFF
--- a/.github/workflows/runlog-archive.yml
+++ b/.github/workflows/runlog-archive.yml
@@ -1,0 +1,22 @@
+name: Runlog Archive
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  archive:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Collect run logs
+        run: |
+          mkdir -p runlogs
+          find . -name '*runlog*.jsonl' -exec cp {} runlogs/ \; || true
+          tar -czf runlogs.tar.gz runlogs
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: runlogs
+          path: runlogs.tar.gz

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12552,7 +12552,7 @@
     "path": ".github/workflows/runlog-archive.yml",
     "task": "Archive JSONL run logs nightly as GitHub artifacts",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Document vector index env snippet",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12244,7 +12244,7 @@
   path: .github/workflows/runlog-archive.yml
   task: Archive JSONL run logs nightly as GitHub artifacts
   test: ""
-  status: open
+  status: done
 - commit: Document vector index env snippet
   path: docs/snippets/ENV_VECTOR_INDEX.md
   task: Provide VECTOR_INDEX_URL environment variable example

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add RAG pipeline and smoke test",
+  "lastCommit": "chore: add runlog archive workflow",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4284,6 +4284,10 @@
     },
     {
       "commit": "Add Sigil RAG hook docs and ingest script",
+      "status": "done"
+    },
+    {
+      "commit": "Add runlog archive workflow",
       "status": "done"
     }
   ],


### PR DESCRIPTION
## Summary
- archive run logs nightly and upload as artifact
- mark runlog archive workflow task complete in advanced ToDo lists
- sync fractal progress ledger for updated runlog workflow

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a39031f4f48322875665eda7f743c9