### PR TITLE
feat(rag): add citation index

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13266,7 +13266,7 @@
     "path": "packages/rag/CitationIndex.ts",
     "task": "Store chunk citation metadata and render markdown and HTML",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add RAG citation demo script",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12754,7 +12754,7 @@
   path: packages/rag/CitationIndex.ts
   task: Store chunk citation metadata and render markdown and HTML
   test: ""
-  status: open
+  status: done
 - commit: Add RAG citation demo script
   path: scripts/rag-cite-demo.ts
   task: Demonstrate citation rendering from RAG hits

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5087,6 +5087,10 @@
     {
       "commit": "Add RAGSearchPanel component",
       "status": "done"
+    },
+    {
+      "commit": "Add CitationIndex",
+      "status": "done"
     }
   ],
   "fractalTodos": [

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -110,3 +110,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Introduced LocalEventBus with versioned subjects for lightweight event handling.
 
 - Implemented generate-sigillin-jsonl script to aggregate sigil files into RAG-ready corpus.
+- Added CitationIndex to manage RAG chunk citations and rendering.

--- a/packages/rag/CitationIndex.test.ts
+++ b/packages/rag/CitationIndex.test.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+import { CitationIndex } from './CitationIndex';
+
+describe('CitationIndex', () => {
+  const tmpDir = path.join(__dirname, '__test__');
+  const file = path.join(tmpDir, 'cites.json');
+
+  beforeEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('stores citations and renders output', () => {
+    const idx = new CitationIndex(file);
+    idx.add({ id: 'c1', docId: 'doc1', chunk: 0, text: 'Hello World', source: 'file://doc1' });
+    expect(idx.get('c1')?.docId).toBe('doc1');
+
+    const md = idx.renderMarkdown(['c1']);
+    expect(md).toContain('[1] Hello World');
+    expect(md).toContain('file://doc1');
+
+    const html = idx.renderHTML(['c1']);
+    expect(html).toContain('<ol>');
+    expect(html).toContain('<li>');
+  });
+});

--- a/packages/rag/CitationIndex.ts
+++ b/packages/rag/CitationIndex.ts
@@ -1,0 +1,95 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface CitationRecord {
+  id: string;
+  docId: string;
+  chunk: number;
+  text: string;
+  source?: string;
+}
+
+/**
+ * Stores citation metadata for indexed chunks and can render
+ * markdown or HTML reference lists.
+ */
+export class CitationIndex {
+  private citations: CitationRecord[] = [];
+
+  constructor(private filePath: string) {
+    if (fs.existsSync(filePath)) {
+      try {
+        const json = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        this.citations = Array.isArray(json.citations) ? json.citations : [];
+      } catch {
+        this.citations = [];
+      }
+    }
+  }
+
+  /** Add or replace a citation record. */
+  add(record: CitationRecord): void {
+    const existingIdx = this.citations.findIndex((c) => c.id === record.id);
+    if (existingIdx >= 0) {
+      this.citations[existingIdx] = record;
+    } else {
+      this.citations.push(record);
+    }
+    this.save();
+  }
+
+  get(id: string): CitationRecord | undefined {
+    const rec = this.citations.find((c) => c.id === id);
+    return rec ? { ...rec } : undefined;
+  }
+
+  list(): CitationRecord[] {
+    return this.citations.map((c) => ({ ...c }));
+  }
+
+  /** Render markdown list for given citation ids. */
+  renderMarkdown(ids: string[]): string {
+    return ids
+      .map((id, idx) => {
+        const c = this.get(id);
+        if (!c) return '';
+        const link = c.source ? ` ([source](${c.source}))` : '';
+        return `[${idx + 1}] ${c.text}${link}`;
+      })
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  /** Render HTML ordered list for given citation ids. */
+  renderHTML(ids: string[]): string {
+    const items = ids
+      .map((id) => {
+        const c = this.get(id);
+        if (!c) return '';
+        const link = c.source ? ` (<a href="${c.source}">source</a>)` : '';
+        return `<li>${escapeHtml(c.text)}${link}</li>`;
+      })
+      .filter(Boolean)
+      .join('');
+    return `<ol>${items}</ol>`;
+  }
+
+  private save(): void {
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    fs.writeFileSync(
+      this.filePath,
+      JSON.stringify({ citations: this.citations }, null, 2)
+    );
+  }
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+export default CitationIndex;


### PR DESCRIPTION
## Summary
- implement CitationIndex for RAG to manage chunk citation metadata and render markdown/HTML
- add CitationIndex test and mark related tasks as complete in advanced ToDo and progress trackers
- log CitationIndex feature in feedback codex

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: venvPath /workspace/unified-mandala/.venv is not a valid directory)*
- `npx tsc -p tsconfig.json`
- `npx jest packages/rag/CitationIndex.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a397740c108322b6ae88e8684cc04f