### PR TITLE
feat: add agent workflow engine

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-18, in der Zeit des Abend.
+Am 2025-08-18, in der Zeit des Nacht.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Reflexion (Fokus: P)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12566,14 +12566,14 @@
     "path": "packages/agents/AgentWorkflowEngine.ts",
     "task": "Load agents.yaml and emit lifecycle events with status snapshot",
     "test": "scripts/system-start.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create agent registry file",
     "path": "agents.yaml",
     "task": "List core agents with ids, capabilities and lifecycle events",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add event bus subjects and LocalEventBus",
@@ -12587,7 +12587,7 @@
     "path": "scripts/system-start.ts",
     "task": "Initialize agents and log lifecycle events with dry-run option",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement model router and providers",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12254,12 +12254,12 @@
   path: packages/agents/AgentWorkflowEngine.ts
   task: Load agents.yaml and emit lifecycle events with status snapshot
   test: scripts/system-start.ts
-  status: open
+  status: done
 - commit: Create agent registry file
   path: agents.yaml
   task: List core agents with ids, capabilities and lifecycle events
   test: ""
-  status: open
+  status: done
 - commit: Add event bus subjects and LocalEventBus
   path: packages/event-bus/subjects.ts
   task: Define versioned event names and simple local bus
@@ -12269,7 +12269,7 @@
   path: scripts/system-start.ts
   task: Initialize agents and log lifecycle events with dry-run option
   test: ""
-  status: open
+  status: done
 - commit: Implement model router and providers
   path: packages/gpt-bridges/router/ModelRouter.ts
   task: Route generation requests to Ollama, TGI or vLLM providers

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: add runlog archive workflow",
+  "lastCommit": "feat: add agent workflow engine",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -7,11 +7,1094 @@
   "mergeConflicts": [],
   "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.; Documented Mandala prompt patterns; Implemented RAG Chunker for document tokenization; Extended SymbolMapper to accept NumPy arrays; Added VectorStore for RAG.; Declared gpt-5 capabilities for core agents.; Implemented RAGPipeline with smoke test.",
   "pendingTasks": [
-    "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129 (GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json)",
-    "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e (GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json)",
-    "Integrate new GPT teams from Zukunft conversation (packages/agents)",
-    "chore: scaffold Wissenschaftliche Versuche project (packages/wissenschaftliche-versuche)",
-    "feat: add MasterGPTBridge orchestrator (packages/agents/MasterGPTBridge.ts)"
+    {
+      "commit": "Add gpt-5 ModelMatrix and routing",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce ToolAdapter for unified tool calling",
+      "status": "open"
+    },
+    {
+      "commit": "Add gpt-5 QA script and Fourier logging",
+      "status": "open"
+    },
+    {
+      "commit": "Tune ethics policy for gpt-5",
+      "status": "open"
+    },
+    {
+      "commit": "Configure gpt-5 KEDA scaler and budget guard",
+      "status": "open"
+    },
+    {
+      "commit": "Expose gpt-5 metrics in admin panel",
+      "status": "open"
+    },
+    {
+      "commit": "Enable gpt-5 filter in MandalaNetworkView",
+      "status": "open"
+    },
+    {
+      "commit": "Switch OpenAI provider to responses API",
+      "status": "open"
+    },
+    {
+      "commit": "Add gpt-5 smoke test suite",
+      "status": "open"
+    },
+    {
+      "commit": "Implement voice note to advancedToDo pipeline",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Sigil RAG search hooks",
+      "status": "open"
+    },
+    {
+      "commit": "Expose Sigil search API",
+      "status": "open"
+    },
+    {
+      "commit": "Add Mandala Sigil link bridge",
+      "status": "open"
+    },
+    {
+      "commit": "Implement model router and providers",
+      "status": "open"
+    },
+    {
+      "commit": "Add open-source model provider interfaces",
+      "status": "open"
+    },
+    {
+      "commit": "Expose agent status API",
+      "status": "open"
+    },
+    {
+      "commit": "Expose agent status in UI",
+      "status": "open"
+    },
+    {
+      "commit": "Document agent workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Document open source model setup",
+      "status": "open"
+    },
+    {
+      "commit": "Provide model env snippet",
+      "status": "open"
+    },
+    {
+      "commit": "Document system start workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Add agent workflow CI check",
+      "status": "open"
+    },
+    {
+      "commit": "Extend NatsEventBus with auth options",
+      "status": "open"
+    },
+    {
+      "commit": "Bridge LocalEventBus with NATS",
+      "status": "open"
+    },
+    {
+      "commit": "Add NATS bridge start script",
+      "status": "open"
+    },
+    {
+      "commit": "Provide NATS env snippet",
+      "status": "open"
+    },
+    {
+      "commit": "Implement ToolRegistry",
+      "status": "open"
+    },
+    {
+      "commit": "Add chatWithTools helper",
+      "status": "open"
+    },
+    {
+      "commit": "Create tool-calling demo script",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce AgentHeartbeat class",
+      "status": "open"
+    },
+    {
+      "commit": "Expose agent health API",
+      "status": "open"
+    },
+    {
+      "commit": "Add AgentHealthPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Add JetStreamBus for persistent events",
+      "status": "open"
+    },
+    {
+      "commit": "Create JetStream setup script",
+      "status": "open"
+    },
+    {
+      "commit": "Create JetStream replay script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement OpenAIProvider with Responses API fallback",
+      "status": "open"
+    },
+    {
+      "commit": "Validate tool arguments with AJV",
+      "status": "open"
+    },
+    {
+      "commit": "Add PolicyEnforcer for governance",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce HmacSigner for event envelopes",
+      "status": "open"
+    },
+    {
+      "commit": "Start metrics server script",
+      "status": "open"
+    },
+    {
+      "commit": "Provide KEDA autoscaling template",
+      "status": "open"
+    },
+    {
+      "commit": "Add BudgetGuard utility",
+      "status": "open"
+    },
+    {
+      "commit": "Add ToolRegistry tests",
+      "status": "open"
+    },
+    {
+      "commit": "Document MaxBundle runbook",
+      "status": "open"
+    },
+    {
+      "commit": "Extend event subjects for agent health and errors",
+      "status": "open"
+    },
+    {
+      "commit": "Implement WebSocketHub for live events",
+      "status": "open"
+    },
+    {
+      "commit": "Add ws-start bridge script",
+      "status": "open"
+    },
+    {
+      "commit": "Create live event React hook",
+      "status": "open"
+    },
+    {
+      "commit": "Add EventStreamPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Implement JetStreamKV wrapper",
+      "status": "open"
+    },
+    {
+      "commit": "Implement JetStreamObjectStore",
+      "status": "open"
+    },
+    {
+      "commit": "Load tools from YAML specs",
+      "status": "open"
+    },
+    {
+      "commit": "Provide sigil search tool spec",
+      "status": "open"
+    },
+    {
+      "commit": "Add sigil search tool handler",
+      "status": "open"
+    },
+    {
+      "commit": "Define diverse research agents",
+      "status": "open"
+    },
+    {
+      "commit": "Write reproducibility protocol",
+      "status": "open"
+    },
+    {
+      "commit": "Write dataset provenance protocol",
+      "status": "open"
+    },
+    {
+      "commit": "Write CREP research protocol",
+      "status": "open"
+    },
+    {
+      "commit": "Write research safety guidelines",
+      "status": "open"
+    },
+    {
+      "commit": "Create PipelineOrchestrator",
+      "status": "open"
+    },
+    {
+      "commit": "Add universe pulse pipeline",
+      "status": "open"
+    },
+    {
+      "commit": "Add UniversePulse E2E demo",
+      "status": "open"
+    },
+    {
+      "commit": "Provide Prometheus scrape config",
+      "status": "open"
+    },
+    {
+      "commit": "Add Grafana mini dashboard",
+      "status": "open"
+    },
+    {
+      "commit": "Create ResearchHub UI",
+      "status": "open"
+    },
+    {
+      "commit": "Implement FeatureFlags service",
+      "status": "open"
+    },
+    {
+      "commit": "Seed feature flags script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement ExperimentRegistry",
+      "status": "open"
+    },
+    {
+      "commit": "Add experiment sample script",
+      "status": "open"
+    },
+    {
+      "commit": "Add Personhood Protocol documentation",
+      "status": "open"
+    },
+    {
+      "commit": "Create personhood policy config",
+      "status": "open"
+    },
+    {
+      "commit": "Implement ConsentRegistry",
+      "status": "open"
+    },
+    {
+      "commit": "Implement AuditTrail",
+      "status": "open"
+    },
+    {
+      "commit": "Add RefusalEngine",
+      "status": "open"
+    },
+    {
+      "commit": "Implement PolicyGuard",
+      "status": "open"
+    },
+    {
+      "commit": "Implement flags API",
+      "status": "open"
+    },
+    {
+      "commit": "Add FeatureFlagsPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Implement experiments API",
+      "status": "open"
+    },
+    {
+      "commit": "Add ExperimentBoard component",
+      "status": "open"
+    },
+    {
+      "commit": "Add provenance card type",
+      "status": "open"
+    },
+    {
+      "commit": "Implement PDF ingest",
+      "status": "open"
+    },
+    {
+      "commit": "Implement GeoTIFF ingest",
+      "status": "open"
+    },
+    {
+      "commit": "Implement VCF ingest",
+      "status": "open"
+    },
+    {
+      "commit": "Add ingest demo script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement ReviewerQueue",
+      "status": "open"
+    },
+    {
+      "commit": "Add reviewer API",
+      "status": "open"
+    },
+    {
+      "commit": "Add AutoTuningAgent",
+      "status": "open"
+    },
+    {
+      "commit": "Implement SecureAggregator",
+      "status": "open"
+    },
+    {
+      "commit": "Add federated API",
+      "status": "open"
+    },
+    {
+      "commit": "Update agent permissions",
+      "status": "open"
+    },
+    {
+      "commit": "Add rag-api server",
+      "status": "open"
+    },
+    {
+      "commit": "Implement DatasetRegistry",
+      "status": "open"
+    },
+    {
+      "commit": "Add dataset API",
+      "status": "open"
+    },
+    {
+      "commit": "Add RAG citation demo script",
+      "status": "open"
+    },
+    {
+      "commit": "Add RAG API deployment",
+      "status": "open"
+    },
+    {
+      "commit": "Add flags, experiments and reviewer deployments",
+      "status": "open"
+    },
+    {
+      "commit": "Add optional KEDA scaler",
+      "status": "open"
+    },
+    {
+      "commit": "Add dataset registry test",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for dataset and k8s",
+      "status": "open"
+    },
+    {
+      "commit": "Add Realtime StreamProtocol definitions",
+      "status": "open"
+    },
+    {
+      "commit": "Implement ResearchHubWS server",
+      "status": "open"
+    },
+    {
+      "commit": "Create realtime hub HTTP bridge script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement annotations KV store",
+      "status": "open"
+    },
+    {
+      "commit": "Add annotations API with broadcast",
+      "status": "open"
+    },
+    {
+      "commit": "Add ReviewerHotkeys UI hook",
+      "status": "open"
+    },
+    {
+      "commit": "Implement HMAC signed URLs",
+      "status": "open"
+    },
+    {
+      "commit": "Create share API server",
+      "status": "open"
+    },
+    {
+      "commit": "Add RealtimeResearchHub UI component",
+      "status": "open"
+    },
+    {
+      "commit": "Add AnnotationsPanel UI component",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for realtime APIs",
+      "status": "open"
+    },
+    {
+      "commit": "Add signed URL test",
+      "status": "open"
+    },
+    {
+      "commit": "Add realtime flow smoke test",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows dev scripts and cross-env support",
+      "status": "open"
+    },
+    {
+      "commit": "Create Windows start-all PowerShell script",
+      "status": "open"
+    },
+    {
+      "commit": "Add OS Bridge capability policy",
+      "status": "open"
+    },
+    {
+      "commit": "Implement CapabilityGuard for OS Bridge",
+      "status": "open"
+    },
+    {
+      "commit": "Add WindowsPS helper",
+      "status": "open"
+    },
+    {
+      "commit": "Implement OS Bridge API",
+      "status": "open"
+    },
+    {
+      "commit": "Add OSControlPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Create DesktopAutomationAgent",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows UIA and hotkey tools",
+      "status": "open"
+    },
+    {
+      "commit": "Add voice and screen control API",
+      "status": "open"
+    },
+    {
+      "commit": "Extend OS Bridge API with UIA and screen routes",
+      "status": "open"
+    },
+    {
+      "commit": "Add VoicePanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Add ScreenCapturePanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows tools build script and package entries",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for Windows OS bridge",
+      "status": "open"
+    },
+    {
+      "commit": "Add UIA screen redaction tool",
+      "status": "open"
+    },
+    {
+      "commit": "Add WinUI tree inspector utility",
+      "status": "open"
+    },
+    {
+      "commit": "Add AutoHotkey hook scripts",
+      "status": "open"
+    },
+    {
+      "commit": "Add desktop recorder tool",
+      "status": "open"
+    },
+    {
+      "commit": "Implement UIMacroSynth agent",
+      "status": "open"
+    },
+    {
+      "commit": "Add PII regex patterns module",
+      "status": "open"
+    },
+    {
+      "commit": "Add image redactor utility",
+      "status": "open"
+    },
+    {
+      "commit": "Implement redaction API service",
+      "status": "open"
+    },
+    {
+      "commit": "Add AutoHotkey template script",
+      "status": "open"
+    },
+    {
+      "commit": "Create AutoHotkey macro compiler",
+      "status": "open"
+    },
+    {
+      "commit": "Add AutoHotkey runner script",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce macro DSL validator",
+      "status": "open"
+    },
+    {
+      "commit": "Add macro execution script",
+      "status": "open"
+    },
+    {
+      "commit": "Add session log utility",
+      "status": "open"
+    },
+    {
+      "commit": "Add macro replay script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement desktop recorder API",
+      "status": "open"
+    },
+    {
+      "commit": "Create MacroEditor component",
+      "status": "open"
+    },
+    {
+      "commit": "Create RedactionPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Define role permissions map",
+      "status": "open"
+    },
+    {
+      "commit": "Extend capability policy for UI consent",
+      "status": "open"
+    },
+    {
+      "commit": "Add topology index registry",
+      "status": "open"
+    },
+    {
+      "commit": "Implement admin API gateway",
+      "status": "open"
+    },
+    {
+      "commit": "Create admin console app",
+      "status": "open"
+    },
+    {
+      "commit": "Add AI peer connector module",
+      "status": "open"
+    },
+    {
+      "commit": "Implement admin peers API",
+      "status": "open"
+    },
+    {
+      "commit": "Create spaces management module",
+      "status": "open"
+    },
+    {
+      "commit": "Implement commons API",
+      "status": "open"
+    },
+    {
+      "commit": "Add commons presence websocket",
+      "status": "open"
+    },
+    {
+      "commit": "Create commons hub app",
+      "status": "open"
+    },
+    {
+      "commit": "Add system overview widget",
+      "status": "open"
+    },
+    {
+      "commit": "Add capability graph widget",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce task router module",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for admin and commons modules",
+      "status": "open"
+    },
+    {
+      "commit": "Add ContributionEvent schema",
+      "status": "open"
+    },
+    {
+      "commit": "Add PluginManifest schema",
+      "status": "open"
+    },
+    {
+      "commit": "Add AIPeerHandshake protocol",
+      "status": "open"
+    },
+    {
+      "commit": "Create CoIntel orchestrator service",
+      "status": "open"
+    },
+    {
+      "commit": "Implement collab websocket server",
+      "status": "open"
+    },
+    {
+      "commit": "Add CreditLedger module",
+      "status": "open"
+    },
+    {
+      "commit": "Add AttributionIndex module",
+      "status": "open"
+    },
+    {
+      "commit": "Add Provenance hashing utilities",
+      "status": "open"
+    },
+    {
+      "commit": "Create peer handshake service",
+      "status": "open"
+    },
+    {
+      "commit": "Add setup wizard script",
+      "status": "open"
+    },
+    {
+      "commit": "Create CoauthorCanvas component",
+      "status": "open"
+    },
+    {
+      "commit": "Create TaskBoard component",
+      "status": "open"
+    },
+    {
+      "commit": "Add ConsentTimeline component",
+      "status": "open"
+    },
+    {
+      "commit": "Add PeerManager component",
+      "status": "open"
+    },
+    {
+      "commit": "Add ModelRouterEditor component",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce Tenant and Instance types",
+      "status": "open"
+    },
+    {
+      "commit": "Add RBAC permission helper",
+      "status": "open"
+    },
+    {
+      "commit": "Create identity API service",
+      "status": "open"
+    },
+    {
+      "commit": "Define UI templates",
+      "status": "open"
+    },
+    {
+      "commit": "Create instance registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Add ACL API service",
+      "status": "open"
+    },
+    {
+      "commit": "Create InitialAdminPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Define federation manifest type",
+      "status": "open"
+    },
+    {
+      "commit": "Create federation registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Create federation bridge websocket",
+      "status": "open"
+    },
+    {
+      "commit": "Add collab federation bridge script",
+      "status": "open"
+    },
+    {
+      "commit": "Create GlobalMandalaGraph component",
+      "status": "open"
+    },
+    {
+      "commit": "Add unified AppShell",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for Co-Intelligence services",
+      "status": "open"
+    },
+    {
+      "commit": "Append identity and federation services to code agent tasks",
+      "status": "open"
+    },
+    {
+      "commit": "Add OIDC stub service",
+      "status": "open"
+    },
+    {
+      "commit": "Add UI switchboard service",
+      "status": "open"
+    },
+    {
+      "commit": "Add policy lint script",
+      "status": "open"
+    },
+    {
+      "commit": "Add compose override for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows stack start script",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows services installer",
+      "status": "open"
+    },
+    {
+      "commit": "Add UM integration GitHub workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Document UM integration guide",
+      "status": "open"
+    },
+    {
+      "commit": "Add integration copier script",
+      "status": "open"
+    },
+    {
+      "commit": "Expose UM service scripts in package.json",
+      "status": "open"
+    },
+    {
+      "commit": "Provide tsconfig for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add production docker compose file",
+      "status": "open"
+    },
+    {
+      "commit": "Create generic Dockerfile for TypeScript services",
+      "status": "open"
+    },
+    {
+      "commit": "Configure NGINX reverse proxy for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add Kong gateway configuration",
+      "status": "open"
+    },
+    {
+      "commit": "Implement Ed25519 key generation script",
+      "status": "open"
+    },
+    {
+      "commit": "Add manifest signing script",
+      "status": "open"
+    },
+    {
+      "commit": "Add manifest verification script",
+      "status": "open"
+    },
+    {
+      "commit": "Create verified federation registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Implement SSO broker service",
+      "status": "open"
+    },
+    {
+      "commit": "Generate systemd unit files script",
+      "status": "open"
+    },
+    {
+      "commit": "Provide environment example",
+      "status": "open"
+    },
+    {
+      "commit": "Document production setup",
+      "status": "open"
+    },
+    {
+      "commit": "Add Keycloak OIDC dev bundle",
+      "status": "open"
+    },
+    {
+      "commit": "Add Kubernetes manifests with Kustomize overlays",
+      "status": "open"
+    },
+    {
+      "commit": "Add monitoring configuration",
+      "status": "open"
+    },
+    {
+      "commit": "Add Caddy TLS reverse proxy",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitHub Actions workflow for Kubernetes deployment",
+      "status": "open"
+    },
+    {
+      "commit": "Add Helm OIDC bundle",
+      "status": "open"
+    },
+    {
+      "commit": "Add Traefik mTLS ingress",
+      "status": "open"
+    },
+    {
+      "commit": "Add SLO monitoring pack",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps manifests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Add Go OIDC quickstart",
+      "status": "open"
+    },
+    {
+      "commit": "Add Keycloak auto-import helmfile",
+      "status": "open"
+    },
+    {
+      "commit": "Add Cloudflare DNS01 ClusterIssuer",
+      "status": "open"
+    },
+    {
+      "commit": "Add Argo Rollouts canary stack",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps app factory script",
+      "status": "open"
+    },
+    {
+      "commit": "Add Observability++ stack",
+      "status": "open"
+    },
+    {
+      "commit": "Add secret management examples",
+      "status": "open"
+    },
+    {
+      "commit": "Add NetworkPolicy templates",
+      "status": "open"
+    },
+    {
+      "commit": "Add blue/green rollouts with Slack alerts",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps golden path template",
+      "status": "open"
+    },
+    {
+      "commit": "Add one-click cluster bootstrap",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Vault CSI for secret file mounts",
+      "status": "open"
+    },
+    {
+      "commit": "Add ServiceMap-based NetworkPolicy generator",
+      "status": "open"
+    },
+    {
+      "commit": "Set up Cypress UI smoke tests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Set up k6 API smoke tests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Configure promotion gates for rollouts",
+      "status": "open"
+    },
+    {
+      "commit": "Deploy gate-controller for E2E gating",
+      "status": "open"
+    },
+    {
+      "commit": "Add Playwright synthetics with OTel",
+      "status": "open"
+    },
+    {
+      "commit": "Provide RUM OTel web snippet",
+      "status": "open"
+    },
+    {
+      "commit": "Implement multi-signal quorum gates",
+      "status": "open"
+    },
+    {
+      "commit": "Add Terraform synthetics and alerting",
+      "status": "open"
+    },
+    {
+      "commit": "Enable auto-rollback on SLO violation",
+      "status": "open"
+    },
+    {
+      "commit": "Schedule weekly SLO and error budget reports",
+      "status": "open"
+    },
+    {
+      "commit": "Support multi-tenant E2E gates",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows E2E workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Track SLO budget consumption",
+      "status": "open"
+    },
+    {
+      "commit": "Capture debug snapshots on aborted rollouts",
+      "status": "open"
+    },
+    {
+      "commit": "Provide tenant admin API and UI",
+      "status": "open"
+    },
+    {
+      "commit": "Automate image builds and Kustomize validation",
+      "status": "open"
+    },
+    {
+      "commit": "Bootstrap GitOps root application",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce multi-cluster ApplicationSet and security policies",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Kyverno policies with Gatekeeper audit layer",
+      "status": "open"
+    },
+    {
+      "commit": "Apply Cilium default-deny and service allow policies",
+      "status": "open"
+    },
+    {
+      "commit": "Deploy Falco with RBAC-abuse rules and Slack alerts",
+      "status": "open"
+    },
+    {
+      "commit": "Wire OpenTelemetry collector to Tempo and Loki",
+      "status": "open"
+    },
+    {
+      "commit": "Add unified security Grafana dashboard",
+      "status": "open"
+    },
+    {
+      "commit": "Add Red Team Day exercise scripts",
+      "status": "open"
+    },
+    {
+      "commit": "Enable Alertmanager night mode routing",
+      "status": "open"
+    },
+    {
+      "commit": "Define per-namespace Cilium FQDN allowlists",
+      "status": "open"
+    },
+    {
+      "commit": "Switch Kyverno verifyImages to enforce",
+      "status": "open"
+    },
+    {
+      "commit": "Implement EPI scanning CLI",
+      "status": "open"
+    },
+    {
+      "commit": "Merge EPI with abundance dataset",
+      "status": "open"
+    },
+    {
+      "commit": "Add Universe Tree simulation",
+      "status": "open"
+    },
+    {
+      "commit": "Provide Universe Tree config",
+      "status": "open"
+    },
+    {
+      "commit": "Evaluate Universe Tree outputs",
+      "status": "open"
+    },
+    {
+      "commit": "Add Universe Tree sanity checks",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Utopie-to-Do adapter",
+      "status": "open"
+    },
+    {
+      "commit": "Extend CREP metrics with hope activation",
+      "status": "open"
+    },
+    {
+      "commit": "Compare tech vs society branches in Universe Tree",
+      "status": "open"
+    },
+    {
+      "commit": "Implement Consent Mesh for utopia packages",
+      "status": "open"
+    }
   ],
   "progress": [
     {
@@ -4288,6 +5371,50 @@
     },
     {
       "commit": "Add runlog archive workflow",
+      "status": "done"
+    },
+    {
+      "commit": "Add AgentWorkflowEngine and system start script",
+      "status": "done"
+    },
+    {
+      "commit": "Implement vector index ingest script",
+      "status": "done"
+    },
+    {
+      "commit": "Document Sigil RAG hooks",
+      "status": "done"
+    },
+    {
+      "commit": "Add AgentWorkflowEngine",
+      "status": "done"
+    },
+    {
+      "commit": "Create agent registry file",
+      "status": "done"
+    },
+    {
+      "commit": "Provide system start script",
+      "status": "done"
+    },
+    {
+      "commit": "Implement RAGPipeline",
+      "status": "done"
+    },
+    {
+      "commit": "Add ReviewerPanel component",
+      "status": "done"
+    },
+    {
+      "commit": "Add RAGSearchPanel component",
+      "status": "done"
+    },
+    {
+      "commit": "Add RAG smoke test",
+      "status": "done"
+    },
+    {
+      "commit": "Add CitationIndex",
       "status": "done"
     }
   ],

--- a/packages/agents/AgentWorkflowEngine.ts
+++ b/packages/agents/AgentWorkflowEngine.ts
@@ -1,0 +1,55 @@
+import { EventEmitter } from 'events';
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+export interface AgentEntry {
+  id: string;
+  description?: string;
+  start?: string;
+  capabilities?: Record<string, unknown>;
+}
+
+export interface WorkflowEvents {
+  loaded: { count: number };
+  start: { dryRun: boolean };
+  'agent:dry-run': AgentEntry;
+  'agent:start': AgentEntry;
+  'agent:started': AgentEntry;
+  finished: { count: number };
+}
+
+export default class AgentWorkflowEngine extends EventEmitter {
+  private agents: AgentEntry[] = [];
+  constructor(private registryPath: string = path.resolve('agents.yaml')) {
+    super();
+  }
+
+  /** Load agents from YAML registry and emit a loaded event. */
+  loadAgents(): void {
+    const raw = fs.readFileSync(this.registryPath, 'utf8');
+    const data = yaml.load(raw) as { agents?: AgentEntry[] };
+    this.agents = data?.agents ?? [];
+    this.emit('loaded', { count: this.agents.length });
+  }
+
+  /** Return lightweight snapshot of loaded agents. */
+  snapshot(): AgentEntry[] {
+    return this.agents.map(a => ({ id: a.id, start: a.start, description: a.description, capabilities: a.capabilities }));
+  }
+
+  /** Iterate through agents and emit lifecycle events. */
+  async start(dryRun = false): Promise<void> {
+    this.emit('start', { dryRun });
+    for (const agent of this.agents) {
+      if (dryRun) {
+        this.emit('agent:dry-run', agent);
+        continue;
+      }
+      this.emit('agent:start', agent);
+      // Placeholder for actual boot logic
+      this.emit('agent:started', agent);
+    }
+    this.emit('finished', { count: this.agents.length });
+  }
+}

--- a/scripts/system-start.ts
+++ b/scripts/system-start.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env ts-node
+import AgentWorkflowEngine from '../packages/agents/AgentWorkflowEngine';
+
+const dryRun = process.argv.includes('--dry-run');
+
+const engine = new AgentWorkflowEngine();
+engine.on('loaded', ({ count }) => console.log(`Loaded ${count} agents`));
+engine.on('agent:dry-run', a => console.log(`[dry-run] ${a.id}`));
+engine.on('agent:start', a => console.log(`Starting ${a.id}`));
+engine.on('agent:started', a => console.log(`Started ${a.id}`));
+engine.on('finished', ({ count }) => console.log(`Finished ${count} agents`));
+
+engine.loadAgents();
+engine.start(dryRun);


### PR DESCRIPTION
## Summary
- add `AgentWorkflowEngine` to load agents and emit lifecycle events
- provide `system-start.ts` script with dry-run option
- mark related advanced todo items as completed and record progress

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx ts-node scripts/system-start.ts --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68a39eedf90483229c1abdde45099d49