### PR TITLE
feat: add tool adapter for unified tool calling

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12398,7 +12398,7 @@
     "path": "packages/gpt-bridges/tool-adapter.ts",
     "task": "Normalize parallel and multi-tool calls across providers",
     "test": "packages/gpt-bridges/tool-adapter.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Adjust text fragmenter for gpt-5 context",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12132,7 +12132,7 @@
   path: packages/gpt-bridges/tool-adapter.ts
   task: Normalize parallel and multi-tool calls across providers
   test: packages/gpt-bridges/tool-adapter.test.ts
-  status: open
+  status: done
 - commit: Adjust text fragmenter for gpt-5 context
   path: packages/shared-utils/textFragmenter.ts
   task: Set MAX_TOKENS_BY_MODEL['gpt-5']=200000 and update chunking

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -13,7 +13,7 @@
     },
     {
       "commit": "Introduce ToolAdapter for unified tool calling",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add gpt-5 QA script and Fourier logging",

--- a/packages/gpt-bridges/tool-adapter.test.ts
+++ b/packages/gpt-bridges/tool-adapter.test.ts
@@ -1,0 +1,30 @@
+import { normalizeToolCalls, toProviderFormat, ToolCall } from './tool-adapter';
+
+describe('ToolAdapter', () => {
+  test('normalizes OpenAI tool calls', () => {
+    const payload = {
+      tool_calls: [
+        { function: { name: 'weather', arguments: '{"city":"Berlin"}' } }
+      ]
+    };
+    expect(normalizeToolCalls('openai', payload)).toEqual([
+      { name: 'weather', args: { city: 'Berlin' } }
+    ]);
+  });
+
+  test('normalizes Anthropic tool calls', () => {
+    const payload = [
+      { name: 'weather', input: { city: 'Berlin' } }
+    ];
+    expect(normalizeToolCalls('anthropic', payload)).toEqual([
+      { name: 'weather', args: { city: 'Berlin' } }
+    ]);
+  });
+
+  test('converts normalized calls to OpenAI format', () => {
+    const calls: ToolCall[] = [{ name: 'weather', args: { city: 'Berlin' } }];
+    expect(toProviderFormat('openai', calls)).toEqual([
+      { type: 'function', function: { name: 'weather', arguments: '{"city":"Berlin"}' } }
+    ]);
+  });
+});

--- a/packages/gpt-bridges/tool-adapter.ts
+++ b/packages/gpt-bridges/tool-adapter.ts
@@ -1,0 +1,52 @@
+export interface ToolCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+/**
+ * Normalizes provider specific tool call structures into a unified format.
+ */
+export function normalizeToolCalls(provider: string, payload: any): ToolCall[] {
+  if (!payload) return [];
+  if (provider === 'openai') {
+    const calls = payload.tool_calls || [];
+    return calls.map((c: any) => ({
+      name: c.function?.name ?? '',
+      args: safeParse(c.function?.arguments)
+    }));
+  }
+  if (provider === 'anthropic') {
+    const calls = Array.isArray(payload) ? payload : payload.tool_calls || [];
+    return calls.map((c: any) => ({
+      name: c.name || '',
+      args: c.input || {}
+    }));
+  }
+  const calls = Array.isArray(payload.tool_calls) ? payload.tool_calls : Array.isArray(payload) ? payload : [];
+  return calls.map((c: any) => ({ name: c.name || '', args: c.args || {} }));
+}
+
+function safeParse(str: any): Record<string, unknown> {
+  if (typeof str !== 'string') return str || {};
+  try {
+    return JSON.parse(str);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Converts normalized tool calls back to provider specific structures.
+ */
+export function toProviderFormat(provider: string, calls: ToolCall[]): any[] {
+  if (provider === 'openai') {
+    return calls.map((c) => ({
+      type: 'function',
+      function: { name: c.name, arguments: JSON.stringify(c.args) }
+    }));
+  }
+  if (provider === 'anthropic') {
+    return calls.map((c) => ({ name: c.name, input: c.args }));
+  }
+  return calls.map((c) => ({ name: c.name, args: c.args }));
+}


### PR DESCRIPTION
## Summary
- add ToolAdapter utility to normalize tool calls and convert to provider formats
- cover ToolAdapter with unit tests for OpenAI and Anthropic payloads
- mark ToolAdapter task as complete in advanced ToDo tracking

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/gpt-bridges/tool-adapter.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a41b2668248322b45f3b10bb6e7362