### PR TITLE
feat: add RAG citation demo script

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13273,7 +13273,7 @@
     "path": "scripts/rag-cite-demo.ts",
     "task": "Demonstrate citation rendering from RAG hits",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add RAG API deployment",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12759,7 +12759,7 @@
   path: scripts/rag-cite-demo.ts
   task: Demonstrate citation rendering from RAG hits
   test: ""
-  status: open
+  status: done
 - commit: Add RAG API deployment
   path: k8s/deploy-rag-api.yaml
   task: Deploy RAG API with horizontal pod autoscaling

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: update advanced progress statuses",
+  "lastCommit": "chore: update progress metadata",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -373,10 +373,6 @@
     },
     {
       "commit": "Add dataset API",
-      "status": "open"
-    },
-    {
-      "commit": "Add RAG citation demo script",
       "status": "open"
     },
     {
@@ -5416,6 +5412,10 @@
     },
     {
       "commit": "Introduce ToolAdapter for unified tool calling",
+      "status": "done"
+    },
+    {
+      "commit": "Add RAG citation demo script",
       "status": "done"
     }
   ],

--- a/scripts/rag-cite-demo.ts
+++ b/scripts/rag-cite-demo.ts
@@ -1,0 +1,55 @@
+import path from 'path';
+import { createEmbedder } from '../packages/rag/Embedder';
+import { VectorStore } from '../packages/rag/VectorStore';
+import { DocStore } from '../packages/rag/DocStore';
+import { CitationIndex } from '../packages/rag/CitationIndex';
+
+const STORE_DIR = process.env.RAG_STORE_DIR || path.join('data', 'rag');
+const VECTOR_PATH = path.join(STORE_DIR, 'vectors.json');
+const DOC_PATH = path.join(STORE_DIR, 'docs.json');
+const CITE_PATH = path.join(STORE_DIR, 'citations.json');
+
+async function queryWithCitations(question: string, k = 3) {
+  const embedder = createEmbedder();
+  const vectorStore = new VectorStore(VECTOR_PATH);
+  const docStore = new DocStore(DOC_PATH);
+  const citeIndex = new CitationIndex(CITE_PATH);
+
+  const qVec = await embedder.embed(question);
+  const results = vectorStore.search(qVec, k);
+
+  const citeIds: string[] = [];
+  results.forEach(({ id, score }) => {
+    const doc = docStore.get(id);
+    if (!doc) return;
+    const [docId, chunkStr] = id.split('#');
+    const chunk = Number(chunkStr || 0);
+    citeIndex.add({
+      id,
+      docId,
+      chunk,
+      text: doc.text.slice(0, 80).replace(/\s+/g, ' '),
+      source: doc.source,
+    });
+    citeIds.push(id);
+    console.log(`${score.toFixed(4)}\t${doc.text.slice(0, 80).replace(/\s+/g, ' ')}`);
+  });
+
+  const markdown = citeIndex.renderMarkdown(citeIds);
+  if (markdown) {
+    console.log('\nCitations:\n' + markdown);
+  }
+}
+
+async function main() {
+  const query = process.argv.slice(2).join(' ');
+  if (!query) {
+    console.error('Usage: ts-node scripts/rag-cite-demo.ts <query>');
+    process.exit(1);
+  }
+  await queryWithCitations(query);
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add `rag-cite-demo` script to render markdown citations for RAG results
- mark RAG citation demo task as complete across todo and progress trackers
- sync progress metadata

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a425a4f7f48322a6c70303f1e2d0d3