### PR TITLE
feat: add dataset registry

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13252,7 +13252,7 @@
     "path": "packages/datasets/DatasetRegistry.ts",
     "task": "Register datasets, versions, splits and artifacts with personhood checks",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add dataset API",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12744,7 +12744,7 @@
   path: packages/datasets/DatasetRegistry.ts
   task: Register datasets, versions, splits and artifacts with personhood checks
   test: ""
-  status: open
+  status: done
 - commit: Add dataset API
   path: scripts/dataset-api.ts
   task: Serve dataset registry over HTTP

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1319 from GenesisAeon/codex/implement-features-from-advancedtodo.yaml-8uxptf",
+  "lastCommit": "feat: add dataset registry",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -357,10 +357,6 @@
     },
     {
       "commit": "Add federated API",
-      "status": "open"
-    },
-    {
-      "commit": "Implement DatasetRegistry",
       "status": "open"
     },
     {
@@ -5416,6 +5412,10 @@
     },
     {
       "commit": "Add rag-api server",
+      "status": "done"
+    },
+    {
+      "commit": "Implement DatasetRegistry",
       "status": "done"
     }
   ],

--- a/packages/datasets/DatasetRegistry.ts
+++ b/packages/datasets/DatasetRegistry.ts
@@ -1,0 +1,72 @@
+import { requireConsent } from '../personhood/PolicyGuard';
+
+export interface DatasetVersion {
+  version: string;
+  splits: Record<string, string>;
+  artifacts: Record<string, string>;
+}
+
+export interface DatasetRecord {
+  name: string;
+  versions: Map<string, DatasetVersion>;
+}
+
+/**
+ * DatasetRegistry keeps track of datasets, their versions,
+ * splits and artifacts. All operations require personhood consent.
+ */
+export class DatasetRegistry {
+  private static datasets = new Map<string, DatasetRecord>();
+
+  static registerDataset(name: string, personId: string): void {
+    requireConsent(personId);
+    if (!this.datasets.has(name)) {
+      this.datasets.set(name, { name, versions: new Map() });
+    }
+  }
+
+  static addVersion(name: string, version: string, personId: string): void {
+    requireConsent(personId);
+    const record = this.datasets.get(name);
+    if (!record) throw new Error(`Unknown dataset: ${name}`);
+    if (!record.versions.has(version)) {
+      record.versions.set(version, { version, splits: {}, artifacts: {} });
+    }
+  }
+
+  static addSplit(
+    name: string,
+    version: string,
+    splitName: string,
+    uri: string,
+    personId: string
+  ): void {
+    requireConsent(personId);
+    const ver = this.getVersion(name, version);
+    ver.splits[splitName] = uri;
+  }
+
+  static addArtifact(
+    name: string,
+    version: string,
+    artifactName: string,
+    uri: string,
+    personId: string
+  ): void {
+    requireConsent(personId);
+    const ver = this.getVersion(name, version);
+    ver.artifacts[artifactName] = uri;
+  }
+
+  static getDataset(name: string): DatasetRecord | undefined {
+    return this.datasets.get(name);
+  }
+
+  static getVersion(name: string, version: string): DatasetVersion {
+    const record = this.datasets.get(name);
+    if (!record) throw new Error(`Unknown dataset: ${name}`);
+    const ver = record.versions.get(version);
+    if (!ver) throw new Error(`Unknown version: ${version}`);
+    return ver;
+  }
+}

--- a/tests/datasets.registry.test.ts
+++ b/tests/datasets.registry.test.ts
@@ -1,0 +1,32 @@
+import { DatasetRegistry } from '../packages/datasets/DatasetRegistry';
+import { ConsentRegistry } from '../packages/personhood/ConsentRegistry';
+
+describe('DatasetRegistry', () => {
+  const personId = 'tester';
+
+  beforeEach(() => {
+    // reset consent and registry
+    (ConsentRegistry as any).consentMap = new Map();
+    (DatasetRegistry as any).datasets = new Map();
+  });
+
+  it('requires consent to register dataset', () => {
+    expect(() => DatasetRegistry.registerDataset('sample', personId)).toThrow(
+      /Consent required/
+    );
+  });
+
+  it('registers dataset versions, splits and artifacts with consent', () => {
+    ConsentRegistry.grant(personId);
+    DatasetRegistry.registerDataset('sample', personId);
+    DatasetRegistry.addVersion('sample', 'v1', personId);
+    DatasetRegistry.addSplit('sample', 'v1', 'train', '/train.txt', personId);
+    DatasetRegistry.addArtifact('sample', 'v1', 'card', '/card.md', personId);
+
+    const dataset = DatasetRegistry.getDataset('sample');
+    expect(dataset).toBeDefined();
+    const version = DatasetRegistry.getVersion('sample', 'v1');
+    expect(version.splits.train).toBe('/train.txt');
+    expect(version.artifacts.card).toBe('/card.md');
+  });
+});


### PR DESCRIPTION
## Summary
- add DatasetRegistry with personhood consent checks
- track datasets in tests
- sync advanced progress files

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: venvPath is not a valid directory)*
- `npx tsc -p tsconfig.json`
- `pnpm test tests/datasets.registry.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a45b9b49b0832298cd6efa679fc978