### PR TITLE
feat: add dataset registry API

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13259,7 +13259,7 @@
     "path": "scripts/dataset-api.ts",
     "task": "Serve dataset registry over HTTP",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add CitationIndex",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12749,7 +12749,7 @@
   path: scripts/dataset-api.ts
   task: Serve dataset registry over HTTP
   test: ""
-  status: open
+  status: done
 - commit: Add CitationIndex
   path: packages/rag/CitationIndex.ts
   task: Store chunk citation metadata and render markdown and HTML

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -357,7 +357,7 @@
     },
     {
       "commit": "Add dataset API",
-      "status": "open"
+      "status": "done"
     },
     {
       "commit": "Add RAG API deployment",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -111,3 +111,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 
 - Implemented generate-sigillin-jsonl script to aggregate sigil files into RAG-ready corpus.
 - Added CitationIndex to manage RAG chunk citations and rendering.
+- Implemented dataset API server to expose DatasetRegistry over HTTP.

--- a/scripts/dataset-api.ts
+++ b/scripts/dataset-api.ts
@@ -1,0 +1,105 @@
+import express from 'express';
+import { DatasetRegistry } from '../packages/datasets/DatasetRegistry';
+import { ConsentRegistry } from '../packages/personhood/ConsentRegistry';
+
+const app = express();
+app.use(express.json());
+
+app.post('/consent', (req, res) => {
+  const { personId } = req.body;
+  if (!personId) {
+    return res.status(400).json({ error: 'personId required' });
+  }
+  ConsentRegistry.grant(personId);
+  res.json({ status: 'granted' });
+});
+
+app.delete('/consent/:personId', (req, res) => {
+  ConsentRegistry.revoke(req.params.personId);
+  res.json({ status: 'revoked' });
+});
+
+app.post('/datasets', (req, res) => {
+  const { name, personId } = req.body;
+  if (!name || !personId) {
+    return res.status(400).json({ error: 'name and personId required' });
+  }
+  try {
+    DatasetRegistry.registerDataset(name, personId);
+    res.status(201).json({ status: 'registered' });
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.post('/datasets/:name/versions', (req, res) => {
+  const { version, personId } = req.body;
+  const { name } = req.params;
+  if (!version || !personId) {
+    return res.status(400).json({ error: 'version and personId required' });
+  }
+  try {
+    DatasetRegistry.addVersion(name, version, personId);
+    res.status(201).json({ status: 'version added' });
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.post('/datasets/:name/versions/:version/splits', (req, res) => {
+  const { splitName, uri, personId } = req.body;
+  const { name, version } = req.params;
+  if (!splitName || !uri || !personId) {
+    return res
+      .status(400)
+      .json({ error: 'splitName, uri and personId required' });
+  }
+  try {
+    DatasetRegistry.addSplit(name, version, splitName, uri, personId);
+    res.status(201).json({ status: 'split added' });
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.post('/datasets/:name/versions/:version/artifacts', (req, res) => {
+  const { artifactName, uri, personId } = req.body;
+  const { name, version } = req.params;
+  if (!artifactName || !uri || !personId) {
+    return res
+      .status(400)
+      .json({ error: 'artifactName, uri and personId required' });
+  }
+  try {
+    DatasetRegistry.addArtifact(name, version, artifactName, uri, personId);
+    res.status(201).json({ status: 'artifact added' });
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.get('/datasets/:name', (req, res) => {
+  const ds = DatasetRegistry.getDataset(req.params.name);
+  if (!ds) {
+    return res.status(404).json({ error: 'dataset not found' });
+  }
+  res.json(ds);
+});
+
+app.get('/datasets/:name/versions/:version', (req, res) => {
+  try {
+    const ver = DatasetRegistry.getVersion(
+      req.params.name,
+      req.params.version
+    );
+    res.json(ver);
+  } catch (err: any) {
+    res.status(404).json({ error: err.message });
+  }
+});
+
+const port = parseInt(process.env.PORT || '3000', 10);
+app.listen(port, () => {
+  console.log(`Dataset API server listening on ${port}`);
+});
+


### PR DESCRIPTION
## Summary
- serve DatasetRegistry via new Express API with consent checks
- mark dataset API task complete in advanced ToDo and progress trackers
- note addition in feedback codex

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test tests/datasets.registry.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a477dd47a88322a969fba91748707e