### PR TITLE
feat: parse voice notes into advanced tasks

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12468,7 +12468,7 @@
     "path": "scripts/parse-advanced-conversations.js",
     "task": "Convert voice notes into advancedToDo entries using parse-advanced-conversations.js",
     "test": "scripts/__tests__/parse-advanced-conversations.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Generate sigillin JSONL index",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12184,7 +12184,7 @@
   task: Convert voice notes into advancedToDo entries using
     parse-advanced-conversations.js
   test: scripts/__tests__/parse-advanced-conversations.test.ts
-  status: open
+  status: done
 - commit: Generate sigillin JSONL index
   path: data/sigils/sigillin.jsonl
   task: Aggregate existing sigil files into a RAG-ready JSONL corpus

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "chore: tune ethics policy for gpt-5",
-  "fractalStep": "implementiert",
+  "lastCommit": "feat: parse voice notes into advanced tasks",
+  "fractalStep": "voice note pipeline implemented",
   "openBranches": [
     "work"
   ],
@@ -13,6 +13,10 @@
     },
     {
       "commit": "Add gpt-5 QA script and Fourier logging",
+      "status": "open"
+    },
+    {
+      "commit": "Tune ethics policy for gpt-5",
       "status": "open"
     },
     {
@@ -33,10 +37,6 @@
     },
     {
       "commit": "Add gpt-5 smoke test suite",
-      "status": "open"
-    },
-    {
-      "commit": "Implement voice note to advancedToDo pipeline",
       "status": "open"
     },
     {
@@ -354,10 +354,6 @@
     {
       "commit": "Add federated API",
       "status": "open"
-    },
-    {
-      "commit": "Add dataset API",
-      "status": "done"
     },
     {
       "commit": "Add RAG API deployment",
@@ -750,10 +746,6 @@
     {
       "commit": "Add UI switchboard service",
       "status": "open"
-    },
-    {
-      "commit": "Add policy lint script",
-      "status": "done"
     },
     {
       "commit": "Add compose override for UM services",

--- a/scripts/__tests__/parse-advanced-conversations.test.ts
+++ b/scripts/__tests__/parse-advanced-conversations.test.ts
@@ -1,6 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-const { parseAdvancedConversations } = require('../parse-advanced-conversations');
+const {
+  parseAdvancedConversations,
+  extractTodosFromVoiceNote,
+} = require('../parse-advanced-conversations');
 
 test('parseAdvancedConversations extracts TODO fragments', () => {
   const tmpDir = fs.mkdtempSync(path.join(__dirname, 'tmp'));
@@ -13,4 +16,11 @@ test('parseAdvancedConversations extracts TODO fragments', () => {
   const out = fs.readFileSync(path.join(dest, 'convos-grep.json'), 'utf8');
   expect(out.includes('test')).toBe(true);
   fs.rmSync(tmpDir, { recursive: true });
+});
+
+test('extractTodosFromVoiceNote converts TODO lines', () => {
+  const transcript = 'random line\nTODO: finish docs\nAnother';
+  const tasks = extractTodosFromVoiceNote(transcript);
+  expect(tasks).toHaveLength(1);
+  expect(tasks[0].task).toBe('finish docs');
 });

--- a/scripts/parse-advanced-conversations.js
+++ b/scripts/parse-advanced-conversations.js
@@ -1,4 +1,6 @@
+const fs = require('fs');
 const path = require('path');
+const yaml = require('js-yaml');
 const { grepJsonArrayFile } = require('../packages/shared-utils/jsonFragmenter');
 
 function parseAdvancedConversations(filePath, destDir, keyword = 'TODO') {
@@ -6,15 +8,74 @@ function parseAdvancedConversations(filePath, destDir, keyword = 'TODO') {
   return grepJsonArrayFile(filePath, destDir, regex);
 }
 
-if (require.main === module) {
-  const file = path.join(__dirname, '../docs/sigils/advancedconversations.json');
-  const dest = path.join(__dirname, '../docs/sigils/advancedconversations');
-  const keyword = process.argv[2] || 'TODO';
-  const matches = parseAdvancedConversations(file, dest, keyword);
-  console.log(
-    `Parsed ${matches.length} fragments containing '${keyword}'. Output: ${dest}`
-  );
+/**
+ * Convert a plain voice note transcript into advancedToDo entries.
+ * Each line beginning with "TODO:" becomes a task object.
+ *
+ * @param {string} transcript - Raw transcript text
+ * @param {string} [outDir] - Optional output directory for JSON/YAML files
+ * @returns {Array} List of task objects
+ */
+function extractTodosFromVoiceNote(transcript, outDir) {
+  const tasks = [];
+  transcript.split(/\r?\n/).forEach((line) => {
+    const match = line.match(/TODO:\s*(.+)/i);
+    if (match) {
+      tasks.push({
+        commit: match[0].trim(),
+        path: '',
+        task: match[1].trim(),
+        test: '',
+        status: 'open',
+      });
+    }
+  });
+
+  if (outDir) {
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(outDir, 'advancedToDo.voice.json'),
+      JSON.stringify(tasks, null, 2)
+    );
+    fs.writeFileSync(
+      path.join(outDir, 'advancedToDo.voice.yaml'),
+      yaml.dump(tasks)
+    );
+  }
+
+  return tasks;
 }
 
-module.exports = { parseAdvancedConversations };
+if (require.main === module) {
+  const arg = process.argv[2];
+  if (arg === '--voice-note') {
+    const voiceFile = process.argv[3];
+    if (!voiceFile) {
+      console.error('Usage: parse-advanced-conversations.js --voice-note <file>');
+      process.exit(1);
+    }
+    const transcript = fs.readFileSync(voiceFile, 'utf8');
+    const outDir = path.join(__dirname, '../advancedToDo_parts');
+    const tasks = extractTodosFromVoiceNote(transcript, outDir);
+    console.log(
+      `Extracted ${tasks.length} tasks from voice note to ${outDir}`
+    );
+  } else {
+    const file = path.join(
+      __dirname,
+      '../docs/sigils/advancedconversations.json'
+    );
+    const dest = path.join(
+      __dirname,
+      '../docs/sigils/advancedconversations'
+    );
+    const keyword = arg || 'TODO';
+    const matches = parseAdvancedConversations(file, dest, keyword);
+    console.log(
+      `Parsed ${matches.length} fragments containing '${keyword}'. Output: ${dest}`
+    );
+  }
+}
+
+module.exports = { parseAdvancedConversations, extractTodosFromVoiceNote };
 


### PR DESCRIPTION
## Summary
- expand conversation parser with `extractTodosFromVoiceNote` to convert spoken transcripts into advancedToDo entries
- add unit test for voice note extraction
- mark voice note pipeline task as completed and refresh progress tracker

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `pnpm test scripts/__tests__/parse-advanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a4ad0ac3b88322a84d64d6bca40030