### PR TITLE
feat: add gpt-5 model matrix routing

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12385,7 +12385,7 @@
     "path": "packages/gpt-bridges/aeon-gpt-synapse.ts",
     "task": "Define model capabilities and route tasks with gpt-5 fallback",
     "test": "packages/gpt-bridges/aeon-gpt-synapse.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Declare gpt-5 capabilities for agents",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12123,7 +12123,7 @@
   path: packages/gpt-bridges/aeon-gpt-synapse.ts
   task: Define model capabilities and route tasks with gpt-5 fallback
   test: packages/gpt-bridges/aeon-gpt-synapse.test.ts
-  status: open
+  status: done
 - commit: Declare gpt-5 capabilities for agents
   path: agents.yaml
   task: Set capabilities.model to ["gpt-5","gpt-4.1"] for core agents

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "Add gpt-5 QA script and Fourier logging",
-  "fractalStep": "gpt-5 QA script integrated",
+  "lastCommit": "Add gpt-5 ModelMatrix and routing",
+  "fractalStep": "gpt-5 model matrix integrated",
   "openBranches": [
     "work"
   ],
@@ -13,6 +13,10 @@
     "chore: scaffold Wissenschaftliche Versuche project (packages/wissenschaftliche-versuche)"
   ],
   "progress": [
+    {
+      "commit": "Add gpt-5 ModelMatrix and routing",
+      "status": "done"
+    },
     {
       "commit": "Provide model env snippet",
       "status": "done"
@@ -278,7 +282,7 @@
       "status": "done"
     },
     {
-      "commit": "meta:update-progress \u2013 mark memory governance done",
+      "commit": "meta:update-progress – mark memory governance done",
       "status": "done"
     },
     {
@@ -551,7 +555,7 @@
       "status": "done"
     },
     {
-      "commit": "Chat-Log Parser f\u00fcr Aufgaben",
+      "commit": "Chat-Log Parser für Aufgaben",
       "status": "done"
     },
     {
@@ -683,7 +687,7 @@
       "status": "done"
     },
     {
-      "commit": "Der *SymbolMapper*-Agent \u00fcbersetzt numerische und textuelle Muster in definierte Symbol-Glyphen\u301015\u2020L53-L61\u3011. Er schlie\u00dft die L\u00fccke zwischen quantitativen Werten (z.\u202fB. statistische Ergebnisse, Scores) und der symbolischen **Sigillin-Sprache** des Systems. Manifest-Spezifikation: Der SymbolMapper v1 hat Methoden `map_numeric_to_symbol` und `map_text_to_glyph`\u301015\u2020L55-L63\u3011. Im Python-Skeleton (`agents/symbolmapper/main.py`) implementieren wir z.\u202fB. eine Liste vordefinierter Glyphen (im Manifest-Beispiel: \u25cb, \u2206, \u03c8, \u2605\u301015\u2020L67-L73\u3011) und die Abbildungsfunktionen analog zum YAML-Snippet: ein Durchschnittswert wird auf einen Index im Glyphen-Array gemappt\u301015\u2020L67-L75\u3011, Texte werden auf Basis von Schl\u00fcsselbegriffen einem Symbol zugeordnet (Bsp: enth\u00e4lt der Text \"Erweckung\", dann \u2605 als Glyph)\u301015\u2020L69-L73\u3011. Integration: Dieser Agent kann von anderen Modulen genutzt werden, die rohe Daten symbolisch darstellen wollen \u2013 z.\u202fB. der CREPBridge k\u00f6nnte SymbolMapper fragen, welcher Glyph einem bestimmten Score entspricht (um dann einen Sigil zu generieren). Auch f\u00fcr Graphen/Charts in der UI k\u00f6nnte SymbolMapper herangezogen werden, um interessante Datenpunkte mit Symbolen zu markieren. Orchestrator: wahrscheinlich auf Abruf, nicht dauernd laufend \u2013 d.h. Module rufen ihn als Library auf (alternativ EventBus-Request/Reply-Pattern). UI: Keine direkte, aber z.\u202fB. im Sigil-Portfolio des Nutzers k\u00f6nnten diese Glyphen vorkommen. Test & Deploy: Test, ob gegebene Werte die richtigen Symbole liefern (z.\u202fB. Eingabe [0.1, 0.9] ergibt einen Index im g\u00fcltigen Bereich und ein Symbol aus der Liste\u301015\u2020L137-L142\u3011). Deployment: Sicherstellen, dass NumPy verf\u00fcgbar ist (im Manifest als Dependency angegeben\u301015\u2020L61-L69\u3011) und dass das System die Unicode-Symbole unterst\u00fctzt (Fonts in UI etc.).",
+      "commit": "Der *SymbolMapper*-Agent übersetzt numerische und textuelle Muster in definierte Symbol-Glyphen【15†L53-L61】. Er schließt die Lücke zwischen quantitativen Werten (z. B. statistische Ergebnisse, Scores) und der symbolischen **Sigillin-Sprache** des Systems. Manifest-Spezifikation: Der SymbolMapper v1 hat Methoden `map_numeric_to_symbol` und `map_text_to_glyph`【15†L55-L63】. Im Python-Skeleton (`agents/symbolmapper/main.py`) implementieren wir z. B. eine Liste vordefinierter Glyphen (im Manifest-Beispiel: ○, ∆, ψ, ★【15†L67-L73】) und die Abbildungsfunktionen analog zum YAML-Snippet: ein Durchschnittswert wird auf einen Index im Glyphen-Array gemappt【15†L67-L75】, Texte werden auf Basis von Schlüsselbegriffen einem Symbol zugeordnet (Bsp: enthält der Text \"Erweckung\", dann ★ als Glyph)【15†L69-L73】. Integration: Dieser Agent kann von anderen Modulen genutzt werden, die rohe Daten symbolisch darstellen wollen – z. B. der CREPBridge könnte SymbolMapper fragen, welcher Glyph einem bestimmten Score entspricht (um dann einen Sigil zu generieren). Auch für Graphen/Charts in der UI könnte SymbolMapper herangezogen werden, um interessante Datenpunkte mit Symbolen zu markieren. Orchestrator: wahrscheinlich auf Abruf, nicht dauernd laufend – d.h. Module rufen ihn als Library auf (alternativ EventBus-Request/Reply-Pattern). UI: Keine direkte, aber z. B. im Sigil-Portfolio des Nutzers könnten diese Glyphen vorkommen. Test & Deploy: Test, ob gegebene Werte die richtigen Symbole liefern (z. B. Eingabe [0.1, 0.9] ergibt einen Index im gültigen Bereich und ein Symbol aus der Liste【15†L137-L142】). Deployment: Sicherstellen, dass NumPy verfügbar ist (im Manifest als Dependency angegeben【15†L61-L69】) und dass das System die Unicode-Symbole unterstützt (Fonts in UI etc.).",
       "status": "done"
     },
     {
@@ -871,7 +875,7 @@
       "status": "done"
     },
     {
-      "commit": "Aktivit\u00e4tsdaten via Dispatcher laden",
+      "commit": "Aktivitätsdaten via Dispatcher laden",
       "status": "done"
     },
     {
@@ -1603,7 +1607,7 @@
       "status": "done"
     },
     {
-      "commit": "docs: add Genesis_Ver\u00f6ffentlichungsstrategie",
+      "commit": "docs: add Genesis_Veröffentlichungsstrategie",
       "status": "done"
     },
     {
@@ -1611,7 +1615,7 @@
       "status": "done"
     },
     {
-      "commit": "c & Manifest-Generator \u2013 Dokumentation auf Knopfdruck",
+      "commit": "c & Manifest-Generator – Dokumentation auf Knopfdruck",
       "status": "done"
     },
     {
@@ -2203,7 +2207,7 @@
       "status": "done"
     },
     {
-      "commit": "SVG-Export oder WebSocket-Event f\u00fcr UI",
+      "commit": "SVG-Export oder WebSocket-Event für UI",
       "status": "done"
     },
     {
@@ -4019,7 +4023,7 @@
       "status": "done"
     },
     {
-      "commit": "die Simulation so aufbauen, dass sie **Variablen f\u00fcr Fortschritt und m\u00f6gliche H\u00fcrden** integriert",
+      "commit": "die Simulation so aufbauen, dass sie **Variablen für Fortschritt und mögliche Hürden** integriert",
       "status": "done"
     },
     {
@@ -4131,7 +4135,7 @@
       "status": "done"
     },
     {
-      "commit": "den Mechanismus zur **Energieumwandlung und Abk\u00fchlung zu Masse** in der Simulation explizit umsetzen",
+      "commit": "den Mechanismus zur **Energieumwandlung und Abkühlung zu Masse** in der Simulation explizit umsetzen",
       "status": "done"
     },
     {
@@ -4420,67 +4424,67 @@
   "featureLog": [
     {
       "featureId": "open-ethik-dashboard",
-      "commit": "meta:implement-features \u2013 open-ethik-dashboard",
+      "commit": "meta:implement-features – open-ethik-dashboard",
       "status": "done"
     },
     {
       "featureId": "implicit-todos",
-      "commit": "meta:extract-features \u2013 implicit todo extraction",
+      "commit": "meta:extract-features – implicit todo extraction",
       "status": "done"
     },
     {
       "featureId": "zivilisations-sandboxen",
-      "commit": "meta:extract-features \u2013 Zivilisations-Sandboxen",
+      "commit": "meta:extract-features – Zivilisations-Sandboxen",
       "status": "done"
     },
     {
       "featureId": "climate-integration",
-      "commit": "meta:extract-features \u2013 climate integration",
+      "commit": "meta:extract-features – climate integration",
       "status": "done"
     },
     {
       "featureId": "keilschrift",
-      "commit": "meta:extract-features \u2013 keilschrift",
+      "commit": "meta:extract-features – keilschrift",
       "status": "done"
     },
     {
       "featureId": "grok-agent",
-      "commit": "meta:implement-features \u2013 grok agent skeleton",
+      "commit": "meta:implement-features – grok agent skeleton",
       "status": "done"
     },
     {
       "featureId": "shadow-integration",
-      "commit": "meta:extract-features \u2013 shadow integration",
+      "commit": "meta:extract-features – shadow integration",
       "status": "done"
     },
     {
       "featureId": "self-reflection",
-      "commit": "meta:extract-features \u2013 self reflection",
+      "commit": "meta:extract-features – self reflection",
       "status": "done"
     },
     {
       "featureId": "memory-governance",
-      "commit": "meta:extract-features \u2013 memory governance",
+      "commit": "meta:extract-features – memory governance",
       "status": "done"
     },
     {
       "featureId": "turing-tests",
-      "commit": "meta:extract-features \u2013 turing tests",
+      "commit": "meta:extract-features – turing tests",
       "status": "done"
     },
     {
       "featureId": "schwerewellen",
-      "commit": "meta:extract-features \u2013 schwerewellen",
+      "commit": "meta:extract-features – schwerewellen",
       "status": "done"
     },
     {
       "featureId": "anthropic-multiversum",
-      "commit": "meta:extract-features \u2013 anthropic multiversum",
+      "commit": "meta:extract-features – anthropic multiversum",
       "status": "done"
     },
     {
       "featureId": "memory-governance",
-      "commit": "meta:implement-features \u2013 memory governance service",
+      "commit": "meta:implement-features – memory governance service",
       "status": "done"
     },
     {
@@ -4975,7 +4979,7 @@
       "status": "done"
     },
     {
-      "commit": "die Simulation so aufbauen, dass sie Variablen f\u00fcr Fortschritt und m\u00f6gliche H\u00fcrden integriert",
+      "commit": "die Simulation so aufbauen, dass sie Variablen für Fortschritt und mögliche Hürden integriert",
       "status": "done"
     },
     {

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -114,3 +114,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented dataset API server to expose DatasetRegistry over HTTP.
 - Added policy lint script to enforce baseline safety rules on policy files.
 - Provided model provider env snippet for local model setup.
+- Added gpt-5 ModelMatrix with fallback routing in AeonGPTSynapse.

--- a/packages/gpt-bridges/aeon-gpt-synapse.test.ts
+++ b/packages/gpt-bridges/aeon-gpt-synapse.test.ts
@@ -15,6 +15,8 @@ describe('sendToGPT', () => {
     ) as any;
     const result = await sendToGPT({ role: GPTRole.AEON, input: 'test' });
     expect(fetch).toHaveBeenCalled();
+    const body = JSON.parse((fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.model).toBe('gpt-4.1');
     expect(result).toContain('Hallo');
   });
 
@@ -32,12 +34,33 @@ describe('sendToGPT', () => {
     expect(result).toContain('Hallo');
   });
 
+  it('falls back to gpt-5 when primary model fails', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ response: 'Hallo' })
+      });
+    global.fetch = mockFetch as any;
+    const result = await sendToGPT({ role: GPTRole.AEON, input: 'test' });
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+    const firstBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const fourthBody = JSON.parse(mockFetch.mock.calls[3][1].body);
+    expect(firstBody.model).toBe('gpt-4.1');
+    expect(fourthBody.model).toBe('gpt-5');
+    expect(result).toContain('Hallo');
+  });
+
   it('throws after max retries', async () => {
     const mockFetch = jest.fn().mockRejectedValue(new Error('offline'));
     global.fetch = mockFetch as any;
     await expect(
       sendToGPT({ role: GPTRole.AEON, input: 'test' })
     ).rejects.toThrow(/Network request failed/);
-    expect(mockFetch).toHaveBeenCalledTimes(3);
+    // 3 attempts for each of two models
+    expect(mockFetch).toHaveBeenCalledTimes(6);
   });
 });

--- a/packages/gpt-bridges/aeon-gpt-synapse.ts
+++ b/packages/gpt-bridges/aeon-gpt-synapse.ts
@@ -10,6 +10,14 @@ import { getSymbolzeitPhase } from '../shared-utils/symbolzeitModulator';
 import { loadSymbolphasen } from '../shared-utils/loadSymbolphasen';
 import { isValidRole } from './gptRoles';
 
+// Mapping of GPT roles to supported models in priority order.
+// AEON tries gpt-4.1 first and falls back to gpt-5 when needed.
+const MODEL_MATRIX: Record<GPTRole, string[]> = {
+  [GPTRole.AEON]: ['gpt-4.1', 'gpt-5'],
+  [GPTRole.CREP]: ['gpt-4.1'],
+  [GPTRole.POET]: ['gpt-4.1']
+};
+
 export async function sendToGPT(
   request: GPTRequest,
   retries = 2
@@ -22,24 +30,32 @@ export async function sendToGPT(
   const prefix = phases[phaseId]?.phase ? `[${phases[phaseId].phase}] ` : '';
 
   const endpoint = process.env.GPT_ENDPOINT || 'http://localhost:3000/gpt';
-  for (let attempt = 0; attempt <= retries; attempt++) {
-    try {
-      const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...request, phase: phaseId })
-      });
-      if (!response.ok) {
-        throw new Error(`GPT request failed: ${response.status}`);
-      }
-      const data = await response.json();
-      const answer = data.response ?? '';
-      return `${prefix}${answer}`;
-    } catch (err) {
-      if (attempt === retries) {
-        throw new Error(
-          `Network request failed after ${retries + 1} attempts: ${(err as Error).message}`
-        );
+  const models = MODEL_MATRIX[request.role] || ['gpt-4.1'];
+
+  for (const model of models) {
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      try {
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...request, phase: phaseId, model })
+        });
+        if (!response.ok) {
+          throw new Error(`GPT request failed: ${response.status}`);
+        }
+        const data = await response.json();
+        const answer = data.response ?? '';
+        return `${prefix}${answer}`;
+      } catch (err) {
+        if (attempt === retries) {
+          if (model === models[models.length - 1]) {
+            throw new Error(
+              `Network request failed after ${retries + 1} attempts: ${(err as Error).message}`
+            );
+          }
+          // try next model
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- route GPT requests using a role-based model matrix with gpt-5 fallback
- cover new routing logic with tests
- mark gpt-5 ModelMatrix task as complete in progress trackers

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/gpt-bridges/aeon-gpt-synapse.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a4daf82bc483229fa6512c228d8b2a