### PR TITLE
test: expand DatasetRegistry coverage and sync progress

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13302,7 +13302,7 @@
     "path": "tests/datasets.registry.test.ts",
     "task": "Verify dataset creation, versioning and splitting",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Extend code agent tasks for dataset and k8s",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12780,7 +12780,7 @@
   path: tests/datasets.registry.test.ts
   task: Verify dataset creation, versioning and splitting
   test: ""
-  status: open
+  status: done
 - commit: Extend code agent tasks for dataset and k8s
   path: code-agent-tasks.yaml
   task: Add dataset.api, rag.cite.demo and k8s.apply.base tasks

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "Add gpt-5 ModelMatrix and routing",
-  "fractalStep": "gpt-5 model matrix integrated",
+  "lastCommit": "Add dataset registry test",
+  "fractalStep": "dataset registry verified",
   "openBranches": [
     "work"
   ],
@@ -10,9 +10,14 @@
     "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129 (GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json)",
     "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e (GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json)",
     "Integrate new GPT teams from Zukunft conversation (packages/agents)",
-    "chore: scaffold Wissenschaftliche Versuche project (packages/wissenschaftliche-versuche)"
+    "chore: scaffold Wissenschaftliche Versuche project (packages/wissenschaftliche-versuche)",
+    "feat: integrate FutureTechFramework (packages/agents/FutureTechFramework.ts)"
   ],
   "progress": [
+    {
+      "commit": "Add dataset registry test",
+      "status": "done"
+    },
     {
       "commit": "Add gpt-5 ModelMatrix and routing",
       "status": "done"

--- a/tests/datasets.registry.test.ts
+++ b/tests/datasets.registry.test.ts
@@ -29,4 +29,19 @@ describe('DatasetRegistry', () => {
     expect(version.splits.train).toBe('/train.txt');
     expect(version.artifacts.card).toBe('/card.md');
   });
+
+  it('throws when adding version to unknown dataset', () => {
+    ConsentRegistry.grant(personId);
+    expect(() =>
+      DatasetRegistry.addVersion('missing', 'v1', personId)
+    ).toThrow(/Unknown dataset/);
+  });
+
+  it('throws when adding split for unknown version', () => {
+    ConsentRegistry.grant(personId);
+    DatasetRegistry.registerDataset('sample', personId);
+    expect(() =>
+      DatasetRegistry.addSplit('sample', 'v1', 'train', '/t.txt', personId)
+    ).toThrow(/Unknown version/);
+  });
 });


### PR DESCRIPTION
## Summary
- extend DatasetRegistry tests to cover missing dataset and version cases
- mark dataset registry task as complete in advanced todo references
- record dataset registry progress in advancedprogress log

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx jest tests/datasets.registry.test.ts`
- `npx pyright`
- `npx tsc -p tsconfig.json --listFilesOnly`


------
https://chatgpt.com/codex/tasks/task_e_68a4dfca122483228225e97f82837102