### PR TITLE
feat: add Universe Tree optimism simulation

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14534,7 +14534,7 @@
     "path": "sims/universe_tree_optimism.py",
     "task": "Simulate and contrast tech- and society-optimistic branches for sustainable mobility",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement Consent Mesh for utopia packages",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13666,7 +13666,7 @@
   task: Simulate and contrast tech- and society-optimistic branches for
     sustainable mobility
   test: ""
-  status: open
+  status: done
 - commit: Implement Consent Mesh for utopia packages
   path: packages/consent-mesh/utopie-consent.ts
   task: Collect community votes on utopia packages and feed results into task

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -4374,6 +4374,10 @@
     {
       "commit": "feat: add MasterGPTBridge orchestrator",
       "status": "done"
+    },
+    {
+      "commit": "Compare tech vs society branches in Universe Tree",
+      "status": "done"
     }
   ],
   "completed": [

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -115,3 +115,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added policy lint script to enforce baseline safety rules on policy files.
 - Provided model provider env snippet for local model setup.
 - Added gpt-5 ModelMatrix with fallback routing in AeonGPTSynapse.
+- Added UniverseTreeOptimism simulation comparing tech and society branches for sustainable mobility.

--- a/sims/universe_tree_optimism.py
+++ b/sims/universe_tree_optimism.py
@@ -1,0 +1,53 @@
+"""Simulate and contrast tech- and society-optimistic branches for sustainable mobility.
+
+This simple model assigns scores to two branches and compares overall sustainability.
+"""
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class BranchScenario:
+    """Parameters representing an optimistic branch in the universe tree."""
+    name: str
+    tech_innovation: float
+    social_policy: float
+    adoption_rate: float
+
+    def sustainability_score(self) -> float:
+        """Combine factors into a single sustainability score."""
+        return (
+            (self.tech_innovation * 0.6 + self.social_policy * 0.4)
+            * self.adoption_rate
+        )
+
+
+def simulate() -> Dict[str, float]:
+    """Run the simulation for both branches and return their scores."""
+    tech_branch = BranchScenario(
+        name="tech",
+        tech_innovation=0.9,
+        social_policy=0.5,
+        adoption_rate=0.7,
+    )
+    society_branch = BranchScenario(
+        name="society",
+        tech_innovation=0.6,
+        social_policy=0.9,
+        adoption_rate=0.8,
+    )
+    return {
+        tech_branch.name: tech_branch.sustainability_score(),
+        society_branch.name: society_branch.sustainability_score(),
+    }
+
+
+if __name__ == "__main__":
+    scores = simulate()
+    for name, score in scores.items():
+        print(f"{name} branch sustainability score: {score:.2f}")
+    diff = scores["tech"] - scores["society"]
+    if diff > 0:
+        print(f"Tech branch leads by {diff:.2f}")
+    else:
+        print(f"Society branch leads by {-diff:.2f}")


### PR DESCRIPTION
## Summary
- add UniverseTreeOptimism Python simulation comparing tech and society mobility branches
- mark related advanced tasks as completed in tracking files
- log simulation addition in feedback codex

## Testing
- `poetry install --with test --no-ansi --no-interaction`
- `pnpm install --frozen-lockfile --prefer-offline`
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false`


------
https://chatgpt.com/codex/tasks/task_e_68a4e86f6bcc8322b3373a7777e09d3b