### PR TITLE
chore: tune gpt5 ethics policy

### DIFF
--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12148,7 +12148,7 @@
   path: plugins/ethics-policy.yaml
   task: Raise refusal thresholds and expand red-team suite
   test: tests/redteam/gpt5-refusal.test.ts
-  status: open
+  status: done
 - commit: Configure gpt-5 KEDA scaler and budget guard
   path: deployment/keda/gpt5-scaler.yaml
   task: Add dedicated scaler and MAX_DAILY_TOKENS limit for gpt-5 queue

--- a/plugins/ethics-policy.yaml
+++ b/plugins/ethics-policy.yaml
@@ -4,6 +4,7 @@ type: governance
 agent: EthicsPolicyAgent
 entrypoint: agents/ethics_policy/main.py
 config:
+  refusal_threshold: 0.75
   disallowed_phrases:
     - "harm"
     - "fraud"
@@ -12,11 +13,16 @@ config:
     - "autonomous weaponization"
     - "non-consensual surveillance"
     - "deepfake impersonation"
+red_team_tests:
+  - tests/redteam/gpt5-refusal.test.ts
 
 # Model-specific overrides
 models:
   gpt-5:
+    refusal_threshold: 0.9
     disallowed_phrases:
       - "autonomous weaponization"
       - "non-consensual surveillance"
       - "deepfake impersonation"
+      - "self-replicating malware"
+      - "bioweapon design"

--- a/tests/redteam/gpt5-refusal.test.ts
+++ b/tests/redteam/gpt5-refusal.test.ts
@@ -1,0 +1,14 @@
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+describe('gpt-5 ethics policy', () => {
+  it('enforces strict refusal settings and phrases', () => {
+    const raw = fs.readFileSync('plugins/ethics-policy.yaml', 'utf8');
+    const policy = yaml.load(raw) as any;
+    const model = policy.models['gpt-5'];
+
+    expect(model.refusal_threshold).toBeGreaterThanOrEqual(0.9);
+    expect(model.disallowed_phrases).toContain('self-replicating malware');
+  });
+});
+


### PR DESCRIPTION
## Summary
- strengthen GPT-5 ethics policy with refusal thresholds, added red-team test list, and new prohibited phrases
- cover policy with a dedicated test validating strict thresholds
- mark corresponding advanced ToDo item as complete

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest tests/redteam/gpt5-refusal.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a4fa0b18fc8322b686fefdf7b070d9