### PR TITLE
feat: add OpenAI responses provider

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12448,7 +12448,7 @@
     "path": "packages/gpt-bridges/provider/openai.ts",
     "task": "Use responses API with fallback to chat completions",
     "test": "packages/gpt-bridges/provider/openai.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add gpt-5 smoke test suite",
@@ -12675,12 +12675,12 @@
     "status": "open"
   },
   {
-  "commit": "Provide NATS env snippet",
-  "path": "docs/snippets/ENV_NATS.example",
-  "task": "Document NATS_URL and credentials placeholders",
-  "test": "",
-  "status": "done"
-},
+    "commit": "Provide NATS env snippet",
+    "path": "docs/snippets/ENV_NATS.example",
+    "task": "Document NATS_URL and credentials placeholders",
+    "test": "",
+    "status": "done"
+  },
   {
     "commit": "Implement ToolRegistry",
     "path": "packages/gpt-bridges/tools/ToolRegistry.ts",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12168,7 +12168,7 @@
   path: packages/gpt-bridges/provider/openai.ts
   task: Use responses API with fallback to chat completions
   test: packages/gpt-bridges/provider/openai.test.ts
-  status: open
+  status: done
 - commit: Add gpt-5 smoke test suite
   path: tests/gpt5-smoke.test.ts
   task: Verify JSON tool call, RAG answer and image caption using gpt-5

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5022,6 +5022,10 @@
     {
       "commit": "Add summary output to sync-todo-progress script",
       "status": "done"
+    },
+    {
+      "commit": "Switch OpenAI provider to responses API",
+      "status": "done"
     }
   ],
   "metacommitTags": [
@@ -5215,6 +5219,10 @@
     },
     {
       "commit": "Extend code agent tasks for dataset and k8s",
+      "status": "done"
+    },
+    {
+      "commit": "Switch OpenAI provider to responses API",
       "status": "done"
     }
   ],

--- a/packages/gpt-bridges/provider/openai.test.ts
+++ b/packages/gpt-bridges/provider/openai.test.ts
@@ -1,0 +1,34 @@
+import { callOpenAI, RESPONSES_URL, CHAT_URL } from './openai';
+
+describe('OpenAI provider', () => {
+  const originalFetch = global.fetch;
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = 'test-key';
+  });
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+  });
+
+  test('uses responses API when available', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ output: [{ content: [{ text: 'hi' }] }] })
+    }) as any;
+    const result = await callOpenAI({ model: 'gpt-4o-mini', messages: [{ role: 'user', content: 'hi' }] });
+    expect(result).toBe('hi');
+    expect((global.fetch as any).mock.calls[0][0]).toBe(RESPONSES_URL);
+  });
+
+  test('falls back to chat completions when responses fail', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ choices: [{ message: { content: 'fallback' } }] }) }) as any;
+    const result = await callOpenAI({ model: 'gpt-4o-mini', messages: [{ role: 'user', content: 'hi' }] });
+    expect(result).toBe('fallback');
+    const calls = (global.fetch as any).mock.calls;
+    expect(calls[0][0]).toBe(RESPONSES_URL);
+    expect(calls[1][0]).toBe(CHAT_URL);
+  });
+});

--- a/packages/gpt-bridges/provider/openai.ts
+++ b/packages/gpt-bridges/provider/openai.ts
@@ -1,0 +1,54 @@
+
+export interface OpenAIMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface OpenAIParams {
+  model: string;
+  messages: OpenAIMessage[];
+}
+
+const RESPONSES_URL = 'https://api.openai.com/v1/responses';
+const CHAT_URL = 'https://api.openai.com/v1/chat/completions';
+
+async function post(url: string, apiKey: string, body: unknown) {
+  const init: RequestInit = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify(body)
+  };
+  const res = await fetch(url, init);
+  return res;
+}
+
+export async function callOpenAI({ model, messages }: OpenAIParams): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY is required');
+  }
+  try {
+    const res = await post(RESPONSES_URL, apiKey, { model, input: messages });
+    if (res.ok) {
+      const json = await res.json();
+      const text = json.output?.[0]?.content?.[0]?.text ?? json.output_text;
+      if (typeof text === 'string') {
+        return text;
+      }
+    }
+  } catch {
+    // ignore network errors and fall back
+  }
+
+  const res = await post(CHAT_URL, apiKey, { model, messages });
+  if (!res.ok) {
+    throw new Error(`OpenAI request failed with status ${res.status}`);
+  }
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content ?? '';
+}
+
+export { RESPONSES_URL, CHAT_URL };


### PR DESCRIPTION
## Summary
- use OpenAI responses API with fallback to chat completions
- add tests verifying responses-first and chat-completions fallback paths
- mark ToDo and progress entries for the new provider as complete

## Testing
- `pnpm install`
- `poetry install --with test`
- `pnpm test packages/gpt-bridges/provider/openai.test.ts`
- `npx tsc -p tsconfig.json`
- `npx pyright`

------
https://chatgpt.com/codex/tasks/task_e_68a593bb2048832298a16a1c9d448f32