### PR TITLE
feat(crep): add hope activation metric

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14527,7 +14527,7 @@
     "path": "packages/crep/metrics.ts",
     "task": "Add hopeActivation field to CREP evaluation schema",
     "test": "packages/crep/metrics.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Compare tech vs society branches in Universe Tree",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13660,7 +13660,7 @@
   path: packages/crep/metrics.ts
   task: Add hopeActivation field to CREP evaluation schema
   test: packages/crep/metrics.test.ts
-  status: open
+  status: done
 - commit: Compare tech vs society branches in Universe Tree
   path: sims/universe_tree_optimism.py
   task: Simulate and contrast tech- and society-optimistic branches for

--- a/packages/crep/metrics.test.ts
+++ b/packages/crep/metrics.test.ts
@@ -1,0 +1,9 @@
+import { evaluateCREP, CREPEvaluation } from './metrics';
+
+describe('evaluateCREP', () => {
+  it('includes hopeActivation in average', () => {
+    const metrics: CREPEvaluation = { C: 1, R: 1, E: 1, P: 1, hopeActivation: 5 };
+    const score = evaluateCREP(metrics);
+    expect(score).toBeCloseTo(1.8);
+  });
+});

--- a/packages/crep/metrics.ts
+++ b/packages/crep/metrics.ts
@@ -1,0 +1,17 @@
+export interface CREPEvaluation {
+  C: number;
+  R: number;
+  E: number;
+  P: number;
+  hopeActivation: number;
+}
+
+/**
+ * Computes overall CREP score including hope activation.
+ */
+export function evaluateCREP(metrics: CREPEvaluation): number {
+  const { C, R, E, P, hopeActivation } = metrics;
+  const values = [C, R, E, P, hopeActivation];
+  const total = values.reduce((a, b) => a + b, 0);
+  return total / values.length;
+}


### PR DESCRIPTION
## Summary
- add `hopeActivation` metric to CREP evaluation schema
- test hope activation influence on computed CREP score
- mark hope activation task as complete in advanced ToDo

## Testing
- `pnpm install`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx jest packages/crep/metrics.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a59bc3e184832282b6bc8add6b1831