### PR TITLE
feat(security): add HMAC signed URL utility

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13358,7 +13358,7 @@
     "path": "packages/security/SignedURL.ts",
     "task": "Generate and verify expiring share tokens",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create share API server",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12820,7 +12820,7 @@
   path: packages/security/SignedURL.ts
   task: Generate and verify expiring share tokens
   test: ""
-  status: open
+  status: done
 - commit: Create share API server
   path: scripts/share-api.ts
   task: Serve signed links for object store artifacts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Introduce HmacSigner for event envelopes",
+  "lastCommit": "Implement HMAC signed URLs",
   "fractalStep": "universe tree prototype ready",
   "openBranches": [
     "work"
@@ -14,6 +14,10 @@
     "feat: integrate FutureTechFramework (packages/agents/FutureTechFramework.ts)"
   ],
   "progress": [
+    {
+      "commit": "Implement HMAC signed URLs",
+      "status": "done"
+    },
     {
       "commit": "Introduce HmacSigner for event envelopes",
       "status": "done"

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -119,3 +119,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Documented agent workflow and system start sequence to guide future contributors.
 - Added Universe Tree simulation scaffold, EPI scan CLI, dataset merge, and sanity validation.
 - Added NATS environment snippet for messaging configuration.
+- Implemented SignedURL utility for expiring HMAC-signed links.

--- a/packages/security/SignedURL.test.ts
+++ b/packages/security/SignedURL.test.ts
@@ -1,0 +1,17 @@
+import { SignedURL } from './SignedURL';
+
+describe('SignedURL', () => {
+  const secret = 'share-secret';
+
+  it('generates and verifies signed url', () => {
+    const signer = new SignedURL(secret);
+    const url = signer.sign('https://example.com/resource', 60);
+    expect(signer.verify(url)).toBe(true);
+  });
+
+  it('rejects expired urls', () => {
+    const signer = new SignedURL(secret);
+    const url = signer.sign('https://example.com/resource', -10);
+    expect(signer.verify(url)).toBe(false);
+  });
+});

--- a/packages/security/SignedURL.ts
+++ b/packages/security/SignedURL.ts
@@ -1,0 +1,40 @@
+import crypto from 'crypto';
+import { URL } from 'url';
+
+export class SignedURL {
+  private secret: string;
+
+  constructor(secret: string) {
+    this.secret = secret;
+  }
+
+  sign(rawUrl: string, expiresInSeconds: number): string {
+    const url = new URL(rawUrl);
+    const expiry = Math.floor(Date.now() / 1000) + expiresInSeconds;
+    url.searchParams.set('exp', expiry.toString());
+    const data = this.dataToSign(url);
+    const sig = crypto.createHmac('sha256', this.secret).update(data).digest('hex');
+    url.searchParams.set('sig', sig);
+    return url.toString();
+  }
+
+  verify(signedUrl: string): boolean {
+    const url = new URL(signedUrl);
+    const sig = url.searchParams.get('sig');
+    const exp = url.searchParams.get('exp');
+    if (!sig || !exp) return false;
+    const expiry = parseInt(exp, 10);
+    if (isNaN(expiry) || expiry < Math.floor(Date.now() / 1000)) {
+      return false;
+    }
+    url.searchParams.delete('sig');
+    const data = this.dataToSign(url);
+    const expected = crypto.createHmac('sha256', this.secret).update(data).digest('hex');
+    return crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected));
+  }
+
+  private dataToSign(url: URL): string {
+    url.searchParams.sort();
+    return `${url.pathname}?${url.searchParams.toString()}`;
+  }
+}


### PR DESCRIPTION
## Summary
- add `SignedURL` helper to generate and validate expiring HMAC signed links
- mark SignedURL task as done in advanced todo trackers and progress log
- note SignedURL utility in feedback codex

## Testing
- `pnpm install`
- `poetry install --with test`
- `pnpm update:advanced-progress`
- `npx pyright` *(fails: venvPath /workspace/unified-mandala/.venv is not a valid directory)*
- `npx tsc -p tsconfig.json`
- `npx jest packages/security/SignedURL.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a5a218e2108322916bceebda6919b3