### PR TITLE
feat: add gpt-5 scaler and budget guard

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12428,7 +12428,7 @@
     "path": "deployment/keda/gpt5-scaler.yaml",
     "task": "Add dedicated scaler and MAX_DAILY_TOKENS limit for gpt-5 queue",
     "test": "deployment/keda/gpt5-scaler.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Expose gpt-5 metrics in admin panel",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12154,7 +12154,7 @@
   path: deployment/keda/gpt5-scaler.yaml
   task: Add dedicated scaler and MAX_DAILY_TOKENS limit for gpt-5 queue
   test: deployment/keda/gpt5-scaler.test.ts
-  status: open
+  status: done
 - commit: Expose gpt-5 metrics in admin panel
   path: packages/unifiedmandala-ui/components/AdminMetrics.tsx
   task: Show gpt-5 badge with avg latency and success rate

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -4405,6 +4405,10 @@
     {
       "commit": "Provide NATS env snippet",
       "status": "done"
+    },
+    {
+      "commit": "Configure gpt-5 KEDA scaler and budget guard",
+      "status": "done"
     }
   ],
   "completed": [

--- a/deployment/keda/gpt5-scaler.test.ts
+++ b/deployment/keda/gpt5-scaler.test.ts
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+test('gpt-5 scaler defines daily token limit', () => {
+  const raw = fs.readFileSync('deployment/keda/gpt5-scaler.yaml', 'utf8');
+  const conf = yaml.load(raw) as any;
+  const trigger = (conf.spec?.triggers || []).find((t: any) => t.type === 'metrics-api');
+  expect(trigger).toBeDefined();
+  expect(trigger.metadata?.value).toBe('MAX_DAILY_TOKENS');
+});

--- a/deployment/keda/gpt5-scaler.yaml
+++ b/deployment/keda/gpt5-scaler.yaml
@@ -1,0 +1,22 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: gpt5-queue-scaledobject
+spec:
+  scaleTargetRef:
+    name: gpt5-worker
+  pollingInterval: 30
+  cooldownPeriod: 300
+  minReplicaCount: 1
+  maxReplicaCount: 5
+  triggers:
+    - type: nats-jetstream
+      metadata:
+        natsServerMonitoringEndpoint: "http://nats.monitoring:8222"
+        streamName: gpt5
+        consumerName: gpt5-worker
+        pendingMessages: "100"
+    - type: metrics-api
+      metadata:
+        url: "http://gpt5-budget-guard:8080/usage"
+        value: "MAX_DAILY_TOKENS"

--- a/feedbackcodex.json
+++ b/feedbackcodex.json
@@ -1,5 +1,6 @@
 {
   "feedback": "New advanced conversations processed and TODOs extracted",
   "notes": "aeon:2025-0623-ANCHOR-V2 complete",
-  "analysis": "Deployment readiness tasks created"
+  "analysis": "Deployment readiness tasks created",
+  "recent": "Configured gpt-5 KEDA scaler with daily token budget guard"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -121,3 +121,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added NATS environment snippet for messaging configuration.
 - Implemented SignedURL utility for expiring HMAC-signed links.
 - Added FutureTechFramework agent skeleton with module registry.
+- Configured gpt-5 KEDA scaler with daily token budget guard.


### PR DESCRIPTION
## Summary
- add KEDA scaled object for gpt-5 queue with daily token budget guard
- cover scaler with unit test and mark advanced progress entries as done
- note scaler addition in feedback codex

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npm test deployment/keda/gpt5-scaler.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a5bf2335648322a95793bf2a0f5980