### PR TITLE
feat: add realtime stream protocol

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13317,7 +13317,7 @@
     "path": "packages/realtime/StreamProtocol.ts",
     "task": "Define LiveMsg types for realtime hub",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement ResearchHubWS server",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12791,7 +12791,7 @@
   path: packages/realtime/StreamProtocol.ts
   task: Define LiveMsg types for realtime hub
   test: ""
-  status: open
+  status: done
 - commit: Implement ResearchHubWS server
   path: packages/realtime/ResearchHubWS.ts
   task: Broadcast live RAG events over WebSocket

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -4413,6 +4413,10 @@
   ],
   "completed": [
     {
+      "commit": "Add Realtime StreamProtocol definitions",
+      "status": "done"
+    },
+    {
       "commit": "CosmicTheoryAgent MetricsStore interface",
       "status": "done"
     },

--- a/packages/realtime/StreamProtocol.ts
+++ b/packages/realtime/StreamProtocol.ts
@@ -1,0 +1,35 @@
+/**
+ * StreamProtocol defines message shapes for the realtime hub.
+ * Each message is wrapped in an envelope that carries a protocol
+ * version for forward/backward compatibility.
+ */
+
+export const PROTOCOL_VERSION = '1.0';
+
+/**
+ * Core message types exchanged with the realtime hub.
+ */
+export type LiveMsg =
+  | { type: 'ping'; ts: number }
+  | { type: 'pong'; ts: number }
+  | { type: 'subscribe'; channel: string }
+  | { type: 'unsubscribe'; channel: string }
+  | { type: 'event'; channel: string; payload: unknown };
+
+/**
+ * Envelope sent over the wire.
+ */
+export interface StreamEnvelope<T extends LiveMsg = LiveMsg> {
+  /** protocol version */
+  v: string;
+  /** wrapped message */
+  msg: T;
+}
+
+/**
+ * Helper to wrap a message in a protocol envelope.
+ */
+export function wrap<T extends LiveMsg>(msg: T): StreamEnvelope<T> {
+  return { v: PROTOCOL_VERSION, msg };
+}
+

--- a/packages/realtime/index.ts
+++ b/packages/realtime/index.ts
@@ -1,0 +1,1 @@
+export * from './StreamProtocol';


### PR DESCRIPTION
## Summary
- define LiveMsg and StreamEnvelope types for realtime hub
- mark StreamProtocol task complete in todo and progress trackers

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a5cef3b144832280b544c64fbca1b6