### PR TITLE
feat: expose gpt-5 metrics in admin panel

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12435,7 +12435,7 @@
     "path": "packages/unifiedmandala-ui/components/AdminMetrics.tsx",
     "task": "Show gpt-5 badge with avg latency and success rate",
     "test": "packages/unifiedmandala-ui/components/AdminMetrics.test.tsx",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Enable gpt-5 filter in MandalaNetworkView",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12159,7 +12159,7 @@
   path: packages/unifiedmandala-ui/components/AdminMetrics.tsx
   task: Show gpt-5 badge with avg latency and success rate
   test: packages/unifiedmandala-ui/components/AdminMetrics.test.tsx
-  status: open
+  status: done
 - commit: Enable gpt-5 filter in MandalaNetworkView
   path: packages/unifiedmandala-ui/components/MandalaNetworkView.tsx
   task: Allow filtering network view to runs using gpt-5

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -10,9 +10,14 @@
     "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129 (GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json)",
     "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e (GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json)",
     "Integrate new GPT teams from Zukunft conversation (packages/agents)",
-    "chore: scaffold Wissenschaftliche Versuche project (packages/wissenschaftliche-versuche)"
+    "chore: scaffold Wissenschaftliche Versuche project (packages/wissenschaftliche-versuche)",
+    "chore: scaffold WVH simulation modules (packages/universum-simulationen/modules)"
   ],
   "progress": [
+    {
+      "commit": "Expose gpt-5 metrics in admin panel",
+      "status": "done"
+    },
     {
       "commit": "Implement HMAC signed URLs",
       "status": "done"

--- a/apps/sharedream-interface/components/AdminMetrics.test.tsx
+++ b/apps/sharedream-interface/components/AdminMetrics.test.tsx
@@ -3,7 +3,17 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import AdminMetrics from './AdminMetrics';
 
-test('renders admin metrics', () => {
-  render(<AdminMetrics avgCREP={0.5} sigillinAdoption={2} openTodos={1} />);
-  expect(screen.getByLabelText('Admin Metrics')).toHaveTextContent('0.50');
+test('renders admin metrics with gpt-5 badge', () => {
+  render(
+    <AdminMetrics
+      avgCREP={0.5}
+      sigillinAdoption={2}
+      openTodos={1}
+      gpt5AvgLatency={200}
+      gpt5SuccessRate={0.99}
+    />
+  );
+  const metrics = screen.getByLabelText('Admin Metrics');
+  expect(metrics).toHaveTextContent('0.50');
+  expect(metrics).toHaveTextContent('GPT-5');
 });

--- a/apps/sharedream-interface/components/AdminMetrics.tsx
+++ b/apps/sharedream-interface/components/AdminMetrics.tsx
@@ -4,14 +4,25 @@ export interface AdminMetricsProps {
   avgCREP: number;
   sigillinAdoption: number;
   openTodos: number;
+  gpt5AvgLatency: number;
+  gpt5SuccessRate: number;
 }
 
-export default function AdminMetrics({ avgCREP, sigillinAdoption, openTodos }: AdminMetricsProps) {
+export default function AdminMetrics({
+  avgCREP,
+  sigillinAdoption,
+  openTodos,
+  gpt5AvgLatency,
+  gpt5SuccessRate,
+}: AdminMetricsProps) {
   return (
     <div aria-label="Admin Metrics">
       <div>CREP Durchschnitt: {avgCREP.toFixed(2)}</div>
       <div>Sigillin Adoption: {sigillinAdoption}</div>
       <div>Offene ToDos: {openTodos}</div>
+      <div className="gpt5-badge">
+        GPT-5: {gpt5AvgLatency}ms / {Math.round(gpt5SuccessRate * 100)}%
+      </div>
     </div>
   );
 }

--- a/apps/sharedream-interface/hooks/useAdminMetrics.test.ts
+++ b/apps/sharedream-interface/hooks/useAdminMetrics.test.ts
@@ -1,7 +1,13 @@
 import { renderHook, act } from '@testing-library/react';
 import { useAdminMetrics } from './useAdminMetrics';
 
-const apiResponse = { avgCREP: 0.8, sigillinAdoption: 3, openTodos: 2 };
+const apiResponse = {
+  avgCREP: 0.8,
+  sigillinAdoption: 3,
+  openTodos: 2,
+  gpt5AvgLatency: 250,
+  gpt5SuccessRate: 0.95,
+};
 
 describe('useAdminMetrics', () => {
   beforeEach(() => {
@@ -18,5 +24,6 @@ describe('useAdminMetrics', () => {
     const { result } = renderHook(() => useAdminMetrics());
     await act(async () => {});
     expect(result.current.metrics?.avgCREP).toBe(0.8);
+    expect(result.current.metrics?.gpt5AvgLatency).toBe(250);
   });
 });

--- a/apps/sharedream-interface/hooks/useAdminMetrics.ts
+++ b/apps/sharedream-interface/hooks/useAdminMetrics.ts
@@ -4,6 +4,8 @@ export interface AdminMetric {
   avgCREP: number;
   sigillinAdoption: number;
   openTodos: number;
+  gpt5AvgLatency: number;
+  gpt5SuccessRate: number;
 }
 
 export function useAdminMetrics() {

--- a/apps/sharedream-interface/pages/api/admin-metrics.ts
+++ b/apps/sharedream-interface/pages/api/admin-metrics.ts
@@ -3,5 +3,7 @@ export default function handler(req: any, res: any) {
     avgCREP: 0.7,
     sigillinAdoption: 5,
     openTodos: 3,
+    gpt5AvgLatency: 220,
+    gpt5SuccessRate: 0.98,
   });
 }


### PR DESCRIPTION
## Summary
- show GPT-5 badge with latency and success rate in admin metrics panel
- expand admin metrics hook and API to include GPT-5 statistics
- sync advanced ToDo and progress trackers

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test apps/sharedream-interface`


------
https://chatgpt.com/codex/tasks/task_e_68a63e9809e48322a03fa6b18160bd2a