### PR TITLE
feat(ui): add gpt-5 filter to network view

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12442,7 +12442,7 @@
     "path": "packages/unifiedmandala-ui/components/MandalaNetworkView.tsx",
     "task": "Allow filtering network view to runs using gpt-5",
     "test": "packages/unifiedmandala-ui/components/MandalaNetworkView.test.tsx",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Switch OpenAI provider to responses API",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12164,7 +12164,7 @@
   path: packages/unifiedmandala-ui/components/MandalaNetworkView.tsx
   task: Allow filtering network view to runs using gpt-5
   test: packages/unifiedmandala-ui/components/MandalaNetworkView.test.tsx
-  status: open
+  status: done
 - commit: Switch OpenAI provider to responses API
   path: packages/gpt-bridges/provider/openai.ts
   task: Use responses API with fallback to chat completions

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: integrate FutureTechFramework",
+  "lastCommit": "Enable gpt-5 filter in MandalaNetworkView",
   "fractalStep": "universe tree prototype ready",
   "openBranches": [
     "work"
@@ -4413,6 +4413,10 @@
     },
     {
       "commit": "Configure gpt-5 KEDA scaler and budget guard",
+      "status": "done"
+    },
+    {
+      "commit": "Enable gpt-5 filter in MandalaNetworkView",
       "status": "done"
     }
   ],

--- a/packages/unifiedmandala-ui/components/MandalaNetworkView.test.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaNetworkView.test.tsx
@@ -1,5 +1,5 @@
 // d3 ist ESM-only, daher hier minimal gemockt
-const mockOn = jest.fn();
+const mockData = jest.fn().mockReturnThis();
 jest.mock('d3', () => ({
   select: () => ({
     selectAll: () => ({ remove: jest.fn() }),
@@ -7,12 +7,12 @@ jest.mock('d3', () => ({
     append: () => ({
       attr: jest.fn().mockReturnThis(),
       selectAll: jest.fn().mockReturnThis(),
-      data: jest.fn().mockReturnThis(),
+      data: mockData,
       enter: jest.fn().mockReturnThis(),
       append: jest.fn().mockReturnThis(),
       text: jest.fn().mockReturnThis(),
       call: jest.fn().mockReturnThis(),
-      on: mockOn,
+      on: jest.fn(),
     }),
   }),
   forceSimulation: () => ({ force: jest.fn().mockReturnThis(), on: jest.fn() }),
@@ -21,10 +21,30 @@ jest.mock('d3', () => ({
   forceCenter: jest.fn(),
   drag: () => ({ on: jest.fn().mockReturnThis() }),
   zoom: () => ({ on: jest.fn().mockReturnThis() }),
-  interpolateRainbow: jest.fn(() => '#fff'),
 }));
 
-import { render, screen } from '@testing-library/react';
+jest.mock('../data/sigillin_nodes.json', () => [
+  {
+    id: 'run1',
+    label: 'Run1',
+    crep: { C: 1, R: 1, E: 1, P: 1 },
+    related: [],
+    type: 'run',
+    status: 'active',
+    model: 'gpt-5',
+  },
+  {
+    id: 'run2',
+    label: 'Run2',
+    crep: { C: 1, R: 1, E: 1, P: 1 },
+    related: [],
+    type: 'run',
+    status: 'active',
+    model: 'gpt-4',
+  },
+]);
+
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import MandalaNetworkView from './MandalaNetworkView';
 
@@ -32,13 +52,19 @@ test('renders svg and filter options', () => {
   render(<MandalaNetworkView />);
   expect(screen.getByLabelText('Mandala Netzwerk')).toBeInTheDocument();
   const selects = screen.getAllByRole('combobox');
-  expect(selects.length).toBe(2);
-  // one option per type plus "Alle"
-  const options = screen.getAllByRole('option');
-  expect(options.length).toBeGreaterThan(2);
+  expect(selects.length).toBe(3);
 });
 
 test('shows placeholder when no node is selected', () => {
   render(<MandalaNetworkView />);
   expect(screen.getByTestId('node-details')).toHaveTextContent('No node selected');
+});
+
+test('filters nodes by gpt-5 model', () => {
+  render(<MandalaNetworkView />);
+  const modelSelect = screen.getByLabelText('Model:');
+  fireEvent.change(modelSelect, { target: { value: 'gpt-5' } });
+  const lastCallArg = mockData.mock.calls[mockData.mock.calls.length - 1][0];
+  expect(lastCallArg).toHaveLength(1);
+  expect(lastCallArg[0].model).toBe('gpt-5');
 });

--- a/packages/unifiedmandala-ui/components/MandalaNetworkView.tsx
+++ b/packages/unifiedmandala-ui/components/MandalaNetworkView.tsx
@@ -3,7 +3,7 @@ import * as d3 from "d3";
 import { Tooltip } from "react-tooltip";
 
 // Annahme: sigillin_nodes.json ist bereits im Projekt und importierbar
-import nodesData from "../data/sigillin_nodes.json";
+import rawNodesData from "../data/sigillin_nodes.json";
 import { getCREPPhaseColor } from "../../shared-utils";
 
 interface MandalaNode {
@@ -13,6 +13,7 @@ interface MandalaNode {
   related: Array<{ id: string; relation: string }>;
   type: string;
   status: string;
+  model?: string;
   poetry?: string;
   x?: number;
   y?: number;
@@ -28,9 +29,12 @@ export const MandalaNetworkView: React.FC = () => {
   const svgRef = useRef<SVGSVGElement>(null);
   const [filterType, setFilterType] = useState<string>('all');
   const [filterLevel, setFilterLevel] = useState<string>('all');
+  const [filterModel, setFilterModel] = useState<string>('all');
   const [selectedNode, setSelectedNode] = useState<MandalaNode | null>(null);
+  const nodesData = rawNodesData as MandalaNode[];
   // verfügbare Sigillin-Typen für die Filter-UI ermitteln
   const types = Array.from(new Set(nodesData.map(n => n.type)));
+  const models = Array.from(new Set(nodesData.map(n => n.model).filter(Boolean))) as string[];
 
   useEffect(() => {
     // D3-Force-Simulation
@@ -44,6 +48,7 @@ export const MandalaNetworkView: React.FC = () => {
       if (filterLevel === 'low' && sum >= 10) return false;
       if (filterLevel === 'medium' && (sum < 10 || sum > 20)) return false;
       if (filterLevel === 'high' && sum <= 20) return false;
+      if (filterModel !== 'all' && n.model !== filterModel) return false;
       return true;
     });
     const links = nodes.flatMap(n =>
@@ -132,7 +137,7 @@ export const MandalaNetworkView: React.FC = () => {
         .attr("x", d => d.x!)
         .attr("y", d => d.y!);
     });
-  }, [filterType, filterLevel]);
+  }, [filterType, filterLevel, filterModel]);
 
   const handleExportSVG = () => {
     const svg = svgRef.current;
@@ -174,6 +179,19 @@ export const MandalaNetworkView: React.FC = () => {
           <option value="low">Niedrig</option>
           <option value="medium">Mittel</option>
           <option value="high">Hoch</option>
+        </select>
+      </label>
+      <label className="mb-2">
+        Model:
+        <select
+          value={filterModel}
+          onChange={e => setFilterModel(e.target.value)}
+          className="ml-2 border p-1 rounded"
+        >
+          <option value="all">Alle</option>
+          {models.map(m => (
+            <option key={m} value={m}>{m}</option>
+          ))}
         </select>
       </label>
       <svg ref={svgRef} width={800} height={600} tabIndex={0} aria-label="Mandala Netzwerk" />


### PR DESCRIPTION
## Summary
- allow Mandala network view to filter nodes by model, including gpt-5 runs
- cover new filter with unit test
- mark task complete in advanced todo and progress trackers

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest packages/unifiedmandala-ui/components/MandalaNetworkView.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a644c813808322a0ca4cfee1c11db1