### PR TITLE
docs: add open source model setup

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-19, in der Zeit des Morgen.
+Am 2025-08-20, in der Zeit des Nacht.
 
-Symbolphase: Initiation (Fokus: C)
+Symbolphase: Reflexion (Fokus: P)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12631,7 +12631,7 @@
     "path": "docs/models/OpenSourceModels.md",
     "task": "Describe configuration and routing for Ollama, TGI and vLLM",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Provide model env snippet",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12301,7 +12301,7 @@
   path: docs/models/OpenSourceModels.md
   task: Describe configuration and routing for Ollama, TGI and vLLM
   test: ""
-  status: open
+  status: done
 - commit: Provide model env snippet
   path: docs/snippets/ENV_MODELS.example
   task: List environment variables for local model providers

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Merge pull request #1346 from GenesisAeon/codex/implement-features-from-advancedtodo-files-j07jfv",
+  "lastCommit": "chore: finalize progress",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.; Documented Mandala prompt patterns; Implemented RAG Chunker for document tokenization; Extended SymbolMapper to accept NumPy arrays; Added VectorStore for RAG.; Declared gpt-5 capabilities for core agents.; Implemented RAGPipeline with smoke test.; Documented agent workflow and system start sequence; Added Universe Tree simulation with config, evaluation, and sanity checks. Implemented EPI scan CLI and dataset merge.; Extended code agent tasks for dataset API, citation demo and k8s base deployment.; Introduced HmacSigner for event envelopes. Added FutureTechFramework agent skeleton.",
+  "notes": "Implemented region profile REST endpoint and completed country/region model set. Added mitigation service microservice stub. Enhanced ethics supervisor with pattern checks. Added ClimateSocialPanel UI for dashboard metrics. Added InteractiveSymbolzeitExplorer UI. Added IoTSensorWidget UI for realtime sensor data.; Added repository map duplicate checker.; Added IoT sensor agent plugin and container.; Added provenance agent scaffold.; Added societal impact agent container.; Added catalyst agent container.; Documented Mandala prompt patterns; Implemented RAG Chunker for document tokenization; Extended SymbolMapper to accept NumPy arrays; Added VectorStore for RAG.; Declared gpt-5 capabilities for core agents.; Implemented RAGPipeline with smoke test.; Documented agent workflow and system start sequence; Added Universe Tree simulation with config, evaluation, and sanity checks. Implemented EPI scan CLI and dataset merge.; Extended code agent tasks for dataset API, citation demo and k8s base deployment.; Introduced HmacSigner for event envelopes. Added FutureTechFramework agent skeleton.; Documented open source model setup for Ollama, TGI and vLLM.",
   "pendingTasks": [
     {
       "commit": "Add gpt-5 smoke test suite",
@@ -37,10 +37,6 @@
     },
     {
       "commit": "Expose agent status in UI",
-      "status": "open"
-    },
-    {
-      "commit": "Document open source model setup",
       "status": "open"
     },
     {
@@ -5429,7 +5425,7 @@
     {
       "commit": "Extend CREP metrics with hope activation",
       "status": "done"
-    }
+    },
   ],
   "completed": [
     {

--- a/docs/models/OpenSourceModels.md
+++ b/docs/models/OpenSourceModels.md
@@ -1,0 +1,58 @@
+# Open Source Model Setup
+
+This guide outlines how to configure local open‑source model servers and how Mandala routes requests between them.
+
+## Environment Variables
+Each provider exposes an HTTP endpoint. Set the following variables or copy `docs/snippets/ENV_MODELS.example` to your environment:
+
+```bash
+# Ollama model server endpoint
+OLLAMA_URL=http://localhost:11434
+
+# Text Generation Inference (TGI) endpoint
+TGI_URL=http://localhost:8080
+
+# vLLM endpoint
+VLLM_URL=http://localhost:8000
+```
+
+## Providers
+
+### Ollama
+[Ollama](https://ollama.ai) serves lightweight models locally. Launch the daemon and pull a model, e.g.:
+
+```bash
+ollama serve &
+ollama pull mistral
+```
+
+### Text Generation Inference
+[Text Generation Inference](https://github.com/huggingface/text-generation-inference) (TGI) powers larger transformers.
+A minimal Docker launch looks like:
+
+```bash
+docker run -p 8080:80 ghcr.io/huggingface/text-generation-inference:latest --model-id mistralai/Mistral-7B-Instruct-v0.2
+```
+
+### vLLM
+[vLLM](https://github.com/vllm-project/vllm) provides fast generation with continuous batching:
+
+```bash
+python -m vllm.entrypoints.api_server --model facebook/opt-125m --host 0.0.0.0 --port 8000
+```
+
+## Routing with ModelRouter
+The upcoming `ModelRouter` module dispatches generation requests to a provider based on configuration. Example usage:
+
+```ts
+import { ModelRouter } from "packages/gpt-bridges/router/ModelRouter";
+
+const router = new ModelRouter();
+const result = await router.generate({ model: "ollama:mistral", prompt: "Hello" });
+```
+
+The prefix before `:` selects the provider (`ollama`, `tgi`, `vllm`). Provider URLs are read from the environment variables above.
+
+## Troubleshooting
+Ensure each service is reachable at its URL. Network errors or missing models will surface in router logs. Consult provider documentation for advanced configuration.
+

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -123,3 +123,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added FutureTechFramework agent skeleton with module registry.
 - Configured gpt-5 KEDA scaler with daily token budget guard.
 - Added SignedURL root test verifying signing, expiration, and tampering logic.
+- Documented open source model setup for local providers.


### PR DESCRIPTION
## Summary
- document local open-source model configuration and routing for Ollama, TGI and vLLM
- mark open source model documentation tasks as complete and sync progress trackers
- note documentation addition in feedback codex

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68a64c723c6c8322ad387d5a64f0e801