### PR TITLE
feat: add OvernightWorkerAgent for nightly orchestration

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2753,7 +2753,8 @@
     "commit": "feat: add OvernightWorkerAgent",
     "path": "packages/agents/OvernightWorkerAgent.ts",
     "task": "Maintain nightly analysis and orchestrate progress",
-    "test": "packages/agents/__tests__/OvernightWorkerAgent.test.ts"
+    "test": "packages/agents/__tests__/OvernightWorkerAgent.test.ts",
+    "status": "done"
   },
   {
     "commit": "feat: add NullmembranQuantization module",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4461,6 +4461,7 @@
   path: packages/agents/OvernightWorkerAgent.ts
   task: Maintain nightly analysis and orchestrate progress
   test: packages/agents/__tests__/OvernightWorkerAgent.test.ts
+  status: done
 - commit: "feat: add NullmembranQuantization module"
   path: packages/universum-simulationen/modules/nullmembran_quantization.py
   task: Implement start conditions and binary reproduction

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: expose agent status API route",
+  "lastCommit": "feat: add OvernightWorkerAgent",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -5436,6 +5436,10 @@
     },
     {
       "commit": "Document open source model setup",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add OvernightWorkerAgent",
       "status": "done"
     }
   ],

--- a/packages/agents/OvernightWorkerAgent.ts
+++ b/packages/agents/OvernightWorkerAgent.ts
@@ -1,0 +1,36 @@
+import { Agent, Task } from '../core/interfaces';
+import { NightWorkScheduler } from './NightWorkScheduler';
+import { OvernightProgressReporter } from './OvernightProgressReporter';
+
+export class OvernightWorkerAgent implements Agent {
+  id = 'OvernightWorkerAgent';
+  layer: 'Worker' = 'Worker';
+  private scheduler: NightWorkScheduler;
+  private reporter: OvernightProgressReporter;
+
+  constructor(
+    private dispatch: (task: Task) => Promise<void> = async () => {},
+    output = 'overnight-report.log',
+    now: () => Date = () => new Date()
+  ) {
+    this.reporter = new OvernightProgressReporter(output);
+    this.scheduler = new NightWorkScheduler(async (task: Task) => {
+      await this.dispatch(task);
+      await this.reporter.handle(task);
+    }, 0, 6, now);
+  }
+
+  async handle(task: Task): Promise<void> {
+    await this.scheduler.handle(task);
+  }
+
+  async process(): Promise<void> {
+    this.scheduler.processQueue();
+    await new Promise((r) => setImmediate(r));
+  }
+
+  getQueueLength(): number {
+    return this.scheduler.getQueueLength();
+  }
+}
+

--- a/packages/agents/__tests__/OvernightWorkerAgent.test.ts
+++ b/packages/agents/__tests__/OvernightWorkerAgent.test.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+import { test, expect, vi } from 'vitest';
+import { OvernightWorkerAgent } from '../OvernightWorkerAgent';
+
+const day = new Date('2020-01-01T12:00:00Z');
+const night = new Date('2020-01-01T02:00:00Z');
+
+test('processes queued tasks at night and logs progress', async () => {
+  const dispatch = vi.fn();
+  const logFile = path.join(__dirname, 'overnight.log');
+  let current = day;
+  const now = () => current;
+  const agent = new OvernightWorkerAgent(dispatch, logFile, now);
+
+  await agent.handle({ id: 't1', summary: 'work' } as any);
+  expect(dispatch).not.toHaveBeenCalled();
+  expect(agent.getQueueLength()).toBe(1);
+
+  current = night;
+  await agent.process();
+  expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ id: 't1' }));
+  const log = fs.readFileSync(logFile, 'utf8').trim();
+  expect(log).toContain('t1:work');
+  fs.unlinkSync(logFile);
+});

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -57,3 +57,4 @@ export * from './QuantumTheoryAgent';
 export * from './ReviewAgent';
 export * from './MasterGPTBridge';
 export * from './FutureTechFramework';
+export * from './OvernightWorkerAgent';


### PR DESCRIPTION
## Summary
- add OvernightWorkerAgent to dispatch tasks at night and log progress
- cover with vitest and export from agents index
- mark OvernightWorkerAgent task as done and sync advanced progress

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json --showConfig`
- `npx vitest run packages/agents/__tests__/OvernightWorkerAgent.test.ts`
- `node repositorypflege/update-advanced-progress.js 5`


------
https://chatgpt.com/codex/tasks/task_e_68a6dc9f9eb08322b47eba3cbb064785