### PR TITLE
feat: validate tool arguments with ajv

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12759,7 +12759,7 @@
     "path": "packages/gpt-bridges/tools/validateArgs.ts",
     "task": "Check tool call inputs against JSON schema before execution",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add PolicyEnforcer for governance",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12393,7 +12393,7 @@
   path: packages/gpt-bridges/tools/validateArgs.ts
   task: Check tool call inputs against JSON schema before execution
   test: ""
-  status: open
+  status: done
 - commit: Add PolicyEnforcer for governance
   path: packages/governance/PolicyEnforcer.ts
   task: Restrict tools, models and subjects based on permissions.yaml

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add sigil search panel and api",
+  "lastCommit": "feat: validate tool arguments with AJV",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4509,6 +4509,10 @@
     },
     {
       "commit": "Add Mandala Sigil link bridge",
+      "status": "done"
+    },
+    {
+      "commit": "Validate tool arguments with AJV",
       "status": "done"
     }
   ],

--- a/packages/gpt-bridges/tools/validateArgs.ts
+++ b/packages/gpt-bridges/tools/validateArgs.ts
@@ -1,0 +1,13 @@
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+
+const ajv = new Ajv({ allErrors: true });
+addFormats(ajv);
+
+export function validateArgs(schema: object, args: unknown): void {
+  const validate = ajv.compile(schema);
+  if (!validate(args)) {
+    const msg = ajv.errorsText(validate.errors, { separator: ', ' });
+    throw new Error(`Invalid tool arguments: ${msg}`);
+  }
+}

--- a/tests/validateArgs.test.ts
+++ b/tests/validateArgs.test.ts
@@ -1,0 +1,21 @@
+import { validateArgs } from '../packages/gpt-bridges/tools/validateArgs';
+
+describe('validateArgs', () => {
+  const schema = {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      age: { type: 'number' }
+    },
+    required: ['name'],
+    additionalProperties: false
+  };
+
+  it('accepts valid arguments', () => {
+    expect(() => validateArgs(schema, { name: 'Alice', age: 30 })).not.toThrow();
+  });
+
+  it('throws on invalid arguments', () => {
+    expect(() => validateArgs(schema, { age: 10 })).toThrow(/Invalid tool arguments/);
+  });
+});


### PR DESCRIPTION
## Summary
- add `validateArgs` helper to check tool call inputs against JSON Schema with AJV
- cover argument validation with new unit tests
- mark AJV validation task complete in advanced progress trackers

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test tests/validateArgs.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a72d823af08322a72b4ee6d93c11a0