### PR TITLE
feat: merge advanced todos from yaml

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,27 +1,17 @@
 {
-  "lastCommit": "ci: add agent workflow check",
+  "lastCommit": "feat: combine advancedToDo YAML and JSON",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added agent workflow CI validation and refreshed advanced progress.",
+  "notes": "Extended list-open-advanced-todos to merge YAML with JSON and synced progress.",
   "pendingTasks": [
     "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129 (GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json)",
     "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e (GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json)",
     "Integrate new GPT teams from Zukunft conversation (packages/agents)",
     "chore: scaffold WVH simulation modules (packages/universum-simulationen/modules)",
-    "feat: add NullmembranQuantization module (packages/universum-simulationen/modules/nullmembran_quantization.py)",
-    "feat: add FieldQuantization module (packages/universum-simulationen/modules/field_quantization.py)",
-    "feat: add FusionEvolution module (packages/universum-simulationen/modules/fusion_evolution.py)",
-    "feat: add Consciousness module (packages/universum-simulationen/modules/consciousness.py)",
-    "feat: add GermanGrammarAssistant agent (packages/agents/GermanGrammarAssistant.ts)",
-    "feat: add SimulationOrchestrator agent (packages/agents/SimulationOrchestrator.ts)",
-    "feat: extend FutureKIAgent (packages/agents/FutureKIAgent.ts)",
-    "feat: add DocumentGenerator agent (packages/agents/DocumentGenerator.ts)",
-    "feat: add TeamboardManager module (packages/agents/TeamboardManager.ts)",
-    "feat: implement PipelineService module (packages/core/PipelineService.ts)",
-    "feat: implement ChannelScribe utility (packages/core/ChannelScribe.ts)"
+    "feat: add NullmembranQuantization module (packages/universum-simulationen/modules/nullmembran_quantization.py)"
   ],
   "progress": [
     {

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -126,3 +126,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Documented open source model setup for local providers.
 - Scaffolded Wissenschaftliche Versuche package with placeholder modules and tests.
 - Implemented agent status API route serving agents/status.json.
+- Extended `list-open-advanced-todos` script to merge YAML and JSON tasks and added tests for multi-file support.

--- a/repositorypflege/__tests__/list-open-advanced-todos.test.js
+++ b/repositorypflege/__tests__/list-open-advanced-todos.test.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const yaml = require('js-yaml');
 const { listOpenAdvancedTodos } = require('../list-open-advanced-todos');
 
 test('lists and filters open advanced todos', () => {
@@ -16,4 +17,22 @@ test('lists and filters open advanced todos', () => {
   expect(todos).toEqual([{ commit: 'Test C', path: 'c' }]);
 
   fs.unlinkSync(tmp);
+});
+
+test('combines tasks from multiple JSON and YAML files', () => {
+  const tmpJson = path.join(__dirname, 'tmp-advancedToDo.json');
+  const tmpYaml = path.join(__dirname, 'tmp-advancedToDo.yaml');
+  const jsonSample = [{ commit: 'Task A', path: 'a', status: 'open' }];
+  const yamlSample = [{ commit: 'Task B', path: 'b', status: 'open' }];
+  fs.writeFileSync(tmpJson, JSON.stringify(jsonSample, null, 2));
+  fs.writeFileSync(tmpYaml, yaml.dump(yamlSample));
+
+  const todos = listOpenAdvancedTodos(undefined, [tmpJson, tmpYaml]);
+  expect(todos).toEqual([
+    { commit: 'Task A', path: 'a' },
+    { commit: 'Task B', path: 'b' }
+  ]);
+
+  fs.unlinkSync(tmpJson);
+  fs.unlinkSync(tmpYaml);
 });

--- a/repositorypflege/list-open-advanced-todos.js
+++ b/repositorypflege/list-open-advanced-todos.js
@@ -1,10 +1,29 @@
 const fs = require('fs');
 const path = require('path');
+const yaml = require('js-yaml');
 
-function listOpenAdvancedTodos(pattern, todoPath) {
-  const file = todoPath || path.resolve(__dirname, '..', 'advancedToDo.json');
+function readTodoFile(file) {
   const raw = fs.readFileSync(file, 'utf-8');
-  const data = JSON.parse(raw);
+  const ext = path.extname(file).toLowerCase();
+  return ext === '.yaml' || ext === '.yml' ? yaml.load(raw) : JSON.parse(raw);
+}
+
+function listOpenAdvancedTodos(pattern, todoPaths) {
+  const files =
+    todoPaths && todoPaths.length
+      ? Array.isArray(todoPaths)
+        ? todoPaths
+        : [todoPaths]
+      : [
+          path.resolve(__dirname, '..', 'advancedToDo.json'),
+          path.resolve(__dirname, '..', 'advancedToDo.yaml')
+        ];
+  let data = [];
+  for (const file of files) {
+    if (fs.existsSync(file)) {
+      data = data.concat(readTodoFile(file));
+    }
+  }
   const regex = pattern ? new RegExp(pattern, 'i') : null;
   return data
     .filter(
@@ -21,7 +40,10 @@ if (require.main === module) {
   const limit = parseInt(process.argv[2], 10) || 5;
   const grepIndex = process.argv.indexOf('--grep');
   const pattern = grepIndex >= 0 ? process.argv[grepIndex + 1] : undefined;
-  const open = listOpenAdvancedTodos(pattern);
+  const pathIndex = process.argv.indexOf('--path');
+  const pathArg = pathIndex >= 0 ? process.argv[pathIndex + 1] : undefined;
+  const todoPaths = pathArg ? pathArg.split(',') : undefined;
+  const open = listOpenAdvancedTodos(pattern, todoPaths);
   const display = open.slice(0, limit);
   display.forEach((t) => {
     const commitText =


### PR DESCRIPTION
## Summary
- allow list-open-advanced-todos to merge tasks from both JSON and YAML sources
- add CLI flag to point to custom todo files and update tests accordingly
- sync advancedprogress and log change in feedbackcodex

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest repositorypflege/__tests__/list-open-advanced-todos.test.js repositorypflege/__tests__/update-advanced-progress.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a755d57668832288ffd346f898bc12