### PR TITLE
feat: add chatWithTools helper and demo script

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12696,14 +12696,14 @@
     "path": "packages/gpt-bridges/router/callWithTools.ts",
     "task": "Iterate model responses and execute registered tools",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create tool-calling demo script",
     "path": "scripts/tools-demo.ts",
     "task": "Demonstrate tool execution with vLLM/OpenAI-compatible model",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Introduce AgentHeartbeat class",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12348,12 +12348,12 @@
   path: packages/gpt-bridges/router/callWithTools.ts
   task: Iterate model responses and execute registered tools
   test: ""
-  status: open
+  status: done
 - commit: Create tool-calling demo script
   path: scripts/tools-demo.ts
   task: Demonstrate tool execution with vLLM/OpenAI-compatible model
   test: ""
-  status: open
+  status: done
 - commit: Introduce AgentHeartbeat class
   path: packages/agents/AgentHeartbeat.ts
   task: Auto-register agent and emit periodic health events with JSONL log

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: bridge LocalEventBus with NATS",
+  "lastCommit": "Add chatWithTools helper and demo script",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented LocalEventBus<->NATS bridge and start script",
+  "notes": "Implemented chatWithTools helper and tool-calling demo script",
   "pendingTasks": [
     {
       "commit": "Add gpt-5 smoke test suite",
@@ -17,14 +17,6 @@
     },
     {
       "commit": "Add open-source model provider interfaces",
-      "status": "open"
-    },
-    {
-      "commit": "Add chatWithTools helper",
-      "status": "open"
-    },
-    {
-      "commit": "Create tool-calling demo script",
       "status": "open"
     },
     {
@@ -909,6 +901,14 @@
     }
   ],
   "progress": [
+    {
+      "commit": "Add chatWithTools helper",
+      "status": "done"
+    },
+    {
+      "commit": "Create tool-calling demo script",
+      "status": "done"
+    },
     {
       "commit": "Add Provenance hashing utilities",
       "status": "done"

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -130,3 +130,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added AgentStatusPanel component to display agent status snapshots.
 - Added provenance hashing utility and tests for traceable artifact signatures.
 - Implemented bridge between LocalEventBus and NATS with start script.
+- Implemented chatWithTools helper and demonstration script for tool execution.

--- a/packages/gpt-bridges/router/callWithTools.ts
+++ b/packages/gpt-bridges/router/callWithTools.ts
@@ -1,0 +1,34 @@
+import { toolRegistry } from '../tools/ToolRegistry';
+import { normalizeToolCalls, ToolCall } from '../tool-adapter';
+
+export interface ChatMessage {
+  role: string;
+  content: string;
+  name?: string;
+}
+
+export interface ChatModel {
+  (payload: { messages: ChatMessage[]; tools?: any[] }): Promise<any>;
+}
+
+/**
+ * Iterates model responses and executes registered tools until no tool calls remain.
+ */
+export async function chatWithTools(
+  model: ChatModel,
+  options: { messages: ChatMessage[]; provider?: string }
+): Promise<any> {
+  const { provider = 'openai' } = options;
+  const history = [...options.messages];
+  while (true) {
+    const response = await model({ messages: history, tools: toolRegistry.list() });
+    const calls: ToolCall[] = normalizeToolCalls(provider, (response as any));
+    if (!calls.length) {
+      return response;
+    }
+    for (const call of calls) {
+      const result = await toolRegistry.invoke(call.name, call.args);
+      history.push({ role: 'tool', name: call.name, content: JSON.stringify(result) });
+    }
+  }
+}

--- a/scripts/tools-demo.ts
+++ b/scripts/tools-demo.ts
@@ -1,0 +1,35 @@
+import { chatWithTools } from '../packages/gpt-bridges/router/callWithTools';
+import { toolRegistry } from '../packages/gpt-bridges/tools/ToolRegistry';
+
+// Register a simple echo tool
+toolRegistry.register(
+  {
+    name: 'echo',
+    description: 'returns the provided text',
+    parameters: {
+      type: 'object',
+      properties: { text: { type: 'string' } },
+      required: ['text']
+    }
+  },
+  ({ text }) => `echo: ${text}`
+);
+
+// Mock model that triggers the echo tool on first call
+async function mockModel(payload: any): Promise<any> {
+  if (!payload.__called) {
+    payload.__called = true;
+    return { tool_calls: [{ name: 'echo', args: { text: 'hello' } }] };
+  }
+  return { content: 'echo: hello' };
+}
+
+async function main() {
+  const res = await chatWithTools(mockModel, {
+    messages: [{ role: 'user', content: 'say hello' }],
+    provider: 'local'
+  });
+  console.log(res);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- add chatWithTools helper to iterate model responses and call registered tools
- provide tools-demo script with echo example
- mark tasks done in advanced ToDo and progress trackers

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest packages/gpt-bridges/tool-adapter.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a76c5929088322a1f8cfa5828a3066