### PR TITLE
feat: add BudgetGuard utility for token limits

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12794,7 +12794,7 @@
     "path": "packages/costs/BudgetGuard.ts",
     "task": "Track token spend per agent and enforce daily limits",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add ToolRegistry tests",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12418,7 +12418,7 @@
   path: packages/costs/BudgetGuard.ts
   task: Track token spend per agent and enforce daily limits
   test: ""
-  status: open
+  status: done
 - commit: Add ToolRegistry tests
   path: tests/toolRegistry.test.ts
   task: Verify tool registration, listing and handler invocation

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Add chatWithTools helper and demo script",
+  "lastCommit": "feat: add BudgetGuard utility",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented chatWithTools helper and tool-calling demo script",
+  "notes": "Implemented BudgetGuard utility for token limits",
   "pendingTasks": [
     {
       "commit": "Add gpt-5 smoke test suite",
@@ -57,10 +57,6 @@
     },
     {
       "commit": "Provide KEDA autoscaling template",
-      "status": "open"
-    },
-    {
-      "commit": "Add BudgetGuard utility",
       "status": "open"
     },
     {
@@ -5444,6 +5440,10 @@
     },
     {
       "commit": "Add NATS bridge start script",
+      "status": "done"
+    },
+    {
+      "commit": "Add BudgetGuard utility",
       "status": "done"
     }
   ],

--- a/packages/costs/BudgetGuard.test.ts
+++ b/packages/costs/BudgetGuard.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { BudgetGuard } from './BudgetGuard';
+
+describe('BudgetGuard', () => {
+  let guard: BudgetGuard;
+  beforeEach(() => {
+    guard = new BudgetGuard(100);
+  });
+
+  it('allows spend within limit and tracks totals', () => {
+    expect(guard.spend('agentA', 60)).toBe(true);
+    expect(guard.spend('agentA', 30)).toBe(true);
+    expect(guard.getSpent('agentA')).toBe(90);
+  });
+
+  it('blocks spend exceeding limit', () => {
+    expect(guard.spend('agentB', 80)).toBe(true);
+    expect(guard.spend('agentB', 30)).toBe(false);
+    expect(guard.getSpent('agentB')).toBe(80);
+  });
+});

--- a/packages/costs/BudgetGuard.ts
+++ b/packages/costs/BudgetGuard.ts
@@ -1,0 +1,49 @@
+export interface BudgetRecord {
+  date: string; // YYYY-MM-DD
+  spent: number;
+}
+
+/**
+ * BudgetGuard tracks token spend per agent and enforces daily limits.
+ */
+export class BudgetGuard {
+  private records: Map<string, BudgetRecord> = new Map();
+
+  constructor(private dailyLimit: number) {}
+
+  /**
+   * Attempt to record a token spend for an agent.
+   * @returns true if within budget, false if limit exceeded.
+   */
+  spend(agentId: string, tokens: number): boolean {
+    const today = new Date().toISOString().slice(0, 10);
+    const record = this.records.get(agentId);
+    if (!record || record.date !== today) {
+      this.records.set(agentId, { date: today, spent: tokens });
+      return tokens <= this.dailyLimit;
+    }
+
+    const newTotal = record.spent + tokens;
+    if (newTotal > this.dailyLimit) {
+      return false;
+    }
+    record.spent = newTotal;
+    return true;
+  }
+
+  /** Get the amount spent today for the given agent. */
+  getSpent(agentId: string): number {
+    const record = this.records.get(agentId);
+    const today = new Date().toISOString().slice(0, 10);
+    return record && record.date === today ? record.spent : 0;
+  }
+
+  /** Reset budget tracking for an agent or all agents. */
+  reset(agentId?: string): void {
+    if (agentId) {
+      this.records.delete(agentId);
+    } else {
+      this.records.clear();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add BudgetGuard utility to track daily token spend per agent
- mark BudgetGuard task as complete in advanced todo and progress files

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx vitest run packages/costs/BudgetGuard.test.ts` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7734dcc5c8322884d01fb3874c9bd