### PR TITLE
feat: add metrics server script

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12780,7 +12780,7 @@
     "path": "scripts/metrics-start.ts",
     "task": "Expose Prometheus /metrics for runtime stats",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Provide KEDA autoscaling template",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12408,7 +12408,7 @@
   path: scripts/metrics-start.ts
   task: Expose Prometheus /metrics for runtime stats
   test: ""
-  status: open
+  status: done
 - commit: Provide KEDA autoscaling template
   path: deployment/keda/scaledobject-natsjs.yaml
   task: Scale workers by JetStream lag using KEDA

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add BudgetGuard utility",
+  "lastCommit": "feat: add metrics server script",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -49,10 +49,6 @@
     },
     {
       "commit": "Add PolicyEnforcer for governance",
-      "status": "open"
-    },
-    {
-      "commit": "Start metrics server script",
       "status": "open"
     },
     {
@@ -5445,6 +5441,10 @@
     {
       "commit": "Add BudgetGuard utility",
       "status": "done"
+    },
+    {
+      "commit": "Start metrics server script",
+      "status": "done"
     }
   ],
   "completed": [
@@ -5498,6 +5498,10 @@
     },
     {
       "commit": "Document vector index env snippet",
+      "status": "done"
+    },
+    {
+      "commit": "Start metrics server script",
       "status": "done"
     }
   ],
@@ -6288,3 +6292,4 @@
     }
   ]
 }
+

--- a/scripts/metrics-start.ts
+++ b/scripts/metrics-start.ts
@@ -1,0 +1,10 @@
+import express from 'express';
+import { metricsEndpoint } from '../packages/core/middleware/metrics';
+
+const app = express();
+app.get('/metrics', metricsEndpoint);
+
+const port = Number(process.env.METRICS_PORT) || 9108;
+app.listen(port, () => {
+  console.log(`Metrics server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add standalone metrics server script exposing Prometheus `/metrics`
- mark metrics server task completed in advanced ToDo lists
- update progress log with metrics server completion

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`


------
https://chatgpt.com/codex/tasks/task_e_68a7833b301883229b54006e8fb33119