### PR TITLE
feat: add JetStream setup script

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12738,7 +12738,7 @@
     "path": "scripts/js-setup.ts",
     "task": "Ensure JetStream stream exists using environment options",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create JetStream replay script",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12378,7 +12378,7 @@
   path: scripts/js-setup.ts
   task: Ensure JetStream stream exists using environment options
   test: ""
-  status: open
+  status: done
 - commit: Create JetStream replay script
   path: scripts/js-replay.ts
   task: Replay events from JetStream durable consumer

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -36,10 +36,6 @@
       "status": "open"
     },
     {
-      "commit": "Create JetStream setup script",
-      "status": "open"
-    },
-    {
       "commit": "Create JetStream replay script",
       "status": "open"
     },
@@ -6283,6 +6279,10 @@
     {
       "commit": "Switch OpenAI provider to responses API",
       "status": "done"
+    },
+    {
+      "commit": "Create JetStream setup script",
+      "status": "done"
     }
   ],
   "fractalTodos": [
@@ -6292,4 +6292,3 @@
     }
   ]
 }
-

--- a/scripts/js-setup.ts
+++ b/scripts/js-setup.ts
@@ -1,0 +1,36 @@
+import { connect, type StreamConfig } from 'nats';
+
+async function main() {
+  const url = process.env.NATS_URL || 'nats://localhost:4222';
+  const stream = process.env.NATS_STREAM || 'MANDALA';
+  const subjects = (process.env.NATS_SUBJECTS || `${stream}.>`).split(',');
+  const creds = process.env.NATS_CREDS;
+  const maxReconnects = process.env.NATS_MAX_RECONNECTS ? parseInt(process.env.NATS_MAX_RECONNECTS, 10) : undefined;
+
+  const connOpts: any = { servers: url, maxReconnectAttempts: maxReconnects };
+  if (creds) {
+    connOpts.userCreds = creds;
+  }
+  const nc = await connect(connOpts);
+  const jsm = await nc.jetstreamManager();
+
+  try {
+    await jsm.streams.info(stream);
+    console.log(`Stream ${stream} already exists`);
+  } catch {
+    const cfg: Partial<StreamConfig> = { name: stream, subjects };
+    await jsm.streams.add(cfg);
+    console.log(`Stream ${stream} created`);
+  } finally {
+    await nc.close();
+  }
+}
+
+if (require.main === module) {
+  main()
+    .then(() => console.log('JetStream ready'))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- add script to ensure NATS JetStream stream exists using env configuration
- mark JetStream setup task completed in advancedToDo files
- record completion in advancedprogress log

## Testing
- `npx pyright` *(fails: venvPath ... not a valid directory)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a787ca59648322aded844f8da4c8ae