### PR TITLE
feat: add utopie consent mesh voting

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14544,7 +14544,7 @@
     "path": "packages/consent-mesh/utopie-consent.ts",
     "task": "Collect community votes on utopia packages and feed results into task prioritization",
     "test": "packages/consent-mesh/utopie-consent.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add Mandala transparency policy block",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13675,7 +13675,7 @@
   task: Collect community votes on utopia packages and feed results into task
     prioritization
   test: packages/consent-mesh/utopie-consent.test.ts
-  status: open
+  status: done
 - commit: Add Mandala transparency policy block
   path: README.md
   task: Document transparency principles in README

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add system overview widget",
+  "lastCommit": "feat: add utopie consent mesh voting",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Implemented SystemOverview component to display core service health",
+  "notes": "Implemented voting-based task prioritization for utopia packages",
   "pendingTasks": [
     "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129 (GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json)",
     "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e (GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json)",
@@ -4573,6 +4573,10 @@
     },
     {
       "commit": "Document MaxBundle runbook",
+      "status": "done"
+    },
+    {
+      "commit": "Implement Consent Mesh for utopia packages",
       "status": "done"
     }
   ],

--- a/packages/consent-mesh/utopie-consent.test.ts
+++ b/packages/consent-mesh/utopie-consent.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { submitVote, getConsentRatio, prioritizeTasks, resetVotes } from './utopie-consent';
+
+describe('utopie-consent', () => {
+  beforeEach(() => resetVotes());
+
+  it('calculates consent ratio', () => {
+    submitVote('pkgA', true);
+    submitVote('pkgA', true);
+    submitVote('pkgA', false);
+    expect(getConsentRatio('pkgA')).toBeCloseTo(2 / 3);
+  });
+
+  it('prioritizes tasks based on consent', () => {
+    submitVote('pkgA', true);
+    submitVote('pkgA', true);
+    submitVote('pkgB', true);
+    submitVote('pkgB', false);
+    const tasks = [
+      { package: 'pkgB', task: 'B' },
+      { package: 'pkgA', task: 'A' }
+    ];
+    const result = prioritizeTasks(tasks);
+    expect(result[0].package).toBe('pkgA');
+  });
+});

--- a/packages/consent-mesh/utopie-consent.ts
+++ b/packages/consent-mesh/utopie-consent.ts
@@ -1,0 +1,46 @@
+export interface VoteRecord {
+  approve: number;
+  reject: number;
+}
+
+const voteStore: Record<string, VoteRecord> = {};
+
+/**
+ * Submit a community vote for a utopia package.
+ * @param packageName Name of the package to vote on.
+ * @param approve True for approve, false for reject.
+ */
+export function submitVote(packageName: string, approve: boolean): void {
+  if (!voteStore[packageName]) {
+    voteStore[packageName] = { approve: 0, reject: 0 };
+  }
+  if (approve) {
+    voteStore[packageName].approve++;
+  } else {
+    voteStore[packageName].reject++;
+  }
+}
+
+/**
+ * Returns approval ratio for a given package between 0 and 1.
+ */
+export function getConsentRatio(packageName: string): number {
+  const record = voteStore[packageName];
+  if (!record) return 0;
+  const total = record.approve + record.reject;
+  return total === 0 ? 0 : record.approve / total;
+}
+
+/**
+ * Prioritize tasks based on community consent scores.
+ */
+export function prioritizeTasks<T extends { package: string }>(tasks: T[]): T[] {
+  return tasks.slice().sort((a, b) => getConsentRatio(b.package) - getConsentRatio(a.package));
+}
+
+/**
+ * Reset stored votes (mainly for tests).
+ */
+export function resetVotes(): void {
+  for (const key of Object.keys(voteStore)) delete voteStore[key];
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
       'packages/boundary-engine/**/*.{test,spec}.ts',
       'packages/api/**/*.{test,spec}.ts',
       'scripts/**/*.{test,spec}.ts',
-      'packages/wissenschaftliche-versuche/**/*.{test,spec}.ts'
+      'packages/wissenschaftliche-versuche/**/*.{test,spec}.ts',
+      'packages/consent-mesh/**/*.{test,spec}.ts'
     ],
     environment: 'node'
   }


### PR DESCRIPTION
## Summary
- implement consent-mesh voting utilities for utopia packages
- register consent-mesh tests in Vitest config
- track consent-mesh completion in advanced ToDo and progress files

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run packages/consent-mesh/utopie-consent.test.ts`
- `node repositorypflege/update-advanced-progress.js`


------
https://chatgpt.com/codex/tasks/task_e_68a792c4cda083228cbe898a71ece9c0