### PR TITLE
feat: add RAG API deployment manifest

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13293,7 +13293,7 @@
     "path": "k8s/deploy-rag-api.yaml",
     "task": "Deploy RAG API with horizontal pod autoscaling",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add flags, experiments and reviewer deployments",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12775,7 +12775,7 @@
   path: k8s/deploy-rag-api.yaml
   task: Deploy RAG API with horizontal pod autoscaling
   test: ""
-  status: open
+  status: done
 - commit: Add flags, experiments and reviewer deployments
   path: k8s/deploy-flags-exp-review.yaml
   task: Deploy flags, experiments and reviewer APIs

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Add Red Team Day exercise scripts",
+  "lastCommit": "Add RAG API deployment manifest",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts",
+  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest",
   "pendingTasks": [
     "feat: add FusionEvolution module (packages/universum-simulationen/modules/fusion_evolution.py)",
     "feat: add FusionEvolution module (simulations/universe-sim/modules/fusion_evolution.go)",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -135,3 +135,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented FusionEvolution module for basic energy fusion simulation.
 - Added CLI options and YAML export to parse-newadvanced-conversations script.
 - Added Red Team Day exercise script for reproducible security drills.
+- Added RAG API deployment manifest with autoscaling support.

--- a/k8s/deploy-rag-api.yaml
+++ b/k8s/deploy-rag-api.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rag-api
+  labels:
+    app: rag-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rag-api
+  template:
+    metadata:
+      labels:
+        app: rag-api
+    spec:
+      containers:
+        - name: rag-api
+          image: ghcr.io/unified-mandala/rag-api:latest
+          ports:
+            - containerPort: 3000
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rag-api
+  labels:
+    app: rag-api
+spec:
+  selector:
+    app: rag-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: rag-api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: rag-api
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80


### PR DESCRIPTION
## Summary
- add Kubernetes deployment for RAG API with service and autoscaler
- mark RAG API deployment task complete in advancedToDo files and progress log
- note deployment manifest in feedback codex

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68a7a2bed4c083229aabf3c115549547