### PR TITLE
feat(agents): add AgentHeartbeat for health logging

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12719,7 +12719,7 @@
     "path": "packages/agents/AgentHeartbeat.ts",
     "task": "Auto-register agent and emit periodic health events with JSONL log",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Expose agent health API",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12365,7 +12365,7 @@
   path: packages/agents/AgentHeartbeat.ts
   task: Auto-register agent and emit periodic health events with JSONL log
   test: ""
-  status: open
+  status: done
 - commit: Expose agent health API
   path: apps/sharedream-interface/pages/api/agents/health.ts
   task: Serve latest heartbeat records from data/agents/heartbeats.jsonl

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "Add RAG API deployment manifest",
+  "lastCommit": "Introduce AgentHeartbeat class",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest",
+  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module",
   "pendingTasks": [
     "feat: add FusionEvolution module (packages/universum-simulationen/modules/fusion_evolution.py)",
     "feat: add FusionEvolution module (simulations/universe-sim/modules/fusion_evolution.go)",

--- a/packages/agents/AgentHeartbeat.ts
+++ b/packages/agents/AgentHeartbeat.ts
@@ -1,0 +1,59 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+/**
+ * AgentHeartbeat automatically registers an agent and periodically
+ * emits heartbeat events to a JSONL log file.
+ */
+export class AgentHeartbeat {
+  private intervalId?: NodeJS.Timer;
+  private readonly logFile: string;
+
+  constructor(private agentId: string, private intervalMs = 60000, logFile?: string) {
+    this.logFile = logFile ?? path.resolve('data/agents/heartbeats.jsonl');
+    this.register().catch(console.error);
+    this.start();
+  }
+
+  /**
+   * Append an event record to the heartbeat log file.
+   */
+  private async append(event: Record<string, unknown>): Promise<void> {
+    await fs.ensureDir(path.dirname(this.logFile));
+    await fs.appendFile(this.logFile, JSON.stringify(event) + '\n');
+  }
+
+  /**
+   * Register the agent in the log.
+   */
+  private async register(): Promise<void> {
+    await this.append({
+      type: 'register',
+      agentId: this.agentId,
+      ts: new Date().toISOString(),
+    });
+  }
+
+  /**
+   * Start emitting heartbeat events on the configured interval.
+   */
+  start(): void {
+    this.intervalId = setInterval(() => {
+      this.append({
+        type: 'heartbeat',
+        agentId: this.agentId,
+        ts: new Date().toISOString(),
+      }).catch(console.error);
+    }, this.intervalMs);
+  }
+
+  /**
+   * Stop emitting heartbeat events.
+   */
+  stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = undefined;
+    }
+  }
+}

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -58,3 +58,4 @@ export * from './ReviewAgent';
 export * from './MasterGPTBridge';
 export * from './FutureTechFramework';
 export * from './OvernightWorkerAgent';
+export * from './AgentHeartbeat';


### PR DESCRIPTION
## Summary
- add `AgentHeartbeat` class to auto-register agents and log periodic heartbeats
- export `AgentHeartbeat` in agents index
- track progress by marking AgentHeartbeat task as done in advanced to-dos

## Testing
- `npx pyright` *(fails: venvPath /workspace/unified-mandala/.venv is not a valid directory)*
- `npx tsc -p tsconfig.json` *(fails: process terminated)*
- `npx jest tests/rag.flow.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a7aa052fb48322bc22f06a82d195bb