### PR TITLE
Add deployments and scaling manifests for flags, experiments, and reviewer APIs

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13300,14 +13300,14 @@
     "path": "k8s/deploy-flags-exp-review.yaml",
     "task": "Deploy flags, experiments and reviewer APIs",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add optional KEDA scaler",
     "path": "k8s/keda-scalers.yaml",
     "task": "Configure Prometheus based auto scaling",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add dataset registry test",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12780,12 +12780,12 @@
   path: k8s/deploy-flags-exp-review.yaml
   task: Deploy flags, experiments and reviewer APIs
   test: ""
-  status: open
+  status: done
 - commit: Add optional KEDA scaler
   path: k8s/keda-scalers.yaml
   task: Configure Prometheus based auto scaling
   test: ""
-  status: open
+  status: done
 - commit: Add dataset registry test
   path: tests/datasets.registry.test.ts
   task: Verify dataset creation, versioning and splitting

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add JetStream replay script",
+  "lastCommit": "chore: add flags, experiments and reviewer deployments",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4641,6 +4641,14 @@
     },
     {
       "commit": "Add RAG API deployment",
+      "status": "done"
+    },
+    {
+      "commit": "Add flags, experiments and reviewer deployments",
+      "status": "done"
+    },
+    {
+      "commit": "Add optional KEDA scaler",
       "status": "done"
     }
   ],

--- a/k8s/deploy-flags-exp-review.yaml
+++ b/k8s/deploy-flags-exp-review.yaml
@@ -1,0 +1,128 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flags-api
+  labels:
+    app: flags-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: flags-api
+  template:
+    metadata:
+      labels:
+        app: flags-api
+    spec:
+      containers:
+        - name: flags-api
+          image: ghcr.io/unified-mandala/flags-api:latest
+          ports:
+            - containerPort: 3000
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flags-api
+  labels:
+    app: flags-api
+spec:
+  selector:
+    app: flags-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: experiments-api
+  labels:
+    app: experiments-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: experiments-api
+  template:
+    metadata:
+      labels:
+        app: experiments-api
+    spec:
+      containers:
+        - name: experiments-api
+          image: ghcr.io/unified-mandala/experiments-api:latest
+          ports:
+            - containerPort: 3000
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: experiments-api
+  labels:
+    app: experiments-api
+spec:
+  selector:
+    app: experiments-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviewer-api
+  labels:
+    app: reviewer-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reviewer-api
+  template:
+    metadata:
+      labels:
+        app: reviewer-api
+    spec:
+      containers:
+        - name: reviewer-api
+          image: ghcr.io/unified-mandala/reviewer-api:latest
+          ports:
+            - containerPort: 3000
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviewer-api
+  labels:
+    app: reviewer-api
+spec:
+  selector:
+    app: reviewer-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000

--- a/k8s/keda-scalers.yaml
+++ b/k8s/keda-scalers.yaml
@@ -1,0 +1,50 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: flags-api
+spec:
+  scaleTargetRef:
+    name: flags-api
+  minReplicaCount: 1
+  maxReplicaCount: 10
+  triggers:
+    - type: prometheus
+      metadata:
+        serverAddress: http://prometheus.monitoring.svc.cluster.local:9090
+        metricName: http_requests_total
+        threshold: "100"
+        query: sum(rate(http_requests_total{app="flags-api"}[2m]))
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: experiments-api
+spec:
+  scaleTargetRef:
+    name: experiments-api
+  minReplicaCount: 1
+  maxReplicaCount: 10
+  triggers:
+    - type: prometheus
+      metadata:
+        serverAddress: http://prometheus.monitoring.svc.cluster.local:9090
+        metricName: http_requests_total
+        threshold: "100"
+        query: sum(rate(http_requests_total{app="experiments-api"}[2m]))
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: reviewer-api
+spec:
+  scaleTargetRef:
+    name: reviewer-api
+  minReplicaCount: 1
+  maxReplicaCount: 10
+  triggers:
+    - type: prometheus
+      metadata:
+        serverAddress: http://prometheus.monitoring.svc.cluster.local:9090
+        metricName: http_requests_total
+        threshold: "100"
+        query: sum(rate(http_requests_total{app="reviewer-api"}[2m]))


### PR DESCRIPTION
## Summary
- mark k8s deployment tasks as complete in advanced todo/progress lists
- add Kubernetes deployments and services for flags, experiments and reviewer APIs
- provide optional KEDA ScaledObjects for Prometheus-based autoscaling

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a8233d00908322985e080c7602f067