### PR TITLE
feat: add unified security Grafana dashboard

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14434,7 +14434,7 @@
     "path": "grafana/dashboards/unified-security-board.json",
     "task": "Visualize Falco, Kyverno, Cilium, and audit log metrics in one board",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add Red Team Day exercise scripts",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13593,7 +13593,7 @@
   path: grafana/dashboards/unified-security-board.json
   task: Visualize Falco, Kyverno, Cilium, and audit log metrics in one board
   test: ""
-  status: open
+  status: done
 - commit: Add Red Team Day exercise scripts
   path: scripts/rt-start.sh
   task: Provide reproducible security drill setup and cleanup scripts

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "chore: add flags, experiments and reviewer deployments",
+  "lastCommit": "feat: add unified security Grafana dashboard",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module",
+  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard",
   "pendingTasks": [
     {
       "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129",
@@ -4649,6 +4649,10 @@
     },
     {
       "commit": "Add optional KEDA scaler",
+      "status": "done"
+    },
+    {
+      "commit": "Add unified security Grafana dashboard",
       "status": "done"
     }
   ],

--- a/grafana/dashboards/unified-security-board.json
+++ b/grafana/dashboards/unified-security-board.json
@@ -1,0 +1,41 @@
+{
+  "id": null,
+  "title": "Unified Security Board",
+  "timezone": "browser",
+  "schemaVersion": 36,
+  "version": 1,
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Falco Alerts",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "sum(rate(falco_events[5m]))" }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Kyverno Policy Violations",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "sum(kyverno_policy_violations_total)" }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Cilium Drops",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "sum(rate(cilium_drop_count_total[5m]))" }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "Audit Log Errors",
+      "datasource": "Loki",
+      "targets": [
+        { "expr": "{job=\"apiserver\"} |= \"error\"" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- visualize Falco, Kyverno, Cilium, and audit log metrics in a new Grafana dashboard
- track dashboard task completion in advancedToDo files
- log dashboard addition in advancedprogress

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a8272899988322bbb3afdb0b2f5072