### PR TITLE
feat: expose agent health API

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12726,7 +12726,7 @@
     "path": "apps/sharedream-interface/pages/api/agents/health.ts",
     "task": "Serve latest heartbeat records from data/agents/heartbeats.jsonl",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add AgentHealthPanel component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12370,7 +12370,7 @@
   path: apps/sharedream-interface/pages/api/agents/health.ts
   task: Serve latest heartbeat records from data/agents/heartbeats.jsonl
   test: ""
-  status: open
+  status: done
 - commit: Add AgentHealthPanel component
   path: packages/unifiedmandala-ui/components/AgentHealthPanel.tsx
   task: Display heartbeat status in UI with polling refresh

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add unified security Grafana dashboard",
+  "lastCommit": "feat: expose agent health API",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard",
+  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API",
   "pendingTasks": [
     {
       "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129",
@@ -4653,6 +4653,10 @@
     },
     {
       "commit": "Add unified security Grafana dashboard",
+      "status": "done"
+    },
+    {
+      "commit": "Expose agent health API",
       "status": "done"
     }
   ],

--- a/apps/sharedream-interface/pages/api/agents/health.ts
+++ b/apps/sharedream-interface/pages/api/agents/health.ts
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+
+export default function handler(req: any, res: any) {
+  const logPath = path.join(process.cwd(), 'data', 'agents', 'heartbeats.jsonl');
+  try {
+    if (!fs.existsSync(logPath)) {
+      res.status(200).json([]);
+      return;
+    }
+    const lines = fs.readFileSync(logPath, 'utf8').trim().split('\n');
+    const latest: Record<string, any> = {};
+    for (const line of lines) {
+      try {
+        const event = JSON.parse(line);
+        if (event.type === 'heartbeat') {
+          latest[event.agentId] = event;
+        }
+      } catch {
+        // ignore malformed lines
+      }
+    }
+    res.status(200).json(Object.values(latest));
+  } catch (err) {
+    res.status(500).json({ error: 'unable to load agent heartbeats' });
+  }
+}

--- a/data/agents/heartbeats.jsonl
+++ b/data/agents/heartbeats.jsonl
@@ -1,0 +1,2 @@
+{"type":"register","agentId":"demo-agent","ts":"2023-01-01T00:00:00.000Z"}
+{"type":"heartbeat","agentId":"demo-agent","ts":"2023-01-01T00:05:00.000Z"}


### PR DESCRIPTION
## Summary
- add agent health API route serving latest heartbeat events
- track heartbeat progress in project metadata

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68a828dce83c8322ad015ff2b1fd927b