### PR TITLE
feat(ui): add reviewer hotkeys component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13365,8 +13365,8 @@
     "commit": "Add ReviewerHotkeys UI hook",
     "path": "packages/unifiedmandala-ui/components/ReviewerHotkeys.tsx",
     "task": "Trigger reviewer decisions via keyboard shortcuts",
-    "test": "",
-    "status": "open"
+    "test": "packages/unifiedmandala-ui/components/ReviewerHotkeys.test.tsx",
+    "status": "done"
   },
   {
     "commit": "Implement HMAC signed URLs",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12827,8 +12827,8 @@
 - commit: Add ReviewerHotkeys UI hook
   path: packages/unifiedmandala-ui/components/ReviewerHotkeys.tsx
   task: Trigger reviewer decisions via keyboard shortcuts
-  test: ""
-  status: open
+  test: packages/unifiedmandala-ui/components/ReviewerHotkeys.test.tsx
+  status: done
 - commit: Implement HMAC signed URLs
   path: packages/security/SignedURL.ts
   task: Generate and verify expiring share tokens

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5,7 +5,7 @@
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API",
+  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook",
   "pendingTasks": [
     {
       "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129",

--- a/packages/unifiedmandala-ui/components/ReviewerHotkeys.test.tsx
+++ b/packages/unifiedmandala-ui/components/ReviewerHotkeys.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ReviewerHotkeys from './ReviewerHotkeys';
+
+describe('ReviewerHotkeys', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn().mockResolvedValue({});
+  });
+
+  test('sends approve decision on "A" key', () => {
+    render(<ReviewerHotkeys currentId="1" />);
+    fireEvent.keyDown(window, { key: 'a' });
+    expect(fetch).toHaveBeenCalledWith(
+      '/review/decision',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ id: '1', decision: 'approve' })
+      })
+    );
+  });
+
+  test('sends reject decision on "R" key', () => {
+    render(<ReviewerHotkeys currentId="2" />);
+    fireEvent.keyDown(window, { key: 'r' });
+    expect(fetch).toHaveBeenCalledWith(
+      '/review/decision',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ id: '2', decision: 'reject' })
+      })
+    );
+  });
+
+  test('sends hold decision on "H" key', () => {
+    render(<ReviewerHotkeys currentId="3" />);
+    fireEvent.keyDown(window, { key: 'h' });
+    expect(fetch).toHaveBeenCalledWith(
+      '/review/decision',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ id: '3', decision: 'hold' })
+      })
+    );
+  });
+});

--- a/packages/unifiedmandala-ui/components/ReviewerHotkeys.tsx
+++ b/packages/unifiedmandala-ui/components/ReviewerHotkeys.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+
+interface ReviewerHotkeysProps {
+  currentId: string | null;
+}
+
+/**
+ * ReviewerHotkeys listens for A/R/H keys and submits review decisions.
+ * Derived from guidance in `newadvancedconversations.json`.
+ */
+export default function ReviewerHotkeys({ currentId }: ReviewerHotkeysProps) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (!currentId) return;
+      const key = e.key.toLowerCase();
+      if (!['a', 'r', 'h'].includes(key)) return;
+      const decision = key === 'a' ? 'approve' : key === 'r' ? 'reject' : 'hold';
+      fetch('/review/decision', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: currentId, decision })
+      });
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [currentId]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- implement ReviewerHotkeys component to handle A/R/H decisions
- mark ReviewerHotkeys task done in advanced ToDo and progress
- add tests verifying keyboard shortcuts trigger reviewer API

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest packages/unifiedmandala-ui/components/ReviewerHotkeys.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a8335b42e88322aca4bb72b6f33f81