### PR TITLE
feat: add sigil search tool spec and handler

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12883,14 +12883,14 @@
     "path": "tools/specs/sigil.search.yaml",
     "task": "Define YAML schema for sigil search tool",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add sigil search tool handler",
     "path": "tools/handlers/sigil_search.js",
     "task": "Implement JSONL search handler for sigils",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Define diverse research agents",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12483,12 +12483,12 @@
   path: tools/specs/sigil.search.yaml
   task: Define YAML schema for sigil search tool
   test: ""
-  status: open
+  status: done
 - commit: Add sigil search tool handler
   path: tools/handlers/sigil_search.js
   task: Implement JSONL search handler for sigils
   test: ""
-  status: open
+  status: done
 - commit: Define diverse research agents
   path: agents.research.yaml
   task: List climate, bio, materials, governance, RAG and astro agents

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: scaffold WVH simulation modules",
+  "lastCommit": "feat: add sigil search tool spec and handler",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4661,6 +4661,10 @@
     },
     {
       "commit": "Expose agent health API",
+      "status": "done"
+    },
+    {
+      "commit": "feat: add sigil search tool spec and handler",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -139,3 +139,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added JetStream replay script and removed fs-extra dependency from AgentHeartbeat.
 - Improved advanced progress sync to store pending task paths and deduplicate TODO sources.
 - Implemented ResearchHubWS server and realtime hub HTTP bridge to stream live questions and answers.
+- Added sigil search tool spec and handler for JSONL-based sigil queries.

--- a/tools/handlers/sigil_search.js
+++ b/tools/handlers/sigil_search.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports = async function sigil_search({ query, tag }) {
+  const file = path.join(__dirname, '../../data/sigils/sigillin.jsonl');
+  const q = String(query || '').toLowerCase();
+  const t = tag ? String(tag).toLowerCase() : null;
+  const results = [];
+
+  const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/);
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      const obj = JSON.parse(line);
+      const haystack = JSON.stringify(obj).toLowerCase();
+      if (!haystack.includes(q)) continue;
+      if (t && !haystack.includes(t)) continue;
+      results.push(obj);
+    } catch {
+      // ignore malformed lines
+    }
+  }
+  return results;
+};

--- a/tools/specs/sigil.search.yaml
+++ b/tools/specs/sigil.search.yaml
@@ -1,0 +1,13 @@
+name: sigil_search
+description: Search sigillin index by keyword and optional tag filter
+parameters:
+  type: object
+  properties:
+    query:
+      type: string
+      description: Search term
+    tag:
+      type: string
+      description: Optional tag to filter results
+  required:
+    - query


### PR DESCRIPTION
## Summary
- define `sigil_search` tool spec for querying the sigillin index
- implement `sigil_search` handler to scan `sigillin.jsonl`
- mark related advanced ToDo entries as completed and update progress

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a83621806c8322aefb8e21919835a3