### PR TITLE
feat: add agent health and error event subjects

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-21, in der Zeit des Nacht.
+Am 2025-08-22, in der Zeit des Morgen.
 
-Symbolphase: Reflexion (Fokus: P)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12827,7 +12827,7 @@
     "path": "packages/event-bus/subjects.ts",
     "task": "Add agent.health.v1 and agent.error.v1 subjects",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement WebSocketHub for live events",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12443,7 +12443,7 @@
   path: packages/event-bus/subjects.ts
   task: Add agent.health.v1 and agent.error.v1 subjects
   test: ""
-  status: open
+  status: done
 - commit: Implement WebSocketHub for live events
   path: packages/event-bus/WebSocketHub.ts
   task: Provide WebSocket server to broadcast LocalEventBus events

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add sigil search tool spec and handler",
+  "lastCommit": "feat: extend agent event subjects",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4665,6 +4665,10 @@
     },
     {
       "commit": "feat: add sigil search tool spec and handler",
+      "status": "done"
+    },
+    {
+      "commit": "Extend event subjects for agent health and errors",
       "status": "done"
     }
   ],

--- a/packages/event-bus/LocalEventBus.test.ts
+++ b/packages/event-bus/LocalEventBus.test.ts
@@ -16,5 +16,23 @@ describe('LocalEventBus', () => {
     bus.publish(Subjects.CREP_UPDATE, { value: 7 });
     expect(handler).toHaveBeenCalledTimes(1);
   });
+
+  it('handles agent health and error events', () => {
+    const bus = new LocalEventBus();
+    const healthHandler = jest.fn();
+    const errorHandler = jest.fn();
+
+    bus.subscribe(Subjects.AGENT_HEALTH, healthHandler);
+    bus.subscribe(Subjects.AGENT_ERROR, errorHandler);
+
+    const healthPayload = { ok: true };
+    const errorPayload = { message: 'boom' };
+
+    bus.publish(Subjects.AGENT_HEALTH, healthPayload);
+    bus.publish(Subjects.AGENT_ERROR, errorPayload);
+
+    expect(healthHandler).toHaveBeenCalledWith(healthPayload);
+    expect(errorHandler).toHaveBeenCalledWith(errorPayload);
+  });
 });
 

--- a/packages/event-bus/subjects.ts
+++ b/packages/event-bus/subjects.ts
@@ -8,8 +8,16 @@ export enum Subjects {
   /**
    * Heartbeat events emitted by agents to signal liveness.
    * Versioned for forward compatibility.
-   */
+  */
   AGENT_HEARTBEAT = 'v1.agent.heartbeat',
+  /**
+   * Periodic health summaries emitted by agents to report status.
+   */
+  AGENT_HEALTH = 'v1.agent.health',
+  /**
+   * Error events emitted when an agent encounters a failure.
+   */
+  AGENT_ERROR = 'v1.agent.error',
   /**
    * Client submitted live question.
    */


### PR DESCRIPTION
## Summary
- extend Subjects enum with `agent.health` and `agent.error`
- cover new subjects with LocalEventBus tests
- mark related advancedToDo entries as complete and update progress log

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx jest packages/event-bus/LocalEventBus.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a839d959b88322bf2d659aec0afb9c