### PR TITLE
feat: add AgentHealthPanel component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12736,7 +12736,7 @@
     "path": "packages/unifiedmandala-ui/components/AgentHealthPanel.tsx",
     "task": "Display heartbeat status in UI with polling refresh",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add JetStreamBus for persistent events",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12378,7 +12378,7 @@
   path: packages/unifiedmandala-ui/components/AgentHealthPanel.tsx
   task: Display heartbeat status in UI with polling refresh
   test: ""
-  status: open
+  status: done
 - commit: Add JetStreamBus for persistent events
   path: packages/event-bus/JetStreamBus.ts
   task: Publish and consume durable events via NATS JetStream

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: extend agent event subjects",
+  "lastCommit": "feat: add AgentHealthPanel component",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook",
+  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component",
   "pendingTasks": [
     {
       "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129",
@@ -4669,6 +4669,10 @@
     },
     {
       "commit": "Extend event subjects for agent health and errors",
+      "status": "done"
+    },
+    {
+      "commit": "Add AgentHealthPanel component",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -140,3 +140,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Improved advanced progress sync to store pending task paths and deduplicate TODO sources.
 - Implemented ResearchHubWS server and realtime hub HTTP bridge to stream live questions and answers.
 - Added sigil search tool spec and handler for JSONL-based sigil queries.
+- Added AgentHealthPanel component for live heartbeat monitoring.

--- a/packages/unifiedmandala-ui/components/AgentHealthPanel.test.tsx
+++ b/packages/unifiedmandala-ui/components/AgentHealthPanel.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AgentHealthPanel from './AgentHealthPanel';
+
+test('renders agent heartbeat entries', async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve([{ agentId: 'alpha', status: 'ok' }]),
+    }) as any
+  );
+
+  render(<AgentHealthPanel />);
+
+  await waitFor(() => screen.getByLabelText('agent-alpha'));
+  expect(screen.getByLabelText('agent-alpha')).toHaveTextContent('alpha: ok');
+});

--- a/packages/unifiedmandala-ui/components/AgentHealthPanel.tsx
+++ b/packages/unifiedmandala-ui/components/AgentHealthPanel.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+
+export interface AgentHeartbeat {
+  agentId: string;
+  status?: string;
+  [key: string]: any;
+}
+
+export const AgentHealthPanel: React.FC = () => {
+  const [data, setData] = useState<AgentHeartbeat[]>([]);
+
+  const load = () => {
+    fetch('/api/agents/health')
+      .then((r) => r.json())
+      .then((d) => {
+        const arr = Array.isArray(d) ? d : d.agents || [];
+        setData(arr);
+      })
+      .catch(() => setData([]));
+  };
+
+  useEffect(() => {
+    load();
+    const id = setInterval(load, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div aria-label="agent-health-panel">
+      <ul>
+        {data.map((hb) => (
+          <li key={hb.agentId} aria-label={`agent-${hb.agentId}`}>
+            {hb.agentId}: {hb.status ?? 'unknown'}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AgentHealthPanel;
+


### PR DESCRIPTION
## Summary
- add AgentHealthPanel React component with polling to show heartbeat data
- cover AgentHealthPanel with unit test
- mark AgentHealthPanel task complete in advanced TODO and progress files

## Testing
- `npx jest packages/unifiedmandala-ui/components/AgentHealthPanel.test.tsx`
- `npx tsc -p tsconfig.json`
- `npx pyright packages/unifiedmandala-ui/components/AgentHealthPanel.tsx packages/unifiedmandala-ui/components/AgentHealthPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a84a9392a083229ee6e30dca4245a5