### PR TITLE
feat: add CSV option to repository map summary

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12333,6 +12333,13 @@
     "status": "done"
   },
   {
+    "commit": "Add CSV option to repository map summary",
+    "path": "scripts/repository-map-summary.ts",
+    "task": "Support --csv flag for comma-separated module counts",
+    "test": "scripts/repository-map-summary.test.ts",
+    "status": "done"
+  },
+  {
     "commit": "Fix sigillin-cli Node runtime",
     "path": "packages/cli-tools/sigillin-cli.js",
     "task": "Ensure CLI commands work without build using JS fallbacks",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12087,6 +12087,11 @@
   task: Support --json flag for machine-readable module counts
   test: scripts/repository-map-summary.test.ts
   status: done
+- commit: Add CSV option to repository map summary
+  path: scripts/repository-map-summary.ts
+  task: Support --csv flag for comma-separated module counts
+  test: scripts/repository-map-summary.test.ts
+  status: done
 - commit: Fix sigillin-cli Node runtime
   path: packages/cli-tools/sigillin-cli.js
   task: Ensure CLI commands work without build using JS fallbacks

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add Prometheus scrape config",
+  "lastCommit": "feat: add CSV option to repository map summary",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4756,6 +4756,10 @@
     },
     {
       "commit": "Add JSON option to repository map summary",
+      "status": "done"
+    },
+    {
+      "commit": "Add CSV option to repository map summary",
       "status": "done"
     },
     {

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -8,6 +8,7 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added `init_modules` script to verify presence of key modules for new chat bootstrap.
 
 - Added onboarding service catalog and agent service mapping configurations.
+- Added CSV output option to repository-map-summary script for spreadsheet-friendly module counts.
 - Added DefensiveShieldAgent plugin and sanitization service.
 
 - Implemented RefusalNotice component to show ethical refusal messages.

--- a/scripts/repository-map-summary.test.ts
+++ b/scripts/repository-map-summary.test.ts
@@ -11,4 +11,9 @@ describe('summarizeRepositoryMap', () => {
     const result = summarizeRepositoryMap({ json: true }) as Record<string, number>;
     expect(result.aeon).toBeGreaterThan(0);
   });
+
+  it('returns CSV summary when csv option is true', () => {
+    const result = summarizeRepositoryMap({ csv: true }) as string;
+    expect(result.split('\n')[0]).toBe('name,count');
+  });
 });

--- a/scripts/repository-map-summary.ts
+++ b/scripts/repository-map-summary.ts
@@ -14,6 +14,7 @@ const file = path.join(__dirname, '../repositorypflege/repository_map.yaml');
 
 export interface SummaryOptions {
   json?: boolean;
+  csv?: boolean;
 }
 
 export function summarizeRepositoryMap(options: SummaryOptions = {}) {
@@ -32,6 +33,13 @@ export function summarizeRepositoryMap(options: SummaryOptions = {}) {
     return summary;
   }
 
+  if (options.csv) {
+    const lines = Object.entries(summary).map(
+      ([name, count]) => `${name},${count}`
+    );
+    return ['name,count', ...lines].join('\n');
+  }
+
   return Object.entries(summary)
     .map(([name, count]) => `${name}: ${count} module(s)`)
     .join('\n');
@@ -39,7 +47,8 @@ export function summarizeRepositoryMap(options: SummaryOptions = {}) {
 
 if (require.main === module) {
   const jsonFlag = process.argv.includes('--json');
-  const result = summarizeRepositoryMap({ json: jsonFlag });
+  const csvFlag = process.argv.includes('--csv');
+  const result = summarizeRepositoryMap({ json: jsonFlag, csv: csvFlag });
   if (jsonFlag) {
     console.log(JSON.stringify(result, null, 2));
   } else {


### PR DESCRIPTION
## Summary
- extend repository-map-summary script with `--csv` flag for comma-separated output
- cover CSV output in tests and track completion in advanced todos

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/repository-map-summary.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a898eff1b88322aa19204ff18b1b11