### PR TITLE
feat: add JetStreamBus for persistent events

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12750,7 +12750,7 @@
     "path": "packages/event-bus/JetStreamBus.ts",
     "task": "Publish and consume durable events via NATS JetStream",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create JetStream setup script",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12388,7 +12388,7 @@
   path: packages/event-bus/JetStreamBus.ts
   task: Publish and consume durable events via NATS JetStream
   test: ""
-  status: open
+  status: done
 - commit: Create JetStream setup script
   path: scripts/js-setup.ts
   task: Ensure JetStream stream exists using environment options

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "feat: add live events hook and panel",
+  "lastCommit": "feat: add JetStreamBus for persistent events",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config",
+  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events",
   "pendingTasks": [
     {
       "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129",
@@ -5612,6 +5612,10 @@
     },
     {
       "commit": "Integrate Utopie-to-Do adapter",
+      "status": "done"
+    },
+    {
+      "commit": "Add JetStreamBus for persistent events",
       "status": "done"
     }
   ],

--- a/packages/event-bus/JetStreamBus.test.ts
+++ b/packages/event-bus/JetStreamBus.test.ts
@@ -1,0 +1,51 @@
+import { JetStreamBus } from './JetStreamBus';
+import { Subjects } from './subjects';
+import { connect, consumerOpts } from 'nats';
+
+const mockPublish = jest.fn();
+const mockSubscribe = jest.fn(() => ({
+  [Symbol.asyncIterator]: async function* () {},
+}));
+const mockClose = jest.fn();
+const mockJetstream = jest.fn(() => ({ publish: mockPublish, subscribe: mockSubscribe }));
+
+jest.mock('nats', () => {
+  const actual = jest.requireActual('nats');
+  return {
+    ...actual,
+    connect: jest.fn(() => Promise.resolve({ jetstream: mockJetstream, close: mockClose })),
+    StringCodec: jest.fn(() => ({ encode: (v: string) => Buffer.from(v), decode: (b: Uint8Array) => Buffer.from(b).toString() })),
+    consumerOpts: jest.fn(() => ({ durable: jest.fn(), manualAck: jest.fn() })),
+  };
+});
+
+const mockConnect = connect as unknown as jest.Mock;
+const mockConsumerOpts = consumerOpts as unknown as jest.Mock;
+
+describe('JetStreamBus', () => {
+  beforeEach(() => {
+    mockConnect.mockClear();
+    mockPublish.mockClear();
+    mockSubscribe.mockClear();
+    mockConsumerOpts.mockClear();
+  });
+
+  it('connects with default url', async () => {
+    const bus = new JetStreamBus();
+    await bus.connect();
+    expect(mockConnect).toHaveBeenCalledWith({ servers: 'nats://localhost:4222' });
+  });
+
+  it('throws when publishing without connection', async () => {
+    const bus = new JetStreamBus();
+    await expect(bus.publish(Subjects.CREP_UPDATE, { a: 1 })).rejects.toThrow('Not connected');
+  });
+
+  it('subscribes using durable consumer', async () => {
+    const bus = new JetStreamBus({ durable: 'TEST' });
+    await bus.connect();
+    await bus.subscribe(Subjects.CREP_UPDATE, () => {});
+    expect(mockConsumerOpts).toHaveBeenCalled();
+    expect(mockSubscribe).toHaveBeenCalled();
+  });
+});

--- a/packages/event-bus/JetStreamBus.ts
+++ b/packages/event-bus/JetStreamBus.ts
@@ -1,0 +1,58 @@
+import { connect, consumerOpts, type JetStreamClient, type JetStreamSubscription, type NatsConnection, StringCodec, type ConnectionOptions } from 'nats';
+import { Subjects } from './subjects';
+
+export interface JetStreamBusOptions {
+  url?: string;
+  creds?: string;
+  maxReconnects?: number;
+  durable?: string;
+}
+
+export class JetStreamBus {
+  private nc?: NatsConnection;
+  private js?: JetStreamClient;
+  private sc = StringCodec();
+  private durable: string;
+
+  constructor(private opts: JetStreamBusOptions = {}) {
+    this.durable = opts.durable || 'UM_WORKER';
+  }
+
+  async connect(): Promise<void> {
+    const { url = 'nats://localhost:4222', creds, maxReconnects } = this.opts;
+    const connectOpts: ConnectionOptions = { servers: url } as ConnectionOptions;
+    if (creds) {
+      (connectOpts as any).userCreds = creds;
+    }
+    if (typeof maxReconnects === 'number') {
+      (connectOpts as any).maxReconnectAttempts = maxReconnects;
+    }
+    this.nc = await connect(connectOpts);
+    this.js = this.nc.jetstream();
+  }
+
+  async publish(subject: Subjects, payload: unknown): Promise<void> {
+    if (!this.js) throw new Error('Not connected');
+    const data = this.sc.encode(JSON.stringify(payload));
+    await this.js.publish(subject, data);
+  }
+
+  async subscribe(subject: Subjects, handler: (data: unknown) => void): Promise<JetStreamSubscription> {
+    if (!this.js) throw new Error('Not connected');
+    const opts = consumerOpts();
+    opts.durable(this.durable);
+    opts.manualAck();
+    const sub = await this.js.subscribe(subject, opts);
+    (async () => {
+      for await (const msg of sub) {
+        handler(JSON.parse(this.sc.decode(msg.data)));
+        msg.ack();
+      }
+    })();
+    return sub;
+  }
+
+  async close(): Promise<void> {
+    await this.nc?.close();
+  }
+}

--- a/packages/event-bus/README.md
+++ b/packages/event-bus/README.md
@@ -1,9 +1,10 @@
 # Event Bus
 
-The `NatsEventBus` provides a lightweight wrapper over the NATS client for communication between UnifiedMandala services.
+Wrappers over the NATS client provide communication between UnifiedMandala services.
 
 ## Key modules
 - `NatsEventBus.ts` – connect, publish, subscribe and close helpers.
+- `JetStreamBus.ts` – publish and consume durable events via JetStream.
 - `subjects.ts` – enumerates all well known subjects.
 
 ## Available subjects
@@ -25,4 +26,4 @@ await bus.publish(Subjects.CREP_UPDATE, { score: 0.9 });
 ```
 
 ## Tests
-See [`NatsEventBus.test.ts`](./NatsEventBus.test.ts).
+See [`NatsEventBus.test.ts`](./NatsEventBus.test.ts) and [`JetStreamBus.test.ts`](./JetStreamBus.test.ts).

--- a/packages/event-bus/index.ts
+++ b/packages/event-bus/index.ts
@@ -3,3 +3,4 @@ export * from './LocalEventBus';
 export * from './subjects';
 export * from './bridge';
 export * from './WebSocketHub';
+export * from './JetStreamBus';


### PR DESCRIPTION
## Summary
- implement JetStreamBus wrapper to publish and consume durable NATS JetStream events
- expose JetStreamBus in event-bus package and document usage
- mark JetStreamBus task as complete in advanced progress tracking

## Testing
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx jest packages/event-bus/JetStreamBus.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a8bb3eb7408322a86b05224913f451