### PR TITLE
feat: allow excluding patterns in advanced todo sync

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add JetStreamBus for persistent events",
+  "lastCommit": "Add exclude filter to advanced todo scripts",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -30,31 +30,6 @@
     {
       "commit": "feat: add Consciousness module",
       "path": "packages/universum-simulationen/modules/consciousness.py",
-      "status": "open"
-    },
-    {
-      "commit": "feat: add GermanGrammarAssistant agent",
-      "path": "packages/agents/GermanGrammarAssistant.ts",
-      "status": "open"
-    },
-    {
-      "commit": "feat: add SimulationOrchestrator agent",
-      "path": "packages/agents/SimulationOrchestrator.ts",
-      "status": "open"
-    },
-    {
-      "commit": "feat: extend FutureKIAgent",
-      "path": "packages/agents/FutureKIAgent.ts",
-      "status": "open"
-    },
-    {
-      "commit": "feat: add DocumentGenerator agent",
-      "path": "packages/agents/DocumentGenerator.ts",
-      "status": "open"
-    },
-    {
-      "commit": "feat: add TeamboardManager module",
-      "path": "packages/agents/TeamboardManager.ts",
       "status": "open"
     }
   ],
@@ -5616,6 +5591,10 @@
     },
     {
       "commit": "Add JetStreamBus for persistent events",
+      "status": "done"
+    },
+    {
+      "commit": "Add exclude filter to advanced todo scripts",
       "status": "done"
     }
   ],

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -146,3 +146,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Integrated Utopie-to-Do adapter skeleton and synced progress files.
 
 - Added Prometheus scrape config for metrics server.
+- Added exclude filter to advanced todo scripts to ignore conversation-heavy tasks.

--- a/repositorypflege/__tests__/list-open-advanced-todos.test.js
+++ b/repositorypflege/__tests__/list-open-advanced-todos.test.js
@@ -37,6 +37,20 @@ test('combines tasks from multiple JSON and YAML files', () => {
   fs.unlinkSync(tmpYaml);
 });
 
+test('excludes tasks matching pattern', () => {
+  const tmp = path.join(__dirname, 'tmp-exclude.json');
+  const sample = [
+    { commit: 'Keep me', path: 'a', status: 'open' },
+    { commit: 'Skip this conversation task', path: 'conversations/b', status: 'open' }
+  ];
+  fs.writeFileSync(tmp, JSON.stringify(sample, null, 2));
+
+  const todos = listOpenAdvancedTodos(undefined, tmp, 'conversations');
+  expect(todos).toEqual([{ commit: 'Keep me', path: 'a' }]);
+
+  fs.unlinkSync(tmp);
+});
+
 test('deduplicates tasks with same commit and path', () => {
   const tmp = path.join(__dirname, 'tmp-dup.json');
   const sample = [

--- a/repositorypflege/__tests__/update-advanced-progress.test.js
+++ b/repositorypflege/__tests__/update-advanced-progress.test.js
@@ -23,3 +23,17 @@ test('updates pendingTasks with limited todos', () => {
     { commit: 'Task B', path: 'b', status: 'open' }
   ]);
 });
+
+test('forwards exclude pattern to listOpenAdvancedTodos', () => {
+  const tmp = path.join(__dirname, 'tmp-progress.json');
+  fs.writeFileSync(tmp, JSON.stringify({ pendingTasks: [] }, null, 2));
+  listOpenAdvancedTodos.mockClear();
+  listOpenAdvancedTodos.mockReturnValue([]);
+
+  updateAdvancedProgress(5, tmp, undefined, undefined, 'conversations');
+  expect(listOpenAdvancedTodos).toHaveBeenCalledWith(
+    undefined,
+    undefined,
+    'conversations'
+  );
+});

--- a/repositorypflege/list-open-advanced-todos.js
+++ b/repositorypflege/list-open-advanced-todos.js
@@ -8,7 +8,7 @@ function readTodoFile(file) {
   return ext === '.yaml' || ext === '.yml' ? yaml.load(raw) : JSON.parse(raw);
 }
 
-function listOpenAdvancedTodos(pattern, todoPaths) {
+function listOpenAdvancedTodos(pattern, todoPaths, excludePattern) {
   const files =
     todoPaths && todoPaths.length
       ? Array.isArray(todoPaths)
@@ -25,6 +25,7 @@ function listOpenAdvancedTodos(pattern, todoPaths) {
     }
   }
   const regex = pattern ? new RegExp(pattern, 'i') : null;
+  const excludeRegex = excludePattern ? new RegExp(excludePattern, 'i') : null;
   const seen = new Set();
   const result = [];
   for (const item of data) {
@@ -32,7 +33,8 @@ function listOpenAdvancedTodos(pattern, todoPaths) {
       item.status !== 'done' &&
       item.commit &&
       item.path &&
-      (!regex || regex.test(item.commit) || regex.test(item.path))
+      (!regex || regex.test(item.commit) || regex.test(item.path)) &&
+      (!excludeRegex || (!excludeRegex.test(item.commit) && !excludeRegex.test(item.path)))
     ) {
       const key = `${item.commit}|${item.path}`;
       if (!seen.has(key)) {
@@ -51,7 +53,9 @@ if (require.main === module) {
   const pathIndex = process.argv.indexOf('--path');
   const pathArg = pathIndex >= 0 ? process.argv[pathIndex + 1] : undefined;
   const todoPaths = pathArg ? pathArg.split(',') : undefined;
-  const open = listOpenAdvancedTodos(pattern, todoPaths);
+  const exclIndex = process.argv.indexOf('--exclude');
+  const exclude = exclIndex >= 0 ? process.argv[exclIndex + 1] : undefined;
+  const open = listOpenAdvancedTodos(pattern, todoPaths, exclude);
   const display = open.slice(0, limit);
   display.forEach((t) => {
     const commitText =

--- a/repositorypflege/update-advanced-progress.js
+++ b/repositorypflege/update-advanced-progress.js
@@ -2,10 +2,10 @@ const fs = require('fs');
 const path = require('path');
 const { listOpenAdvancedTodos } = require('./list-open-advanced-todos');
 
-function updateAdvancedProgress(limit = 5, progressFile, pattern, todoPaths) {
+function updateAdvancedProgress(limit = 5, progressFile, pattern, todoPaths, excludePattern) {
   const progressPath = progressFile || path.resolve(__dirname, '..', 'advancedprogress.json');
   const progress = JSON.parse(fs.readFileSync(progressPath, 'utf8'));
-  const todos = listOpenAdvancedTodos(pattern, todoPaths).slice(0, limit);
+  const todos = listOpenAdvancedTodos(pattern, todoPaths, excludePattern).slice(0, limit);
   progress.pendingTasks = todos.map((t) => ({ commit: t.commit, path: t.path, status: 'open' }));
   fs.writeFileSync(progressPath, JSON.stringify(progress, null, 2));
   console.log(`Synced ${todos.length} tasks to ${progressPath}`);
@@ -18,7 +18,9 @@ if (require.main === module) {
   const pathIndex = process.argv.indexOf('--path');
   const pathArg = pathIndex >= 0 ? process.argv[pathIndex + 1] : undefined;
   const todoPaths = pathArg ? pathArg.split(',') : undefined;
-  updateAdvancedProgress(limit, undefined, pattern, todoPaths);
+  const exclIndex = process.argv.indexOf('--exclude');
+  const exclude = exclIndex >= 0 ? process.argv[exclIndex + 1] : undefined;
+  updateAdvancedProgress(limit, undefined, pattern, todoPaths, exclude);
 }
 
 module.exports = { updateAdvancedProgress };


### PR DESCRIPTION
## Summary
- add optional `--exclude` regex to `list-open-advanced-todos`
- propagate exclusion to progress sync
- record progress and note repo maintenance

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx jest repositorypflege/__tests__/list-open-advanced-todos.test.js repositorypflege/__tests__/update-advanced-progress.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8c1f3e0d083229a02789d77b79d39