### PR TITLE
feat: add KEDA autoscaling template

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12806,7 +12806,7 @@
     "path": "deployment/keda/scaledobject-natsjs.yaml",
     "task": "Scale workers by JetStream lag using KEDA",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add BudgetGuard utility",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12428,7 +12428,7 @@
   path: deployment/keda/scaledobject-natsjs.yaml
   task: Scale workers by JetStream lag using KEDA
   test: ""
-  status: open
+  status: done
 - commit: Add BudgetGuard utility
   path: packages/costs/BudgetGuard.ts
   task: Track token spend per agent and enforce daily limits

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5596,6 +5596,10 @@
     {
       "commit": "Add exclude filter to advanced todo scripts",
       "status": "done"
+    },
+    {
+      "commit": "Provide KEDA autoscaling template",
+      "status": "done"
     }
   ],
   "fractalTodos": [

--- a/deployment/keda/scaledobject-natsjs.yaml
+++ b/deployment/keda/scaledobject-natsjs.yaml
@@ -1,0 +1,19 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: natsjs-worker-autoscaler
+spec:
+  scaleTargetRef:
+    name: natsjs-worker
+  pollingInterval: 30 # seconds
+  cooldownPeriod: 300 # seconds
+  minReplicaCount: 1
+  maxReplicaCount: 20
+  triggers:
+    - type: nats-jetstream
+      metadata:
+        natsServerMonitoringEndpoint: "http://nats.monitoring:8222"
+        streamName: tasks
+        consumerName: worker
+        lagThreshold: "100"
+

--- a/feedbackcodex.json
+++ b/feedbackcodex.json
@@ -2,5 +2,5 @@
   "feedback": "New advanced conversations processed and TODOs extracted",
   "notes": "aeon:2025-0623-ANCHOR-V2 complete",
   "analysis": "Deployment readiness tasks created",
-  "recent": "Configured gpt-5 KEDA scaler with daily token budget guard"
+  "recent": "Added KEDA autoscaling template for JetStream workers"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -147,3 +147,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 
 - Added Prometheus scrape config for metrics server.
 - Added exclude filter to advanced todo scripts to ignore conversation-heavy tasks.
+- Added KEDA autoscaling template for JetStream workers to scale by lag.


### PR DESCRIPTION
## Summary
- add KEDA ScaledObject template for JetStream workers
- mark autoscaling task as complete in advanced ToDo and progress trackers
- log autoscaling template in feedback codex

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `node scripts/parse-newadvanced-conversations.js --dest /tmp/newadv --file docs/sigils/newadvancedconversations.json --keyword TODO --yaml`


------
https://chatgpt.com/codex/tasks/task_e_68a8c6b9a09c832296cc1c2b609c4a00