### PR TITLE
chore: track changed files in progress updater

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5639,5 +5639,8 @@
       "commit": "Add YAML output to split-newadvanced-conversations script",
       "status": "done"
     }
+  ],
+  "changedFiles": [
+    "repositorypflege/update-advanced-progress.js"
   ]
 }

--- a/docs/sigils/advancedprogress-guide.md
+++ b/docs/sigils/advancedprogress-guide.md
@@ -1,0 +1,14 @@
+# Advanced Progress Guide
+
+This guide describes how to keep `advancedprogress.json` in sync.
+
+## Updating Progress
+
+Run the maintenance script after making changes:
+
+```bash
+node repositorypflege/update-advanced-progress.js
+```
+
+The script now records a `changedFiles` list which captures the files currently
+modified in the working tree. This helps trace fractal updates across commits.

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -151,3 +151,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 
 - Added Consciousness module and tests; marked related advanced todos as done.
 \n- Added research agent definitions and reproducibility protocol.
+- Tracked changed files in advanced progress updater for clearer fractal steps.

--- a/repositorypflege/update-advanced-progress.js
+++ b/repositorypflege/update-advanced-progress.js
@@ -1,12 +1,27 @@
 const fs = require('fs');
 const path = require('path');
+const { execSync } = require('child_process');
 const { listOpenAdvancedTodos } = require('./list-open-advanced-todos');
+
+function getChangedFiles() {
+  try {
+    const output = execSync('git status --porcelain').toString();
+    return output
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => line.slice(3).trim());
+  } catch {
+    return [];
+  }
+}
 
 function updateAdvancedProgress(limit = 5, progressFile, pattern, todoPaths, excludePattern) {
   const progressPath = progressFile || path.resolve(__dirname, '..', 'advancedprogress.json');
   const progress = JSON.parse(fs.readFileSync(progressPath, 'utf8'));
   const todos = listOpenAdvancedTodos(pattern, todoPaths, excludePattern).slice(0, limit);
   progress.pendingTasks = todos.map((t) => ({ commit: t.commit, path: t.path, status: 'open' }));
+  const changed = getChangedFiles().filter((f) => f !== path.relative(path.resolve(__dirname, '..'), progressPath));
+  progress.changedFiles = changed;
   fs.writeFileSync(progressPath, JSON.stringify(progress, null, 2));
   console.log(`Synced ${todos.length} tasks to ${progressPath}`);
 }


### PR DESCRIPTION
## Summary
- log working tree changes in repositorypflege/update-advanced-progress.js
- document advancedprogress workflow in docs/sigils/advancedprogress-guide.md
- note progress updater enhancement in feedbackcodex

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a8e318c22083228d46354e159d0ccd