### PR TITLE
feat: enforce personhood policies with audit trail

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13039,7 +13039,7 @@
     "path": "packages/personhood/AuditTrail.ts",
     "task": "Record signed personhood events to JSONL log",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add RefusalEngine",
@@ -13053,7 +13053,7 @@
     "path": "packages/personhood/PolicyGuard.ts",
     "task": "Enforce consent, region, review and model rules",
     "test": "tests/personhood.guard.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement flags API",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12595,7 +12595,7 @@
   path: packages/personhood/AuditTrail.ts
   task: Record signed personhood events to JSONL log
   test: ""
-  status: open
+  status: done
 - commit: Add RefusalEngine
   path: packages/personhood/RefusalEngine.ts
   task: Generate structured refusal objects
@@ -12605,7 +12605,7 @@
   path: packages/personhood/PolicyGuard.ts
   task: Enforce consent, region, review and model rules
   test: tests/personhood.guard.test.ts
-  status: open
+  status: done
 - commit: Implement flags API
   path: scripts/flags-api.ts
   task: Expose HTTP API to toggle feature flags via KV

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add consciousness simulation module",
+  "lastCommit": "feat: enforce personhood policies with audit trail",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -8,28 +8,747 @@
   "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events | Added JetStream KV/ObjectStore wrappers and tool loader",
   "pendingTasks": [
     {
-      "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129",
-      "path": "GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json",
+      "commit": "Add gpt-5 smoke test suite",
       "status": "open"
     },
     {
-      "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e",
-      "path": "GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json",
+      "commit": "Implement OpenAIProvider with Responses API fallback",
       "status": "open"
     },
     {
-      "commit": "Integrate new GPT teams from Zukunft conversation",
-      "path": "packages/agents",
+      "commit": "Add PolicyEnforcer for governance",
       "status": "open"
     },
     {
-      "commit": "feat: add GermanGrammarAssistant agent",
-      "path": "packages/agents/GermanGrammarAssistant.ts",
+      "commit": "Write dataset provenance protocol",
       "status": "open"
     },
     {
-      "commit": "feat: add SimulationOrchestrator agent",
-      "path": "packages/agents/SimulationOrchestrator.ts",
+      "commit": "Write CREP research protocol",
+      "status": "open"
+    },
+    {
+      "commit": "Write research safety guidelines",
+      "status": "open"
+    },
+    {
+      "commit": "Create PipelineOrchestrator",
+      "status": "open"
+    },
+    {
+      "commit": "Add universe pulse pipeline",
+      "status": "open"
+    },
+    {
+      "commit": "Add UniversePulse E2E demo",
+      "status": "open"
+    },
+    {
+      "commit": "Add Grafana mini dashboard",
+      "status": "open"
+    },
+    {
+      "commit": "Create ResearchHub UI",
+      "status": "open"
+    },
+    {
+      "commit": "Implement FeatureFlags service",
+      "status": "open"
+    },
+    {
+      "commit": "Seed feature flags script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement ExperimentRegistry",
+      "status": "open"
+    },
+    {
+      "commit": "Add experiment sample script",
+      "status": "open"
+    },
+    {
+      "commit": "Create personhood policy config",
+      "status": "open"
+    },
+    {
+      "commit": "Implement ConsentRegistry",
+      "status": "open"
+    },
+    {
+      "commit": "Add RefusalEngine",
+      "status": "open"
+    },
+    {
+      "commit": "Implement flags API",
+      "status": "open"
+    },
+    {
+      "commit": "Add FeatureFlagsPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Implement experiments API",
+      "status": "open"
+    },
+    {
+      "commit": "Add ExperimentBoard component",
+      "status": "open"
+    },
+    {
+      "commit": "Add provenance card type",
+      "status": "open"
+    },
+    {
+      "commit": "Implement PDF ingest",
+      "status": "open"
+    },
+    {
+      "commit": "Implement GeoTIFF ingest",
+      "status": "open"
+    },
+    {
+      "commit": "Implement VCF ingest",
+      "status": "open"
+    },
+    {
+      "commit": "Add ingest demo script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement ReviewerQueue",
+      "status": "open"
+    },
+    {
+      "commit": "Add reviewer API",
+      "status": "open"
+    },
+    {
+      "commit": "Add AutoTuningAgent",
+      "status": "open"
+    },
+    {
+      "commit": "Implement SecureAggregator",
+      "status": "open"
+    },
+    {
+      "commit": "Add federated API",
+      "status": "open"
+    },
+    {
+      "commit": "Implement ResearchHubWS server",
+      "status": "open"
+    },
+    {
+      "commit": "Create realtime hub HTTP bridge script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement annotations KV store",
+      "status": "open"
+    },
+    {
+      "commit": "Add annotations API with broadcast",
+      "status": "open"
+    },
+    {
+      "commit": "Create share API server",
+      "status": "open"
+    },
+    {
+      "commit": "Add RealtimeResearchHub UI component",
+      "status": "open"
+    },
+    {
+      "commit": "Add AnnotationsPanel UI component",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for realtime APIs",
+      "status": "open"
+    },
+    {
+      "commit": "Add realtime flow smoke test",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows dev scripts and cross-env support",
+      "status": "open"
+    },
+    {
+      "commit": "Create Windows start-all PowerShell script",
+      "status": "open"
+    },
+    {
+      "commit": "Add OS Bridge capability policy",
+      "status": "open"
+    },
+    {
+      "commit": "Implement CapabilityGuard for OS Bridge",
+      "status": "open"
+    },
+    {
+      "commit": "Add WindowsPS helper",
+      "status": "open"
+    },
+    {
+      "commit": "Implement OS Bridge API",
+      "status": "open"
+    },
+    {
+      "commit": "Add OSControlPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Create DesktopAutomationAgent",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows UIA and hotkey tools",
+      "status": "open"
+    },
+    {
+      "commit": "Add voice and screen control API",
+      "status": "open"
+    },
+    {
+      "commit": "Extend OS Bridge API with UIA and screen routes",
+      "status": "open"
+    },
+    {
+      "commit": "Add VoicePanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Add ScreenCapturePanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows tools build script and package entries",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for Windows OS bridge",
+      "status": "open"
+    },
+    {
+      "commit": "Add UIA screen redaction tool",
+      "status": "open"
+    },
+    {
+      "commit": "Add WinUI tree inspector utility",
+      "status": "open"
+    },
+    {
+      "commit": "Add AutoHotkey hook scripts",
+      "status": "open"
+    },
+    {
+      "commit": "Add desktop recorder tool",
+      "status": "open"
+    },
+    {
+      "commit": "Implement UIMacroSynth agent",
+      "status": "open"
+    },
+    {
+      "commit": "Add PII regex patterns module",
+      "status": "open"
+    },
+    {
+      "commit": "Add image redactor utility",
+      "status": "open"
+    },
+    {
+      "commit": "Implement redaction API service",
+      "status": "open"
+    },
+    {
+      "commit": "Add AutoHotkey template script",
+      "status": "open"
+    },
+    {
+      "commit": "Create AutoHotkey macro compiler",
+      "status": "open"
+    },
+    {
+      "commit": "Add AutoHotkey runner script",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce macro DSL validator",
+      "status": "open"
+    },
+    {
+      "commit": "Add macro execution script",
+      "status": "open"
+    },
+    {
+      "commit": "Add session log utility",
+      "status": "open"
+    },
+    {
+      "commit": "Add macro replay script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement desktop recorder API",
+      "status": "open"
+    },
+    {
+      "commit": "Create MacroEditor component",
+      "status": "open"
+    },
+    {
+      "commit": "Create RedactionPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Define role permissions map",
+      "status": "open"
+    },
+    {
+      "commit": "Extend capability policy for UI consent",
+      "status": "open"
+    },
+    {
+      "commit": "Add topology index registry",
+      "status": "open"
+    },
+    {
+      "commit": "Implement admin API gateway",
+      "status": "open"
+    },
+    {
+      "commit": "Create admin console app",
+      "status": "open"
+    },
+    {
+      "commit": "Add AI peer connector module",
+      "status": "open"
+    },
+    {
+      "commit": "Implement admin peers API",
+      "status": "open"
+    },
+    {
+      "commit": "Create spaces management module",
+      "status": "open"
+    },
+    {
+      "commit": "Implement commons API",
+      "status": "open"
+    },
+    {
+      "commit": "Add commons presence websocket",
+      "status": "open"
+    },
+    {
+      "commit": "Create commons hub app",
+      "status": "open"
+    },
+    {
+      "commit": "Add capability graph widget",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce task router module",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for admin and commons modules",
+      "status": "open"
+    },
+    {
+      "commit": "Add ContributionEvent schema",
+      "status": "open"
+    },
+    {
+      "commit": "Add PluginManifest schema",
+      "status": "open"
+    },
+    {
+      "commit": "Add AIPeerHandshake protocol",
+      "status": "open"
+    },
+    {
+      "commit": "Create CoIntel orchestrator service",
+      "status": "open"
+    },
+    {
+      "commit": "Implement collab websocket server",
+      "status": "open"
+    },
+    {
+      "commit": "Add CreditLedger module",
+      "status": "open"
+    },
+    {
+      "commit": "Add AttributionIndex module",
+      "status": "open"
+    },
+    {
+      "commit": "Create peer handshake service",
+      "status": "open"
+    },
+    {
+      "commit": "Add setup wizard script",
+      "status": "open"
+    },
+    {
+      "commit": "Create CoauthorCanvas component",
+      "status": "open"
+    },
+    {
+      "commit": "Create TaskBoard component",
+      "status": "open"
+    },
+    {
+      "commit": "Add ConsentTimeline component",
+      "status": "open"
+    },
+    {
+      "commit": "Add PeerManager component",
+      "status": "open"
+    },
+    {
+      "commit": "Add ModelRouterEditor component",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce Tenant and Instance types",
+      "status": "open"
+    },
+    {
+      "commit": "Add RBAC permission helper",
+      "status": "open"
+    },
+    {
+      "commit": "Create identity API service",
+      "status": "open"
+    },
+    {
+      "commit": "Define UI templates",
+      "status": "open"
+    },
+    {
+      "commit": "Create instance registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Add ACL API service",
+      "status": "open"
+    },
+    {
+      "commit": "Create InitialAdminPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Define federation manifest type",
+      "status": "open"
+    },
+    {
+      "commit": "Create federation registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Create federation bridge websocket",
+      "status": "open"
+    },
+    {
+      "commit": "Add collab federation bridge script",
+      "status": "open"
+    },
+    {
+      "commit": "Create GlobalMandalaGraph component",
+      "status": "open"
+    },
+    {
+      "commit": "Add unified AppShell",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for Co-Intelligence services",
+      "status": "open"
+    },
+    {
+      "commit": "Append identity and federation services to code agent tasks",
+      "status": "open"
+    },
+    {
+      "commit": "Add OIDC stub service",
+      "status": "open"
+    },
+    {
+      "commit": "Add UI switchboard service",
+      "status": "open"
+    },
+    {
+      "commit": "Add compose override for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows stack start script",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows services installer",
+      "status": "open"
+    },
+    {
+      "commit": "Add UM integration GitHub workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Document UM integration guide",
+      "status": "open"
+    },
+    {
+      "commit": "Add integration copier script",
+      "status": "open"
+    },
+    {
+      "commit": "Expose UM service scripts in package.json",
+      "status": "open"
+    },
+    {
+      "commit": "Provide tsconfig for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add production docker compose file",
+      "status": "open"
+    },
+    {
+      "commit": "Create generic Dockerfile for TypeScript services",
+      "status": "open"
+    },
+    {
+      "commit": "Configure NGINX reverse proxy for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add Kong gateway configuration",
+      "status": "open"
+    },
+    {
+      "commit": "Implement Ed25519 key generation script",
+      "status": "open"
+    },
+    {
+      "commit": "Add manifest signing script",
+      "status": "open"
+    },
+    {
+      "commit": "Add manifest verification script",
+      "status": "open"
+    },
+    {
+      "commit": "Create verified federation registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Implement SSO broker service",
+      "status": "open"
+    },
+    {
+      "commit": "Generate systemd unit files script",
+      "status": "open"
+    },
+    {
+      "commit": "Provide environment example",
+      "status": "open"
+    },
+    {
+      "commit": "Document production setup",
+      "status": "open"
+    },
+    {
+      "commit": "Add Keycloak OIDC dev bundle",
+      "status": "open"
+    },
+    {
+      "commit": "Add Kubernetes manifests with Kustomize overlays",
+      "status": "open"
+    },
+    {
+      "commit": "Add monitoring configuration",
+      "status": "open"
+    },
+    {
+      "commit": "Add Caddy TLS reverse proxy",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitHub Actions workflow for Kubernetes deployment",
+      "status": "open"
+    },
+    {
+      "commit": "Add Helm OIDC bundle",
+      "status": "open"
+    },
+    {
+      "commit": "Add Traefik mTLS ingress",
+      "status": "open"
+    },
+    {
+      "commit": "Add SLO monitoring pack",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps manifests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Add Go OIDC quickstart",
+      "status": "open"
+    },
+    {
+      "commit": "Add Keycloak auto-import helmfile",
+      "status": "open"
+    },
+    {
+      "commit": "Add Cloudflare DNS01 ClusterIssuer",
+      "status": "open"
+    },
+    {
+      "commit": "Add Argo Rollouts canary stack",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps app factory script",
+      "status": "open"
+    },
+    {
+      "commit": "Add Observability++ stack",
+      "status": "open"
+    },
+    {
+      "commit": "Add secret management examples",
+      "status": "open"
+    },
+    {
+      "commit": "Add NetworkPolicy templates",
+      "status": "open"
+    },
+    {
+      "commit": "Add blue/green rollouts with Slack alerts",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps golden path template",
+      "status": "open"
+    },
+    {
+      "commit": "Add one-click cluster bootstrap",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Vault CSI for secret file mounts",
+      "status": "open"
+    },
+    {
+      "commit": "Add ServiceMap-based NetworkPolicy generator",
+      "status": "open"
+    },
+    {
+      "commit": "Set up Cypress UI smoke tests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Set up k6 API smoke tests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Configure promotion gates for rollouts",
+      "status": "open"
+    },
+    {
+      "commit": "Deploy gate-controller for E2E gating",
+      "status": "open"
+    },
+    {
+      "commit": "Add Playwright synthetics with OTel",
+      "status": "open"
+    },
+    {
+      "commit": "Provide RUM OTel web snippet",
+      "status": "open"
+    },
+    {
+      "commit": "Implement multi-signal quorum gates",
+      "status": "open"
+    },
+    {
+      "commit": "Add Terraform synthetics and alerting",
+      "status": "open"
+    },
+    {
+      "commit": "Enable auto-rollback on SLO violation",
+      "status": "open"
+    },
+    {
+      "commit": "Schedule weekly SLO and error budget reports",
+      "status": "open"
+    },
+    {
+      "commit": "Support multi-tenant E2E gates",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows E2E workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Track SLO budget consumption",
+      "status": "open"
+    },
+    {
+      "commit": "Capture debug snapshots on aborted rollouts",
+      "status": "open"
+    },
+    {
+      "commit": "Provide tenant admin API and UI",
+      "status": "open"
+    },
+    {
+      "commit": "Automate image builds and Kustomize validation",
+      "status": "open"
+    },
+    {
+      "commit": "Bootstrap GitOps root application",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce multi-cluster ApplicationSet and security policies",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Kyverno policies with Gatekeeper audit layer",
+      "status": "open"
+    },
+    {
+      "commit": "Apply Cilium default-deny and service allow policies",
+      "status": "open"
+    },
+    {
+      "commit": "Deploy Falco with RBAC-abuse rules and Slack alerts",
+      "status": "open"
+    },
+    {
+      "commit": "Wire OpenTelemetry collector to Tempo and Loki",
+      "status": "open"
+    },
+    {
+      "commit": "Enable Alertmanager night mode routing",
+      "status": "open"
+    },
+    {
+      "commit": "Define per-namespace Cilium FQDN allowlists",
+      "status": "open"
+    },
+    {
+      "commit": "Switch Kyverno verifyImages to enforce",
       "status": "open"
     }
   ],
@@ -4758,6 +5477,22 @@
     {
       "commit": "feat: add Consciousness module",
       "status": "done"
+    },
+    {
+      "commit": "Define diverse research agents",
+      "status": "done"
+    },
+    {
+      "commit": "Write reproducibility protocol",
+      "status": "done"
+    },
+    {
+      "commit": "Implement AuditTrail",
+      "status": "done"
+    },
+    {
+      "commit": "Implement PolicyGuard",
+      "status": "done"
     }
   ],
   "completed": [
@@ -5641,6 +6376,10 @@
     }
   ],
   "changedFiles": [
-    "repositorypflege/update-advanced-progress.js"
+    "advancedToDo.json",
+    "advancedToDo.yaml",
+    "packages/personhood/PolicyGuard.ts",
+    "tests/personhood.guard.test.ts",
+    "packages/personhood/AuditTrail.ts"
   ]
 }

--- a/packages/personhood/AuditTrail.ts
+++ b/packages/personhood/AuditTrail.ts
@@ -1,0 +1,28 @@
+import { appendFileSync, existsSync, mkdirSync } from 'fs';
+import { createHash } from 'crypto';
+import { dirname, resolve } from 'path';
+
+export interface AuditEvent {
+  personId: string;
+  action: string;
+  [key: string]: unknown;
+}
+
+function getLogPath(): string {
+  const log = process.env.PERSONHOOD_AUDIT_LOG || 'personhood.audit.log';
+  const full = resolve(log);
+  const dir = dirname(full);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return full;
+}
+
+export class AuditTrail {
+  static record(event: AuditEvent): void {
+    const timestamp = new Date().toISOString();
+    const payload = { ...event, timestamp };
+    const signature = createHash('sha256')
+      .update(JSON.stringify(payload))
+      .digest('hex');
+    appendFileSync(getLogPath(), JSON.stringify({ ...payload, signature }) + '\n');
+  }
+}

--- a/packages/personhood/PolicyGuard.ts
+++ b/packages/personhood/PolicyGuard.ts
@@ -1,7 +1,36 @@
 import { ConsentRegistry } from './ConsentRegistry';
+import { AuditTrail } from './AuditTrail';
+
+const ALLOWED_REGIONS = ['eu', 'us'];
+const APPROVED_MODELS = ['gpt-4o', 'gpt-4.1'];
+
+export interface PolicyOptions {
+  personId: string;
+  region: string;
+  model: string;
+  reviewed?: boolean;
+}
 
 export function requireConsent(personId: string): void {
   if (!ConsentRegistry.hasConsent(personId)) {
+    AuditTrail.record({ personId, action: 'consent_missing' });
     throw new Error(`Consent required for PII research: ${personId}`);
   }
+}
+
+export function enforcePolicy(opts: PolicyOptions): void {
+  requireConsent(opts.personId);
+  if (!ALLOWED_REGIONS.includes(opts.region)) {
+    AuditTrail.record({ personId: opts.personId, action: 'region_block', region: opts.region });
+    throw new Error(`Region not allowed: ${opts.region}`);
+  }
+  if (!APPROVED_MODELS.includes(opts.model)) {
+    AuditTrail.record({ personId: opts.personId, action: 'model_block', model: opts.model });
+    throw new Error(`Model not allowed: ${opts.model}`);
+  }
+  if (!opts.reviewed) {
+    AuditTrail.record({ personId: opts.personId, action: 'review_required', model: opts.model });
+    throw new Error('Review required');
+  }
+  AuditTrail.record({ personId: opts.personId, action: 'policy_pass', region: opts.region, model: opts.model });
 }

--- a/tests/personhood.guard.test.ts
+++ b/tests/personhood.guard.test.ts
@@ -1,7 +1,16 @@
 import { ConsentRegistry } from '../packages/personhood/ConsentRegistry';
-import { requireConsent } from '../packages/personhood/PolicyGuard';
+import { requireConsent, enforcePolicy } from '../packages/personhood/PolicyGuard';
+import { join } from 'path';
+import os from 'os';
+import { existsSync, unlinkSync } from 'fs';
 
 describe('Personhood Policy Guard', () => {
+  beforeAll(() => {
+    const logPath = join(os.tmpdir(), 'personhood_audit.log');
+    process.env.PERSONHOOD_AUDIT_LOG = logPath;
+    if (existsSync(logPath)) unlinkSync(logPath);
+  });
+
   test('throws when consent missing', () => {
     expect(() => requireConsent('user1')).toThrow('Consent required');
   });
@@ -9,5 +18,13 @@ describe('Personhood Policy Guard', () => {
   test('allows when consent granted', () => {
     ConsentRegistry.grant('user2');
     expect(() => requireConsent('user2')).not.toThrow();
+  });
+
+  test('enforces region and model and review rules', () => {
+    ConsentRegistry.grant('user3');
+    expect(() => enforcePolicy({ personId: 'user3', region: 'xx', model: 'gpt-4o', reviewed: true })).toThrow('Region not allowed');
+    expect(() => enforcePolicy({ personId: 'user3', region: 'eu', model: 'bad-model', reviewed: true })).toThrow('Model not allowed');
+    expect(() => enforcePolicy({ personId: 'user3', region: 'eu', model: 'gpt-4o', reviewed: false })).toThrow('Review required');
+    expect(() => enforcePolicy({ personId: 'user3', region: 'eu', model: 'gpt-4o', reviewed: true })).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- add AuditTrail to log signed personhood events
- expand PolicyGuard with consent, region, model, and review checks
- update tasks and progress tracking

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test tests/personhood.guard.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a8e738d16c8322a3fe0eb8b3b16c8c