### PR TITLE
feat: stream live answers over SSE

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-22, in der Zeit des Abend.
+Am 2025-08-22, in der Zeit des Nacht.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Reflexion (Fokus: P)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: enforce personhood policies with audit trail",
+  "lastCommit": "chore: sync progress metadata",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4774,6 +4774,14 @@
     {
       "commit": "Implement PolicyGuard",
       "status": "done"
+    },
+    {
+      "commit": "Introduce Tenant and Instance types",
+      "status": "done"
+    },
+    {
+      "commit": "Add RBAC permission helper",
+      "status": "done"
     }
   ],
   "completed": [
@@ -5656,9 +5664,5 @@
       "status": "done"
     }
   ],
-  "changedFiles": [
-    "advancedToDo.json",
-    "advancedToDo.yaml",
-    "packages/identity/"
-  ]
+  "changedFiles": []
 }

--- a/scripts/realtime-hub.ts
+++ b/scripts/realtime-hub.ts
@@ -9,12 +9,29 @@ new ResearchHubWS({ port: wsPort, bus });
 const app = express();
 app.use(express.json());
 
-app.post('/live/ask', (req, res) => {
-  const question = (req.body && req.body.question) || '';
+app.get('/live/ask', (req, res) => {
+  const question = (req.query.question as string) || '';
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  // flushHeaders is only present in some frameworks
+  (res as any).flushHeaders?.();
+
+  const unsub = bus.subscribe(Subjects.LIVE_ANSWER, (payload) => {
+    res.write(`data: ${JSON.stringify(payload)}\n\n`);
+  });
+
   bus.publish(Subjects.LIVE_ASK, { question });
-  // Echo back a placeholder answer for now
-  bus.publish(Subjects.LIVE_ANSWER, { question, answer: 'acknowledged' });
-  res.json({ status: 'queued' });
+
+  // send placeholder answer if no other responder is active
+  setTimeout(() => {
+    bus.publish(Subjects.LIVE_ANSWER, { question, answer: 'acknowledged' });
+  }, 0);
+
+  req.on('close', () => {
+    unsub();
+    res.end();
+  });
 });
 
 const port = Number(process.env.PORT || 3000);


### PR DESCRIPTION
## Summary
- stream live answers via Server-Sent Events on `/live/ask`
- sync advanced progress metadata and chronopoem

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `node repositorypflege/update-advanced-progress.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8eff80ac88322a0cb48be0b45c0d3