### PR TITLE
feat: add personhood policy config

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13025,7 +13025,7 @@
     "path": "governance/personhood.policy.yaml",
     "task": "Define consent, retention and model access rules",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement ConsentRegistry",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12585,7 +12585,7 @@
   path: governance/personhood.policy.yaml
   task: Define consent, retention and model access rules
   test: ""
-  status: open
+  status: done
 - commit: Implement ConsentRegistry
   path: packages/personhood/ConsentRegistry.ts
   task: Store and fetch consent records via JetStream KV

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: sync progress metadata",
+  "lastCommit": "feat: add personhood policy config",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4782,6 +4782,10 @@
     {
       "commit": "Add RBAC permission helper",
       "status": "done"
+    },
+    {
+      "commit": "Create personhood policy config",
+      "status": "done"
     }
   ],
   "completed": [
@@ -5664,5 +5668,10 @@
       "status": "done"
     }
   ],
-  "changedFiles": []
+  "changedFiles": [
+    "advancedToDo.json",
+    "advancedToDo.yaml",
+    "feedbackcodex.md",
+    "governance/personhood.policy.yaml"
+  ]
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -152,3 +152,5 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added Consciousness module and tests; marked related advanced todos as done.
 \n- Added research agent definitions and reproducibility protocol.
 - Tracked changed files in advanced progress updater for clearer fractal steps.
+
+- Added initial personhood policy configuration and marked corresponding advanced todos complete.

--- a/governance/personhood.policy.yaml
+++ b/governance/personhood.policy.yaml
@@ -1,0 +1,21 @@
+# Mandala Personhood Policy
+version: "1.0"
+consent:
+  required: true
+  methods:
+    - explicit
+    - revocable
+retention:
+  default_days: 365
+  overrides:
+    eu: 730
+    children: 0
+models:
+  allow:
+    - openai/gpt-4o
+    - local/phi-3
+  deny:
+    - openai/gpt-4o-experimental
+notes: >
+  Defines baseline consent requirements, data retention limits and
+  model access rules for personhood-aware operations.


### PR DESCRIPTION
## Summary
- add initial personhood policy with consent, retention and model access rules
- mark personhood policy advanced todos complete and sync progress metadata
- note addition in feedback codex

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a905585e5c8322be247b09ad0c162a