### PR TITLE
feat: add provenance card type

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13088,7 +13088,7 @@
     "path": "packages/ingest/ProvenanceCard.ts",
     "task": "Track source, license, hash and personhood metadata",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement PDF ingest",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12630,7 +12630,7 @@
   path: packages/ingest/ProvenanceCard.ts
   task: Track source, license, hash and personhood metadata
   test: ""
-  status: open
+  status: done
 - commit: Implement PDF ingest
   path: packages/ingest/PDFIngest.ts
   task: Extract text and provenance from PDFs

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5671,7 +5671,6 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "feedbackcodex.md",
-    "governance/personhood.policy.yaml"
+    "packages/ingest/"
   ]
 }

--- a/packages/ingest/ProvenanceCard.test.ts
+++ b/packages/ingest/ProvenanceCard.test.ts
@@ -1,0 +1,17 @@
+import { createProvenanceCard } from './ProvenanceCard';
+import { sha256 } from '../provenance/Provenance';
+
+test('creates provenance card with hash and personhood', () => {
+  const card = createProvenanceCard(
+    'https://example.com/data.txt',
+    'hello',
+    'CC-BY-4.0',
+    { subjectId: 'user1', consentScope: 'research' }
+  );
+  expect(card).toEqual({
+    sourceUri: 'https://example.com/data.txt',
+    license: 'CC-BY-4.0',
+    sha256: sha256('hello'),
+    personhood: { subjectId: 'user1', consentScope: 'research' }
+  });
+});

--- a/packages/ingest/ProvenanceCard.ts
+++ b/packages/ingest/ProvenanceCard.ts
@@ -1,0 +1,27 @@
+export interface PersonhoodMetadata {
+  subjectId: string;
+  consentScope: string;
+}
+
+export interface ProvenanceCard {
+  sourceUri: string;
+  license: string;
+  sha256: string;
+  personhood?: PersonhoodMetadata;
+}
+
+import { sha256 } from '../provenance/Provenance';
+
+export function createProvenanceCard(
+  sourceUri: string,
+  content: string | Buffer,
+  license: string,
+  personhood?: PersonhoodMetadata
+): ProvenanceCard {
+  return {
+    sourceUri,
+    license,
+    sha256: sha256(content),
+    personhood,
+  };
+}


### PR DESCRIPTION
## Summary
- add ProvenanceCard interface and helper to track source, license, hash and personhood metadata
- mark provenance card task as completed in advancedToDo files
- sync advancedprogress metadata

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json --diagnostics`
- `npx jest packages/ingest/ProvenanceCard.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a981874c1c8322b0add55b194bbd8c