### PR TITLE
docs: note large conversation files

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5669,8 +5669,6 @@
     }
   ],
   "changedFiles": [
-    "advancedToDo.json",
-    "advancedToDo.yaml",
-    "packages/ingest/"
+    "docs/sigils/advancedprogress-guide.md"
   ]
 }

--- a/docs/sigils/advancedprogress-guide.md
+++ b/docs/sigils/advancedprogress-guide.md
@@ -12,3 +12,10 @@ node repositorypflege/update-advanced-progress.js
 
 The script now records a `changedFiles` list which captures the files currently
 modified in the working tree. This helps trace fractal updates across commits.
+
+## Handling Large Conversation Files
+
+Datasets such as `newadvancedconversations.json` in this directory are
+intentionally **not** opened directly—they are huge. Use the parsing utilities
+in `scripts/` (for example `split-newadvanced-conversations.ts`) whenever you
+need to extract snippets or generate tasks from them.


### PR DESCRIPTION
## Summary
- document how to handle large conversation datasets in sigils docs
- sync advanced progress tracking with updated docs

## Testing
- `node repositorypflege/list-open-advanced-todos.js 3`
- `node repositorypflege/update-advanced-progress.js`
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a9865901f48322bd16664fd50a6c6f