### PR TITLE
meta:update-progress – record last updated time

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5669,6 +5669,9 @@
     }
   ],
   "changedFiles": [
-    "docs/sigils/advancedprogress-guide.md"
-  ]
+    "docs/sigils/advancedprogress-guide.md",
+    "repositorypflege/__tests__/update-advanced-progress.test.js",
+    "repositorypflege/update-advanced-progress.js"
+  ],
+  "lastUpdated": "2025-08-23T10:56:56.223Z"
 }

--- a/docs/sigils/advancedprogress-guide.md
+++ b/docs/sigils/advancedprogress-guide.md
@@ -11,7 +11,8 @@ node repositorypflege/update-advanced-progress.js
 ```
 
 The script now records a `changedFiles` list which captures the files currently
-modified in the working tree. This helps trace fractal updates across commits.
+modified in the working tree and stamps a `lastUpdated` timestamp. This helps
+trace fractal updates across commits.
 
 ## Handling Large Conversation Files
 

--- a/repositorypflege/__tests__/update-advanced-progress.test.js
+++ b/repositorypflege/__tests__/update-advanced-progress.test.js
@@ -22,6 +22,8 @@ test('updates pendingTasks with limited todos', () => {
     { commit: 'Task A', path: 'a', status: 'open' },
     { commit: 'Task B', path: 'b', status: 'open' }
   ]);
+  expect(typeof updated.lastUpdated).toBe('string');
+  expect(isNaN(Date.parse(updated.lastUpdated))).toBe(false);
 });
 
 test('forwards exclude pattern to listOpenAdvancedTodos', () => {

--- a/repositorypflege/update-advanced-progress.js
+++ b/repositorypflege/update-advanced-progress.js
@@ -22,6 +22,7 @@ function updateAdvancedProgress(limit = 5, progressFile, pattern, todoPaths, exc
   progress.pendingTasks = todos.map((t) => ({ commit: t.commit, path: t.path, status: 'open' }));
   const changed = getChangedFiles().filter((f) => f !== path.relative(path.resolve(__dirname, '..'), progressPath));
   progress.changedFiles = changed;
+  progress.lastUpdated = new Date().toISOString();
   fs.writeFileSync(progressPath, JSON.stringify(progress, null, 2));
   console.log(`Synced ${todos.length} tasks to ${progressPath}`);
 }


### PR DESCRIPTION
## Summary
- Stamp `advancedprogress.json` updates with a `lastUpdated` timestamp via repository maintenance script
- Document new timestamp behavior in advanced progress guide
- Cover timestamp generation with a dedicated test

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest repositorypflege/__tests__/update-advanced-progress.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a99dedcdec8322910eaa951456e61f