### PR TITLE
feat: add Grafana mini Grafana dashboard

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12972,7 +12972,7 @@
     "path": "observability/grafana_universe_pulse_mini.json",
     "task": "Visualize UniversePulse metrics in Grafana",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement PIIRedactor utility",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12995,7 +12995,7 @@
   path: observability/grafana_universe_pulse_mini.json
   task: Visualize UniversePulse metrics in Grafana
   test: ''
-  status: open
+  status: done
 - commit: Implement PIIRedactor utility
   path: packages/security/PIIRedactor.ts
   task: Mask phone numbers, emails and card numbers in text

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5699,9 +5699,7 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "feedbackcodex.md",
-    "repositorypflege/__tests__/parse-md-todos.test.js",
-    "repositorypflege/parse-md-todos.js"
+    "observability/grafana_universe_pulse_mini.json"
   ],
-  "lastUpdated": "2025-08-23T13:07:39.743Z"
+  "lastUpdated": "2025-08-23T14:11:27.744Z"
 }

--- a/observability/grafana_universe_pulse_mini.json
+++ b/observability/grafana_universe_pulse_mini.json
@@ -1,0 +1,21 @@
+{
+  "dashboard": {
+    "id": null,
+    "title": "Universe Pulse Mini",
+    "panels": [
+      {
+        "type": "timeseries",
+        "title": "Pulse Rate",
+        "datasource": "Prometheus",
+        "targets": [
+          { "expr": "universe_pulse_rate" }
+        ],
+        "fieldConfig": { "defaults": {} }
+      }
+    ],
+    "schemaVersion": 39,
+    "version": 1
+  },
+  "overwrite": true
+}
+


### PR DESCRIPTION
## Summary
- mark Grafana dashboard task complete in advancedToDo lists
- record changes in advancedprogress and add mini Universe Pulse dashboard JSON

## Testing
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a9cb94a3b48322924c89c151e151bc