### PR TITLE
feat: add waveform option to CREP sonification

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "docs: outline research protocols",
+  "lastCommit": "feat: add waveform option to CREP sonification",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events | Added JetStream KV/ObjectStore wrappers and tool loader",
+  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events | Added JetStream KV/ObjectStore wrappers and tool loader | Added waveform option to CREP sonification",
   "pendingTasks": [
     {
       "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129",
@@ -5697,9 +5697,8 @@
     }
   ],
   "changedFiles": [
-    "advancedToDo.json",
-    "advancedToDo.yaml",
-    "observability/grafana_universe_pulse_mini.json"
+    "packages/visuals/RealTimeCREPSonification.ts",
+    "packages/visuals/__tests__/RealTimeCREPSonification.test.ts"
   ],
-  "lastUpdated": "2025-08-23T14:11:27.744Z"
+  "lastUpdated": "2025-08-23T14:27:14.744Z"
 }

--- a/packages/visuals/RealTimeCREPSonification.ts
+++ b/packages/visuals/RealTimeCREPSonification.ts
@@ -8,11 +8,13 @@ export interface SonifyOptions {
   ctx?: AudioContext;
   /** Output volume 0..1 */
   volume?: number;
+  /** Waveform type for the oscillator */
+  type?: OscillatorType;
 }
 
 export function sonifyCREP(
   crep: number,
-  { duration = 0.5, ctx, volume = 1 }: SonifyOptions = {}
+  { duration = 0.5, ctx, volume = 1, type = 'sine' }: SonifyOptions = {}
 ): OscillatorNode | undefined {
   const AudioCtx =
     (typeof window !== 'undefined' &&
@@ -30,6 +32,7 @@ export function sonifyCREP(
   const osc = audioCtx.createOscillator();
   const gain = audioCtx.createGain();
   gain.gain.value = volume;
+  osc.type = type;
   osc.frequency.value = 220 + crep * 220;
   osc.connect(gain);
   gain.connect(audioCtx.destination);

--- a/packages/visuals/__tests__/RealTimeCREPSonification.test.ts
+++ b/packages/visuals/__tests__/RealTimeCREPSonification.test.ts
@@ -10,7 +10,7 @@ test('creates oscillator with mapped frequency', () => {
       connect: oscConnect,
       start,
       stop,
-    }),
+    }) as any,
     createGain: () => gainNode,
     destination: {},
     currentTime: 0,
@@ -19,11 +19,12 @@ test('creates oscillator with mapped frequency', () => {
     return ctx;
   } as any;
   const { sonifyCREP } = require('../RealTimeCREPSonification');
-  const osc = sonifyCREP(0.5, { duration: 1, volume: 0.3 });
+  const osc = sonifyCREP(0.5, { duration: 1, volume: 0.3, type: 'square' });
   expect(osc.frequency.value).toBeCloseTo(330);
   expect(start).toHaveBeenCalled();
   expect(stop).toHaveBeenCalledWith(1);
   expect(gainNode.gain.value).toBeCloseTo(0.3);
+  expect(osc.type).toBe('square');
   expect(oscConnect).toHaveBeenCalledWith(gainNode);
   expect(gainConnect).toHaveBeenCalledWith(ctx.destination);
 });


### PR DESCRIPTION
## Summary
- support custom oscillator waveforms when sonifying CREP values
- note progress of waveform option in advancedprogress log

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `pnpm test packages/visuals/__tests__/RealTimeCREPSonification.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a9cf12b14c832285e1b70471e6009c