### PR TITLE
feat: add limit to newadvanced conversations parser

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5688,6 +5688,10 @@
     {
       "commit": "Provide KEDA autoscaling template",
       "status": "done"
+    },
+    {
+      "commit": "feat: add limit option to newadvanced-conversations parser",
+      "status": "done"
     }
   ],
   "fractalTodos": [
@@ -5697,8 +5701,9 @@
     }
   ],
   "changedFiles": [
-    "packages/visuals/RealTimeCREPSonification.ts",
-    "packages/visuals/__tests__/RealTimeCREPSonification.test.ts"
+    "scripts/parse-newadvanced-conversations.js",
+    "packages/shared-utils/jsonFragmenter.ts",
+    "packages/shared-utils/jsonFragmenter.js"
   ],
-  "lastUpdated": "2025-08-23T14:27:14.744Z"
+  "lastUpdated": "2025-08-23T16:17:12Z"
 }

--- a/packages/shared-utils/jsonFragmenter.js
+++ b/packages/shared-utils/jsonFragmenter.js
@@ -58,14 +58,22 @@ function writeJsonChunks(filePath, destDir, chunkSize) {
  * @param filePath Input JSON array file.
  * @param destDir Destination directory for grep result file.
  * @param pattern Regular expression used to match items.
+ * @param limit Optional maximum number of matches to return.
  */
-function grepJsonArrayFile(filePath, destDir, pattern) {
+function grepJsonArrayFile(filePath, destDir, pattern, limit) {
     const raw = fs_1.default.readFileSync(filePath, 'utf8');
     const data = JSON.parse(raw);
     if (!Array.isArray(data)) {
         throw new Error('Input JSON must be an array');
     }
-    const matches = data.filter(item => pattern.test(JSON.stringify(item)));
+    const matches = [];
+    for (const item of data) {
+        if (pattern.test(JSON.stringify(item))) {
+            matches.push(item);
+            if (limit && matches.length >= limit)
+                break;
+        }
+    }
     if (!fs_1.default.existsSync(destDir))
         fs_1.default.mkdirSync(destDir, { recursive: true });
     const base = filePath.replace(/\.json$/i, '');

--- a/packages/shared-utils/jsonFragmenter.ts
+++ b/packages/shared-utils/jsonFragmenter.ts
@@ -50,14 +50,26 @@ export function writeJsonChunks(filePath: string, destDir: string, chunkSize: nu
  * @param filePath Input JSON array file.
  * @param destDir Destination directory for grep result file.
  * @param pattern Regular expression used to match items.
+ * @param limit Optional maximum number of matches to return.
  */
-export function grepJsonArrayFile<T>(filePath: string, destDir: string, pattern: RegExp): T[] {
+export function grepJsonArrayFile<T>(
+  filePath: string,
+  destDir: string,
+  pattern: RegExp,
+  limit?: number
+): T[] {
   const raw = fs.readFileSync(filePath, 'utf8');
   const data: T[] = JSON.parse(raw);
   if (!Array.isArray(data)) {
     throw new Error('Input JSON must be an array');
   }
-  const matches = data.filter(item => pattern.test(JSON.stringify(item)));
+  const matches: T[] = [];
+  for (const item of data) {
+    if (pattern.test(JSON.stringify(item))) {
+      matches.push(item);
+      if (limit && matches.length >= limit) break;
+    }
+  }
   if (!fs.existsSync(destDir)) fs.mkdirSync(destDir, { recursive: true });
   const base = filePath.replace(/\.json$/i, '');
   const outPath = `${destDir}/${base.split('/').pop()}-grep.json`;

--- a/scripts/parse-newadvanced-conversations.js
+++ b/scripts/parse-newadvanced-conversations.js
@@ -38,9 +38,9 @@ function extractSessionTodos(filePath, titles) {
 }
 
 function parseNewAdvancedConversations(filePath, destDir, keyword = 'TODO', options = {}) {
-  const { writeYaml = false } = options;
+  const { writeYaml = false, limit } = options;
   const regex = new RegExp(keyword, 'i');
-  const matches = grepJsonArrayFile(filePath, destDir, regex);
+  const matches = grepJsonArrayFile(filePath, destDir, regex, limit);
   if (writeYaml) {
     const base = filePath.replace(/\.json$/i, '');
     const outPath = path.join(destDir, `${path.basename(base)}-grep.yaml`);
@@ -61,6 +61,7 @@ if (require.main === module) {
       'Programm testen Feedback',
     ],
     yaml: false,
+    limit: undefined,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -90,6 +91,10 @@ if (require.main === module) {
       case '--yaml':
         opts.yaml = true;
         break;
+      case '--limit':
+      case '-n':
+        opts.limit = parseInt(args[++i], 10);
+        break;
       default:
         // legacy positional keyword
         if (!arg.startsWith('-')) opts.keyword = arg;
@@ -105,7 +110,7 @@ if (require.main === module) {
     fs.writeFileSync(outYaml, yaml.dump(tasks));
     console.log(`Extracted ${tasks.length} tasks to ${outJson}`);
   } else {
-    const matches = parseNewAdvancedConversations(opts.file, opts.dest, opts.keyword, { writeYaml: opts.yaml });
+    const matches = parseNewAdvancedConversations(opts.file, opts.dest, opts.keyword, { writeYaml: opts.yaml, limit: opts.limit });
     console.log(`Parsed ${matches.length} fragments containing '${opts.keyword}'. Output: ${opts.dest}`);
   }
 }


### PR DESCRIPTION
## Summary
- allow limiting matches when grepping large newadvanced conversation arrays
- expose `--limit` flag on `parse-newadvanced-conversations` script
- track change in `advancedprogress.json`

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `poetry install --with test`
- `pnpm install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e90f79608322828ae2a6b813fc62