### PR TITLE
feat: include advancedToDo parts in task list

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5701,9 +5701,9 @@
     }
   ],
   "changedFiles": [
-    "scripts/parse-newadvanced-conversations.js",
-    "packages/shared-utils/jsonFragmenter.ts",
-    "packages/shared-utils/jsonFragmenter.js"
+    "docs/sigils/advancedprogress-guide.md",
+    "repositorypflege/__tests__/list-open-advanced-todos.test.js",
+    "repositorypflege/list-open-advanced-todos.js"
   ],
-  "lastUpdated": "2025-08-23T16:17:12Z"
+  "lastUpdated": "2025-08-23T16:38:54.926Z"
 }

--- a/docs/sigils/advancedprogress-guide.md
+++ b/docs/sigils/advancedprogress-guide.md
@@ -10,9 +10,10 @@ Run the maintenance script after making changes:
 node repositorypflege/update-advanced-progress.js
 ```
 
-The script now records a `changedFiles` list which captures the files currently
-modified in the working tree and stamps a `lastUpdated` timestamp. This helps
-trace fractal updates across commits.
+The script collects open items from `advancedToDo.json`, `advancedToDo.yaml`
+and every fragment in `advancedToDo_parts/`. It also records a `changedFiles`
+list capturing the files currently modified in the working tree and stamps a
+`lastUpdated` timestamp. This helps trace fractal updates across commits.
 
 ## Handling Large Conversation Files
 

--- a/repositorypflege/__tests__/list-open-advanced-todos.test.js
+++ b/repositorypflege/__tests__/list-open-advanced-todos.test.js
@@ -37,6 +37,23 @@ test('combines tasks from multiple JSON and YAML files', () => {
   fs.unlinkSync(tmpYaml);
 });
 
+test('reads tasks from directory of part files', () => {
+  const tmpDir = path.join(__dirname, 'tmp-parts');
+  fs.mkdirSync(tmpDir);
+  const part1 = [{ commit: 'Part A', path: 'pa', status: 'open' }];
+  const part2 = [{ commit: 'Part B', path: 'pb', status: 'open' }];
+  fs.writeFileSync(path.join(tmpDir, 'part1.json'), JSON.stringify(part1, null, 2));
+  fs.writeFileSync(path.join(tmpDir, 'part2.yaml'), yaml.dump(part2));
+
+  const todos = listOpenAdvancedTodos(undefined, tmpDir);
+  expect(todos).toEqual([
+    { commit: 'Part A', path: 'pa' },
+    { commit: 'Part B', path: 'pb' }
+  ]);
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
 test('excludes tasks matching pattern', () => {
   const tmp = path.join(__dirname, 'tmp-exclude.json');
   const sample = [

--- a/repositorypflege/list-open-advanced-todos.js
+++ b/repositorypflege/list-open-advanced-todos.js
@@ -8,16 +8,36 @@ function readTodoFile(file) {
   return ext === '.yaml' || ext === '.yml' ? yaml.load(raw) : JSON.parse(raw);
 }
 
+function collectFiles(inputPaths) {
+  const files = [];
+  for (const p of inputPaths) {
+    if (!fs.existsSync(p)) continue;
+    const stat = fs.statSync(p);
+    if (stat.isDirectory()) {
+      for (const f of fs.readdirSync(p)) {
+        if (/\.(json|ya?ml)$/i.test(f)) {
+          files.push(path.join(p, f));
+        }
+      }
+    } else {
+      files.push(p);
+    }
+  }
+  return files;
+}
+
 function listOpenAdvancedTodos(pattern, todoPaths, excludePattern) {
-  const files =
+  const basePaths =
     todoPaths && todoPaths.length
       ? Array.isArray(todoPaths)
         ? todoPaths
         : [todoPaths]
       : [
           path.resolve(__dirname, '..', 'advancedToDo.json'),
-          path.resolve(__dirname, '..', 'advancedToDo.yaml')
+          path.resolve(__dirname, '..', 'advancedToDo.yaml'),
+          path.resolve(__dirname, '..', 'advancedToDo_parts')
         ];
+  const files = collectFiles(basePaths);
   let data = [];
   for (const file of files) {
     if (fs.existsSync(file)) {


### PR DESCRIPTION
## Summary
- extend advanced todo listing to scan `advancedToDo_parts` fragments
- document the new fragment support in the advanced progress guide
- sync `advancedprogress.json` with latest changes and tests

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest repositorypflege/__tests__/list-open-advanced-todos.test.js`
- `node repositorypflege/update-advanced-progress.js`


------
https://chatgpt.com/codex/tasks/task_e_68a9ed9883708322a4becff47c399d8a