### PR TITLE
feat: add feature flag service and seed script

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12994,14 +12994,14 @@
     "path": "packages/featureflags/FeatureFlags.ts",
     "task": "Read and write toggle values via JetStream KV",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Seed feature flags script",
     "path": "scripts/feature-flags-seed.ts",
     "task": "Populate KV store with default flags",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement ExperimentRegistry",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13011,12 +13011,12 @@
   path: packages/featureflags/FeatureFlags.ts
   task: Read and write toggle values via JetStream KV
   test: ''
-  status: open
+  status: done
 - commit: Seed feature flags script
   path: scripts/feature-flags-seed.ts
   task: Populate KV store with default flags
   test: ''
-  status: open
+  status: done
 - commit: Implement ExperimentRegistry
   path: packages/experiments/ExperimentRegistry.ts
   task: Track experiment metadata and artifacts in JetStream

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5703,8 +5703,8 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "packages/agents/GermanGrammarAssistant.test.ts",
-    "packages/agents/GermanGrammarAssistant.ts"
+    "packages/featureflags/",
+    "scripts/feature-flags-seed.ts"
   ],
-  "lastUpdated": "2025-08-23T16:52:22.391Z"
+  "lastUpdated": "2025-08-23T17:10:45.549Z"
 }

--- a/packages/featureflags/FeatureFlags.ts
+++ b/packages/featureflags/FeatureFlags.ts
@@ -1,0 +1,35 @@
+import { JetStreamKV, type JetStreamKVOptions } from '../event-bus';
+
+export interface FeatureFlagsOptions extends JetStreamKVOptions {}
+
+/**
+ * Simple feature flag service backed by NATS JetStream KV buckets.
+ */
+export class FeatureFlags {
+  private kv: JetStreamKV;
+
+  constructor(opts: FeatureFlagsOptions) {
+    this.kv = new JetStreamKV(opts);
+  }
+
+  async connect() {
+    await this.kv.connect();
+  }
+
+  async set(name: string, enabled: boolean) {
+    await this.kv.put(name, { enabled });
+  }
+
+  async get(name: string): Promise<boolean | null> {
+    const data = await this.kv.get<{ enabled: boolean }>(name);
+    return data ? data.enabled : null;
+  }
+
+  async delete(name: string) {
+    await this.kv.delete(name);
+  }
+
+  async close() {
+    await this.kv.close();
+  }
+}

--- a/scripts/feature-flags-seed.ts
+++ b/scripts/feature-flags-seed.ts
@@ -1,0 +1,22 @@
+import { FeatureFlags } from '../packages/featureflags/FeatureFlags';
+
+async function main() {
+  const ff = new FeatureFlags({
+    servers: process.env.NATS_URL || 'nats://localhost:4222',
+    bucket: process.env.NATS_FEATURE_FLAGS_BUCKET || 'featureflags'
+  });
+  await ff.connect();
+  const defaults: Record<string, boolean> = {
+    'researchHub.enabled': true
+  };
+  for (const [name, enabled] of Object.entries(defaults)) {
+    await ff.set(name, enabled);
+  }
+  await ff.close();
+  console.log('Seeded feature flags');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add JetStream-backed FeatureFlags service for toggles
- provide feature-flag seed script with default flag
- mark corresponding advanced ToDo items as done and sync progress

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: venvPath /workspace/unified-mandala/.venv is not a valid directory)*
- `npx tsc -p tsconfig.json`
- `node repositorypflege/update-advanced-progress.js`


------
https://chatgpt.com/codex/tasks/task_e_68a9f50c1b5883229f23d9268918f9bf