### PR TITLE
feat(governance): add policy enforcer

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12791,7 +12791,7 @@
     "path": "packages/governance/PolicyEnforcer.ts",
     "task": "Restrict tools, models and subjects based on permissions.yaml",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Introduce HmacSigner for event envelopes",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12866,7 +12866,7 @@
   path: packages/governance/PolicyEnforcer.ts
   task: Restrict tools, models and subjects based on permissions.yaml
   test: ''
-  status: open
+  status: done
 - commit: Introduce HmacSigner for event envelopes
   path: packages/security/HmacSigner.ts
   task: Sign and verify events using shared secret

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5703,8 +5703,7 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "packages/featureflags/",
-    "scripts/feature-flags-seed.ts"
+    "packages/governance/"
   ],
-  "lastUpdated": "2025-08-23T17:10:45.549Z"
+  "lastUpdated": "2025-08-23T18:38:34.666Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -157,3 +157,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added dataset provenance, CREP research protocol, and research safety docs, syncing advanced progress.
 
 - Implemented Markdown ToDo parser and synced advanced ToDo progress.
+- Added PolicyEnforcer to enforce tool and model permissions from permissions.yaml.

--- a/packages/governance/PolicyEnforcer.test.ts
+++ b/packages/governance/PolicyEnforcer.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { PolicyEnforcer } from './PolicyEnforcer';
+
+describe('PolicyEnforcer', () => {
+  const enforcer = new PolicyEnforcer();
+
+  it('allows configured tool for agent', () => {
+    expect(enforcer.isAllowed('personhood-agent', 'tools', 'consent-registry')).toBe(true);
+  });
+
+  it('blocks unconfigured model for agent', () => {
+    expect(enforcer.isAllowed('personhood-agent', 'models', 'gpt-4o')).toBe(false);
+  });
+});

--- a/packages/governance/PolicyEnforcer.ts
+++ b/packages/governance/PolicyEnforcer.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import path from 'path';
+import YAML from 'yaml';
+
+export type PolicyType = 'tools' | 'models' | 'subjects';
+
+interface AgentPolicy {
+  tools?: string[];
+  models?: string[];
+  subjects?: string[];
+}
+
+interface PermissionsFile {
+  agents?: Record<string, AgentPolicy>;
+}
+
+export class PolicyEnforcer {
+  private policies: Record<string, AgentPolicy>;
+
+  constructor(permissionsPath: string = path.resolve(process.cwd(), 'governance/permissions.yaml')) {
+    const raw = fs.readFileSync(permissionsPath, 'utf8');
+    const parsed: PermissionsFile = YAML.parse(raw) || {};
+    this.policies = parsed.agents || {};
+  }
+
+  isAllowed(agent: string, type: PolicyType, name: string): boolean {
+    const policy = this.policies[agent];
+    if (!policy) return false;
+    const list = policy[type] || [];
+    return list.includes(name);
+  }
+
+  enforce(agent: string, type: PolicyType, name: string): void {
+    if (!this.isAllowed(agent, type, name)) {
+      throw new Error(`${agent} not permitted to use ${type}: ${name}`);
+    }
+  }
+}
+
+export default PolicyEnforcer;


### PR DESCRIPTION
## Summary
- add PolicyEnforcer to load governance permissions and enforce tool/model access
- cover allowed and blocked cases with unit tests
- sync advanced todo/progress and note addition in feedback codex

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run packages/governance/PolicyEnforcer.test.ts` *(fails: No test files found)*
- `node repositorypflege/update-advanced-progress.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa08e1b34883229208efcc7d1dcb4b