### PR TITLE
test: add gpt5 smoke suite

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12483,7 +12483,7 @@
     "path": "tests/gpt5-smoke.test.ts",
     "task": "Verify JSON tool call, RAG answer and image caption using gpt-5",
     "test": "tests/gpt5-smoke.test.ts",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add voice intent cheat sheet and YAML mapping",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12642,7 +12642,7 @@
   path: tests/gpt5-smoke.test.ts
   task: Verify JSON tool call, RAG answer and image caption using gpt-5
   test: tests/gpt5-smoke.test.ts
-  status: open
+  status: done
 - commit: Add voice intent cheat sheet and YAML mapping
   path: voice_intents.yaml
   task: >-

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add GermanGrammarAssistant agent",
+  "lastCommit": "Add gpt-5 smoke test suite",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -5692,6 +5692,10 @@
     {
       "commit": "feat: add limit option to newadvanced-conversations parser",
       "status": "done"
+    },
+    {
+      "commit": "Add gpt-5 smoke test suite",
+      "status": "done"
     }
   ],
   "fractalTodos": [
@@ -5703,7 +5707,7 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "packages/governance/"
+    "tests/gpt5-smoke.test.ts"
   ],
-  "lastUpdated": "2025-08-23T18:38:34.666Z"
+  "lastUpdated": "2025-08-23T19:12:12.455Z"
 }

--- a/tests/gpt5-smoke.test.ts
+++ b/tests/gpt5-smoke.test.ts
@@ -1,0 +1,92 @@
+/*
+ * GPT-5 smoke test suite.
+ * These tests verify core capabilities of the gpt-5 model using the
+ * OpenAI Responses API. They are skipped automatically when no
+ * OPENAI_API_KEY is provided.
+ */
+
+const apiKey = process.env.OPENAI_API_KEY;
+const baseUrl = process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1';
+
+// Skip the entire suite if no API key is configured.
+const describeIf = apiKey ? describe : describe.skip;
+
+describeIf('gpt-5 smoke suite', () => {
+  async function callOpenAI(path: string, body: any) {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify(body)
+    });
+    expect(res.ok).toBe(true);
+    return (await res.json()) as any;
+  }
+
+  test('performs JSON tool call', async () => {
+    const result = await callOpenAI('/responses', {
+      model: 'gpt-5',
+      input: [{ role: 'user', content: 'Add 2 and 3.' }],
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'add',
+            parameters: {
+              type: 'object',
+              properties: {
+                a: { type: 'number' },
+                b: { type: 'number' }
+              },
+              required: ['a', 'b']
+            }
+          }
+        }
+      ],
+      tool_choice: { type: 'function', function: { name: 'add' } }
+    });
+    expect(result.output).toBeDefined();
+  });
+
+  test('answers using provided context', async () => {
+    const result = await callOpenAI('/responses', {
+      model: 'gpt-5',
+      input: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_text',
+              text: 'Context: The sky is blue.\nQuestion: What color is the sky?'
+            }
+          ]
+        }
+      ]
+    });
+    const text = result.output_text || result.output?.[0]?.content?.[0]?.text;
+    expect(typeof text).toBe('string');
+  });
+
+  test('generates an image caption', async () => {
+    const result = await callOpenAI('/responses', {
+      model: 'gpt-5',
+      input: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_image',
+              image_url:
+                'https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg'
+            },
+            { type: 'input_text', text: 'Describe the image' }
+          ]
+        }
+      ]
+    });
+    const text = result.output_text || result.output?.[0]?.content?.[0]?.text;
+    expect(typeof text).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary
- add gpt-5 smoke tests covering JSON tool call, RAG answer, and image caption
- mark gpt-5 smoke test TODOs as completed and log progress

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest tests/gpt5-smoke.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aa11b2888083228b5f3f08df89fca2