### PR TITLE
feat: add UniversePulse E2E demo

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12959,7 +12959,7 @@
     "path": "demos/universe_pulse_e2e.ts",
     "task": "Emit simulation events and log run metrics",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Provide Prometheus scrape config",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12986,7 +12986,7 @@
   path: demos/universe_pulse_e2e.ts
   task: Emit simulation events and log run metrics
   test: ''
-  status: open
+  status: done
 - commit: Provide Prometheus scrape config
   path: observability/prometheus.yml
   task: Scrape metrics server on :9108

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5707,7 +5707,7 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "tests/gpt5-smoke.test.ts"
+    "demos/"
   ],
-  "lastUpdated": "2025-08-23T19:12:12.455Z"
+  "lastUpdated": "2025-08-23T19:34:32.644Z"
 }

--- a/demos/universe_pulse_e2e.ts
+++ b/demos/universe_pulse_e2e.ts
@@ -1,0 +1,33 @@
+import { EventEmitter } from 'events';
+import { simulatePulse } from '../packages/universum-simulationen/UniversePulseSimulator';
+
+const emitter = new EventEmitter();
+
+// Log each pulse value when emitted
+emitter.on('pulse', ({ value, index }) => {
+  console.log(`pulse ${index}: ${value.toFixed(3)}`);
+});
+
+// Output final run metrics when simulation ends
+emitter.on('end', metrics => {
+  console.log('metrics', metrics);
+});
+
+function runSimulation(start: number, steps: number) {
+  const values = simulatePulse(start, steps);
+  let max = -Infinity;
+  let min = Infinity;
+  let sum = 0;
+
+  values.forEach((value, index) => {
+    emitter.emit('pulse', { value, index });
+    sum += value;
+    if (value > max) max = value;
+    if (value < min) min = value;
+  });
+
+  const avg = sum / values.length;
+  emitter.emit('end', { avg, max, min });
+}
+
+runSimulation(0, 50);


### PR DESCRIPTION
## Summary
- add UniversePulse end-to-end demo emitting pulses and logging metrics
- mark UniversePulse demo task as complete and sync progress tracker

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68aa174aa4188322b300ed7362c65c3b