### PR TITLE
feat: add pipeline orchestrator and universe pulse pipeline

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12945,14 +12945,14 @@
     "path": "packages/orchestrator/PipelineOrchestrator.ts",
     "task": "Execute YAML-defined steps sequentially",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add universe pulse pipeline",
     "path": "pipelines/universe_pulse.yaml",
     "task": "Configure demo pipeline steps for UniversePulse",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add UniversePulse E2E demo",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12976,12 +12976,12 @@
   path: packages/orchestrator/PipelineOrchestrator.ts
   task: Execute YAML-defined steps sequentially
   test: ''
-  status: open
+  status: done
 - commit: Add universe pulse pipeline
   path: pipelines/universe_pulse.yaml
   task: Configure demo pipeline steps for UniversePulse
   test: ''
-  status: open
+  status: done
 - commit: Add UniversePulse E2E demo
   path: demos/universe_pulse_e2e.ts
   task: Emit simulation events and log run metrics

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5707,7 +5707,9 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "demos/"
+    "packages/orchestrator/PipelineOrchestrator.ts",
+    "pipelines/",
+    "scripts/metrics-push.ts"
   ],
-  "lastUpdated": "2025-08-23T19:34:32.644Z"
+  "lastUpdated": "2025-08-23T20:07:41.828Z"
 }

--- a/packages/orchestrator/PipelineOrchestrator.ts
+++ b/packages/orchestrator/PipelineOrchestrator.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "fs";
+import yaml from "yaml";
+
+type Step = { id: string; uses: string; with?: Record<string, any> };
+type Pipeline = { id: string; steps: Step[] };
+
+export class PipelineOrchestrator {
+  async run(file: string) {
+    const p = yaml.parse(readFileSync(file, "utf8")) as Pipeline;
+    console.log("[UM] Pipeline:", p.id);
+    for (const s of p.steps) {
+      console.log("  ·", s.id, "=>", s.uses);
+      // Demo: call by convention (scripts/<uses>.ts) with args
+      const mod = await import(`${process.cwd()}/scripts/${s.uses}.ts`).catch(() => null);
+      if (mod && typeof (mod as any).default === "function") {
+        await (mod as any).default(s.with || {});
+      } else {
+        console.log("    (stub) no-op");
+      }
+    }
+  }
+}

--- a/pipelines/universe_pulse.yaml
+++ b/pipelines/universe_pulse.yaml
@@ -1,0 +1,8 @@
+id: universe-pulse-demo
+steps:
+  - id: run-sim
+    uses: runlog-demo   # calls scripts/runlog-demo.ts default export if present
+    with: { steps: 25, dt: 0.05 }
+  - id: push-metrics
+    uses: metrics-push
+    with: { file: "data/simulations/runs/universe-pulse-v1.jsonl" }

--- a/scripts/metrics-push.ts
+++ b/scripts/metrics-push.ts
@@ -1,0 +1,3 @@
+export default async function metrics_push({ file = "data/simulations/runs/universe-pulse-v1.jsonl" }) {
+  console.log("[UM] (stub) metrics push from", file);
+}


### PR DESCRIPTION
## Summary
- add PipelineOrchestrator to run YAML pipelines and call step scripts
- provide universe_pulse pipeline spec and stub metrics-push script
- mark related tasks as done and update advanced progress tracking

## Testing
- `poetry install --with test`
- `pnpm install`
- `node repositorypflege/update-advanced-progress.js`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68aa1e5eefac8322bc07e845ff43952d