### PR TITLE
feat: add advanced todo report

### DIFF
--- a/docs/sigils/advancedprogress-guide.md
+++ b/docs/sigils/advancedprogress-guide.md
@@ -15,6 +15,17 @@ and every fragment in `advancedToDo_parts/`. It also records a `changedFiles`
 list capturing the files currently modified in the working tree and stamps a
 `lastUpdated` timestamp. This helps trace fractal updates across commits.
 
+## Generating Reports
+
+To view open tasks grouped by their directories, run:
+
+```bash
+node repositorypflege/advanced-todo-report.js
+```
+
+This summarizes open items per folder without touching the large conversation
+datasets.
+
 ## Handling Large Conversation Files
 
 Datasets such as `newadvancedconversations.json` in this directory are

--- a/repositorypflege/__tests__/advanced-todo-report.test.js
+++ b/repositorypflege/__tests__/advanced-todo-report.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const { groupTodosByDir } = require('../advanced-todo-report');
+
+test('groups open todos by directory', () => {
+  const tmp = path.join(__dirname, 'tmp-report.json');
+  const sample = [
+    { commit: 'Task A', path: 'a/file1', status: 'open' },
+    { commit: 'Task B', path: 'a/file2', status: 'open' },
+    { commit: 'Task C', path: 'b/file3', status: 'open' },
+    { commit: 'Task D', path: 'b/file4', status: 'done' }
+  ];
+  fs.writeFileSync(tmp, JSON.stringify(sample, null, 2));
+
+  const grouped = groupTodosByDir(undefined, tmp);
+  expect(grouped).toEqual({
+    a: [
+      { commit: 'Task A', path: 'a/file1' },
+      { commit: 'Task B', path: 'a/file2' }
+    ],
+    b: [
+      { commit: 'Task C', path: 'b/file3' }
+    ]
+  });
+
+  fs.unlinkSync(tmp);
+});

--- a/repositorypflege/advanced-todo-report.js
+++ b/repositorypflege/advanced-todo-report.js
@@ -1,0 +1,29 @@
+const path = require('path');
+const { listOpenAdvancedTodos } = require('./list-open-advanced-todos');
+
+function groupTodosByDir(pattern, todoPaths, excludePattern) {
+  const todos = listOpenAdvancedTodos(pattern, todoPaths, excludePattern);
+  return todos.reduce((acc, t) => {
+    const dir = path.dirname(t.path || '').replace(/\\/g, '/');
+    if (!acc[dir]) acc[dir] = [];
+    acc[dir].push(t);
+    return acc;
+  }, {});
+}
+
+if (require.main === module) {
+  const grepIndex = process.argv.indexOf('--grep');
+  const pattern = grepIndex >= 0 ? process.argv[grepIndex + 1] : undefined;
+  const pathIndex = process.argv.indexOf('--path');
+  const todoPaths = pathIndex >= 0 ? process.argv[pathIndex + 1].split(',') : undefined;
+  const exclIndex = process.argv.indexOf('--exclude');
+  const exclude = exclIndex >= 0 ? process.argv[exclIndex + 1] : undefined;
+
+  const grouped = groupTodosByDir(pattern, todoPaths, exclude);
+  for (const [dir, tasks] of Object.entries(grouped)) {
+    console.log(`${dir}:`);
+    tasks.forEach((t) => console.log(`  - ${t.commit}`));
+  }
+}
+
+module.exports = { groupTodosByDir };


### PR DESCRIPTION
## Summary
- add `advanced-todo-report.js` to group open advanced todos by directory
- document report script in advanced progress guide
- test report grouping logic

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test repositorypflege/__tests__/advanced-todo-report.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa20fa8a5c8322be1bab4de5b1cbf7