### PR TITLE
feat: add ChannelScribe utility

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2841,7 +2841,8 @@
     "commit": "feat: implement ChannelScribe utility",
     "path": "packages/core/ChannelScribe.ts",
     "task": "Record conversation channels and transitions",
-    "test": "packages/core/__tests__/ChannelScribe.test.ts"
+    "test": "packages/core/__tests__/ChannelScribe.test.ts",
+    "status": "done"
   },
   {
     "commit": "feat: add S07_Supernova_Strahlungseinfluss simulation",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4605,6 +4605,7 @@
   path: packages/core/ChannelScribe.ts
   task: Record conversation channels and transitions
   test: packages/core/__tests__/ChannelScribe.test.ts
+  status: done
 - commit: 'feat: add S07_Supernova_Strahlungseinfluss simulation'
   path: packages/universum-simulationen/modules/S07_Supernova_Strahlungseinfluss.py
   task: Simulate supernova radiation effects on environment

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -4814,6 +4814,10 @@
     {
       "commit": "Write research safety guidelines",
       "status": "done"
+    },
+    {
+      "commit": "feat: implement ChannelScribe utility",
+      "status": "done"
     }
   ],
   "completed": [
@@ -5707,9 +5711,9 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "packages/orchestrator/PipelineOrchestrator.ts",
-    "pipelines/",
-    "scripts/metrics-push.ts"
+    "feedbackcodex.md",
+    "packages/core/ChannelScribe.ts",
+    "packages/core/__tests__/ChannelScribe.test.ts"
   ],
-  "lastUpdated": "2025-08-23T20:07:41.828Z"
+  "lastUpdated": "2025-08-23T20:35:59.378Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -158,3 +158,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 
 - Implemented Markdown ToDo parser and synced advanced ToDo progress.
 - Added PolicyEnforcer to enforce tool and model permissions from permissions.yaml.
+- Implemented ChannelScribe utility with log and clear capabilities.

--- a/packages/core/ChannelScribe.ts
+++ b/packages/core/ChannelScribe.ts
@@ -1,0 +1,30 @@
+export interface ChannelEntry {
+  channel: string;
+  message: string;
+  timestamp: number;
+}
+
+/**
+ * ChannelScribe records messages per channel with timestamps.
+ * It can return logs for a specific channel or all channels and
+ * allows clearing logs.
+ */
+export class ChannelScribe {
+  private log: ChannelEntry[] = [];
+
+  record(channel: string, message: string): void {
+    this.log.push({ channel, message, timestamp: Date.now() });
+  }
+
+  getLog(channel?: string): ChannelEntry[] {
+    return channel ? this.log.filter((e) => e.channel === channel) : [...this.log];
+  }
+
+  clear(channel?: string): void {
+    if (channel) {
+      this.log = this.log.filter((e) => e.channel !== channel);
+    } else {
+      this.log = [];
+    }
+  }
+}

--- a/packages/core/__tests__/ChannelScribe.test.ts
+++ b/packages/core/__tests__/ChannelScribe.test.ts
@@ -1,0 +1,27 @@
+import { ChannelScribe } from '../ChannelScribe';
+
+describe('ChannelScribe', () => {
+  it('records and retrieves channel messages', () => {
+    const scribe = new ChannelScribe();
+    scribe.record('alpha', 'hello');
+    scribe.record('beta', 'world');
+    scribe.record('alpha', 'again');
+
+    const alphaLog = scribe.getLog('alpha');
+    expect(alphaLog).toHaveLength(2);
+    expect(alphaLog.map((e) => e.message)).toEqual(['hello', 'again']);
+
+    const all = scribe.getLog();
+    expect(all).toHaveLength(3);
+  });
+
+  it('clears channel logs', () => {
+    const scribe = new ChannelScribe();
+    scribe.record('alpha', 'msg');
+    scribe.clear('alpha');
+    expect(scribe.getLog('alpha')).toHaveLength(0);
+    scribe.record('beta', 'msg');
+    scribe.clear();
+    expect(scribe.getLog()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- implement ChannelScribe utility for channel-based logging
- add tests for ChannelScribe and mark related advanced tasks as done
- sync advanced progress and note change in feedback codex

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest packages/core/__tests__/ChannelScribe.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aa25308a688322b320869a431a707e