### PR TITLE
feat: add feature flags panel

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13072,7 +13072,7 @@
     "path": "packages/unifiedmandala-ui/components/FeatureFlagsPanel.tsx",
     "task": "Render toggle switches for feature flags",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement experiments API",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13067,7 +13067,7 @@
   path: packages/unifiedmandala-ui/components/FeatureFlagsPanel.tsx
   task: Render toggle switches for feature flags
   test: ''
-  status: open
+  status: done
 - commit: Implement experiments API
   path: scripts/experiments-api.ts
   task: Serve experiment metadata and comparisons with personhood checks

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Add gpt-5 smoke test suite",
+  "lastCommit": "Add FeatureFlagsPanel component",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4818,6 +4818,10 @@
     {
       "commit": "feat: implement ChannelScribe utility",
       "status": "done"
+    },
+    {
+      "commit": "Add FeatureFlagsPanel component",
+      "status": "done"
     }
   ],
   "completed": [
@@ -5712,8 +5716,8 @@
     "advancedToDo.json",
     "advancedToDo.yaml",
     "feedbackcodex.md",
-    "packages/core/ChannelScribe.ts",
-    "packages/core/__tests__/ChannelScribe.test.ts"
+    "packages/unifiedmandala-ui/components/FeatureFlagsPanel.test.tsx",
+    "packages/unifiedmandala-ui/components/FeatureFlagsPanel.tsx"
   ],
-  "lastUpdated": "2025-08-23T20:35:59.378Z"
+  "lastUpdated": "2025-08-23T21:12:01.462Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -159,3 +159,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented Markdown ToDo parser and synced advanced ToDo progress.
 - Added PolicyEnforcer to enforce tool and model permissions from permissions.yaml.
 - Implemented ChannelScribe utility with log and clear capabilities.
+- Added FeatureFlagsPanel component to toggle feature flags in UI.

--- a/packages/unifiedmandala-ui/components/FeatureFlagsPanel.test.tsx
+++ b/packages/unifiedmandala-ui/components/FeatureFlagsPanel.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import FeatureFlagsPanel from './FeatureFlagsPanel';
+
+test('renders and toggles feature flags', async () => {
+  const fetchMock = jest.fn()
+    .mockResolvedValueOnce({
+      json: async () => ({ flags: [{ name: 'researchHub.enabled', enabled: false }] })
+    })
+    .mockResolvedValueOnce({});
+  // @ts-ignore
+  global.fetch = fetchMock;
+
+  render(<FeatureFlagsPanel />);
+
+  await waitFor(() => screen.getByLabelText('flag-researchHub.enabled'));
+  const checkbox = screen.getByLabelText('flag-researchHub.enabled') as HTMLInputElement;
+  expect(checkbox.checked).toBe(false);
+  fireEvent.click(checkbox);
+  expect(fetchMock).toHaveBeenLastCalledWith('/flags', expect.any(Object));
+});

--- a/packages/unifiedmandala-ui/components/FeatureFlagsPanel.tsx
+++ b/packages/unifiedmandala-ui/components/FeatureFlagsPanel.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+
+interface Flag {
+  name: string;
+  enabled: boolean;
+}
+
+/**
+ * FeatureFlagsPanel renders toggle switches for feature flags.
+ * It fetches flag states from `/flags` and posts updates back to the same endpoint.
+ * Guidance sourced from `newadvancedconversations.json` snippets.
+ */
+export default function FeatureFlagsPanel() {
+  const [flags, setFlags] = useState<Flag[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/flags')
+      .then((r) => r.json())
+      .then((json) => {
+        setFlags(json.flags || []);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  const toggle = (name: string, enabled: boolean) => {
+    fetch('/flags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, enabled })
+    }).then(() =>
+      setFlags((prev) =>
+        prev.map((f) => (f.name === name ? { ...f, enabled } : f))
+      )
+    );
+  };
+
+  if (loading) {
+    return <div aria-label="FeatureFlagsPanel">Loading...</div>;
+  }
+
+  return (
+    <div aria-label="FeatureFlagsPanel">
+      <ul>
+        {flags.map((flag) => (
+          <li key={flag.name}>
+            <label>
+              <input
+                aria-label={`flag-${flag.name}`}
+                type="checkbox"
+                checked={flag.enabled}
+                onChange={(e) => toggle(flag.name, e.target.checked)}
+              />
+              {flag.name}
+            </label>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add FeatureFlagsPanel component with toggle controls
- mark FeatureFlagsPanel task as complete in advanced ToDo files
- sync advanced progress and feedback notes

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/unifiedmandala-ui/components/FeatureFlagsPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68aa2e002cc88322bdb35171cdcb646d