### PR TITLE
feat: add flags API server

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13065,7 +13065,7 @@
     "path": "scripts/flags-api.ts",
     "task": "Expose HTTP API to toggle feature flags via KV",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add FeatureFlagsPanel component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13062,7 +13062,7 @@
   path: scripts/flags-api.ts
   task: Expose HTTP API to toggle feature flags via KV
   test: ''
-  status: open
+  status: done
 - commit: Add FeatureFlagsPanel component
   path: packages/unifiedmandala-ui/components/FeatureFlagsPanel.tsx
   task: Render toggle switches for feature flags

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5716,8 +5716,7 @@
     "advancedToDo.json",
     "advancedToDo.yaml",
     "feedbackcodex.md",
-    "packages/unifiedmandala-ui/components/FeatureFlagsPanel.test.tsx",
-    "packages/unifiedmandala-ui/components/FeatureFlagsPanel.tsx"
+    "scripts/flags-api.ts"
   ],
-  "lastUpdated": "2025-08-23T21:12:01.462Z"
+  "lastUpdated": "2025-08-23T21:37:53.288Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -160,3 +160,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added PolicyEnforcer to enforce tool and model permissions from permissions.yaml.
 - Implemented ChannelScribe utility with log and clear capabilities.
 - Added FeatureFlagsPanel component to toggle feature flags in UI.
+- Implemented flags API server for HTTP-based feature toggles.

--- a/scripts/flags-api.ts
+++ b/scripts/flags-api.ts
@@ -1,0 +1,45 @@
+import express from 'express';
+import { FeatureFlags } from '../packages/featureflags/FeatureFlags';
+
+async function main() {
+  const app = express();
+  app.use(express.json());
+
+  const ff = new FeatureFlags({
+    servers: process.env.NATS_URL || 'nats://localhost:4222',
+    bucket: process.env.NATS_FEATURE_FLAGS_BUCKET || 'featureflags'
+  });
+  await ff.connect();
+
+  app.get('/flags/:name', async (req, res) => {
+    const enabled = await ff.get(req.params.name);
+    if (enabled === null) {
+      return res.status(404).json({ error: 'not found' });
+    }
+    res.json({ name: req.params.name, enabled });
+  });
+
+  app.put('/flags/:name', async (req, res) => {
+    const { enabled } = req.body;
+    if (typeof enabled !== 'boolean') {
+      return res.status(400).json({ error: 'enabled boolean required' });
+    }
+    await ff.set(req.params.name, enabled);
+    res.json({ status: 'ok' });
+  });
+
+  app.delete('/flags/:name', async (req, res) => {
+    await ff.delete(req.params.name);
+    res.json({ status: 'deleted' });
+  });
+
+  const port = parseInt(process.env.PORT || '3000', 10);
+  app.listen(port, () => {
+    console.log(`Flags API server listening on ${port}`);
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- implement minimal Express-based feature flags API
- mark flags API task as done in advanced ToDo trackers
- document new API in feedback codex and sync progress

## Testing
- `node repositorypflege/update-advanced-progress.js`
- `npx pyright scripts/flags-api.ts`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68aa340a2d8c8322b50df4efc4a7e983