### PR TITLE
feat: add share api server

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13394,7 +13394,7 @@
     "path": "scripts/share-api.ts",
     "task": "Serve signed links for object store artifacts",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add RealtimeResearchHub UI component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13297,7 +13297,7 @@
   path: scripts/share-api.ts
   task: Serve signed links for object store artifacts
   test: ''
-  status: open
+  status: done
 - commit: Add RealtimeResearchHub UI component
   path: packages/unifiedmandala-ui/components/RealtimeResearchHub.tsx
   task: Display live retrieval hits and streamed answers

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5715,8 +5715,7 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "feedbackcodex.md",
-    "scripts/flags-api.ts"
+    "scripts/share-api.ts"
   ],
-  "lastUpdated": "2025-08-23T21:37:53.288Z"
+  "lastUpdated": "2025-08-23T21:47:34.033Z"
 }

--- a/scripts/share-api.ts
+++ b/scripts/share-api.ts
@@ -1,0 +1,39 @@
+import express from 'express';
+import { SignedURL } from '../packages/security/SignedURL';
+
+async function main() {
+  const app = express();
+  app.use(express.json());
+
+  const secret = process.env.SHARE_SECRET || 'change-me';
+  const signer = new SignedURL(secret);
+
+  app.post('/sign', (req, res) => {
+    const { url, expiresIn } = req.body;
+    if (typeof url !== 'string' || typeof expiresIn !== 'number') {
+      return res.status(400).json({ error: 'url (string) and expiresIn (number) required' });
+    }
+    const signed = signer.sign(url, expiresIn);
+    res.json({ url: signed });
+  });
+
+  app.get('/verify', (req, res) => {
+    const url = req.query.url;
+    if (typeof url !== 'string') {
+      return res.status(400).json({ error: 'url query parameter required' });
+    }
+    const valid = signer.verify(url);
+    res.json({ valid });
+  });
+
+  const port = parseInt(process.env.PORT || '3000', 10);
+  app.listen(port, () => {
+    console.log(`Share API server listening on ${port}`);
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
## Summary
- add express share API for signing and verifying expiring URLs
- mark share API todo items as complete and sync progress

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json --pretty false`
- `npx pyright`
- `node repositorypflege/update-advanced-progress.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa362ccf288322972631e0a24b937f