### PR TITLE
feat: add RefusalEngine and sync advanced progress

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-23, in der Zeit des Morgen.
+Am 2025-08-23, in der Zeit des Nacht.
 
-Symbolphase: Initiation (Fokus: C)
+Symbolphase: Reflexion (Fokus: P)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -12778,7 +12778,7 @@
     "path": "packages/gpt-bridges/providers/OpenAIProvider.ts",
     "task": "Use responses endpoint when USE_RESPONSES_API=1 and support tools",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Validate tool arguments with AJV",
@@ -13037,7 +13037,7 @@
     "path": "packages/personhood/ConsentRegistry.ts",
     "task": "Store and fetch consent records via JetStream KV",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement AuditTrail",
@@ -13050,8 +13050,8 @@
     "commit": "Add RefusalEngine",
     "path": "packages/personhood/RefusalEngine.ts",
     "task": "Generate structured refusal objects",
-    "test": "",
-    "status": "open"
+    "test": "tests/refusalengine.test.ts",
+    "status": "done"
   },
   {
     "commit": "Implement PolicyGuard",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12595,7 +12595,7 @@
   path: packages/personhood/ConsentRegistry.ts
   task: Store and fetch consent records via JetStream KV
   test: ""
-  status: open
+  status: done
 - commit: Implement AuditTrail
   path: packages/personhood/AuditTrail.ts
   task: Record signed personhood events to JSONL log
@@ -12604,8 +12604,8 @@
 - commit: Add RefusalEngine
   path: packages/personhood/RefusalEngine.ts
   task: Generate structured refusal objects
-  test: ""
-  status: open
+  test: tests/refusalengine.test.ts
+  status: done
 - commit: Implement PolicyGuard
   path: packages/personhood/PolicyGuard.ts
   task: Enforce consent, region, review and model rules

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1428 from GenesisAeon/codex/optimize-repository-and-implement-features-hmwxvp",
+  "lastCommit": "Merge pull request #1429 from GenesisAeon/codex/optimize-repository-structure-and-features-u0vymk",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -7,14 +7,6 @@
   "mergeConflicts": [],
   "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events | Added JetStream KV/ObjectStore wrappers and tool loader | Added waveform option to CREP sonification | Implemented GermanGrammarAssistant agent",
   "pendingTasks": [
-    {
-      "commit": "Implement ConsentRegistry",
-      "status": "open"
-    },
-    {
-      "commit": "Add RefusalEngine",
-      "status": "open"
-    },
     {
       "commit": "Implement experiments API",
       "status": "open"
@@ -5517,6 +5509,14 @@
     {
       "commit": "Create share API server",
       "status": "done"
+    },
+    {
+      "commit": "Implement ConsentRegistry",
+      "status": "done"
+    },
+    {
+      "commit": "Add RefusalEngine",
+      "status": "done"
     }
   ],
   "completed": [
@@ -6418,8 +6418,8 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "packages/experiments/ExperimentRegistry.ts",
-    "scripts/experiments-sample.ts"
+    "packages/personhood/RefusalEngine.ts",
+    "tests/refusalengine.test.ts"
   ],
-  "lastUpdated": "2025-08-23T23:06:42.839Z"
+  "lastUpdated": "2025-08-23T23:15:48.564Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -161,3 +161,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented ChannelScribe utility with log and clear capabilities.
 - Added FeatureFlagsPanel component to toggle feature flags in UI.
 - Implemented flags API server for HTTP-based feature toggles.
+- Implemented RefusalEngine to generate structured refusal objects and synced progress files.

--- a/packages/personhood/RefusalEngine.ts
+++ b/packages/personhood/RefusalEngine.ts
@@ -1,0 +1,23 @@
+export interface Refusal {
+  reason: string;
+  code?: string;
+  details?: Record<string, any>;
+  timestamp: string;
+}
+
+/**
+ * RefusalEngine generates structured refusal objects
+ * that can be logged or returned to clients.
+ */
+export class RefusalEngine {
+  static create(reason: string, code?: string, details?: Record<string, any>): Refusal {
+    return {
+      reason,
+      code,
+      details,
+      timestamp: new Date().toISOString()
+    };
+  }
+}
+
+export default RefusalEngine;

--- a/tests/refusalengine.test.ts
+++ b/tests/refusalengine.test.ts
@@ -1,0 +1,9 @@
+import { RefusalEngine } from '../packages/personhood/RefusalEngine';
+
+describe('RefusalEngine', () => {
+  it('creates structured refusal objects', () => {
+    const refusal = RefusalEngine.create('policy violation', 'POLICY');
+    expect(refusal).toMatchObject({ reason: 'policy violation', code: 'POLICY' });
+    expect(typeof refusal.timestamp).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary
- add `RefusalEngine` utility to emit structured refusal objects
- sync advanced ToDo and progress trackers, marking personhood registry tasks as complete
- note RefusalEngine addition in feedback codex

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false --diagnostics`
- `npx jest tests/refusalengine.test.ts`
- `node repositorypflege/update-advanced-progress.js`
- `node repositorypflege/advanced-todo-report.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa4b1806908322a76d04d57c532aae