### PR TITLE
feat: add ExperimentBoard component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13086,7 +13086,7 @@
     "path": "packages/unifiedmandala-ui/components/ExperimentBoard.tsx",
     "task": "Compare experiment runs with personhood enforcement",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add provenance card type",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12630,7 +12630,7 @@
   path: packages/unifiedmandala-ui/components/ExperimentBoard.tsx
   task: Compare experiment runs with personhood enforcement
   test: ""
-  status: open
+  status: done
 - commit: Add provenance card type
   path: packages/ingest/ProvenanceCard.ts
   task: Track source, license, hash and personhood metadata

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1430 from GenesisAeon/codex/optimize-repository-and-implement-features-mdi4al",
+  "lastCommit": "chore: finalize progress metadata",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -8,28 +8,639 @@
   "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events | Added JetStream KV/ObjectStore wrappers and tool loader | Added waveform option to CREP sonification | Implemented GermanGrammarAssistant agent",
   "pendingTasks": [
     {
-      "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129",
-      "path": "GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json",
+      "commit": "Implement PDF ingest",
       "status": "open"
     },
     {
-      "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e",
-      "path": "GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json",
+      "commit": "Implement GeoTIFF ingest",
       "status": "open"
     },
     {
-      "commit": "Integrate new GPT teams from Zukunft conversation",
-      "path": "packages/agents",
+      "commit": "Implement VCF ingest",
       "status": "open"
     },
     {
-      "commit": "feat: add SimulationOrchestrator agent",
-      "path": "packages/agents/SimulationOrchestrator.ts",
+      "commit": "Add ingest demo script",
       "status": "open"
     },
     {
-      "commit": "feat: extend FutureKIAgent",
-      "path": "packages/agents/FutureKIAgent.ts",
+      "commit": "Implement ReviewerQueue",
+      "status": "open"
+    },
+    {
+      "commit": "Add reviewer API",
+      "status": "open"
+    },
+    {
+      "commit": "Add AutoTuningAgent",
+      "status": "open"
+    },
+    {
+      "commit": "Implement SecureAggregator",
+      "status": "open"
+    },
+    {
+      "commit": "Add federated API",
+      "status": "open"
+    },
+    {
+      "commit": "Implement ResearchHubWS server",
+      "status": "open"
+    },
+    {
+      "commit": "Create realtime hub HTTP bridge script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement annotations KV store",
+      "status": "open"
+    },
+    {
+      "commit": "Add annotations API with broadcast",
+      "status": "open"
+    },
+    {
+      "commit": "Add RealtimeResearchHub UI component",
+      "status": "open"
+    },
+    {
+      "commit": "Add AnnotationsPanel UI component",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for realtime APIs",
+      "status": "open"
+    },
+    {
+      "commit": "Add realtime flow smoke test",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows dev scripts and cross-env support",
+      "status": "open"
+    },
+    {
+      "commit": "Create Windows start-all PowerShell script",
+      "status": "open"
+    },
+    {
+      "commit": "Add OS Bridge capability policy",
+      "status": "open"
+    },
+    {
+      "commit": "Implement CapabilityGuard for OS Bridge",
+      "status": "open"
+    },
+    {
+      "commit": "Add WindowsPS helper",
+      "status": "open"
+    },
+    {
+      "commit": "Implement OS Bridge API",
+      "status": "open"
+    },
+    {
+      "commit": "Add OSControlPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Create DesktopAutomationAgent",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows UIA and hotkey tools",
+      "status": "open"
+    },
+    {
+      "commit": "Add voice and screen control API",
+      "status": "open"
+    },
+    {
+      "commit": "Extend OS Bridge API with UIA and screen routes",
+      "status": "open"
+    },
+    {
+      "commit": "Add VoicePanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Add ScreenCapturePanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows tools build script and package entries",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for Windows OS bridge",
+      "status": "open"
+    },
+    {
+      "commit": "Add UIA screen redaction tool",
+      "status": "open"
+    },
+    {
+      "commit": "Add WinUI tree inspector utility",
+      "status": "open"
+    },
+    {
+      "commit": "Add AutoHotkey hook scripts",
+      "status": "open"
+    },
+    {
+      "commit": "Add desktop recorder tool",
+      "status": "open"
+    },
+    {
+      "commit": "Implement UIMacroSynth agent",
+      "status": "open"
+    },
+    {
+      "commit": "Add PII regex patterns module",
+      "status": "open"
+    },
+    {
+      "commit": "Add image redactor utility",
+      "status": "open"
+    },
+    {
+      "commit": "Implement redaction API service",
+      "status": "open"
+    },
+    {
+      "commit": "Add AutoHotkey template script",
+      "status": "open"
+    },
+    {
+      "commit": "Create AutoHotkey macro compiler",
+      "status": "open"
+    },
+    {
+      "commit": "Add AutoHotkey runner script",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce macro DSL validator",
+      "status": "open"
+    },
+    {
+      "commit": "Add macro execution script",
+      "status": "open"
+    },
+    {
+      "commit": "Add session log utility",
+      "status": "open"
+    },
+    {
+      "commit": "Add macro replay script",
+      "status": "open"
+    },
+    {
+      "commit": "Implement desktop recorder API",
+      "status": "open"
+    },
+    {
+      "commit": "Create MacroEditor component",
+      "status": "open"
+    },
+    {
+      "commit": "Create RedactionPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Define role permissions map",
+      "status": "open"
+    },
+    {
+      "commit": "Extend capability policy for UI consent",
+      "status": "open"
+    },
+    {
+      "commit": "Add topology index registry",
+      "status": "open"
+    },
+    {
+      "commit": "Implement admin API gateway",
+      "status": "open"
+    },
+    {
+      "commit": "Create admin console app",
+      "status": "open"
+    },
+    {
+      "commit": "Add AI peer connector module",
+      "status": "open"
+    },
+    {
+      "commit": "Implement admin peers API",
+      "status": "open"
+    },
+    {
+      "commit": "Create spaces management module",
+      "status": "open"
+    },
+    {
+      "commit": "Implement commons API",
+      "status": "open"
+    },
+    {
+      "commit": "Add commons presence websocket",
+      "status": "open"
+    },
+    {
+      "commit": "Create commons hub app",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce task router module",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for admin and commons modules",
+      "status": "open"
+    },
+    {
+      "commit": "Add ContributionEvent schema",
+      "status": "open"
+    },
+    {
+      "commit": "Add PluginManifest schema",
+      "status": "open"
+    },
+    {
+      "commit": "Add AIPeerHandshake protocol",
+      "status": "open"
+    },
+    {
+      "commit": "Create CoIntel orchestrator service",
+      "status": "open"
+    },
+    {
+      "commit": "Implement collab websocket server",
+      "status": "open"
+    },
+    {
+      "commit": "Add CreditLedger module",
+      "status": "open"
+    },
+    {
+      "commit": "Add AttributionIndex module",
+      "status": "open"
+    },
+    {
+      "commit": "Create peer handshake service",
+      "status": "open"
+    },
+    {
+      "commit": "Add setup wizard script",
+      "status": "open"
+    },
+    {
+      "commit": "Create CoauthorCanvas component",
+      "status": "open"
+    },
+    {
+      "commit": "Create TaskBoard component",
+      "status": "open"
+    },
+    {
+      "commit": "Add ConsentTimeline component",
+      "status": "open"
+    },
+    {
+      "commit": "Add PeerManager component",
+      "status": "open"
+    },
+    {
+      "commit": "Add ModelRouterEditor component",
+      "status": "open"
+    },
+    {
+      "commit": "Create identity API service",
+      "status": "open"
+    },
+    {
+      "commit": "Define UI templates",
+      "status": "open"
+    },
+    {
+      "commit": "Create instance registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Add ACL API service",
+      "status": "open"
+    },
+    {
+      "commit": "Create InitialAdminPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Define federation manifest type",
+      "status": "open"
+    },
+    {
+      "commit": "Create federation registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Create federation bridge websocket",
+      "status": "open"
+    },
+    {
+      "commit": "Add collab federation bridge script",
+      "status": "open"
+    },
+    {
+      "commit": "Create GlobalMandalaGraph component",
+      "status": "open"
+    },
+    {
+      "commit": "Add unified AppShell",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for Co-Intelligence services",
+      "status": "open"
+    },
+    {
+      "commit": "Append identity and federation services to code agent tasks",
+      "status": "open"
+    },
+    {
+      "commit": "Add OIDC stub service",
+      "status": "open"
+    },
+    {
+      "commit": "Add UI switchboard service",
+      "status": "open"
+    },
+    {
+      "commit": "Add compose override for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows stack start script",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows services installer",
+      "status": "open"
+    },
+    {
+      "commit": "Add UM integration GitHub workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Document UM integration guide",
+      "status": "open"
+    },
+    {
+      "commit": "Add integration copier script",
+      "status": "open"
+    },
+    {
+      "commit": "Expose UM service scripts in package.json",
+      "status": "open"
+    },
+    {
+      "commit": "Provide tsconfig for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add production docker compose file",
+      "status": "open"
+    },
+    {
+      "commit": "Create generic Dockerfile for TypeScript services",
+      "status": "open"
+    },
+    {
+      "commit": "Configure NGINX reverse proxy for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add Kong gateway configuration",
+      "status": "open"
+    },
+    {
+      "commit": "Implement Ed25519 key generation script",
+      "status": "open"
+    },
+    {
+      "commit": "Add manifest signing script",
+      "status": "open"
+    },
+    {
+      "commit": "Add manifest verification script",
+      "status": "open"
+    },
+    {
+      "commit": "Create verified federation registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Implement SSO broker service",
+      "status": "open"
+    },
+    {
+      "commit": "Generate systemd unit files script",
+      "status": "open"
+    },
+    {
+      "commit": "Provide environment example",
+      "status": "open"
+    },
+    {
+      "commit": "Document production setup",
+      "status": "open"
+    },
+    {
+      "commit": "Add Keycloak OIDC dev bundle",
+      "status": "open"
+    },
+    {
+      "commit": "Add Kubernetes manifests with Kustomize overlays",
+      "status": "open"
+    },
+    {
+      "commit": "Add monitoring configuration",
+      "status": "open"
+    },
+    {
+      "commit": "Add Caddy TLS reverse proxy",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitHub Actions workflow for Kubernetes deployment",
+      "status": "open"
+    },
+    {
+      "commit": "Add Helm OIDC bundle",
+      "status": "open"
+    },
+    {
+      "commit": "Add Traefik mTLS ingress",
+      "status": "open"
+    },
+    {
+      "commit": "Add SLO monitoring pack",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps manifests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Add Go OIDC quickstart",
+      "status": "open"
+    },
+    {
+      "commit": "Add Keycloak auto-import helmfile",
+      "status": "open"
+    },
+    {
+      "commit": "Add Cloudflare DNS01 ClusterIssuer",
+      "status": "open"
+    },
+    {
+      "commit": "Add Argo Rollouts canary stack",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps app factory script",
+      "status": "open"
+    },
+    {
+      "commit": "Add Observability++ stack",
+      "status": "open"
+    },
+    {
+      "commit": "Add secret management examples",
+      "status": "open"
+    },
+    {
+      "commit": "Add NetworkPolicy templates",
+      "status": "open"
+    },
+    {
+      "commit": "Add blue/green rollouts with Slack alerts",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps golden path template",
+      "status": "open"
+    },
+    {
+      "commit": "Add one-click cluster bootstrap",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Vault CSI for secret file mounts",
+      "status": "open"
+    },
+    {
+      "commit": "Add ServiceMap-based NetworkPolicy generator",
+      "status": "open"
+    },
+    {
+      "commit": "Set up Cypress UI smoke tests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Set up k6 API smoke tests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Configure promotion gates for rollouts",
+      "status": "open"
+    },
+    {
+      "commit": "Deploy gate-controller for E2E gating",
+      "status": "open"
+    },
+    {
+      "commit": "Add Playwright synthetics with OTel",
+      "status": "open"
+    },
+    {
+      "commit": "Provide RUM OTel web snippet",
+      "status": "open"
+    },
+    {
+      "commit": "Implement multi-signal quorum gates",
+      "status": "open"
+    },
+    {
+      "commit": "Add Terraform synthetics and alerting",
+      "status": "open"
+    },
+    {
+      "commit": "Enable auto-rollback on SLO violation",
+      "status": "open"
+    },
+    {
+      "commit": "Schedule weekly SLO and error budget reports",
+      "status": "open"
+    },
+    {
+      "commit": "Support multi-tenant E2E gates",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows E2E workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Track SLO budget consumption",
+      "status": "open"
+    },
+    {
+      "commit": "Capture debug snapshots on aborted rollouts",
+      "status": "open"
+    },
+    {
+      "commit": "Provide tenant admin API and UI",
+      "status": "open"
+    },
+    {
+      "commit": "Automate image builds and Kustomize validation",
+      "status": "open"
+    },
+    {
+      "commit": "Bootstrap GitOps root application",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce multi-cluster ApplicationSet and security policies",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Kyverno policies with Gatekeeper audit layer",
+      "status": "open"
+    },
+    {
+      "commit": "Apply Cilium default-deny and service allow policies",
+      "status": "open"
+    },
+    {
+      "commit": "Deploy Falco with RBAC-abuse rules and Slack alerts",
+      "status": "open"
+    },
+    {
+      "commit": "Wire OpenTelemetry collector to Tempo and Loki",
+      "status": "open"
+    },
+    {
+      "commit": "Enable Alertmanager night mode routing",
+      "status": "open"
+    },
+    {
+      "commit": "Define per-namespace Cilium FQDN allowlists",
+      "status": "open"
+    },
+    {
+      "commit": "Switch Kyverno verifyImages to enforce",
       "status": "open"
     }
   ],
@@ -4902,6 +5513,10 @@
     {
       "commit": "Add RefusalEngine",
       "status": "done"
+    },
+    {
+      "commit": "Add ExperimentBoard component",
+      "status": "done"
     }
   ],
   "completed": [
@@ -5801,9 +6416,11 @@
     }
   ],
   "changedFiles": [
-    "CHRONOPOEM.md",
     "advancedToDo.json",
-    "scripts/experiments-api.ts"
+    "advancedToDo.yaml",
+    "feedbackcodex.md",
+    "packages/unifiedmandala-ui/components/ExperimentBoard.test.tsx",
+    "packages/unifiedmandala-ui/components/ExperimentBoard.tsx"
   ],
-  "lastUpdated": "2025-08-24T05:48:21.731Z"
+  "lastUpdated": "2025-08-24T09:13:31.863Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -162,3 +162,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added FeatureFlagsPanel component to toggle feature flags in UI.
 - Implemented flags API server for HTTP-based feature toggles.
 - Implemented RefusalEngine to generate structured refusal objects and synced progress files.
+- Implemented ExperimentBoard component comparing experiment runs with personhood enforcement and synced advanced progress.

--- a/packages/unifiedmandala-ui/components/ExperimentBoard.test.tsx
+++ b/packages/unifiedmandala-ui/components/ExperimentBoard.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ExperimentBoard from './ExperimentBoard';
+
+describe('ExperimentBoard', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn().mockResolvedValueOnce({
+      json: async () => ({ experiments: [{ id: 'exp1', result: 'ok' }] })
+    });
+  });
+
+  test('fetches experiments with personhood header', async () => {
+    render(<ExperimentBoard />);
+    expect(fetch).toHaveBeenCalledWith(
+      '/experiments/list',
+      expect.objectContaining({ headers: { 'X-Personhood': 'required' } })
+    );
+    expect(await screen.findByText(/exp1/)).toBeInTheDocument();
+  });
+});

--- a/packages/unifiedmandala-ui/components/ExperimentBoard.tsx
+++ b/packages/unifiedmandala-ui/components/ExperimentBoard.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+
+interface Experiment {
+  id: string;
+  result: string;
+}
+
+/**
+ * ExperimentBoard compares experiment runs and enforces personhood by
+ * sending a required header. It lists each experiment id with its result.
+ */
+export default function ExperimentBoard() {
+  const [experiments, setExperiments] = useState<Experiment[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/experiments/list', { headers: { 'X-Personhood': 'required' } })
+      .then((r) => r.json())
+      .then((json) => {
+        setExperiments(json.experiments || []);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return <div aria-label="ExperimentBoard">Loading...</div>;
+  }
+  if (experiments.length === 0) {
+    return <div aria-label="ExperimentBoard">No experiments</div>;
+  }
+
+  return (
+    <div aria-label="ExperimentBoard">
+      <ul>
+        {experiments.map((exp) => (
+          <li key={exp.id}>
+            <strong>{exp.id}</strong>: {exp.result}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add ExperimentBoard component enforcing personhood headers
- cover ExperimentBoard with jest test
- sync advanced todo and progress metadata

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/unifiedmandala-ui/components/ExperimentBoard.test.tsx`
- `node repositorypflege/update-advanced-progress.js`
- `node repositorypflege/advanced-todo-report.js`


------
https://chatgpt.com/codex/tasks/task_e_68aad75f8624832294daa02447213994