### PR TITLE
feat: add JSON output to advanced todo report

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14579,5 +14579,12 @@
     "task": "Document transparency principles in README",
     "test": "",
     "status": "done"
+  },
+  {
+    "commit": "Add JSON output option to advanced-todo-report script",
+    "path": "repositorypflege/advanced-todo-report.js",
+    "task": "Allow advanced-todo-report to output grouped tasks as JSON when --json flag is used",
+    "test": "repositorypflege/__tests__/advanced-todo-report.test.js",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13704,3 +13704,9 @@
   task: Document transparency principles in README
   test: ""
   status: done
+- commit: Add JSON output option to advanced-todo-report script
+  path: repositorypflege/advanced-todo-report.js
+  task: Allow advanced-todo-report to output grouped tasks as JSON when --json
+    flag is used
+  test: repositorypflege/__tests__/advanced-todo-report.test.js
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1433 from GenesisAeon/codex/optimize-repository-and-implement-features-qxtcz6",
+  "lastCommit": "chore: sync advanced progress",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -5521,6 +5521,10 @@
     {
       "commit": "Add AutoHotkey template script",
       "status": "done"
+    },
+    {
+      "commit": "Add JSON output option to advanced-todo-report script",
+      "status": "done"
     }
   ],
   "completed": [
@@ -6422,8 +6426,8 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "packages/agents/SimulationOrchestrator.ts",
-    "packages/agents/__tests__/SimulationOrchestrator.test.ts"
+    "repositorypflege/__tests__/advanced-todo-report.test.js",
+    "repositorypflege/advanced-todo-report.js"
   ],
-  "lastUpdated": "2025-08-24T17:44:05.877Z"
+  "lastUpdated": "2025-08-24T17:57:35.378Z"
 }

--- a/repositorypflege/__tests__/advanced-todo-report.test.js
+++ b/repositorypflege/__tests__/advanced-todo-report.test.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { execSync } = require('child_process');
 const { groupTodosByDir } = require('../advanced-todo-report');
 
 test('groups open todos by directory', () => {
@@ -21,6 +22,27 @@ test('groups open todos by directory', () => {
     b: [
       { commit: 'Task C', path: 'b/file3' }
     ]
+  });
+
+  fs.unlinkSync(tmp);
+});
+
+test('cli outputs json when --json flag is provided', () => {
+  const tmp = path.join(__dirname, 'tmp-report.json');
+  const sample = [
+    { commit: 'Task A', path: 'a/file1', status: 'open' },
+    { commit: 'Task C', path: 'b/file3', status: 'open' }
+  ];
+  fs.writeFileSync(tmp, JSON.stringify(sample, null, 2));
+
+  const script = path.join(__dirname, '..', 'advanced-todo-report.js');
+  const out = execSync(`node ${script} --path ${tmp} --json`, {
+    encoding: 'utf8'
+  });
+  const grouped = JSON.parse(out);
+  expect(grouped).toEqual({
+    a: [{ commit: 'Task A', path: 'a/file1' }],
+    b: [{ commit: 'Task C', path: 'b/file3' }]
   });
 
   fs.unlinkSync(tmp);

--- a/repositorypflege/advanced-todo-report.js
+++ b/repositorypflege/advanced-todo-report.js
@@ -18,11 +18,16 @@ if (require.main === module) {
   const todoPaths = pathIndex >= 0 ? process.argv[pathIndex + 1].split(',') : undefined;
   const exclIndex = process.argv.indexOf('--exclude');
   const exclude = exclIndex >= 0 ? process.argv[exclIndex + 1] : undefined;
+  const jsonOutput = process.argv.includes('--json');
 
   const grouped = groupTodosByDir(pattern, todoPaths, exclude);
-  for (const [dir, tasks] of Object.entries(grouped)) {
-    console.log(`${dir}:`);
-    tasks.forEach((t) => console.log(`  - ${t.commit}`));
+  if (jsonOutput) {
+    console.log(JSON.stringify(grouped, null, 2));
+  } else {
+    for (const [dir, tasks] of Object.entries(grouped)) {
+      console.log(`${dir}:`);
+      tasks.forEach((t) => console.log(`  - ${t.commit}`));
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- allow `advanced-todo-report` to emit JSON via a `--json` flag
- add CLI test for `advanced-todo-report`
- record task completion in advancedToDo lists and sync advanced progress

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest repositorypflege/__tests__/advanced-todo-report.test.js`
- `node repositorypflege/update-advanced-progress.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab51b0e0308322920af97b2623ffb5