### PR TITLE
feat: add VCF ingest module

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13116,7 +13116,7 @@
     "path": "packages/ingest/VCFIngest.ts",
     "task": "Parse variant records with provenance",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add ingest demo script",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12652,7 +12652,7 @@
   path: packages/ingest/VCFIngest.ts
   task: Parse variant records with provenance
   test: ""
-  status: open
+  status: done
 - commit: Add ingest demo script
   path: scripts/ingest-demo.ts
   task: Demonstrate ingest kit with personhood gate and audit

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add GeoTIFF ingest",
+  "lastCommit": "chore: refresh advanced progress",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4926,6 +4926,14 @@
     {
       "commit": "Implement PDF ingest",
       "status": "done"
+    },
+    {
+      "commit": "Implement GeoTIFF ingest",
+      "status": "done"
+    },
+    {
+      "commit": "Implement VCF ingest",
+      "status": "done"
     }
   ],
   "completed": [
@@ -5824,12 +5832,6 @@
       "status": "done"
     }
   ],
-  "changedFiles": [
-    "advancedToDo.json",
-    "advancedToDo.yaml",
-    "package.json",
-    "pnpm-lock.yaml",
-    "packages/ingest/GeoTIFFIngest.ts"
-  ],
-  "lastUpdated": "2025-08-24T19:06:24.613Z"
+  "changedFiles": [],
+  "lastUpdated": "2025-08-24T19:29:57.860Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -163,3 +163,5 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented flags API server for HTTP-based feature toggles.
 - Implemented RefusalEngine to generate structured refusal objects and synced progress files.
 - Implemented ExperimentBoard component comparing experiment runs with personhood enforcement and synced advanced progress.
+
+- Implemented VCF ingest parser with provenance support and updated progress trackers.

--- a/packages/ingest/VCFIngest.test.ts
+++ b/packages/ingest/VCFIngest.test.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import { ingestVCF } from './VCFIngest';
+
+const sample = `##fileformat=VCFv4.2
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+1\t10177\trs367896724\tA\tAC\t100\tPASS\tDP=100`;
+
+test('parses VCF variants and creates provenance', () => {
+  const file = 'packages/ingest/__tmp.vcf';
+  fs.writeFileSync(file, sample);
+  const result = ingestVCF(file, 'CC-BY-4.0');
+  expect(result.variants).toEqual([
+    {
+      chrom: '1',
+      pos: 10177,
+      id: 'rs367896724',
+      ref: 'A',
+      alt: 'AC',
+      qual: '100',
+      filter: 'PASS',
+      info: 'DP=100',
+    },
+  ]);
+  expect(result.provenance.sourceUri).toBe(file);
+  fs.unlinkSync(file);
+});

--- a/packages/ingest/VCFIngest.ts
+++ b/packages/ingest/VCFIngest.ts
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import { createProvenanceCard, PersonhoodMetadata, ProvenanceCard } from './ProvenanceCard';
+
+export interface VCFVariant {
+  chrom: string;
+  pos: number;
+  id: string;
+  ref: string;
+  alt: string;
+  qual: string;
+  filter: string;
+  info: string;
+}
+
+export interface VCFIngestResult {
+  variants: VCFVariant[];
+  provenance: ProvenanceCard;
+}
+
+export function ingestVCF(
+  filePath: string,
+  license: string,
+  personhood?: PersonhoodMetadata
+): VCFIngestResult {
+  const text = fs.readFileSync(filePath, 'utf-8');
+  const variants: VCFVariant[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    if (!line || line.startsWith('#')) continue;
+    const [chrom, pos, id, ref, alt, qual, filter, info] = line.split('\t');
+    variants.push({
+      chrom,
+      pos: Number(pos),
+      id,
+      ref,
+      alt,
+      qual,
+      filter,
+      info: info ?? '',
+    });
+  }
+  const provenance = createProvenanceCard(filePath, text, license, personhood);
+  return { variants, provenance };
+}

--- a/types/geotiff.d.ts
+++ b/types/geotiff.d.ts
@@ -1,0 +1,1 @@
+declare module 'geotiff';


### PR DESCRIPTION
## Summary
- add `VCFIngest` to parse VCF variant files with provenance metadata
- record VCF ingest completion in advanced ToDo and progress trackers
- leave feedback note and add stub types for geotiff

## Testing
- `npx pyright packages/ingest`
- `npx tsc -p tsconfig.json`
- `npx vitest run packages/ingest/VCFIngest.test.ts` *(no test files found)*


------
https://chatgpt.com/codex/tasks/task_e_68ab63ffaeb08322be08918673db5bfd