### PR TITLE
Add dark matter field model simulation

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2878,9 +2878,10 @@
   },
   {
     "commit": "feat: add DarkMatterFieldModel module",
-    "path": "packages/universum-simulationen/modules/DarkMatterFieldModel.py",
+    "path": "packages/universum-simulationen/modules/dark_matter_field_model.py",
     "task": "Model dark matter effects from Nullmembran interactions",
-    "test": "packages/universum-simulationen/__tests__/DarkMatterFieldModel.test.py"
+    "test": "packages/universum-simulationen/__tests__/dark_matter_field_model_test.py",
+    "status": "done"
   },
   {
     "commit": "feat: add TheoryDatabase service",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4547,9 +4547,10 @@
   task: Simulate dynamic interactions between 0- and 1-states
   test: packages/universum-simulationen/__tests__/NullmembranDynamics.test.py
 - commit: "feat: add DarkMatterFieldModel module"
-  path: packages/universum-simulationen/modules/DarkMatterFieldModel.py
+  path: packages/universum-simulationen/modules/dark_matter_field_model.py
   task: Model dark matter effects from Nullmembran interactions
-  test: packages/universum-simulationen/__tests__/DarkMatterFieldModel.test.py
+  test: packages/universum-simulationen/__tests__/dark_matter_field_model_test.py
+  status: done
 - commit: "feat: add TheoryDatabase service"
   path: packages/universum-simulationen/modules/TheoryDatabase.ts
   task: Store and retrieve scientific theories for simulations

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "test: add AutoTuningAgent",
+  "lastCommit": "chore: sync advanced progress",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -18,18 +18,6 @@
     {
       "commit": "Implement ResearchHubWS server",
       "status": "open"
-    },
-    {
-      "commit": "Create realtime hub HTTP bridge script",
-      "status": "done"
-    },
-    {
-      "commit": "Implement annotations KV store",
-      "status": "done"
-    },
-    {
-      "commit": "Add annotations API with broadcast",
-      "status": "done"
     },
     {
       "commit": "Add RealtimeResearchHub UI component",
@@ -5533,6 +5521,18 @@
     {
       "commit": "Add reviewer API",
       "status": "done"
+    },
+    {
+      "commit": "feat: add DarkMatterFieldModel module",
+      "status": "done"
+    },
+    {
+      "commit": "Implement annotations KV store",
+      "status": "done"
+    },
+    {
+      "commit": "Add annotations API with broadcast",
+      "status": "done"
     }
   ],
   "completed": [
@@ -6439,8 +6439,10 @@
     "advancedToDo.json",
     "advancedToDo.yaml",
     "feedbackcodex.md",
-    "packages/hitloop/",
-    "scripts/reviewer-api.ts"
+    "packages/universum-simulationen/__tests__/__pycache__/",
+    "packages/universum-simulationen/__tests__/dark_matter_field_model_test.py",
+    "packages/universum-simulationen/modules/__pycache__/",
+    "packages/universum-simulationen/modules/dark_matter_field_model.py"
   ],
-  "lastUpdated": "2025-08-24T20:29:50Z"
+  "lastUpdated": "2025-08-24T20:45:47.198Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -167,3 +167,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented VCF ingest parser with provenance support and updated progress trackers.
 - Implemented ReviewerQueue and reviewer API, updating advanced tasks and progress tracking.
 - Added AutoTuningAgent for parameter search with budget guard.
+- Introduced DarkMatterFieldModel module with tests and synced advanced progress.

--- a/packages/universum-simulationen/__tests__/dark_matter_field_model_test.py
+++ b/packages/universum-simulationen/__tests__/dark_matter_field_model_test.py
@@ -1,0 +1,23 @@
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "modules" / "dark_matter_field_model.py"
+spec = importlib.util.spec_from_file_location("dark_matter_field_model", MODULE_PATH)
+mod = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+mass_enclosed = mod.mass_enclosed
+gravitational_field = mod.gravitational_field
+G = mod.G
+
+def test_gravitational_field_matches_expected():
+    density = 1e-21
+    radius = 1e6
+    expected_mass = (4.0 / 3.0) * math.pi * density * radius ** 3
+    expected_field = G * expected_mass / (radius ** 2)
+    assert math.isclose(mass_enclosed(density, radius), expected_mass, rel_tol=1e-9)
+    assert math.isclose(gravitational_field(density, radius), expected_field, rel_tol=1e-9)

--- a/packages/universum-simulationen/modules/dark_matter_field_model.py
+++ b/packages/universum-simulationen/modules/dark_matter_field_model.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+"""Simple dark matter field model utilities.
+
+This module provides helper functions to approximate the
+influence of a uniform dark matter density on a spherical region.
+It is intentionally lightweight and intended for educational
+simulation prototypes.
+"""
+
+import math
+
+# Gravitational constant used for the toy model.
+G: float = 6.67430e-11
+
+def mass_enclosed(density: float, radius: float) -> float:
+    """Return mass enclosed within ``radius`` for constant ``density``.
+
+    Args:
+        density: Mass density of dark matter in kg/m^3.
+        radius: Radius of the sphere in meters.
+    """
+    return (4.0 / 3.0) * math.pi * density * radius ** 3
+
+def gravitational_field(density: float, radius: float) -> float:
+    """Compute gravitational field strength at ``radius``.
+
+    This uses the mass enclosed by a uniform dark matter sphere and
+    returns the Newtonian field strength at the surface.
+    """
+    mass = mass_enclosed(density, radius)
+    return G * mass / (radius ** 2)
+
+__all__ = ["G", "mass_enclosed", "gravitational_field"]


### PR DESCRIPTION
## Summary
- add dark matter field model utilities with mass and field calculations
- cover dark matter model with dedicated unit test
- mark dark matter task done and sync advanced progress/feedback

## Testing
- `poetry install --with test`
- `pnpm install`
- `pytest packages/universum-simulationen/__tests__/dark_matter_field_model_test.py`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68ab790346b08322a67b946fb276ec98