### PR TITLE
feat: add OS Bridge capability policy

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13453,7 +13453,7 @@
     "path": "governance/capabilities.policy.yaml",
     "task": "Define default decisions for Windows OS integration features",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement CapabilityGuard for OS Bridge",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12893,7 +12893,7 @@
   path: governance/capabilities.policy.yaml
   task: Define default decisions for Windows OS integration features
   test: ""
-  status: open
+  status: done
 - commit: Implement CapabilityGuard for OS Bridge
   path: packages/os-bridge/CapabilityGuard.ts
   task: Enforce personhood and capability policy with consent cache

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1445 from GenesisAeon/codex/optimize-repository-and-implement-features-m32e7y",
+  "lastCommit": "chore: update advanced progress",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -4966,6 +4966,10 @@
     {
       "commit": "Add annotations API with broadcast",
       "status": "done"
+    },
+    {
+      "commit": "Add OS Bridge capability policy",
+      "status": "done"
     }
   ],
   "completed": [
@@ -5869,5 +5873,5 @@
     }
   ],
   "changedFiles": [],
-  "lastUpdated": "2025-08-24T20:53:40.825Z"
+  "lastUpdated": "2025-08-24T21:04:07.634Z"
 }

--- a/governance/capabilities.policy.yaml
+++ b/governance/capabilities.policy.yaml
@@ -1,0 +1,20 @@
+# Mandala OS Bridge Capability Policy
+version: "1.0"
+capabilities:
+  allow:
+    - fs.read
+    - fs.write
+    - process.spawn
+    - uia.keyboard
+    - uia.mouse
+  deny:
+    - network.access
+    - system.shutdown
+consent:
+  required: true
+  methods:
+    - explicit
+    - session
+notes: >
+  Defines default capability rules for Windows OS Bridge integration. Most
+  operations require explicit user approval and are scoped per session.


### PR DESCRIPTION
## Summary
- define OS Bridge capability policy for Windows integration
- mark OS Bridge capability task as complete in advanced ToDo lists
- refresh advanced progress tracking

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json` *(fails: npm warn Unknown env config "http-proxy"; process interrupted)*
- `npx tsc --version`
- `pnpm install`
- `poetry install --with test`


------
https://chatgpt.com/codex/tasks/task_e_68ab7d3541308322a62b8adb2c9926b1