### PR TITLE
feat: stream research hub UI

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13406,7 +13406,7 @@
     "path": "packages/unifiedmandala-ui/components/RealtimeResearchHub.tsx",
     "task": "Display live retrieval hits and streamed answers",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add AnnotationsPanel UI component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -12860,7 +12860,7 @@
   path: packages/unifiedmandala-ui/components/RealtimeResearchHub.tsx
   task: Display live retrieval hits and streamed answers
   test: ""
-  status: open
+  status: done
 - commit: Add AnnotationsPanel UI component
   path: packages/unifiedmandala-ui/components/AnnotationsPanel.tsx
   task: Create realtime annotation list and add form

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add SecureAggregator module",
+  "lastCommit": "Merge pull request #1450 from GenesisAeon/codex/optimize-repository-structure-and-implement-features-nsff44",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -17,10 +17,6 @@
     },
     {
       "commit": "Implement ResearchHubWS server",
-      "status": "open"
-    },
-    {
-      "commit": "Add RealtimeResearchHub UI component",
       "status": "open"
     },
     {
@@ -5545,6 +5541,10 @@
     {
       "commit": "Implement SecureAggregator",
       "status": "done"
+    },
+    {
+      "commit": "Add RealtimeResearchHub UI component",
+      "status": "done"
     }
   ],
   "completed": [
@@ -6449,8 +6449,9 @@
   ],
   "changedFiles": [
     "advancedToDo.json",
-    "vitest.config.ts",
-    "packages/federated/"
+    "advancedToDo.yaml",
+    "feedbackcodex.md",
+    "packages/unifiedmandala-ui/components/RealtimeResearchHub.tsx"
   ],
-  "lastUpdated": "2025-08-24T21:49:03.352Z"
+  "lastUpdated": "2025-08-24T21:58:56.391Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -168,3 +168,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented ReviewerQueue and reviewer API, updating advanced tasks and progress tracking.
 - Added AutoTuningAgent for parameter search with budget guard.
 - Introduced DarkMatterFieldModel module with tests and synced advanced progress.
+- Implemented RealtimeResearchHub component for streaming retrieval hits and answers.

--- a/packages/unifiedmandala-ui/components/RealtimeResearchHub.tsx
+++ b/packages/unifiedmandala-ui/components/RealtimeResearchHub.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+
+/**
+ * RealtimeResearchHub streams retrieval hits and answers from the realtime API.
+ * It listens to `/realtime/stream` using Server-Sent Events.
+ */
+export default function RealtimeResearchHub() {
+  const [hits, setHits] = useState<string[]>([]);
+  const [answers, setAnswers] = useState<string[]>([]);
+
+  useEffect(() => {
+    const es = new EventSource('/realtime/stream');
+    es.onmessage = (ev) => {
+      try {
+        const msg = JSON.parse(ev.data);
+        if (msg.type === 'hit') {
+          setHits((h) => [...h, msg.data]);
+        } else if (msg.type === 'answer') {
+          setAnswers((a) => [...a, msg.data]);
+        }
+      } catch {
+        /* noop */
+      }
+    };
+    return () => es.close();
+  }, []);
+
+  return (
+    <div aria-label="RealtimeResearchHub">
+      <h3>Hits</h3>
+      <ul>
+        {hits.map((h, i) => (
+          <li key={i}>{h}</li>
+        ))}
+      </ul>
+      <h3>Answers</h3>
+      <ul>
+        {answers.map((a, i) => (
+          <li key={i}>{a}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `RealtimeResearchHub` component to stream retrieval hits and answers
- mark corresponding advanced todos complete and sync progress trackers
- note addition in feedback codex

## Testing
- `node repositorypflege/update-advanced-progress.js`
- `node repositorypflege/advanced-todo-report.js`
- `npx pyright`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68ab8ac8446883228b6e0bb4bce5da53