### PR TITLE
feat: parse TODOs without specifying file

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5889,12 +5889,11 @@
     }
   ],
   "changedFiles": [
-    "advancedToDo.json",
-    "advancedToDo.yaml",
-    "package.json",
-    "pnpm-lock.yaml",
-    "scripts/validate-sigillin-examples.ts",
-    "scripts/windows/"
+    "go-bridge/cmd/todo-parser/main.go",
+    "go-bridge/cmd/todo-parser/main_test.go",
+    "go-bridge/cmd/todo_server/main.go",
+    "go-bridge/cmd/todo_server/main_test.go",
+    "go-bridge/pkg/codeagent/todo_parser.go"
   ],
-  "lastUpdated": "2025-08-24T22:58:47.179Z"
+  "lastUpdated": "2025-08-24T23:10:33.145Z"
 }

--- a/go-bridge/cmd/todo-parser/main.go
+++ b/go-bridge/cmd/todo-parser/main.go
@@ -14,8 +14,7 @@ func Run(addr string) *http.Server {
 	mux.HandleFunc("/usecases/todo/parse", func(w http.ResponseWriter, r *http.Request) {
 		file := r.URL.Query().Get("file")
 		if file == "" {
-			http.Error(w, "missing file", http.StatusBadRequest)
-			return
+			file = "."
 		}
 		todos, err := codeagent.ParseTODOs(file)
 		if err != nil {

--- a/go-bridge/cmd/todo-parser/main_test.go
+++ b/go-bridge/cmd/todo-parser/main_test.go
@@ -5,19 +5,22 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
 
 func TestRunTodoParser(t *testing.T) {
-	tmp := "./todo_tmp.txt"
-	os.WriteFile(tmp, []byte("// TODO: hi"), 0644)
-	defer os.Remove(tmp)
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "todo.txt"), []byte("// TODO: hi"), 0644)
+	old, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(old)
 	srv := Run(":8092")
 	defer srv.Shutdown(context.Background())
 	time.Sleep(100 * time.Millisecond)
-	resp, err := http.Get("http://localhost:8092/usecases/todo/parse?file=" + tmp)
+	resp, err := http.Get("http://localhost:8092/usecases/todo/parse")
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}

--- a/go-bridge/cmd/todo_server/main.go
+++ b/go-bridge/cmd/todo_server/main.go
@@ -1,29 +1,28 @@
 package main
 
 import (
-    "encoding/json"
-    "log"
-    "net/http"
+	"encoding/json"
+	"log"
+	"net/http"
 
-    "github.com/GenesisAeon/unifiedmandala-go/pkg/codeagent"
+	"github.com/GenesisAeon/unifiedmandala-go/pkg/codeagent"
 )
 
 func parseHandler(w http.ResponseWriter, r *http.Request) {
-    file := r.URL.Query().Get("file")
-    if file == "" {
-        http.Error(w, "missing file", http.StatusBadRequest)
-        return
-    }
-    todos, err := codeagent.ParseTODOs(file)
-    if err != nil {
-        http.Error(w, err.Error(), http.StatusInternalServerError)
-        return
-    }
-    w.Header().Set("Content-Type", "application/json")
-    json.NewEncoder(w).Encode(todos)
+	file := r.URL.Query().Get("file")
+	if file == "" {
+		file = "."
+	}
+	todos, err := codeagent.ParseTODOs(file)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(todos)
 }
 
 func main() {
-    http.HandleFunc("/usecases/todo/parse", parseHandler)
-    log.Fatal(http.ListenAndServe(":8080", nil))
+	http.HandleFunc("/usecases/todo/parse", parseHandler)
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/go-bridge/cmd/todo_server/main_test.go
+++ b/go-bridge/cmd/todo_server/main_test.go
@@ -1,27 +1,31 @@
 package main
 
 import (
-    "io/ioutil"
-    "net/http"
-    "net/http/httptest"
-    "os"
-    "testing"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
 )
 
 func TestParseHandler(t *testing.T) {
-    tmp := "todo_server_tmp.txt"
-    os.WriteFile(tmp, []byte("// TODO: server"), 0644)
-    defer os.Remove(tmp)
+	dir := t.TempDir()
+	file := filepath.Join(dir, "todo.txt")
+	os.WriteFile(file, []byte("// TODO: server"), 0644)
+	old, _ := os.Getwd()
+	defer os.Chdir(old)
+	os.Chdir(dir)
 
-    req, _ := http.NewRequest("GET", "/usecases/todo/parse?file="+tmp, nil)
-    rr := httptest.NewRecorder()
-    parseHandler(rr, req)
+	req, _ := http.NewRequest("GET", "/usecases/todo/parse", nil)
+	rr := httptest.NewRecorder()
+	parseHandler(rr, req)
 
-    if rr.Code != http.StatusOK {
-        t.Fatalf("status %d", rr.Code)
-    }
-    body, _ := ioutil.ReadAll(rr.Body)
-    if string(body) == "" {
-        t.Fatalf("empty response")
-    }
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d", rr.Code)
+	}
+	body, _ := ioutil.ReadAll(rr.Body)
+	if string(body) == "" {
+		t.Fatalf("empty response")
+	}
 }

--- a/go-bridge/pkg/codeagent/todo_parser.go
+++ b/go-bridge/pkg/codeagent/todo_parser.go
@@ -1,27 +1,62 @@
 package codeagent
 
 import (
-    "bufio"
-    "os"
-    "regexp"
+	"bufio"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 )
 
-// ParseTODOs scans a file and returns all TODO comments.
-func ParseTODOs(path string) ([]string, error) {
-    f, err := os.Open(path)
-    if err != nil {
-        return nil, err
-    }
-    defer f.Close()
+var todoRegex = regexp.MustCompile(`(?i)TODO[:]?\s*(.*)`)
 
-    todoRegex := regexp.MustCompile(`(?i)TODO[:]?\s*(.*)`)
-    var todos []string
-    scanner := bufio.NewScanner(f)
-    for scanner.Scan() {
-        line := scanner.Text()
-        if m := todoRegex.FindStringSubmatch(line); m != nil {
-            todos = append(todos, m[1])
-        }
-    }
-    return todos, scanner.Err()
+// ParseTODOs scans a file or directory and returns TODO comments. When a directory
+// is provided it walks recursively and skips paths containing "conversations" to
+// avoid loading massive datasets.
+func ParseTODOs(p string) ([]string, error) {
+	info, err := os.Stat(p)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		var todos []string
+		err := filepath.WalkDir(p, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				if strings.Contains(strings.ToLower(d.Name()), "conversations") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			t, err := parseFileTODOs(path)
+			if err != nil {
+				return err
+			}
+			todos = append(todos, t...)
+			return nil
+		})
+		return todos, err
+	}
+	return parseFileTODOs(p)
+}
+
+func parseFileTODOs(file string) ([]string, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var todos []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if m := todoRegex.FindStringSubmatch(line); m != nil {
+			todos = append(todos, file+":"+m[1])
+		}
+	}
+	return todos, scanner.Err()
 }


### PR DESCRIPTION
## Summary
- allow TODO parser to scan directories and skip massive conversation data
- expose /usecases/todo/parse without requiring a file parameter
- test default parsing via temporary directories

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `go test ./go-bridge/...`
- `pnpm install`
- `poetry install --with test`


------
https://chatgpt.com/codex/tasks/task_e_68ab9af7e0d883228da495a4f694eb78