### PR TITLE
feat: add yaml output to advanced todo report

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5904,6 +5904,9 @@
       "status": "done"
     }
   ],
-  "changedFiles": [],
-  "lastUpdated": "2025-08-25T05:31:59.172Z"
+  "changedFiles": [
+    "repositorypflege/__tests__/advanced-todo-report.test.js",
+    "repositorypflege/advanced-todo-report.js"
+  ],
+  "lastUpdated": "2025-08-25T05:51:25.520Z"
 }

--- a/repositorypflege/__tests__/advanced-todo-report.test.js
+++ b/repositorypflege/__tests__/advanced-todo-report.test.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
+const yaml = require('js-yaml');
 const { groupTodosByDir } = require('../advanced-todo-report');
 
 test('groups open todos by directory', () => {
@@ -40,6 +41,27 @@ test('cli outputs json when --json flag is provided', () => {
     encoding: 'utf8'
   });
   const grouped = JSON.parse(out);
+  expect(grouped).toEqual({
+    a: [{ commit: 'Task A', path: 'a/file1' }],
+    b: [{ commit: 'Task C', path: 'b/file3' }]
+  });
+
+  fs.unlinkSync(tmp);
+});
+
+test('cli outputs yaml when --yaml flag is provided', () => {
+  const tmp = path.join(__dirname, 'tmp-report.json');
+  const sample = [
+    { commit: 'Task A', path: 'a/file1', status: 'open' },
+    { commit: 'Task C', path: 'b/file3', status: 'open' }
+  ];
+  fs.writeFileSync(tmp, JSON.stringify(sample, null, 2));
+
+  const script = path.join(__dirname, '..', 'advanced-todo-report.js');
+  const out = execSync(`node ${script} --path ${tmp} --yaml`, {
+    encoding: 'utf8'
+  });
+  const grouped = yaml.load(out);
   expect(grouped).toEqual({
     a: [{ commit: 'Task A', path: 'a/file1' }],
     b: [{ commit: 'Task C', path: 'b/file3' }]

--- a/repositorypflege/advanced-todo-report.js
+++ b/repositorypflege/advanced-todo-report.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const yaml = require('js-yaml');
 const { listOpenAdvancedTodos } = require('./list-open-advanced-todos');
 
 function groupTodosByDir(pattern, todoPaths, excludePattern) {
@@ -19,9 +20,12 @@ if (require.main === module) {
   const exclIndex = process.argv.indexOf('--exclude');
   const exclude = exclIndex >= 0 ? process.argv[exclIndex + 1] : undefined;
   const jsonOutput = process.argv.includes('--json');
+  const yamlOutput = process.argv.includes('--yaml');
 
   const grouped = groupTodosByDir(pattern, todoPaths, exclude);
-  if (jsonOutput) {
+  if (yamlOutput) {
+    console.log(yaml.dump(grouped));
+  } else if (jsonOutput) {
     console.log(JSON.stringify(grouped, null, 2));
   } else {
     for (const [dir, tasks] of Object.entries(grouped)) {


### PR DESCRIPTION
## Summary
- support `--yaml` flag in advanced todo report script
- cover YAML output with new test
- sync advanced progress metadata

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `node repositorypflege/advanced-todo-report.js --path tmp-sample.json --yaml`

------
https://chatgpt.com/codex/tasks/task_e_68abf95bc26883229845e23b758c2203