### PR TITLE
feat(core): implement PipelineService

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2839,7 +2839,8 @@
     "commit": "feat: implement PipelineService module",
     "path": "packages/core/PipelineService.ts",
     "task": "Process message pipelines and integrate event streams",
-    "test": "packages/core/__tests__/PipelineService.test.ts"
+    "test": "packages/core/__tests__/PipelineService.test.ts",
+    "status": "done"
   },
   {
     "commit": "feat: implement ChannelScribe utility",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4523,6 +4523,7 @@
   path: packages/core/PipelineService.ts
   task: Process message pipelines and integrate event streams
   test: packages/core/__tests__/PipelineService.test.ts
+  status: done
 - commit: "feat: implement ChannelScribe utility"
   path: packages/core/ChannelScribe.ts
   task: Record conversation channels and transitions

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: sync advanced progress",
+  "lastCommit": "feat(core): add PipelineService",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -23,13 +23,13 @@
       "status": "open"
     },
     {
-      "commit": "feat: implement PipelineService module",
-      "path": "packages/core/PipelineService.ts",
+      "commit": "feat: add S07_Supernova_Strahlungseinfluss simulation",
+      "path": "packages/universum-simulationen/modules/S07_Supernova_Strahlungseinfluss.py",
       "status": "open"
     },
     {
-      "commit": "feat: add S07_Supernova_Strahlungseinfluss simulation",
-      "path": "packages/universum-simulationen/modules/S07_Supernova_Strahlungseinfluss.py",
+      "commit": "feat: add S08_DNA_Umweltkoeffizient simulation",
+      "path": "packages/universum-simulationen/modules/S08_DNA_Umweltkoeffizient.py",
       "status": "open"
     }
   ],
@@ -5002,6 +5002,10 @@
     {
       "commit": "Add AnnotationsPanel UI component",
       "status": "done"
+    },
+    {
+      "commit": "feat: implement PipelineService module",
+      "status": "done"
     }
   ],
   "completed": [
@@ -5904,9 +5908,6 @@
       "status": "done"
     }
   ],
-  "changedFiles": [
-    "repositorypflege/__tests__/advanced-todo-report.test.js",
-    "repositorypflege/advanced-todo-report.js"
-  ],
-  "lastUpdated": "2025-08-25T05:51:25.520Z"
+  "changedFiles": [],
+  "lastUpdated": "2025-08-25T06:07:58.574Z"
 }

--- a/packages/core/PipelineService.ts
+++ b/packages/core/PipelineService.ts
@@ -1,0 +1,41 @@
+import { LocalEventBus, Subjects } from '../event-bus';
+
+export type PipelineStep<T> = (context: T) => Promise<T> | T;
+
+export interface PipelineServiceOptions<T> {
+  steps?: PipelineStep<T>[];
+  bus?: LocalEventBus;
+  subject?: Subjects;
+}
+
+/**
+ * PipelineService runs registered steps sequentially and optionally publishes
+ * intermediate results to an event bus. It provides a lightweight mechanism to
+ * compose message processing pipelines while emitting progress to observers.
+ */
+export class PipelineService<T> {
+  private steps: PipelineStep<T>[];
+  private bus?: LocalEventBus;
+  private subject?: Subjects;
+
+  constructor(options: PipelineServiceOptions<T> = {}) {
+    this.steps = options.steps ?? [];
+    this.bus = options.bus;
+    this.subject = options.subject;
+  }
+
+  use(step: PipelineStep<T>): void {
+    this.steps.push(step);
+  }
+
+  async run(initial: T): Promise<T> {
+    let ctx = initial;
+    for (const step of this.steps) {
+      ctx = await step(ctx);
+      if (this.bus && this.subject) {
+        this.bus.publish(this.subject, ctx);
+      }
+    }
+    return ctx;
+  }
+}

--- a/packages/core/__tests__/PipelineService.test.ts
+++ b/packages/core/__tests__/PipelineService.test.ts
@@ -1,0 +1,18 @@
+import { PipelineService } from '../PipelineService';
+import { LocalEventBus, Subjects } from '../../event-bus';
+
+test('runs steps sequentially and emits events', async () => {
+  const bus = new LocalEventBus();
+  const events: number[] = [];
+  bus.subscribe(Subjects.LIVE_ASK, (payload) => {
+    events.push(payload as number);
+  });
+
+  const svc = new PipelineService<number>({ bus, subject: Subjects.LIVE_ASK });
+  svc.use((n) => n + 1);
+  svc.use(async (n) => n * 2);
+
+  const result = await svc.run(1);
+  expect(result).toBe(4);
+  expect(events).toEqual([2, 4]);
+});


### PR DESCRIPTION
## Summary
- add PipelineService for sequential message pipelines with event bus hooks
- test pipeline execution and event emission
- mark PipelineService task complete and sync advanced progress

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest packages/core/__tests__/PipelineService.test.ts`
- `node repositorypflege/update-advanced-progress.js`

------
https://chatgpt.com/codex/tasks/task_e_68abfcfcbae8832294568b82be53ecf2