### PR TITLE
feat: add role permissions map

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13673,7 +13673,7 @@
     "path": "packages/identity/Roles.ts",
     "task": "Map roles to permissions for admin and commons modules",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Extend capability policy for UI consent",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13051,7 +13051,7 @@
   path: packages/identity/Roles.ts
   task: Map roles to permissions for admin and commons modules
   test: ""
-  status: open
+  status: done
 - commit: Extend capability policy for UI consent
   path: governance/capabilities.policy.yaml
   task: Allow admin to grant and revoke consent in UI modules

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5943,13 +5943,9 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "package.json",
-    "pnpm-lock.yaml",
-    "vitest.config.ts",
-    "packages/redaction/ImageRedactor.test.ts",
-    "packages/redaction/ImageRedactor.ts",
     "feedbackcodex.md",
-    "advancedprogress.json"
+    "packages/identity/Roles.ts",
+    "scripts/__tests__/identity-roles.test.ts"
   ],
-  "lastUpdated": "2025-08-25T09:03:05.149Z"
+  "lastUpdated": "2025-08-25T09:27:11.704Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -171,3 +171,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented RealtimeResearchHub component for streaming retrieval hits and answers.
 - Added AnnotationsPanel component for realtime annotations and synced advanced progress.
 - Added ImageRedactor utility to mask selected regions in PNG images.
+- Added role permissions map for admin and commons modules.

--- a/packages/identity/Roles.ts
+++ b/packages/identity/Roles.ts
@@ -1,0 +1,16 @@
+import { RBAC, RolePermissions } from './RBAC';
+
+export type RoleName = 'admin' | 'member' | 'guest';
+
+export const ROLE_PERMISSIONS: Record<RoleName, string[]> = {
+  admin: ['admin:read', 'admin:write', 'commons:read', 'commons:write'],
+  member: ['commons:read', 'commons:write'],
+  guest: ['commons:read'],
+};
+
+/**
+ * Shared RBAC instance using the default role permissions.
+ */
+export const rbac = new RBAC(ROLE_PERMISSIONS as RolePermissions);
+
+export type PermissionName = (typeof ROLE_PERMISSIONS)[RoleName][number];

--- a/scripts/__tests__/identity-roles.test.ts
+++ b/scripts/__tests__/identity-roles.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { rbac } from '../../packages/identity/Roles';
+
+describe('ROLE_PERMISSIONS', () => {
+  it('grants admin full access', () => {
+    expect(rbac.hasPermission('admin', 'admin:write')).toBe(true);
+    expect(rbac.hasPermission('admin', 'commons:read')).toBe(true);
+  });
+
+  it('restricts guest to read-only commons', () => {
+    expect(rbac.hasPermission('guest', 'commons:read')).toBe(true);
+    expect(rbac.hasPermission('guest', 'commons:write')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- map admin, member, and guest roles to permissions for admin and commons modules
- verify RBAC rules with a new identity roles test
- mark role permissions map todo as complete and sync advanced progress

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx vitest run scripts/__tests__/identity-roles.test.ts`
- `node repositorypflege/advanced-todo-report.js`
- `node repositorypflege/update-advanced-progress.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac28a2eb8c8322a89e6a64c04cd891