### PR TITLE
feat(ui): add os control panel component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13485,7 +13485,7 @@
     "path": "packages/unifiedmandala-ui/components/OSControlPanel.tsx",
     "task": "Provide UI for granting consent and triggering OS actions",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create DesktopAutomationAgent",

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5042,6 +5042,10 @@
     {
       "commit": "feat: add ZahlensystemKonverter module",
       "status": "done"
+    },
+    {
+      "commit": "Add OSControlPanel component",
+      "status": "done"
     }
   ],
   "completed": [
@@ -5949,5 +5953,5 @@
     }
   ],
   "changedFiles": [],
-  "lastUpdated": "2025-08-25T11:09:00.259Z"
+  "lastUpdated": "2025-08-25T16:34:23Z"
 }

--- a/packages/unifiedmandala-ui/components/OSControlPanel.test.tsx
+++ b/packages/unifiedmandala-ui/components/OSControlPanel.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import OSControlPanel from './OSControlPanel';
+
+describe('OSControlPanel', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn().mockResolvedValue({});
+  });
+
+  test('grants consent then triggers action', async () => {
+    const { getByText } = render(<OSControlPanel />);
+    fireEvent.click(getByText('Grant Consent'));
+    await waitFor(() =>
+      expect(fetch).toHaveBeenNthCalledWith(1, '/os/consent', { method: 'POST' })
+    );
+    fireEvent.click(getByText('Trigger Action'));
+    await waitFor(() =>
+      expect(fetch).toHaveBeenNthCalledWith(
+        2,
+        '/os/action',
+        expect.objectContaining({ method: 'POST' })
+      )
+    );
+  });
+});

--- a/packages/unifiedmandala-ui/components/OSControlPanel.tsx
+++ b/packages/unifiedmandala-ui/components/OSControlPanel.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+
+/**
+ * OSControlPanel provides a tiny consent gate and action trigger
+ * for the Windows OS Bridge. Inspired by guidance in
+ * `newadvancedconversations.json`.
+ */
+export default function OSControlPanel() {
+  const [consent, setConsent] = useState(false);
+
+  const grantConsent = async () => {
+    await fetch('/os/consent', { method: 'POST' });
+    setConsent(true);
+  };
+
+  const triggerAction = () => {
+    fetch('/os/action', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'open-notepad' })
+    });
+  };
+
+  return (
+    <div>
+      <button onClick={grantConsent} disabled={consent}>
+        Grant Consent
+      </button>
+      <button onClick={triggerAction} disabled={!consent}>
+        Trigger Action
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add OSControlPanel React component for granting OS consent and triggering actions
- track completion in advancedToDo and advancedprogress

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: venvPath is not a valid directory; enumeration takes too long)*
- `npx tsc -p tsconfig.json`
- `npx jest packages/unifiedmandala-ui/components/OSControlPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ac9025e42c832280611d46f0ee5600