### PR TITLE
feat: add RUM OTel web snippet

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14339,7 +14339,7 @@
     "path": "rum/otel-web.js",
     "task": "Collect browser metrics and forward to collector via OTLP",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement multi-signal quorum gates",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13528,7 +13528,7 @@
   path: rum/otel-web.js
   task: Collect browser metrics and forward to collector via OTLP
   test: ""
-  status: open
+  status: done
 - commit: Implement multi-signal quorum gates
   path: quorum/rollouts/rollout-admin-quorum.yaml
   task: Require SLO, error budget, and E2E quorum before promotion

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5952,6 +5952,11 @@
       "status": "done"
     }
   ],
-  "changedFiles": [],
-  "lastUpdated": "2025-08-25T16:34:23Z"
+  "changedFiles": [
+    "advancedToDo.json",
+    "advancedToDo.yaml",
+    "feedbackcodex.md",
+    "rum/"
+  ],
+  "lastUpdated": "2025-08-25T17:00:06.368Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -3,6 +3,7 @@ Diese Datei beschreibt MetaCommits, also Arbeitsaufträge, die zu umfangreich f�
 Alle offenen MetaCommits werden in `metacommit.yaml` und `metacommit.json` referenziert.
 Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren deren Aufgaben, bis sie erledigt und die Dateien gelöscht wurden.
 
+- Implemented browser RUM snippet using OpenTelemetry Web to forward traces to OTLP collector.
 - Implemented `log_triggers` script to collect latest trigger phrases and open ToDos for chat migration.
 - Implemented `export_sigillin` script to aggregate active Sigillin into JSON and YAML for chat migration.
 - Added `init_modules` script to verify presence of key modules for new chat bootstrap.

--- a/rum/otel-web.js
+++ b/rum/otel-web.js
@@ -1,0 +1,19 @@
+// Lightweight OpenTelemetry Web snippet for browser RUM
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+
+const collectorUrl = window.__OTEL_COLLECTOR_URL__ || 'http://localhost:4318/v1/traces';
+
+const provider = new WebTracerProvider();
+provider.addSpanProcessor(new SimpleSpanProcessor(new OTLPTraceExporter({ url: collectorUrl })));
+provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+provider.register();
+
+registerInstrumentations({
+  instrumentations: [new DocumentLoadInstrumentation()],
+});
+
+console.log('OTel web tracer initialized', collectorUrl);


### PR DESCRIPTION
## Summary
- add OpenTelemetry browser snippet for basic RUM trace export
- mark RUM snippet task done in advanced ToDos and sync progress
- log snippet addition in feedback codex

## Testing
- `node scripts/parse-newadvanced-conversations.js --keyword otel --limit 5`
- `node repositorypflege/update-advanced-progress.js`
- `node repositorypflege/advanced-todo-report.js --json | head`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68ac958c1f1c8322af6653b15522e4f0