### PR TITLE
feat(agents): scaffold desktop automation agent

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13491,8 +13491,8 @@
     "commit": "Create DesktopAutomationAgent",
     "path": "packages/agents/DesktopAutomationAgent.ts",
     "task": "Automate Windows workflows through the OS Bridge API",
-    "test": "",
-    "status": "open"
+    "test": "packages/agents/DesktopAutomationAgent.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add Windows UIA and hotkey tools",

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1468 from GenesisAeon/codex/optimize-repo-structure-and-implement-features-hphnhf",
+  "lastCommit": "Merge pull request #1471 from GenesisAeon/codex/optimize-repository-and-implement-features-fnut7c",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -5054,6 +5054,18 @@
     {
       "commit": "Provide RUM OTel web snippet",
       "status": "done"
+    },
+    {
+      "commit": "Der *SymbolMapper*-Agent übersetzt numerische und textuelle Muster in definierte Symbol-Glyphen【15†L53-L61】. Er schließt die Lücke zwischen quantitativen Werten (z. B. statistische Ergebnisse, Scores) und der symbolischen **Sigillin-Sprache** des Systems. Manifest-Spezifikation: Der SymbolMapper v1 hat Methoden `map_numeric_to_symbol` und `map_text_to_glyph`【15†L55-L63】. Im Python-Skeleton (`agents/symbolmapper/main.py`) implementieren wir z. B. eine Liste vordefinierter Glyphen (im Manifest-Beispiel: ○, ∆, ψ, ★【15†L67-L73】) und die Abbildungsfunktionen analog zum YAML-Snippet: ein Durchschnittswert wird auf einen Index im Glyphen-Array gemappt【15†L67-L75】, Texte werden auf Basis von Schlüsselbegriffen einem Symbol zugeordnet (Bsp: enthält der Text \"Erweckung\", dann ★ als Glyph)【15†L69-L73】. Integration: Dieser Agent kann von anderen Modulen genutzt werden, die rohe Daten symbolisch darstellen wollen – z. B. der CREPBridge könnte SymbolMapper fragen, welcher Glyph einem bestimmten Score entspricht (um dann einen Sigil zu generieren). Auch für Graphen/Charts in der UI könnte SymbolMapper herangezogen werden, um interessante Datenpunkte mit Symbolen zu markieren. Orchestrator: wahrscheinlich auf Abruf, nicht dauernd laufend – d.h. Module rufen ihn als Library auf (alternativ EventBus-Request/Reply-Pattern). UI: Keine direkte, aber z. B. im Sigil-Portfolio des Nutzers könnten diese Glyphen vorkommen. Test & Deploy: Test, ob gegebene Werte die richtigen Symbole liefern (z. B. Eingabe [0.1, 0.9] ergibt einen Index im gültigen Bereich und ein Symbol aus der Liste【15†L137-L142】). Deployment: Sicherstellen, dass NumPy verfügbar ist (im Manifest als Dependency angegeben【15†L61-L69】) und dass das System die Unicode-Symbole unterstützt (Fonts in UI etc.). path: agents/symbolmapper/main.py task: >-\n  Der *SymbolMapper*-Agent übersetzt numerische und textuelle Muster in\n  definierte Symbol-Glyphen【15†L53-L61】. Er schließt die Lücke zwischen\n  quantitativen Werten (z. B. statistische Ergebnisse, Scores) und der\n  symbolischen **Sigillin-Sprache** des Systems. Manifest-Spezifikation: Der\n  SymbolMapper v1 hat Methoden `map_numeric_to_symbol` und\n  `map_text_to_glyph`【15†L55-L63】. Im Python-Skeleton\n  (`agents/symbolmapper/main.py`) implementieren wir z. B. eine Liste\n  vordefinierter Glyphen (im Manifest-Beispiel: ○, ∆, ψ, ★【15†L67-L73】) und\n  die Abbildungsfunktionen analog zum YAML-Snippet: ein Durchschnittswert wird\n  auf einen Index im Glyphen-Array gemappt【15†L67-L75】, Texte werden auf Basis\n  von Schlüsselbegriffen einem Symbol zugeordnet (Bsp: enthält der Text\n  \"Erweckung\", dann ★ als Glyph)【15†L69-L73】. Integration: Dieser Agent kann\n  von anderen Modulen genutzt werden, die rohe Daten symbolisch darstellen\n  wollen – z. B. der CREPBridge könnte SymbolMapper fragen, welcher Glyph\n  einem bestimmten Score entspricht (um dann einen Sigil zu generieren). Auch\n  für Graphen/Charts in der UI könnte SymbolMapper herangezogen werden, um\n  interessante Datenpunkte mit Symbolen zu markieren. Orchestrator:\n  wahrscheinlich auf Abruf, nicht dauernd laufend – d.h. Module rufen ihn als\n  Library auf (alternativ EventBus-Request/Reply-Pattern). UI: Keine direkte,\n  aber z. B. im Sigil-Portfolio des Nutzers könnten diese Glyphen vorkommen.\n  Test & Deploy: Test, ob gegebene Werte die richtigen Symbole liefern (z. B.\n  Eingabe [0.1, 0.9] ergibt einen Index im gültigen Bereich und ein Symbol aus\n  der Liste【15†L137-L142】). Deployment: Sicherstellen, dass NumPy verfügbar\n  ist (im Manifest als Dependency angegeben【15†L61-L69】) und dass das System\n  die Unicode-Symbole unterstützt (Fonts in UI etc.).",
+      "status": "done"
+    },
+    {
+      "commit": "Create DesktopAutomationAgent",
+      "status": "done"
+    },
+    {
+      "commit": "Add session log utility",
+      "status": "done"
     }
   ],
   "completed": [
@@ -5965,11 +5977,9 @@
     }
   ],
   "changedFiles": [
-    "advancedToDo_parts/advancedToDo.part6.yaml",
-    "agents/symbolmapper/__init__.py",
-    "agents/symbolmapper/main.py",
-    "agents/symbolmapper/test_main.py",
-    "tests/symbolmapper_test.py"
+    "advancedToDo.json",
+    "packages/agents/DesktopAutomationAgent.test.ts",
+    "packages/agents/DesktopAutomationAgent.ts"
   ],
-  "lastUpdated": "2025-08-25T20:22:13.521Z"
+  "lastUpdated": "2025-08-25T20:31:51.614Z"
 }

--- a/packages/agents/DesktopAutomationAgent.test.ts
+++ b/packages/agents/DesktopAutomationAgent.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { DesktopAutomationAgent, AutomationStep } from './DesktopAutomationAgent';
+
+describe('DesktopAutomationAgent', () => {
+  it('executes automation steps via provided bridge', async () => {
+    const calls: string[] = [];
+    const mockBridge = {
+      openApp: async (p: string) => { calls.push(`open:${p}`); },
+      setClipboard: async (t: string) => { calls.push(`set:${t}`); },
+      getClipboard: async () => { calls.push('get'); return 'clip'; },
+    };
+    const agent = new DesktopAutomationAgent(mockBridge);
+    const steps: AutomationStep[] = [
+      { type: 'open-app', value: 'calc.exe' },
+      { type: 'set-clipboard', value: 'hello' },
+      { type: 'get-clipboard' }
+    ];
+    const result = await agent.runSteps(steps);
+    expect(result).toEqual([null, null, 'clip']);
+    expect(calls).toEqual(['open:calc.exe', 'set:hello', 'get']);
+  });
+});

--- a/packages/agents/DesktopAutomationAgent.ts
+++ b/packages/agents/DesktopAutomationAgent.ts
@@ -1,0 +1,44 @@
+import { openApp, setClipboard, getClipboard } from '../os-bridge/WindowsPS';
+
+export interface AutomationStep {
+  type: 'open-app' | 'set-clipboard' | 'get-clipboard';
+  value?: string;
+}
+
+interface Bridge {
+  openApp: (path: string) => Promise<void>;
+  setClipboard: (text: string) => Promise<void>;
+  getClipboard: () => Promise<string>;
+}
+
+/**
+ * DesktopAutomationAgent executes simple Windows automation workflows
+ * through the OS bridge. Steps are executed sequentially.
+ */
+export class DesktopAutomationAgent {
+  constructor(private bridge: Bridge = { openApp, setClipboard, getClipboard }) {}
+
+  async runSteps(steps: AutomationStep[]): Promise<(string | null)[]> {
+    const results: (string | null)[] = [];
+    for (const step of steps) {
+      switch (step.type) {
+        case 'open-app':
+          if (!step.value) throw new Error('Missing value for open-app');
+          await this.bridge.openApp(step.value);
+          results.push(null);
+          break;
+        case 'set-clipboard':
+          if (!step.value) throw new Error('Missing value for set-clipboard');
+          await this.bridge.setClipboard(step.value);
+          results.push(null);
+          break;
+        case 'get-clipboard':
+          results.push(await this.bridge.getClipboard());
+          break;
+        default:
+          throw new Error(`Unsupported step: ${step.type}`);
+      }
+    }
+    return results;
+  }
+}

--- a/packages/agents/index.ts
+++ b/packages/agents/index.ts
@@ -61,3 +61,4 @@ export * from './OvernightWorkerAgent';
 export * from './AgentHeartbeat';
 export * from './TeamboardManager';
 export * from './FutureKIAgent';
+export * from './DesktopAutomationAgent';


### PR DESCRIPTION
## Summary
- add DesktopAutomationAgent for Windows OS-Bridge workflows
- export DesktopAutomationAgent via agents index
- track progress for desktop automation tasks

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json --diagnostics`
- `npx vitest run packages/agents/DesktopAutomationAgent.test.ts`
- `node repositorypflege/update-advanced-progress.js 5`


------
https://chatgpt.com/codex/tasks/task_e_68acc6e9f7b88322bc4973f755038625