### PR TITLE
feat: allow admin consent management

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13681,7 +13681,7 @@
     "path": "governance/capabilities.policy.yaml",
     "task": "Allow admin to grant and revoke consent in UI modules",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add topology index registry",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13057,7 +13057,7 @@
   path: governance/capabilities.policy.yaml
   task: Allow admin to grant and revoke consent in UI modules
   test: ""
-  status: open
+  status: done
 - commit: Add topology index registry
   path: packages/admin/TopologyIndex.ts
   task: Track service probes and health in admin console

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1472 from GenesisAeon/codex/optimize-repository-and-implement-features-6i48h2",
+  "lastCommit": "chore: sync advanced progress",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -93,10 +93,6 @@
     },
     {
       "commit": "Create RedactionPanel component",
-      "status": "open"
-    },
-    {
-      "commit": "Extend capability policy for UI consent",
       "status": "open"
     },
     {
@@ -5557,6 +5553,10 @@
     {
       "commit": "Add integration copier script",
       "status": "done"
+    },
+    {
+      "commit": "Extend capability policy for UI consent",
+      "status": "done"
     }
   ],
   "completed": [
@@ -6470,9 +6470,7 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "feedbackcodex.md",
-    "docs/INTEGRATION_GUIDE.md",
-    "integration/"
+    "governance/capabilities.policy.yaml"
   ],
-  "lastUpdated": "2025-08-25T20:48:25.028Z"
+  "lastUpdated": "2025-08-25T21:17:02.606Z"
 }

--- a/governance/capabilities.policy.yaml
+++ b/governance/capabilities.policy.yaml
@@ -15,6 +15,11 @@ consent:
   methods:
     - explicit
     - session
+roles:
+  admin:
+    actions:
+      - ui.consent.grant
+      - ui.consent.revoke
 notes: >
   Defines default capability rules for Windows OS Bridge integration. Most
   operations require explicit user approval and are scoped per session.


### PR DESCRIPTION
## Summary
- allow admin role to grant and revoke consent in UI modules via capability policy
- mark capability policy update complete in advanced todo tracking and refresh progress metadata

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `node repositorypflege/advanced-todo-report.js`


------
https://chatgpt.com/codex/tasks/task_e_68acd23b8d308322b900012e82bf5fbd