### PR TITLE
feat: add TextSimplifier agent

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2977,7 +2977,8 @@
     "commit": "feat: add TextSimplifier agent",
     "path": "packages/agents/TextSimplifier.ts",
     "task": "Provide dyslexia-friendly rephrasing for users",
-    "test": "packages/agents/__tests__/TextSimplifier.test.ts"
+    "test": "packages/agents/__tests__/TextSimplifier.test.ts",
+    "status": "done"
   },
   {
     "commit": "feat: add WhiteHoleFormation module",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4617,6 +4617,7 @@
   path: packages/agents/TextSimplifier.ts
   task: Provide dyslexia-friendly rephrasing for users
   test: packages/agents/__tests__/TextSimplifier.test.ts
+  status: done
 - commit: "feat: add WhiteHoleFormation module"
   path: packages/universum-simulationen/modules/S01_WhiteHoleFormation.py
   task: Simulate white hole creation with defined inputs and outputs

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6019,10 +6019,8 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "feedbackcodex.md",
-    "packages/universum-simulationen/__tests__/S07_Supernova_Strahlungseinfluss_test.py",
-    "packages/universum-simulationen/modules/S07_Supernova_Strahlungseinfluss.py",
-    "packages/universum-simulationen/modules/__pycache__/"
+    "packages/agents/TextSimplifier.ts",
+    "packages/agents/__tests__/TextSimplifier.test.ts"
   ],
-  "lastUpdated": "2025-08-26T06:46:10.885Z"
+  "lastUpdated": "2025-08-26T07:06:04.598Z"
 }

--- a/packages/agents/TextSimplifier.ts
+++ b/packages/agents/TextSimplifier.ts
@@ -1,0 +1,34 @@
+import { Agent, Task } from '../core/interfaces';
+
+const defaultMap: Record<string, string> = {
+  utilize: 'use',
+  commence: 'start',
+  terminate: 'end',
+};
+
+/**
+ * TextSimplifier replaces complex words in a task description with
+ * simpler synonyms to support easier reading.
+ */
+export class TextSimplifier implements Agent {
+  id = 'TextSimplifier';
+  layer = 'Utility';
+  private simplified = '';
+
+  constructor(private replacements: Record<string, string> = defaultMap) {}
+
+  handle(task: Task): void {
+    let text = task.description;
+    for (const [complex, simple] of Object.entries(this.replacements)) {
+      const regex = new RegExp(`\\b${complex}\\b`, 'gi');
+      text = text.replace(regex, simple);
+    }
+    this.simplified = text;
+  }
+
+  getSimplified(): string {
+    return this.simplified;
+  }
+}
+
+export default TextSimplifier;

--- a/packages/agents/__tests__/TextSimplifier.test.ts
+++ b/packages/agents/__tests__/TextSimplifier.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { TextSimplifier } from '../TextSimplifier';
+
+describe('TextSimplifier', () => {
+  it('replaces complex words with simpler synonyms', () => {
+    const agent = new TextSimplifier();
+    agent.handle({ id: 't1', description: 'Commence and utilize before you terminate.' } as any);
+    expect(agent.getSimplified()).toBe('start and use before you end.');
+  });
+});


### PR DESCRIPTION
## Summary
- add TextSimplifier agent to replace complex words with simpler synonyms
- test TextSimplifier behavior
- mark TextSimplifier task as completed in advanced todos

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx vitest packages/agents/__tests__/TextSimplifier.test.ts`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `node repositorypflege/update-advanced-progress.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad596a67048322938403d6d81ff203