### PR TITLE
docs: add climate dashboard setup and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ Weitere Hinweise aus dem „Sigil Übergang“:
 - Sozialaktionen anstoßen: `node scripts/trigger-socialgood-workflow.js` (parst ToDos und startet SocialGood-Matching) oder `node scripts/run-parsing-socialgood.js` (lokales Parsing & Matching)
 - MemoryManager verschiebt abgelaufene Einträge automatisch von `daily` zu `weekly` und `longterm`.
 
+## 🌦️ Mandala Climate Dashboard Setup
+
+Der Mandala Climate Dashboard bündelt Klimadaten und Alarme.
+
+1. Konfiguriere KPI-Schwellen in `src/config/climate-dashboard.yaml`.
+2. Adapterschichten für ERA5, OISST, EFFIS, Pegel, Biodiversität, Radar und SPEI werden in `src/adapters` implementiert (TODO).
+3. Einheitliche Zeitreihen-Helfer befinden sich in `src/utils` (TODO).
+
+Diese Adapter und Utilities sind noch offen – Beiträge willkommen.
+
 ## 🔍 Mandala Transparency
 
 Transparenz ist ein zentraler Wert des UnifiedMandala.

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14652,13 +14652,13 @@
     "path": "src/config",
     "task": "Define KPI thresholds und Alarmregeln in YAML",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "docs: add Mandala Climate Dashboard setup",
     "path": "README.md",
     "task": "Document setup und Adapter TODOs für Climate Dashboard",
     "test": "",
-    "status": "open"
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13760,9 +13760,9 @@
   path: src/config
   task: Define KPI thresholds und Alarmregeln in YAML
   test: ""
-  status: open
+  status: done
 - commit: "docs: add Mandala Climate Dashboard setup"
   path: README.md
   task: Document setup und Adapter TODOs für Climate Dashboard
   test: ""
-  status: open
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6069,13 +6069,10 @@
     }
   ],
   "changedFiles": [
+    "README.md",
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "tools/windows/HotkeyDaemon.cs",
-    "tools/windows/README.md",
-    "tools/windows/ScreenGrab.cs",
-    "tools/windows/SpeechListener.cs",
-    "tools/windows/WinUABridge.cs"
+    "src/"
   ],
-  "lastUpdated": "2025-08-26T14:49:55.818Z"
+  "lastUpdated": "2025-08-26T14:56:35.595Z"
 }

--- a/src/config/climate-dashboard.yaml
+++ b/src/config/climate-dashboard.yaml
@@ -1,0 +1,12 @@
+# Configuration for Mandala Climate Dashboard
+# Defines KPI thresholds and alarm rules
+kpis:
+  temperature:
+    threshold: 2.0  # degrees Celsius above baseline
+    alarm: red
+  precipitation:
+    threshold: 150   # millimeters in 24h
+    alarm: yellow
+  co2:
+    threshold: 420   # ppm
+    alarm: orange


### PR DESCRIPTION
## Summary
- add climate dashboard configuration template
- document Mandala Climate Dashboard setup and adapter TODOs
- mark related tasks done in advanced ToDo files and refresh progress tracking

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `node repositorypflege/update-advanced-progress.js`
- `node repositorypflege/advanced-todo-report.js`


------
https://chatgpt.com/codex/tasks/task_e_68adca959d7c8322b405020b9d9e8aff