### PR TITLE
feat: scaffold climate data adapters

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14625,7 +14625,7 @@
     "path": "src/adapters",
     "task": "Stub ERA5, OISST, EFFIS, Pegel, Biodiversität, Radar und SPEI bindings",
     "test": "npx tsc -p tsconfig.json",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "feat: add KI co-designer modules",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13741,7 +13741,7 @@
   path: src/adapters
   task: Stub ERA5, OISST, EFFIS, Pegel, Biodiversität, Radar und SPEI bindings
   test: npx tsc -p tsconfig.json
-  status: open
+  status: done
 - commit: "feat: add KI co-designer modules"
   path: src/modules/ki
   task: Implement BayesDesigner, RLCSOAgent und evolve_green Selektoren

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add timeseries utility modules",
+  "lastCommit": "feat: scaffold climate data adapters",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -6076,6 +6076,10 @@
     {
       "commit": "Extend OS Bridge API with UIA and screen routes",
       "status": "done"
+    },
+    {
+      "commit": "feat: scaffold climate data adapters",
+      "status": "done"
     }
   ],
   "fractalTodos": [
@@ -6087,9 +6091,7 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "feedbackcodex.md",
-    "tsconfig.json",
-    "src/utils/"
+    "src/adapters/"
   ],
-  "lastUpdated": "2025-08-26T15:29:28.421Z"
+  "lastUpdated": "2025-08-26T16:03:34.115Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -179,3 +179,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented redaction API service exposing optional OCR for screenshot redaction.
 - Added Supernova Strahlungseinfluss module with tests and synced progress.
 - Added timeseries utility modules with quality control and MRV helpers for climate dashboard groundwork.
+- Scaffolded climate data adapters for ERA5, OISST, EFFIS, Pegel, Biodiversität, Radar and SPEI.

--- a/src/adapters/biodiversitaet.ts
+++ b/src/adapters/biodiversitaet.ts
@@ -1,0 +1,9 @@
+import { TimeSeries } from '../utils/timeseries/types';
+
+/**
+ * Placeholder for fetching Biodiversität indicators.
+ * TODO: hook into biodiversity monitoring services.
+ */
+export async function fetchBiodiversitaet(): Promise<TimeSeries> {
+  return [];
+}

--- a/src/adapters/effis.ts
+++ b/src/adapters/effis.ts
@@ -1,0 +1,9 @@
+import { TimeSeries } from '../utils/timeseries/types';
+
+/**
+ * Placeholder for fetching EFFIS wildfire data.
+ * TODO: connect to EFFIS datasets.
+ */
+export async function fetchEFFIS(): Promise<TimeSeries> {
+  return [];
+}

--- a/src/adapters/era5.ts
+++ b/src/adapters/era5.ts
@@ -1,0 +1,9 @@
+import { TimeSeries } from '../utils/timeseries/types';
+
+/**
+ * Placeholder for fetching ERA5 reanalysis data.
+ * TODO: implement retrieval from ECMWF API.
+ */
+export async function fetchERA5(): Promise<TimeSeries> {
+  return [];
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,0 +1,7 @@
+export * from './era5';
+export * from './oisst';
+export * from './effis';
+export * from './pegel';
+export * from './biodiversitaet';
+export * from './radar';
+export * from './spei';

--- a/src/adapters/oisst.ts
+++ b/src/adapters/oisst.ts
@@ -1,0 +1,9 @@
+import { TimeSeries } from '../utils/timeseries/types';
+
+/**
+ * Placeholder for fetching OISST sea surface temperature data.
+ * TODO: integrate NOAA OISST API.
+ */
+export async function fetchOISST(): Promise<TimeSeries> {
+  return [];
+}

--- a/src/adapters/pegel.ts
+++ b/src/adapters/pegel.ts
@@ -1,0 +1,9 @@
+import { TimeSeries } from '../utils/timeseries/types';
+
+/**
+ * Placeholder for fetching Pegel water level data.
+ * TODO: connect to national Pegel APIs.
+ */
+export async function fetchPegel(): Promise<TimeSeries> {
+  return [];
+}

--- a/src/adapters/radar.ts
+++ b/src/adapters/radar.ts
@@ -1,0 +1,9 @@
+import { TimeSeries } from '../utils/timeseries/types';
+
+/**
+ * Placeholder for fetching radar precipitation data.
+ * TODO: integrate weather radar feeds.
+ */
+export async function fetchRadar(): Promise<TimeSeries> {
+  return [];
+}

--- a/src/adapters/spei.ts
+++ b/src/adapters/spei.ts
@@ -1,0 +1,9 @@
+import { TimeSeries } from '../utils/timeseries/types';
+
+/**
+ * Placeholder for fetching Standardized Precipitation-Evapotranspiration Index data.
+ * TODO: pull SPEI time series from climate services.
+ */
+export async function fetchSPEI(): Promise<TimeSeries> {
+  return [];
+}


### PR DESCRIPTION
## Summary
- scaffold initial climate data adapter stubs for ERA5, OISST, EFFIS, Pegel, Biodiversität, Radar and SPEI datasets
- mark related advanced todos as complete and sync advanced progress tracking
- note new adapters in feedback codex for future contributors

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `node repositorypflege/update-advanced-progress.js`
- `node repositorypflege/advanced-todo-report.js`


------
https://chatgpt.com/codex/tasks/task_e_68add9dec4e483229c2e4a905db262d3