### PR TITLE
feat: add ffmpeg-based recorder API

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13660,7 +13660,7 @@
     "path": "scripts/recorder-api.ts",
     "task": "Wrap ffmpeg to start and stop screen recording via HTTP",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create MacroEditor component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13491,7 +13491,7 @@
   path: scripts/recorder-api.ts
   task: Wrap ffmpeg to start and stop screen recording via HTTP
   test: ''
-  status: open
+  status: done
 - commit: Create MacroEditor component
   path: packages/unifiedmandala-ui/components/MacroEditor.tsx
   task: Edit and run automation macros in the UI

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6105,25 +6105,21 @@
       "commit": "feat: scaffold climate data adapters",
       "status": "done"
     },
-      {
-        "commit": "feat: add macro automation modules",
-        "status": "done"
-      },
-      {
-        "commit": "feat: create GeophysikSection component",
-        "status": "done"
-      }
-    ],
+    {
+      "commit": "feat: add macro automation modules",
+      "status": "done"
+    },
+    {
+      "commit": "feat: create GeophysikSection component",
+      "status": "done"
+    }
+  ],
   "fractalTodos": [
     {
       "commit": "Add YAML output to split-newadvanced-conversations script",
       "status": "done"
     }
   ],
-  "changedFiles": [
-    "advancedToDo.json",
-    "advancedToDo.yaml",
-    "src/components/"
-  ],
-  "lastUpdated": "2025-08-26T19:10:48.414Z"
+  "changedFiles": [],
+  "lastUpdated": "2025-08-26T19:40:07.701Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -180,3 +180,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added Supernova Strahlungseinfluss module with tests and synced progress.
 - Added timeseries utility modules with quality control and MRV helpers for climate dashboard groundwork.
 - Scaffolded climate data adapters for ERA5, OISST, EFFIS, Pegel, Biodiversität, Radar and SPEI.
+\n- Implemented desktop recorder API with start/stop endpoints for ffmpeg screen capture.

--- a/scripts/recorder-api.ts
+++ b/scripts/recorder-api.ts
@@ -1,0 +1,42 @@
+import express from 'express';
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
+import path from 'path';
+
+const app = express();
+app.use(express.json());
+
+let recorder: ChildProcessWithoutNullStreams | null = null;
+let currentFile: string | null = null;
+
+app.post('/start', (req, res) => {
+  if (recorder) return res.status(400).json({ error: 'recording already in progress' });
+  currentFile = req.body?.output || path.join(process.cwd(), 'recording.mp4');
+  const display = process.platform === 'win32' ? 'desktop' : process.env.DISPLAY || ':0.0';
+  const args =
+    process.platform === 'win32'
+      ? ['-y', '-f', 'gdigrab', '-i', display, currentFile]
+      : ['-y', '-f', 'x11grab', '-i', display, currentFile];
+  recorder = spawn('ffmpeg', args);
+  recorder.on('exit', () => {
+    recorder = null;
+  });
+  res.json({ status: 'started', file: currentFile });
+});
+
+app.post('/stop', (req, res) => {
+  if (!recorder) return res.status(400).json({ error: 'no recording in progress' });
+  recorder.once('exit', () => {
+    const file = currentFile;
+    recorder = null;
+    currentFile = null;
+    res.json({ status: 'stopped', file });
+  });
+  recorder.kill('SIGINT');
+});
+
+const port = parseInt(process.env.PORT || '4001', 10);
+app.listen(port, () => {
+  console.log(`Recorder API listening on ${port}`);
+});
+
+export default app;


### PR DESCRIPTION
## Summary
- implement express recorder API wrapping ffmpeg with start/stop endpoints
- mark recorder API todo as complete and sync advanced progress trackers
- document recorder API addition in feedback codex

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68ae0c532bd4832282b0e00c94a725df