### PR TITLE
feat: add topology index registry

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-26, in der Zeit des Abend.
+Am 2025-08-27, in der Zeit des Morgen.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13697,7 +13697,7 @@
     "path": "packages/admin/TopologyIndex.ts",
     "task": "Track service probes and health in admin console",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Implement admin API gateway",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13071,7 +13071,7 @@
   path: packages/admin/TopologyIndex.ts
   task: Track service probes and health in admin console
   test: ""
-  status: open
+  status: done
 - commit: Implement admin API gateway
   path: scripts/admin-api.ts
   task: Aggregate service statuses and proxy admin commands

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5218,6 +5218,14 @@
     {
       "commit": "feat: add BehavioralDiffViewer analytics module",
       "status": "done"
+    },
+    {
+      "commit": "docs: create Sigillin Ritualbuch",
+      "status": "done"
+    },
+    {
+      "commit": "Add topology index registry",
+      "status": "done"
     }
   ],
   "completed": [
@@ -6148,11 +6156,6 @@
       "status": "done"
     }
   ],
-  "changedFiles": [
-    "advancedToDo.json",
-    "advancedToDo.yaml",
-    "docs/SigilRitualbuch.md",
-    "feedbackcodex.md"
-  ],
-  "lastUpdated": "2025-08-27T04:37:59.539Z"
+  "changedFiles": [],
+  "lastUpdated": "2025-08-27T05:40:11.783Z"
 }

--- a/packages/admin/TopologyIndex.ts
+++ b/packages/admin/TopologyIndex.ts
@@ -1,0 +1,49 @@
+export interface ServiceProbe {
+  name: string;
+  url: string;
+  status: 'online' | 'offline' | 'unknown';
+  lastChecked?: string;
+  latencyMs?: number;
+}
+
+/**
+ * TopologyIndex tracks registered services and their health status.
+ */
+export class TopologyIndex {
+  private probes: Map<string, ServiceProbe> = new Map();
+
+  /** Register a service probe. Existing entries are overwritten. */
+  register(probe: ServiceProbe): void {
+    this.probes.set(probe.name, {
+      ...probe,
+      lastChecked: probe.lastChecked ?? new Date().toISOString(),
+    });
+  }
+
+  /** Update the status and optional latency of a probe. */
+  updateStatus(name: string, status: ServiceProbe['status'], latencyMs?: number): void {
+    const current = this.probes.get(name);
+    if (!current) return;
+    current.status = status;
+    if (latencyMs !== undefined) {
+      current.latencyMs = latencyMs;
+    }
+    current.lastChecked = new Date().toISOString();
+    this.probes.set(name, current);
+  }
+
+  /** Retrieve a probe by name. */
+  get(name: string): ServiceProbe | undefined {
+    return this.probes.get(name);
+  }
+
+  /** List all registered probes. */
+  list(): ServiceProbe[] {
+    return Array.from(this.probes.values());
+  }
+
+  /** Remove a probe from the index. */
+  remove(name: string): void {
+    this.probes.delete(name);
+  }
+}

--- a/packages/admin/index.ts
+++ b/packages/admin/index.ts
@@ -1,0 +1,1 @@
+export * from './TopologyIndex';


### PR DESCRIPTION
## Summary
- add `TopologyIndex` for registering and monitoring service probes
- mark topology index registry todo as done and sync progress state

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68ae992bdb588322a880794ea6803f89