### PR TITLE
feat: expand conversation analysis options

### DIFF
--- a/Handbuch.md
+++ b/Handbuch.md
@@ -23,7 +23,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
   mit aktuellem `update_time` erzeugt.
 Für neue Aufgaben aus Chat-Logs nutze `scripts/parse-advanced-conversations.js` und aktualisiere `advancedToDo.json` sowie `advancedprogress.json`.
 Validiere extrahierte Einträge mit `pnpm run validate:todos` (CI integriert) um fehlende Felder oder Duplikate zu finden.
-- Gesprächsstatistiken (inkl. Titel & Zeitspanne) aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts`
+- Gesprächsstatistiken (inkl. Titel & Zeitspanne) aus neuen Protokollen: `ts-node scripts/analyze-newadvanced-conversations.ts --start 0 --count 10`
 - Struktur-, Zeit-, Root-Knoten-, Eltern- und Kindreferenz-Validierung, leere Nachrichteninhalte, Nachrichtenzeitstempel, Titel (Whitespaces und Steuerzeichen), Autorenrollen sowie Prüfung von `current_node` und `conversation_id` für neue Protokolle: `ts-node scripts/validate-newadvanced-conversations.ts`
 - Archivdaten mit dem QuantumTheoryAgent verknüpfen: `ts-node scripts/quantum-archive-ingest.ts`.
 - QuantumTheoryAgent Tests ausführen und Feedback sammeln: `ts-node scripts/quantum-agent-feedback.ts`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Weitere Hinweise aus dem „Sigil Übergang“:
   synchronisiere ToDo-Dateien vor großen Commits mit
   `scripts/sync-todo-progress.js`.
 - Freundschaftssystem-Konzept siehe [docs/friendship-system.md](docs/friendship-system.md)
-- Gesprächsstatistiken (inkl. Titel & Zeitspanne) aus neuen Chat-Logs: `ts-node scripts/analyze-newadvanced-conversations.ts`
+- Gesprächsstatistiken (inkl. Titel & Zeitspanne) aus neuen Chat-Logs: `ts-node scripts/analyze-newadvanced-conversations.ts --start 0 --count 10`
 - Sozialaktionen anstoßen: `node scripts/trigger-socialgood-workflow.js` (parst ToDos und startet SocialGood-Matching) oder `node scripts/run-parsing-socialgood.js` (lokales Parsing & Matching)
 - MemoryManager verschiebt abgelaufene Einträge automatisch von `daily` zu `weekly` und `longterm`.
 

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: sync advanced progress",
+  "lastCommit": "Merge pull request #1504 from GenesisAeon/codex/optimize-repository-and-implement-features-lhfzs5",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -8,28 +8,419 @@
   "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events | Added JetStream KV/ObjectStore wrappers and tool loader | Added waveform option to CREP sonification | Implemented GermanGrammarAssistant agent | Implemented GeoTIFF ingest | Added ingest demo script | Implemented ReviewerQueue and reviewer API | Added screen capture and UI automation routes | Implemented PatternMapperGPT and TunerGPT agents",
   "pendingTasks": [
     {
-      "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129",
-      "path": "GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json",
+      "commit": "Add desktop recorder tool",
       "status": "open"
     },
     {
-      "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e",
-      "path": "GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json",
+      "commit": "Implement UIMacroSynth agent",
       "status": "open"
     },
     {
-      "commit": "Integrate new GPT teams from Zukunft conversation",
-      "path": "packages/agents",
+      "commit": "Create MacroEditor component",
       "status": "open"
     },
     {
-      "commit": "feat: add 3D_Universumsstruktur visualization",
-      "path": "packages/universum-visualization/3D_Universumsstruktur.py",
+      "commit": "Create RedactionPanel component",
       "status": "open"
     },
     {
-      "commit": "feat: add NullmembranDynamics module",
-      "path": "packages/universum-simulationen/modules/NullmembranDynamics.py",
+      "commit": "Implement admin API gateway",
+      "status": "open"
+    },
+    {
+      "commit": "Create admin console app",
+      "status": "open"
+    },
+    {
+      "commit": "Add AI peer connector module",
+      "status": "open"
+    },
+    {
+      "commit": "Implement admin peers API",
+      "status": "open"
+    },
+    {
+      "commit": "Create spaces management module",
+      "status": "open"
+    },
+    {
+      "commit": "Implement commons API",
+      "status": "open"
+    },
+    {
+      "commit": "Add commons presence websocket",
+      "status": "open"
+    },
+    {
+      "commit": "Create commons hub app",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce task router module",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for admin and commons modules",
+      "status": "open"
+    },
+    {
+      "commit": "Create CoIntel orchestrator service",
+      "status": "open"
+    },
+    {
+      "commit": "Implement collab websocket server",
+      "status": "open"
+    },
+    {
+      "commit": "Add CreditLedger module",
+      "status": "open"
+    },
+    {
+      "commit": "Add AttributionIndex module",
+      "status": "open"
+    },
+    {
+      "commit": "Create peer handshake service",
+      "status": "open"
+    },
+    {
+      "commit": "Add setup wizard script",
+      "status": "open"
+    },
+    {
+      "commit": "Create CoauthorCanvas component",
+      "status": "open"
+    },
+    {
+      "commit": "Create TaskBoard component",
+      "status": "open"
+    },
+    {
+      "commit": "Add ConsentTimeline component",
+      "status": "open"
+    },
+    {
+      "commit": "Add PeerManager component",
+      "status": "open"
+    },
+    {
+      "commit": "Add ModelRouterEditor component",
+      "status": "open"
+    },
+    {
+      "commit": "Create identity API service",
+      "status": "open"
+    },
+    {
+      "commit": "Define UI templates",
+      "status": "open"
+    },
+    {
+      "commit": "Create instance registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Add ACL API service",
+      "status": "open"
+    },
+    {
+      "commit": "Create InitialAdminPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Define federation manifest type",
+      "status": "open"
+    },
+    {
+      "commit": "Create federation registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Create federation bridge websocket",
+      "status": "open"
+    },
+    {
+      "commit": "Add collab federation bridge script",
+      "status": "open"
+    },
+    {
+      "commit": "Create GlobalMandalaGraph component",
+      "status": "open"
+    },
+    {
+      "commit": "Add unified AppShell",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for Co-Intelligence services",
+      "status": "open"
+    },
+    {
+      "commit": "Append identity and federation services to code agent tasks",
+      "status": "open"
+    },
+    {
+      "commit": "Add OIDC stub service",
+      "status": "open"
+    },
+    {
+      "commit": "Add UI switchboard service",
+      "status": "open"
+    },
+    {
+      "commit": "Add compose override for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows stack start script",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows services installer",
+      "status": "open"
+    },
+    {
+      "commit": "Add UM integration GitHub workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Expose UM service scripts in package.json",
+      "status": "open"
+    },
+    {
+      "commit": "Provide tsconfig for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add production docker compose file",
+      "status": "open"
+    },
+    {
+      "commit": "Create generic Dockerfile for TypeScript services",
+      "status": "open"
+    },
+    {
+      "commit": "Configure NGINX reverse proxy for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add Kong gateway configuration",
+      "status": "open"
+    },
+    {
+      "commit": "Implement Ed25519 key generation script",
+      "status": "open"
+    },
+    {
+      "commit": "Add manifest signing script",
+      "status": "open"
+    },
+    {
+      "commit": "Add manifest verification script",
+      "status": "open"
+    },
+    {
+      "commit": "Create verified federation registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Implement SSO broker service",
+      "status": "open"
+    },
+    {
+      "commit": "Generate systemd unit files script",
+      "status": "open"
+    },
+    {
+      "commit": "Provide environment example",
+      "status": "open"
+    },
+    {
+      "commit": "Document production setup",
+      "status": "open"
+    },
+    {
+      "commit": "Add Keycloak OIDC dev bundle",
+      "status": "open"
+    },
+    {
+      "commit": "Add Kubernetes manifests with Kustomize overlays",
+      "status": "open"
+    },
+    {
+      "commit": "Add monitoring configuration",
+      "status": "open"
+    },
+    {
+      "commit": "Add Caddy TLS reverse proxy",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitHub Actions workflow for Kubernetes deployment",
+      "status": "open"
+    },
+    {
+      "commit": "Add Helm OIDC bundle",
+      "status": "open"
+    },
+    {
+      "commit": "Add Traefik mTLS ingress",
+      "status": "open"
+    },
+    {
+      "commit": "Add SLO monitoring pack",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps manifests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Add Go OIDC quickstart",
+      "status": "open"
+    },
+    {
+      "commit": "Add Keycloak auto-import helmfile",
+      "status": "open"
+    },
+    {
+      "commit": "Add Cloudflare DNS01 ClusterIssuer",
+      "status": "open"
+    },
+    {
+      "commit": "Add Argo Rollouts canary stack",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps app factory script",
+      "status": "open"
+    },
+    {
+      "commit": "Add Observability++ stack",
+      "status": "open"
+    },
+    {
+      "commit": "Add secret management examples",
+      "status": "open"
+    },
+    {
+      "commit": "Add NetworkPolicy templates",
+      "status": "open"
+    },
+    {
+      "commit": "Add blue/green rollouts with Slack alerts",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps golden path template",
+      "status": "open"
+    },
+    {
+      "commit": "Add one-click cluster bootstrap",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Vault CSI for secret file mounts",
+      "status": "open"
+    },
+    {
+      "commit": "Add ServiceMap-based NetworkPolicy generator",
+      "status": "open"
+    },
+    {
+      "commit": "Set up Cypress UI smoke tests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Set up k6 API smoke tests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Configure promotion gates for rollouts",
+      "status": "open"
+    },
+    {
+      "commit": "Deploy gate-controller for E2E gating",
+      "status": "open"
+    },
+    {
+      "commit": "Add Playwright synthetics with OTel",
+      "status": "open"
+    },
+    {
+      "commit": "Implement multi-signal quorum gates",
+      "status": "open"
+    },
+    {
+      "commit": "Add Terraform synthetics and alerting",
+      "status": "open"
+    },
+    {
+      "commit": "Enable auto-rollback on SLO violation",
+      "status": "open"
+    },
+    {
+      "commit": "Schedule weekly SLO and error budget reports",
+      "status": "open"
+    },
+    {
+      "commit": "Support multi-tenant E2E gates",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows E2E workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Track SLO budget consumption",
+      "status": "open"
+    },
+    {
+      "commit": "Capture debug snapshots on aborted rollouts",
+      "status": "open"
+    },
+    {
+      "commit": "Provide tenant admin API and UI",
+      "status": "open"
+    },
+    {
+      "commit": "Automate image builds and Kustomize validation",
+      "status": "open"
+    },
+    {
+      "commit": "Bootstrap GitOps root application",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce multi-cluster ApplicationSet and security policies",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Kyverno policies with Gatekeeper audit layer",
+      "status": "open"
+    },
+    {
+      "commit": "Apply Cilium default-deny and service allow policies",
+      "status": "open"
+    },
+    {
+      "commit": "Deploy Falco with RBAC-abuse rules and Slack alerts",
+      "status": "open"
+    },
+    {
+      "commit": "Wire OpenTelemetry collector to Tempo and Loki",
+      "status": "open"
+    },
+    {
+      "commit": "Enable Alertmanager night mode routing",
+      "status": "open"
+    },
+    {
+      "commit": "Define per-namespace Cilium FQDN allowlists",
+      "status": "open"
+    },
+    {
+      "commit": "Switch Kyverno verifyImages to enforce",
       "status": "open"
     }
   ],
@@ -6160,6 +6551,12 @@
       "status": "done"
     }
   ],
-  "changedFiles": [],
-  "lastUpdated": "2025-08-27T06:03:15.080Z"
+  "changedFiles": [
+    "Handbuch.md",
+    "README.md",
+    "feedbackcodex.md",
+    "scripts/analyze-newadvanced-conversations.test.ts",
+    "scripts/analyze-newadvanced-conversations.ts"
+  ],
+  "lastUpdated": "2025-08-27T08:26:59.837Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -182,3 +182,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Scaffolded climate data adapters for ERA5, OISST, EFFIS, Pegel, Biodiversität, Radar and SPEI.
 \n- Implemented desktop recorder API with start/stop endpoints for ffmpeg screen capture.
 - Documented Sigillin Ritualbuch usage and trigger phrases for unified Mandala.
+- Added start/count options to analyze-newadvanced-conversations script for partial dataset analysis.

--- a/scripts/analyze-newadvanced-conversations.test.ts
+++ b/scripts/analyze-newadvanced-conversations.test.ts
@@ -32,6 +32,16 @@ describe('analyzeNewAdvancedConversations', () => {
     expect(stats.todoCount).toBe(0);
   });
 
+  it('respects start and count parameters', () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-multi.json'
+    );
+    const stats = analyzeNewAdvancedConversations(file, undefined, 1, 1);
+    expect(stats.conversationCount).toBe(1);
+    expect(stats.titles).toEqual(['Second']);
+  });
+
   it('writes JSON stats when using --json flag', () => {
     const file = path.join(__dirname, '../tests/fixtures/newadvanced-sample.json');
     const out = path.join(os.tmpdir(), 'newadvanced-stats.json');
@@ -39,5 +49,17 @@ describe('analyzeNewAdvancedConversations', () => {
     execSync(`npx ts-node ${script} ${file} --json ${out}`);
     const written = JSON.parse(fs.readFileSync(out, 'utf8'));
     expect(written.conversationCount).toBe(1);
+  });
+
+  it('honors --start and --count flags', () => {
+    const file = path.join(__dirname, '../tests/fixtures/newadvanced-multi.json');
+    const out = path.join(os.tmpdir(), 'newadvanced-stats2.json');
+    const script = path.join(__dirname, 'analyze-newadvanced-conversations.ts');
+    execSync(
+      `npx ts-node ${script} ${file} --start 1 --count 1 --json ${out}`
+    );
+    const written = JSON.parse(fs.readFileSync(out, 'utf8'));
+    expect(written.conversationCount).toBe(1);
+    expect(written.titles).toEqual(['Second']);
   });
 });

--- a/scripts/analyze-newadvanced-conversations.ts
+++ b/scripts/analyze-newadvanced-conversations.ts
@@ -14,12 +14,15 @@ export interface ConversationStats {
 
 export function analyzeNewAdvancedConversations(
   filePath: string,
-  filterTitles?: string[]
+  filterTitles?: string[],
+  start = 0,
+  count = Infinity
 ): ConversationStats {
   const raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  const sessions = Array.isArray(filterTitles)
+  const allSessions = Array.isArray(filterTitles)
     ? raw.filter((s: any) => filterTitles.includes(s.title))
     : raw;
+  const sessions = allSessions.slice(start, start + count);
   let messageCount = 0;
   const authorCounts: Record<string, number> = {};
   let minTime: number | null = null;
@@ -78,7 +81,12 @@ if (require.main === module) {
           .split(',')
           .map((t: string) => t.trim())
       : undefined;
-  const stats = analyzeNewAdvancedConversations(file, titleList);
+  const startIndex = args.indexOf('--start');
+  const start = startIndex >= 0 ? parseInt(args[startIndex + 1], 10) : 0;
+  const countIndex = args.indexOf('--count');
+  const count =
+    countIndex >= 0 ? parseInt(args[countIndex + 1], 10) : Infinity;
+  const stats = analyzeNewAdvancedConversations(file, titleList, start, count);
   console.log(`Conversations: ${stats.conversationCount}`);
   console.log(`Messages: ${stats.messageCount}`);
   console.log('Authors:', stats.authorCounts);


### PR DESCRIPTION
## Summary
- allow partial dataset analysis in `analyze-newadvanced-conversations.ts` via `--start` and `--count`
- document new options in README and Handbuch and record in feedbackcodex
- sync `advancedprogress.json`

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `npx vitest run scripts/analyze-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aebfefe1548322bbc9214142c4f1d8