### PR TITLE
feat: add Ed25519 key and manifest tools

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14103,21 +14103,21 @@
     "path": "scripts/generate-ed25519.ts",
     "task": "Write key pair to keys/ directory",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add manifest signing script",
     "path": "scripts/sign-manifest.ts",
     "task": "Sign federation manifest with Ed25519 key",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add manifest verification script",
     "path": "scripts/verify-manifest.ts",
     "task": "Verify signed manifest using public key",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create verified federation registry service",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13361,17 +13361,17 @@
   path: scripts/generate-ed25519.ts
   task: Write key pair to keys/ directory
   test: ""
-  status: open
+  status: done
 - commit: Add manifest signing script
   path: scripts/sign-manifest.ts
   task: Sign federation manifest with Ed25519 key
   test: ""
-  status: open
+  status: done
 - commit: Add manifest verification script
   path: scripts/verify-manifest.ts
   task: Verify signed manifest using public key
   test: ""
-  status: open
+  status: done
 - commit: Create verified federation registry service
   path: scripts/federation-registry-verified.ts
   task: Validate manifest signatures on register

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6172,6 +6172,14 @@
       "status": "done"
     }
   ],
-  "changedFiles": [],
-  "lastUpdated": "2025-08-27T12:37:11.468Z"
+  "changedFiles": [
+    "advancedToDo.json",
+    "advancedToDo.yaml",
+    "feedbackcodex.md",
+    "keys/",
+    "scripts/generate-ed25519.ts",
+    "scripts/sign-manifest.ts",
+    "scripts/verify-manifest.ts"
+  ],
+  "lastUpdated": "2025-08-27T12:47:24.586Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -184,3 +184,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Documented Sigillin Ritualbuch usage and trigger phrases for unified Mandala.
 - Added start/count options to analyze-newadvanced-conversations script for partial dataset analysis.
 - Documented core service ports and secrets in .env.example and synced progress files.
+- Added Ed25519 key generation and manifest signing scripts for federation.

--- a/keys/.gitignore
+++ b/keys/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/scripts/generate-ed25519.ts
+++ b/scripts/generate-ed25519.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env ts-node
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { generateKeyPairSync } from 'crypto';
+
+function main() {
+  const dir = join(process.cwd(), 'keys');
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  writeFileSync(join(dir, 'ed25519-public.pem'), publicKey.export({ type: 'spki', format: 'pem' }));
+  writeFileSync(join(dir, 'ed25519-private.pem'), privateKey.export({ type: 'pkcs8', format: 'pem' }));
+  console.log('Generated Ed25519 key pair in keys/');
+}
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/sign-manifest.ts
+++ b/scripts/sign-manifest.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env ts-node
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { sign } from 'crypto';
+
+function main() {
+  const [manifestPath, keyPath] = process.argv.slice(2);
+  if (!manifestPath) {
+    console.error('Usage: sign-manifest <manifest.json> [privateKey]');
+    process.exit(1);
+  }
+  const privateKey = readFileSync(keyPath || join('keys', 'ed25519-private.pem'));
+  const data = readFileSync(manifestPath);
+  const signature = sign(null, data, privateKey).toString('base64');
+  writeFileSync(manifestPath + '.sig', signature);
+  console.log(`Signature written to ${manifestPath}.sig`);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/verify-manifest.ts
+++ b/scripts/verify-manifest.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env ts-node
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { verify } from 'crypto';
+
+function main() {
+  const [manifestPath, signaturePath, pubKeyPath] = process.argv.slice(2);
+  if (!manifestPath) {
+    console.error('Usage: verify-manifest <manifest.json> [signature] [publicKey]');
+    process.exit(1);
+  }
+  const sigPath = signaturePath || manifestPath + '.sig';
+  const publicKey = readFileSync(pubKeyPath || join('keys', 'ed25519-public.pem'));
+  const data = readFileSync(manifestPath);
+  const signature = readFileSync(sigPath, 'utf8').trim();
+  const ok = verify(null, data, publicKey, Buffer.from(signature, 'base64'));
+  if (ok) {
+    console.log('Manifest signature verified.');
+  } else {
+    console.error('Manifest signature verification failed.');
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add script to generate Ed25519 keypairs
- add manifest signing and verification scripts
- mark related advanced ToDo items as complete

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68aefdcfaa78832281f6a2a7dca58aaf