### PR TITLE
feat: add MacroEditor component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13668,8 +13668,8 @@
     "commit": "Create MacroEditor component",
     "path": "packages/unifiedmandala-ui/components/MacroEditor.tsx",
     "task": "Edit and run automation macros in the UI",
-    "test": "",
-    "status": "open"
+    "test": "packages/unifiedmandala-ui/components/MacroEditor.test.tsx",
+    "status": "done"
   },
   {
     "commit": "Create RedactionPanel component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13050,8 +13050,8 @@
 - commit: Create MacroEditor component
   path: packages/unifiedmandala-ui/components/MacroEditor.tsx
   task: Edit and run automation macros in the UI
-  test: ""
-  status: open
+  test: packages/unifiedmandala-ui/components/MacroEditor.test.tsx
+  status: done
 - commit: Create RedactionPanel component
   path: packages/unifiedmandala-ui/components/RedactionPanel.tsx
   task: Upload screenshots and apply manual redaction boxes

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6175,11 +6175,8 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "feedbackcodex.md",
-    "keys/",
-    "scripts/generate-ed25519.ts",
-    "scripts/sign-manifest.ts",
-    "scripts/verify-manifest.ts"
+    "packages/unifiedmandala-ui/components/MacroEditor.test.tsx",
+    "packages/unifiedmandala-ui/components/MacroEditor.tsx"
   ],
-  "lastUpdated": "2025-08-27T12:47:24.586Z"
+  "lastUpdated": "2025-08-27T12:56:14.284Z"
 }

--- a/packages/unifiedmandala-ui/components/MacroEditor.test.tsx
+++ b/packages/unifiedmandala-ui/components/MacroEditor.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MacroEditor from './MacroEditor';
+
+describe('MacroEditor', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      text: () => Promise.resolve('ok')
+    });
+  });
+
+  test('runs macro via API', async () => {
+    const { getByText, getByPlaceholderText, findByText } = render(<MacroEditor />);
+    fireEvent.change(getByPlaceholderText('Enter macro...'), { target: { value: 'print("hi")' } });
+    fireEvent.click(getByText('Run'));
+    await findByText('ok');
+    expect(fetch).toHaveBeenCalledWith(
+      '/macro/run',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+});

--- a/packages/unifiedmandala-ui/components/MacroEditor.tsx
+++ b/packages/unifiedmandala-ui/components/MacroEditor.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+
+/**
+ * MacroEditor allows typing automation macros and executing them via HTTP.
+ * It posts the macro source to `/macro/run` and renders the response.
+ */
+export default function MacroEditor() {
+  const [source, setSource] = useState('');
+  const [output, setOutput] = useState<string | null>(null);
+
+  const run = () => {
+    fetch('/macro/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source })
+    })
+      .then((r) => r.text())
+      .then((text) => setOutput(text))
+      .catch(() => setOutput('error'));
+  };
+
+  return (
+    <div aria-label="MacroEditor">
+      <textarea
+        placeholder="Enter macro..."
+        value={source}
+        onChange={(e) => setSource(e.target.value)}
+      />
+      <button onClick={run}>Run</button>
+      {output && <pre>{output}</pre>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add MacroEditor React component and test for running automation macros
- mark MacroEditor task as done in advancedToDo files
- sync advancedprogress tracker

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: venv path not valid, workspace too large)*
- `npx tsc -p tsconfig.json` *(timed out)*
- `npx jest packages/unifiedmandala-ui/components/MacroEditor.test.tsx` *(timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68aefff8b07c832298ab5ee0be645c8a