### PR TITLE
feat: add AeonUpdateTicketGenerator

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -2938,7 +2938,8 @@
     "commit": "feat: add AeonUpdateTicketGenerator",
     "path": "packages/aeon-shell/AeonUpdateTicketGenerator.ts",
     "task": "Create update ticket templates for Aeon cycles",
-    "test": "packages/aeon-shell/__tests__/AeonUpdateTicketGenerator.test.ts"
+    "test": "packages/aeon-shell/__tests__/AeonUpdateTicketGenerator.test.ts",
+    "status": "done"
   },
   {
     "commit": "feat: add PathkeeperGPT agent",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -4592,6 +4592,7 @@
   path: packages/aeon-shell/AeonUpdateTicketGenerator.ts
   task: Create update ticket templates for Aeon cycles
   test: packages/aeon-shell/__tests__/AeonUpdateTicketGenerator.test.ts
+  status: done
 - commit: "feat: add PathkeeperGPT agent"
   path: packages/agents/PathkeeperGPT.ts
   task: Maintain publication strategy and update docs

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6175,8 +6175,9 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "packages/unifiedmandala-ui/components/MacroEditor.test.tsx",
-    "packages/unifiedmandala-ui/components/MacroEditor.tsx"
+    "packages/aeon-shell/index.ts",
+    "packages/aeon-shell/AeonUpdateTicketGenerator.ts",
+    "packages/aeon-shell/__tests__/"
   ],
-  "lastUpdated": "2025-08-27T12:56:14.284Z"
+  "lastUpdated": "2025-08-27T13:19:20.090Z"
 }

--- a/packages/aeon-shell/AeonUpdateTicketGenerator.ts
+++ b/packages/aeon-shell/AeonUpdateTicketGenerator.ts
@@ -1,0 +1,20 @@
+import { randomUUID } from 'crypto';
+
+export interface AeonUpdateTicket {
+  id: string;
+  description: string;
+  createdAt: Date;
+}
+
+/**
+ * Generates update tickets for Aeon cycles.
+ */
+export class AeonUpdateTicketGenerator {
+  create(description: string): AeonUpdateTicket {
+    return {
+      id: randomUUID(),
+      description,
+      createdAt: new Date(),
+    };
+  }
+}

--- a/packages/aeon-shell/__tests__/AeonUpdateTicketGenerator.test.ts
+++ b/packages/aeon-shell/__tests__/AeonUpdateTicketGenerator.test.ts
@@ -1,0 +1,11 @@
+import { AeonUpdateTicketGenerator } from '../AeonUpdateTicketGenerator';
+
+describe('AeonUpdateTicketGenerator', () => {
+  it('creates ticket with id and description', () => {
+    const gen = new AeonUpdateTicketGenerator();
+    const ticket = gen.create('sync context');
+    expect(ticket.description).toBe('sync context');
+    expect(ticket.id).toBeDefined();
+    expect(ticket.createdAt).toBeInstanceOf(Date);
+  });
+});

--- a/packages/aeon-shell/index.ts
+++ b/packages/aeon-shell/index.ts
@@ -3,3 +3,4 @@ export { SYMBOLZEIT } from './symbolzeit';
 export { SymbolzeitOrchestrator } from './SymbolzeitOrchestrator';
 export { SymbolzeitManager } from './SymbolzeitManager';
 export { runCommand as AeonShellBridge } from './AeonShellBridge';
+export { AeonUpdateTicketGenerator } from './AeonUpdateTicketGenerator';


### PR DESCRIPTION
## Summary
- add `AeonUpdateTicketGenerator` for creating cycle update tickets
- export new generator from aeon-shell package and mark todo as complete
- track progress update in advancedprogress

## Testing
- `npx pyright` *(fails: venvPath /workspace/unified-mandala/.venv is not a valid directory)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: no output, process terminated)*
- `npx jest packages/aeon-shell/__tests__/AeonUpdateTicketGenerator.test.ts` *(fails: no output, process terminated)*
- `node repositorypflege/update-advanced-progress.js`

------
https://chatgpt.com/codex/tasks/task_e_68af04c55dd88322acf81ab7a6bfb397