### PR TITLE
feat: enhance advanced todo reporting

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6173,11 +6173,9 @@
     }
   ],
   "changedFiles": [
-    "advancedToDo.json",
-    "advancedToDo.yaml",
-    "packages/aeon-shell/index.ts",
-    "packages/aeon-shell/AeonUpdateTicketGenerator.ts",
-    "packages/aeon-shell/__tests__/"
+    "docs/sigils/advancedprogress-guide.md",
+    "repositorypflege/advanced-todo-report.js",
+    "repositorypflege/list-open-advanced-todos.js"
   ],
-  "lastUpdated": "2025-08-27T13:19:20.090Z"
+  "lastUpdated": "2025-08-27T13:48:47.427Z"
 }

--- a/docs/sigils/advancedprogress-guide.md
+++ b/docs/sigils/advancedprogress-guide.md
@@ -29,8 +29,10 @@ To view open tasks grouped by their directories, run:
 node repositorypflege/advanced-todo-report.js
 ```
 
-This summarizes open items per folder without touching the large conversation
-datasets.
+By default this report skips any tasks referencing `conversations` files to
+avoid loading massive datasets. Pass `--include-conversations` if you really
+need them. The default text output now also shows how many open tasks exist per
+directory and prints a total at the end.
 
 ## Handling Large Conversation Files
 

--- a/repositorypflege/advanced-todo-report.js
+++ b/repositorypflege/advanced-todo-report.js
@@ -2,8 +2,10 @@ const path = require('path');
 const yaml = require('js-yaml');
 const { listOpenAdvancedTodos } = require('./list-open-advanced-todos');
 
-function groupTodosByDir(pattern, todoPaths, excludePattern) {
-  const todos = listOpenAdvancedTodos(pattern, todoPaths, excludePattern);
+function groupTodosByDir(pattern, todoPaths, excludePattern, includeConversations = false) {
+  const todos = listOpenAdvancedTodos(pattern, todoPaths, excludePattern, {
+    includeConversations
+  });
   return todos.reduce((acc, t) => {
     const dir = path.dirname(t.path || '').replace(/\\/g, '/');
     if (!acc[dir]) acc[dir] = [];
@@ -21,17 +23,21 @@ if (require.main === module) {
   const exclude = exclIndex >= 0 ? process.argv[exclIndex + 1] : undefined;
   const jsonOutput = process.argv.includes('--json');
   const yamlOutput = process.argv.includes('--yaml');
+  const includeConvos = process.argv.includes('--include-conversations');
 
-  const grouped = groupTodosByDir(pattern, todoPaths, exclude);
+  const grouped = groupTodosByDir(pattern, todoPaths, exclude, includeConvos);
   if (yamlOutput) {
     console.log(yaml.dump(grouped));
   } else if (jsonOutput) {
     console.log(JSON.stringify(grouped, null, 2));
   } else {
+    let total = 0;
     for (const [dir, tasks] of Object.entries(grouped)) {
-      console.log(`${dir}:`);
+      total += tasks.length;
+      console.log(`${dir} (${tasks.length}):`);
       tasks.forEach((t) => console.log(`  - ${t.commit}`));
     }
+    console.log(`Total open tasks: ${total}`);
   }
 }
 

--- a/repositorypflege/list-open-advanced-todos.js
+++ b/repositorypflege/list-open-advanced-todos.js
@@ -26,7 +26,12 @@ function collectFiles(inputPaths) {
   return files;
 }
 
-function listOpenAdvancedTodos(pattern, todoPaths, excludePattern) {
+function listOpenAdvancedTodos(
+  pattern,
+  todoPaths,
+  excludePattern,
+  { includeConversations = false } = {}
+) {
   const basePaths =
     todoPaths && todoPaths.length
       ? Array.isArray(todoPaths)
@@ -45,7 +50,13 @@ function listOpenAdvancedTodos(pattern, todoPaths, excludePattern) {
     }
   }
   const regex = pattern ? new RegExp(pattern, 'i') : null;
-  const excludeRegex = excludePattern ? new RegExp(excludePattern, 'i') : null;
+  const exclude =
+    excludePattern !== undefined
+      ? excludePattern
+      : includeConversations
+      ? undefined
+      : 'conversations';
+  const excludeRegex = exclude ? new RegExp(exclude, 'i') : null;
   const seen = new Set();
   const result = [];
   for (const item of data) {
@@ -75,7 +86,10 @@ if (require.main === module) {
   const todoPaths = pathArg ? pathArg.split(',') : undefined;
   const exclIndex = process.argv.indexOf('--exclude');
   const exclude = exclIndex >= 0 ? process.argv[exclIndex + 1] : undefined;
-  const open = listOpenAdvancedTodos(pattern, todoPaths, exclude);
+  const includeConvos = process.argv.includes('--include-conversations');
+  const open = listOpenAdvancedTodos(pattern, todoPaths, exclude, {
+    includeConversations: includeConvos
+  });
   const display = open.slice(0, limit);
   display.forEach((t) => {
     const commitText =


### PR DESCRIPTION
## Summary
- skip heavy conversation files by default when listing advanced todos
- show per-directory counts in advanced todo report and document new `--include-conversations` flag
- refresh advanced progress snapshot

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `node repositorypflege/advanced-todo-report.js --grep universum-visualization`
- `node repositorypflege/update-advanced-progress.js`


------
https://chatgpt.com/codex/tasks/task_e_68af0bb470c48322af64eb9ed4dd4fda