### PR TITLE
feat(agents): add phase A agent framework

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ CREP_THRESHOLD_PERSISTENCE=0.3                # Schwelle P-Wert zur Persistenz-F
 
 JWT_SECRET=dein-geheimes-token                # Secret für JWT-Signatur
 SESSION_SECRET=dein-session-secret            # Secret für Session-Management
+ 
+# Agents Logging/Dirs
+AGENTS_LOG_DIR=./data/agents/logs

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14836,14 +14836,17 @@
         "path": "docs/offline/cards/"
       }
     ]
-  }
-,
+  },
   {
     "id": "GOV-013",
     "title": "HI-Compact + AB-Policy + Runbooks verankern",
     "owner": "genesis-aeon",
     "priority": "high",
-    "labels": ["governance","ethics","docs"],
+    "labels": [
+      "governance",
+      "ethics",
+      "docs"
+    ],
     "status": "open",
     "acceptance": [
       "governance/HI-Compact.md vorhanden",
@@ -14851,9 +14854,15 @@
       "docs/runbooks/* vorhanden und verlinkt"
     ],
     "changes": [
-      {"path":"governance/HI-Compact.md"},
-      {"path":"governance/policies/ab-test.yaml"},
-      {"path":"docs/runbooks/"}
+      {
+        "path": "governance/HI-Compact.md"
+      },
+      {
+        "path": "governance/policies/ab-test.yaml"
+      },
+      {
+        "path": "docs/runbooks/"
+      }
     ]
   },
   {
@@ -14861,16 +14870,26 @@
     "title": "MRV-Logging & Smoke-Tests lauffähig",
     "owner": "genesis-aeon",
     "priority": "high",
-    "labels": ["mrv","smoke","infra"],
+    "labels": [
+      "mrv",
+      "smoke",
+      "infra"
+    ],
     "status": "open",
     "acceptance": [
       "data/mrv/actions/*.json wird erzeugt",
       "smoke:ui, smoke:dev, smoke:mrv laufen lokal"
     ],
     "changes": [
-      {"path":"scripts/mrv/"},
-      {"path":"scripts/smoke/"},
-      {"path":"package.json"}
+      {
+        "path": "scripts/mrv/"
+      },
+      {
+        "path": "scripts/smoke/"
+      },
+      {
+        "path": "package.json"
+      }
     ]
   },
   {
@@ -14878,16 +14897,57 @@
     "title": "Climate-Config/Adapter-Skelette verdrahten",
     "owner": "genesis-aeon",
     "priority": "medium",
-    "labels": ["climate","adapters"],
+    "labels": [
+      "climate",
+      "adapters"
+    ],
     "status": "open",
     "acceptance": [
       "src/config/climate-dashboard.yaml vorhanden",
       "src/adapters/* und src/utils/series.ts vorhanden"
     ],
     "changes": [
-      {"path":"src/config/climate-dashboard.yaml"},
-      {"path":"src/adapters/"},
-      {"path":"src/utils/series.ts"}
+      {
+        "path": "src/config/climate-dashboard.yaml"
+      },
+      {
+        "path": "src/adapters/"
+      },
+      {
+        "path": "src/utils/series.ts"
+      }
+    ]
+  },
+  {
+    "id": "AGT-020",
+    "title": "Agents Guardrails/Registry/Runner (Phase A) aktiv",
+    "owner": "genesis-aeon",
+    "priority": "high",
+    "labels": [
+      "agents",
+      "governance",
+      "infra"
+    ],
+    "status": "open",
+    "acceptance": [
+      "agents/registry.yaml existiert (leer oder mit Einträgen)",
+      "governance/policies/agents-policy.yaml vorhanden",
+      "scripts/agents/runner.ts + shared utils vorhanden",
+      "pnpm agents:health läuft (Exit 0)"
+    ],
+    "changes": [
+      {
+        "path": "agents/registry.yaml"
+      },
+      {
+        "path": "governance/policies/agents-policy.yaml"
+      },
+      {
+        "path": "agents/_shared/"
+      },
+      {
+        "path": "scripts/agents/"
+      }
     ]
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13881,46 +13881,70 @@
   changes:
     - path: docs/offline/offline-kit.md
     - path: docs/offline/cards/
-
 - id: GOV-013
-  title: "HI-Compact + AB-Policy + Runbooks verankern"
-  owner: "genesis-aeon"
+  title: HI-Compact + AB-Policy + Runbooks verankern
+  owner: genesis-aeon
   priority: high
-  labels: [governance, ethics, docs]
+  labels:
+    - governance
+    - ethics
+    - docs
   status: open
   acceptance:
-    - "governance/HI-Compact.md vorhanden"
-    - "governance/policies/ab-test.yaml vorhanden"
-    - "docs/runbooks/* vorhanden und verlinkt"
+    - governance/HI-Compact.md vorhanden
+    - governance/policies/ab-test.yaml vorhanden
+    - docs/runbooks/* vorhanden und verlinkt
   changes:
     - path: governance/HI-Compact.md
     - path: governance/policies/ab-test.yaml
     - path: docs/runbooks/
-
 - id: MRV-014
-  title: "MRV-Logging & Smoke-Tests lauffähig"
-  owner: "genesis-aeon"
+  title: MRV-Logging & Smoke-Tests lauffähig
+  owner: genesis-aeon
   priority: high
-  labels: [mrv, smoke, infra]
+  labels:
+    - mrv
+    - smoke
+    - infra
   status: open
   acceptance:
-    - "data/mrv/actions/*.json wird erzeugt"
-    - "smoke:ui, smoke:dev, smoke:mrv laufen lokal"
+    - data/mrv/actions/*.json wird erzeugt
+    - smoke:ui, smoke:dev, smoke:mrv laufen lokal
   changes:
     - path: scripts/mrv/
     - path: scripts/smoke/
     - path: package.json
-
 - id: CLI-015
-  title: "Climate-Config/Adapter-Skelette verdrahten"
-  owner: "genesis-aeon"
+  title: Climate-Config/Adapter-Skelette verdrahten
+  owner: genesis-aeon
   priority: medium
-  labels: [climate, adapters]
+  labels:
+    - climate
+    - adapters
   status: open
   acceptance:
-    - "src/config/climate-dashboard.yaml vorhanden"
-    - "src/adapters/* und src/utils/series.ts vorhanden"
+    - src/config/climate-dashboard.yaml vorhanden
+    - src/adapters/* und src/utils/series.ts vorhanden
   changes:
     - path: src/config/climate-dashboard.yaml
     - path: src/adapters/
     - path: src/utils/series.ts
+- id: AGT-020
+  title: Agents Guardrails/Registry/Runner (Phase A) aktiv
+  owner: genesis-aeon
+  priority: high
+  labels:
+    - agents
+    - governance
+    - infra
+  status: open
+  acceptance:
+    - agents/registry.yaml existiert (leer oder mit Einträgen)
+    - governance/policies/agents-policy.yaml vorhanden
+    - scripts/agents/runner.ts + shared utils vorhanden
+    - pnpm agents:health läuft (Exit 0)
+  changes:
+    - path: agents/registry.yaml
+    - path: governance/policies/agents-policy.yaml
+    - path: agents/_shared/
+    - path: scripts/agents/

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: normalize advanced todo files",
+  "lastCommit": "feat(agents): add phase A framework",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -377,6 +377,18 @@
     },
     {
       "commit": "Switch Kyverno verifyImages to enforce",
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
       "status": "open"
     },
     {

--- a/agents/_shared/circuit-breaker.ts
+++ b/agents/_shared/circuit-breaker.ts
@@ -1,0 +1,18 @@
+export function makeCircuitBreaker(opts:{ failure_threshold:number; cooldown_ms:number }) {
+  let failures = 0; let openUntil = 0;
+  return {
+    async exec<T>(fn:()=>Promise<T>): Promise<T> {
+      const now = Date.now();
+      if (now < openUntil) throw new Error("circuit_open");
+      try {
+        const res = await fn(); failures = 0; return res;
+      } catch (e) {
+        failures++; if (failures >= opts.failure_threshold) {
+          openUntil = now + opts.cooldown_ms;
+        }
+        throw e;
+      }
+    }
+  };
+}
+

--- a/agents/_shared/guardrails.ts
+++ b/agents/_shared/guardrails.ts
@@ -1,0 +1,38 @@
+import fs from "fs"; import path from "path"; import yaml from "yaml";
+type Policy = {
+  defaults: {
+    max_qps:number; max_concurrency:number; request_timeout_ms:number;
+    retry:{attempts:number;base_delay_ms:number;jitter:boolean};
+    circuit_breaker:{failure_threshold:number;cooldown_ms:number};
+    allowed_domains:string[]; user_consent_required:boolean;
+  };
+  agents?: Record<string, Partial<Policy["defaults"]>>;
+};
+function loadPolicy(): Policy {
+  const p = path.resolve(process.cwd(), "governance/policies/agents-policy.yaml");
+  const txt = fs.readFileSync(p, "utf8");
+  return yaml.parse(txt) as Policy;
+}
+export function makeGuard(agentId: string) {
+  const pol = loadPolicy();
+  const base = pol.defaults;
+  const ov = (pol.agents && pol.agents[agentId]) || {};
+  const merged = { ...base, ...ov };
+  return {
+    consentRequired: !!merged.user_consent_required,
+    requestTimeoutMs: merged.request_timeout_ms,
+    ensureAllowedDomain: (urlStr: string) => {
+      const u = new URL(urlStr);
+      const host = u.hostname.toLowerCase();
+      const ok = merged.allowed_domains.some(d => host === d || host.endsWith("."+d));
+      if (!ok) throw new Error(`domain_not_allowed:${host}`);
+    },
+    limits: {
+      maxQps: merged.max_qps,
+      maxConcurrency: merged.max_concurrency,
+      retry: merged.retry,
+      circuit: merged.circuit_breaker
+    }
+  };
+}
+

--- a/agents/_shared/http.ts
+++ b/agents/_shared/http.ts
@@ -1,0 +1,20 @@
+import { withRetry } from "./retry";
+export function makeHttp(guard:{
+  ensureAllowedDomain:(url:string)=>void,
+  requestTimeoutMs:number
+}) {
+  return async (url: string, init: RequestInit & { timeoutMs?: number } = {}) => {
+    guard.ensureAllowedDomain(url);
+    const timeoutMs = init.timeoutMs ?? guard.requestTimeoutMs ?? 120000;
+    return withRetry(async () => {
+      const ac = new AbortController();
+      const t = setTimeout(()=>ac.abort(), timeoutMs);
+      try {
+        const res = await fetch(url, { ...init, signal: ac.signal });
+        if (!res.ok) throw new Error(`http_${res.status}`);
+        return res;
+      } finally { clearTimeout(t); }
+    }, 3, 400, true);
+  };
+}
+

--- a/agents/_shared/logger.ts
+++ b/agents/_shared/logger.ts
@@ -1,0 +1,14 @@
+import fs from "fs"; import path from "path";
+type Level = "debug"|"info"|"warn"|"error";
+const LOG_DIR = process.env.AGENTS_LOG_DIR || "data/agents/logs";
+export function makeLogger(agentId: string) {
+  const dir = path.resolve(process.cwd(), LOG_DIR);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${agentId}.jsonl`);
+  return (level: Level, msg: string, meta: any = {}) => {
+    const rec = { ts: new Date().toISOString(), level, agent: agentId, msg, ...meta };
+    fs.appendFileSync(file, JSON.stringify(rec) + "\n");
+    if (level !== "debug") console.log(`[${level}] ${agentId}: ${msg}`);
+  };
+}
+

--- a/agents/_shared/rate-limit.ts
+++ b/agents/_shared/rate-limit.ts
@@ -1,0 +1,20 @@
+// sehr einfacher Token-Bucket pro Key (In-Memory)
+const buckets = new Map<string,{ tokens:number; last:number }>();
+export function makeRateLimiter(qps: number) {
+  return async (key = "global") => {
+    const now = Date.now();
+    const b = buckets.get(key) || { tokens: qps, last: now };
+    const refill = ((now - b.last) / 1000) * qps;
+    b.tokens = Math.min(qps, b.tokens + refill);
+    b.last = now;
+    if (b.tokens < 1) {
+      const waitMs = ((1 - b.tokens) / qps) * 1000;
+      await new Promise(r => setTimeout(r, waitMs));
+      b.tokens = 0;
+    } else {
+      b.tokens -= 1;
+    }
+    buckets.set(key, b);
+  };
+}
+

--- a/agents/_shared/retry.ts
+++ b/agents/_shared/retry.ts
@@ -1,0 +1,11 @@
+export async function withRetry<T>(fn:()=>Promise<T>, attempts:number, baseDelayMs:number, jitter=true): Promise<T> {
+  let err: any;
+  for (let i=0;i<attempts;i++) {
+    try { return await fn(); } catch(e){ err = e; }
+    const backoff = baseDelayMs * Math.pow(2, i);
+    const j = jitter ? Math.random() * backoff * 0.2 : 0;
+    await new Promise(r=>setTimeout(r, backoff + j));
+  }
+  throw err;
+}
+

--- a/agents/_shared/types.ts
+++ b/agents/_shared/types.ts
@@ -1,0 +1,18 @@
+export type AgentHealth = { id: string; ok: boolean; info?: Record<string, unknown> };
+export type AgentContext = {
+  logger: (level: "debug"|"info"|"warn"|"error", msg: string, meta?: any) => void;
+  rateLimit: (key?: string) => Promise<void>;
+  http: (url: string, init?: RequestInit & { timeoutMs?: number }) => Promise<Response>;
+  guard: {
+    ensureAllowedDomain: (url: string) => void;
+    consentRequired: boolean;
+    requestTimeoutMs: number;
+  };
+};
+export interface Agent<Input = any, Output = any> {
+  id: string;
+  health(): Promise<AgentHealth>;
+  run(input: Input, ctx: AgentContext): Promise<Output>;
+  getCapabilities?(): Promise<string[]>;
+}
+

--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -1,0 +1,10 @@
+# Liste registrierter Agenten (opt-in). Beispiel-Einträge auskommentiert.
+agents: []
+# Beispiel:
+#  - id: "hydro.cso"
+#    entry: "agents/hydro.cso/index.ts"
+#    description: "CSO-Regelungsagent (Shadow→AB)"
+#  - id: "climate.risk"
+#    entry: "agents/climate.risk/index.ts"
+#    description: "Klimarisiko-Synthese (ERA5/OISST/EFFIS)"
+

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -1,2 +1,3 @@
 # Codex Feedback
 - FR-UM-2025-08-27-C: Alle Änderungen in einem Lauf umgesetzt – kein zweiter Lauf notwendig.
+- FR-UM-2025-08-27-Agents-A: Alle Änderungen in einem Lauf umgesetzt – kein zweiter Lauf notwendig.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,47 @@
+# Agents · Phase A (Registry + Guardrails)
+
+## Ziel
+Nicht-invasiver Rahmen für bestehende/neue Agenten: Registry, Governance-Policy, Logger, Rate-Limit, Circuit-Breaker, Retry, HTTP-Client, Runner & Smoke.
+
+## Opt-in (Bestehenden Agent registrieren)
+1) Eintrag in `agents/registry.yaml`:
+   ```yaml
+   agents:
+     - id: "hydro.cso"
+       entry: "agents/hydro.cso/index.ts"
+       description: "CSO-Regelungsagent (Shadow→AB)"
+   ```
+2) Agent-Modul exportiert `id`, `health()`, `run(input, ctx)`:
+   ```ts
+   import type { Agent } from "../_shared/types";
+   const agent: Agent<any, any> = {
+     id: "hydro.cso",
+     async health() { return { id: "hydro.cso", ok: true }; },
+     async run(input, ctx) {
+       ctx.logger("info", "starting", { input });
+       await ctx.rateLimit();
+       // Beispiel-Call mit Guardrails:
+       // const res = await ctx.http("https://pegelonline.wsv.de/api/...");
+       return { ok: true, echo: input };
+     }
+   };
+   export default agent;
+   ```
+3) Health testen:
+   ```bash
+   pnpm agents:health
+   pnpm agents:run -- --id hydro.cso --input ./example.json
+   ```
+
+## Policies/Guardrails
+- `governance/policies/agents-policy.yaml` → globale Limits & Domain-Whitelist
+- Pro Agent Override unter `agents:` möglich
+- Consent-Flag (falls menschliche Bestätigung nötig)
+
+## Logs/Metrics
+- JSONL unter `data/agents/logs/<agent>.jsonl`
+- (Phase B) Prom-Metriken/Histo; (Phase C) OpenTelemetry
+
+## Smoke
+- `pnpm smoke:agents` → lädt Registry, ruft `health()` auf; leerer Registry ⇒ OK (0)
+

--- a/governance/policies/agents-policy.yaml
+++ b/governance/policies/agents-policy.yaml
@@ -1,0 +1,28 @@
+# Globale Leitplanken für Agenten-Aufrufe (netzwerk-/aktionsbezogen)
+defaults:
+  max_qps: 2                 # max Requests pro Sekunde (pro Agent)
+  max_concurrency: 2         # parallele Tasks pro Agent
+  request_timeout_ms: 120000 # 120s
+  retry:
+    attempts: 3
+    base_delay_ms: 400
+    jitter: true
+  circuit_breaker:
+    failure_threshold: 5
+    cooldown_ms: 60000
+  allowed_domains:
+    - "noaa.gov"
+    - "ecmwf.int"
+    - "copernicus.eu"
+    - "pegelonline.wsv.de"
+    - "effis.jrc.ec.europa.eu"
+    - "gbif.org"
+    - "dwd.de"
+  user_consent_required: false
+agents:
+  # Beispiel-Overrides pro Agent-ID (wenn später eingetragen)
+  # "hydro.cso":
+  #   max_qps: 1
+  #   max_concurrency: 1
+  #   user_consent_required: true
+

--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
     "cy:run": "cypress run",
     "smoke:ui": "node scripts/smoke/ui-dev-smoke.mjs",
     "smoke:dev": "node scripts/smoke/dev-server-smoke.mjs",
-    "smoke:mrv": "node scripts/smoke/mrv-smoke.mjs"
+    "smoke:mrv": "node scripts/smoke/mrv-smoke.mjs",
+    "agents:health": "ts-node scripts/agents/runner.ts --health-all",
+    "agents:run": "ts-node scripts/agents/runner.ts",
+    "smoke:agents": "node scripts/smoke/agents-smoke.mjs"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.9.10",

--- a/scripts/agents/agent-registry.ts
+++ b/scripts/agents/agent-registry.ts
@@ -1,0 +1,22 @@
+import fs from "fs"; import path from "path"; import yaml from "yaml";
+export type RegistryEntry = { id:string; entry:string; description?:string };
+export function loadRegistry(): RegistryEntry[] {
+  const p = path.resolve(process.cwd(), "agents/registry.yaml");
+  if (!fs.existsSync(p)) return [];
+  const { agents } = yaml.parse(fs.readFileSync(p, "utf8")) || { agents: [] };
+  return Array.isArray(agents) ? agents.filter(a=>a && a.id && a.entry) : [];
+}
+export async function loadAgentModule(entry: string) {
+  const full = path.resolve(process.cwd(), entry);
+  if (!fs.existsSync(full)) throw new Error(`agent_entry_not_found:${entry}`);
+  // ESM/CJS-agnostisch importieren
+  const mod = await import(pathToFileURL(full).href).catch(async () => require(full));
+  // @ts-ignore
+  return mod.default || mod.agent || mod;
+  function pathToFileURL(p:string){ const u = new URL("file:");
+    const abs = path.resolve(p).replace(/\\/g,"/");
+    if (!abs.startsWith("/")) { u.pathname = "/"+abs; } else { u.pathname = abs; }
+    return u;
+  }
+}
+

--- a/scripts/agents/runner.ts
+++ b/scripts/agents/runner.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env ts-node
+import { loadRegistry, loadAgentModule } from "./agent-registry";
+import { makeLogger } from "../../agents/_shared/logger";
+import { makeRateLimiter } from "../../agents/_shared/rate-limit";
+import { makeGuard } from "../../agents/_shared/guardrails";
+import { makeHttp } from "../../agents/_shared/http";
+import { makeCircuitBreaker } from "../../agents/_shared/circuit-breaker";
+import type { Agent } from "../../agents/_shared/types";
+import fs from "fs";
+
+type Args = { id?:string; health?:boolean; healthAll?:boolean; input?:string };
+function parseArgs(): Args {
+  const a = process.argv.slice(2);
+  const out: any = {};
+  for (let i=0;i<a.length;i++){
+    const k = a[i];
+    if (k === "--id") out.id = a[++i];
+    else if (k === "--health") out.health = true;
+    else if (k === "--health-all") out.healthAll = true;
+    else if (k === "--input") out.input = a[++i];
+  }
+  return out;
+}
+
+async function buildCtx(agentId: string) {
+  const guard = makeGuard(agentId);
+  const logger = makeLogger(agentId);
+  const rl = makeRateLimiter(guard.limits.maxQps);
+  const http = makeHttp({
+    ensureAllowedDomain: guard.ensureAllowedDomain,
+    requestTimeoutMs: guard.requestTimeoutMs
+  });
+  const cb = makeCircuitBreaker({
+    failure_threshold: guard.limits.circuit.failure_threshold,
+    cooldown_ms: guard.limits.circuit.cooldown_ms
+  });
+  return {
+    logger, rateLimit: rl, http,
+    guard: { ensureAllowedDomain: guard.ensureAllowedDomain, consentRequired: guard.consentRequired, requestTimeoutMs: guard.requestTimeoutMs },
+    circuit: cb
+  };
+}
+
+async function main() {
+  const args = parseArgs();
+  const reg = loadRegistry();
+  if (args.healthAll) {
+    if (reg.length === 0) { console.log("No agents registered."); process.exit(0); }
+    let okAll = true;
+    for (const r of reg) {
+      try {
+        const A = await loadAgentModule(r.entry) as Agent;
+        const ctx = await buildCtx(r.id);
+        const h = await A.health();
+        ctx.logger("info", "health", { ok: h.ok });
+        if (!h.ok) okAll = false;
+      } catch(e:any) { console.error("health error", r.id, e?.message||e); okAll = false; }
+    }
+    process.exit(okAll ? 0 : 2);
+  }
+
+  if (!args.id) throw new Error("--id ist erforderlich (oder --health-all)");
+  const r = reg.find(x=>x.id===args.id);
+  if (!r) throw new Error(`agent_not_registered:${args.id}`);
+
+  const A = await loadAgentModule(r.entry) as Agent;
+  if (args.health) {
+    const h = await A.health();
+    console.log(JSON.stringify(h, null, 2));
+    process.exit(h.ok ? 0 : 2);
+  } else {
+    const ctx:any = await buildCtx(A.id || r.id);
+    const input = args.input ? JSON.parse(fs.readFileSync(args.input,"utf8")) : {};
+    await ctx.rateLimit(); // global tick
+    const out = await ctx.circuit.exec(()=>A.run(input, ctx));
+    console.log(JSON.stringify(out, null, 2));
+  }
+}
+main().catch(e=>{ console.error(e); process.exit(1); });
+

--- a/scripts/smoke/agents-smoke.mjs
+++ b/scripts/smoke/agents-smoke.mjs
@@ -1,0 +1,4 @@
+import { spawn } from "child_process";
+const proc = spawn("pnpm", ["-s", "agents:health"], { shell: true, stdio: "inherit" });
+proc.on("exit", (code)=> process.exit(code ?? 1));
+


### PR DESCRIPTION
## Summary
- add agent governance policy and registry foundation
- implement shared utilities with guardrails, logging, retry, and HTTP helpers
- provide CLI runner, smoke test, and documentation for agents

## Testing
- `pnpm install` *(fails: No matching version found for react-three-fiber@^8.0.27)*
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm run smoke:agents`


------
https://chatgpt.com/codex/tasks/task_e_68af7306e694832289652b138ad86865