### PR TITLE
Add Fraktalrun import pipeline for advancedToDo

### DIFF
--- a/codex/fraktalrun.import.yaml
+++ b/codex/fraktalrun.import.yaml
@@ -1,0 +1,16 @@
+# codex/fraktalrun.import.yaml
+kind: CodexRun
+name: "Fraktalrun – advancedToDo Import"
+triggers:
+  - manual: true
+  - onChange:
+      paths: ["advancedToDo.yaml","advancedToDo.json"]
+steps:
+  - name: "Fraktalrun: Import & Normalize"
+    uses: "fraktalrun/pipeline.yaml#commit"
+    env:
+      REDACTION: "true"
+      DRY_RUN: "false"
+artifacts:
+  - "./tasks/fractal_tasks.yaml"
+  - "./advancedprogress.json"

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -2,3 +2,4 @@
 - FR-UM-2025-08-27-C: Alle Änderungen in einem Lauf umgesetzt – kein zweiter Lauf notwendig.
 - FR-UM-2025-08-27-Agents-A: Alle Änderungen in einem Lauf umgesetzt – kein zweiter Lauf notwendig.
 - FR-UM-2025-08-27-Agents-B: Alle Änderungen in einem Lauf umgesetzt – kein zweiter Lauf notwendig.
+- FR-UM-2025-08-27-Fraktalrun: Alle Änderungen in einem Lauf umgesetzt – kein zweiter Lauf notwendig.

--- a/fraktalrun/manifest.yaml
+++ b/fraktalrun/manifest.yaml
@@ -1,0 +1,40 @@
+# fraktalrun/manifest.yaml
+kind: FraktalRun
+version: 1
+meta:
+  name: "advancedToDo-import"
+  description: "Importiert und harmonisiert advancedToDo.{yaml,json} in ein einheitliches Fraktal-Task-Set."
+  owners: ["codex", "aeon"]
+  tags: ["fraktalrun", "codex", "todo", "crep", "sigillin"]
+sources:
+  - path: "./advancedToDo.yaml"
+    format: "yaml"
+  - path: "./advancedToDo.json"
+    format: "json"
+  - optional:
+      - path: "./ToDoAI.yaml"
+        format: "yaml"
+schema:
+  task: "./fraktalrun/task.schema.json"
+mapping: "./fraktalrun/mapping.yaml"
+output:
+  normalized_tasks: "./tasks/fractal_tasks.yaml"
+  progress_journal: "./advancedprogress.json"   # wird aktualisiert, falls vorhanden
+policies:
+  dedupe:
+    keys: ["title", "id", "slug"]
+    strategy: "keep-highest-priority"
+  priority:
+    weights:
+      resonance: 0.35
+      coherence: 0.35
+      emergence: 0.20
+      urgency: 0.10
+  governance:
+    redaction: true
+    pii_patterns: ["email", "token", "key", "ip"]
+runtime:
+  dryRun: false
+  commit:
+    enabled: true
+    message: "fraktalrun: normalize advancedToDo → tasks/fractal_tasks.yaml"

--- a/fraktalrun/mapping.yaml
+++ b/fraktalrun/mapping.yaml
@@ -1,0 +1,50 @@
+# fraktalrun/mapping.yaml
+defaults:
+  status: "open"
+  phase: "PRÄSENZ"          # 1 | 0 | -1 → Präsenz | Leere | Auflösung
+  trikaya: "Nirmāṇakāya"    # erscheint-weltlich
+  labels: ["advanced", "codex-import"]
+  estimate: "1d"
+
+fields:
+  # Quelle → Ziel
+  title: ["title", "name", "summary"]
+  description: ["description", "desc", "details"]
+  priority: ["priority", "prio", "importance"]
+  status: ["status", "state"]
+  owner: ["owner", "assignee", "responsible"]
+  labels: ["labels", "tags"]
+  due: ["due", "deadline", "date"]
+  id: ["id", "uid", "slug", "key"]
+  area: ["area", "domain", "scope"]
+  component: ["component", "package", "service"]
+  crep:
+    resonance: ["resonance", "r"]
+    coherence: ["coherence", "c"]
+    emergence: ["emergence", "e"]
+    poetics: ["poetics", "p"]
+  sigillin:
+    glyph: ["glyph", "sigil", "symbol"]
+    ritual: ["ritual", "sequence"]
+    phase: ["phase", "zustand"]
+transforms:
+  - name: "normalize-title"
+    when: "title != null"
+    do: "title = title.trim()"
+  - name: "slug-if-missing"
+    when: "id == null && title != null"
+    do: "id = slugify(title)"
+  - name: "priority-range"
+    do: "priority = clamp(priority,1,5)"
+  - name: "labels-lowercase"
+    do: "labels = labels.map(l=>l.toLowerCase())"
+  - name: "derive-phase"
+    do: >
+      if (status in ['blocked','risk']) phase='AUFLÖSUNG';
+      else if (status in ['queued','backlog']) phase='LEERE';
+      else phase='PRÄSENZ';
+  - name: "trikaya-from-area"
+    do: >
+      if (area in ['infra','ops']) trikaya='Nirmāṇakāya';
+      else if (area in ['ui','xr','symbol']) trikaya='Sambhogakāya';
+      else trikaya='Dharmakāya';

--- a/fraktalrun/pipeline.yaml
+++ b/fraktalrun/pipeline.yaml
@@ -1,0 +1,39 @@
+# fraktalrun/pipeline.yaml
+jobs:
+  - id: ingest
+    run: |
+      load("./advancedToDo.yaml", as="yaml") +
+      load("./advancedToDo.json", as="json") → stream("raw")
+  - id: normalize
+    needs: ["ingest"]
+    run: |
+      map(stream("raw"), using="./fraktalrun/mapping.yaml") → stream("norm")
+      validate(stream("norm"), schema="./fraktalrun/task.schema.json")
+  - id: dedupe
+    needs: ["normalize"]
+    run: |
+      dedupe(stream("norm"), using="manifest.policies.dedupe") → stream("clean")
+  - id: prioritize
+    needs: ["dedupe"]
+    run: |
+      score(stream("clean"), weights="manifest.policies.priority.weights") → stream("scored")
+  - id: plan
+    needs: ["prioritize"]
+    run: |
+      planKanban(stream("scored"), wipLimits: {doing:5}) → file("./tasks/fractal_tasks.yaml")
+  - id: dispatch
+    needs: ["plan"]
+    run: |
+      route("./tasks/fractal_tasks.yaml")
+        .toAgent("CodeAgent", when: "labels includes 'code'")
+        .toAgent("GoBridge",   when: "component == 'go-bridge'")
+        .toAgent("Fourier",    when: "labels includes 'crep'")
+  - id: progress
+    needs: ["dispatch"]
+    run: |
+      progressUpdate("./advancedprogress.json", from="./tasks/fractal_tasks.yaml")
+  - id: commit
+    needs: ["progress"]
+    run: |
+      gitAdd(["./tasks/fractal_tasks.yaml","./advancedprogress.json"])
+      gitCommit(message=manifest.runtime.commit.message)

--- a/fraktalrun/task.schema.json
+++ b/fraktalrun/task.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "FraktalTask",
+  "type": "object",
+  "required": ["id", "title", "status", "priority"],
+  "properties": {
+    "id": { "type": "string" },
+    "title": { "type": "string", "minLength": 1 },
+    "description": { "type": "string" },
+    "status": { "type": "string", "enum": ["open","in-progress","blocked","done","queued","backlog","risk"] },
+    "priority": { "type": "integer", "minimum": 1, "maximum": 5 },
+    "owner": { "type": "string" },
+    "labels": { "type": "array", "items": { "type": "string" } },
+    "due": { "type": "string" },
+    "area": { "type": "string" },
+    "component": { "type": "string" },
+    "phase": { "type": "string", "enum": ["PRÄSENZ","LEERE","AUFLÖSUNG"] },
+    "trikaya": { "type": "string", "enum": ["Dharmakāya","Sambhogakāya","Nirmāṇakāya"] },
+    "crep": {
+      "type": "object",
+      "properties": {
+        "resonance": { "type": "number", "minimum": 0, "maximum": 1 },
+        "coherence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "emergence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "poetics": { "type": "number", "minimum": 0, "maximum": 1 }
+      },
+      "additionalProperties": false
+    },
+    "sigillin": {
+      "type": "object",
+      "properties": {
+        "glyph": { "type": "string" },
+        "ritual": { "type": "string" },
+        "phase": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "acceptance": { "type": "array", "items": { "type": "string" } }
+  },
+  "additionalProperties": true
+}

--- a/tasks/fractal_tasks.yaml
+++ b/tasks/fractal_tasks.yaml
@@ -1,0 +1,26 @@
+# tasks/fractal_tasks.yaml
+# ⚠️ Diese Datei wird von Fraktalrun generiert/überschrieben.
+tasks:
+  - id: "adv-001"
+    title: "Adapter: ERA5 + OISST – Zeitreihen-Utils harmonisieren"
+    description: "Implementiere ERA5/OISST Adapter und unify utils in src/utils/time."
+    status: "in-progress"
+    priority: 5
+    owner: "codex"
+    labels: ["climate","adapter","crep"]
+    area: "data"
+    component: "adapters"
+    phase: "PRÄSENZ"
+    trikaya: "Sambhogakāya"
+    crep: { resonance: 0.8, coherence: 0.7, emergence: 0.6, poetics: 0.5 }
+    acceptance:
+      - "ERA5 & OISST liefern identische Normalform (schema v1)"
+      - "Unit-Tests > 80% coverage"
+  - id: "adv-002"
+    title: "FourierMetricsServer → OTel-Tracing end-to-end"
+    description: "Trace-ID Propagation UI→WS→Server; Loglevel + Grafana Panel"
+    status: "open"
+    priority: 4
+    labels: ["observability","otel","crep"]
+    phase: "LEERE"
+    trikaya: "Nirmāṇakāya"


### PR DESCRIPTION
## Summary
- add Fraktalrun manifest, mapping, schema, and pipeline to normalize advancedToDo items
- create Codex job and example normalized task output
- record completion feedback in codexfeedback

## Testing
- `poetry install --with test`
- `pnpm install` *(fails: No matching version found for react-three-fiber@^8.0.27)*
- `npx pyright` *(fails: npm error canceled)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68af7c08bb648322a0c1a3acafbc9fdb