### PR TITLE
fraktalrun: normalize advancedToDo → tasks/fractal_tasks.yaml

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -15023,5 +15023,40 @@
         "path": "tests/agents/golden/"
       }
     ]
+  },
+  {
+    "commit": "Analyse Gesprächsextrakte",
+    "path": "",
+    "task": "Analyse Gesprächsextrakte",
+    "test": "",
+    "status": "offen"
+  },
+  {
+    "commit": "Erzeuge initiale Aufgaben",
+    "path": "",
+    "task": "Erzeuge initiale Aufgaben",
+    "test": "",
+    "status": "offen"
+  },
+  {
+    "commit": "Verzweige in Unteraufgaben",
+    "path": "",
+    "task": "Verzweige in Unteraufgaben",
+    "test": "",
+    "status": "offen"
+  },
+  {
+    "commit": "Bewerte CREP und depth",
+    "path": "",
+    "task": "Bewerte CREP und depth",
+    "test": "",
+    "status": "offen"
+  },
+  {
+    "commit": "Commitiere Ergebnisse",
+    "path": "",
+    "task": "Commitiere Ergebnisse",
+    "test": "",
+    "status": "offen"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13987,3 +13987,28 @@
   changes:
     - path: scripts/agents/golden-runner.ts
     - path: tests/agents/golden/
+- commit: "Analyse Gesprächsextrakte"
+  path: ""
+  task: "Analyse Gesprächsextrakte"
+  test: ""
+  status: offen
+- commit: "Erzeuge initiale Aufgaben"
+  path: ""
+  task: "Erzeuge initiale Aufgaben"
+  test: ""
+  status: offen
+- commit: "Verzweige in Unteraufgaben"
+  path: ""
+  task: "Verzweige in Unteraufgaben"
+  test: ""
+  status: offen
+- commit: "Bewerte CREP und depth"
+  path: ""
+  task: "Bewerte CREP und depth"
+  test: ""
+  status: offen
+- commit: "Commitiere Ergebnisse"
+  path: ""
+  task: "Commitiere Ergebnisse"
+  test: ""
+  status: offen

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "feat(agents): add phase A framework",
-  "fractalStep": "implementiert",
+  "lastCommit": "Merge pull request #1520 from GenesisAeon/codex/implement-fraktalrun-for-advancedtodo-import",
+  "fractalStep": "sync",
   "openBranches": [
     "work"
   ],
@@ -380,37 +380,80 @@
       "status": "open"
     },
     {
+      "commit": null,
       "status": "open"
     },
     {
+      "commit": null,
       "status": "open"
     },
     {
+      "commit": null,
       "status": "open"
     },
     {
+      "commit": null,
       "status": "open"
     },
     {
+      "commit": null,
       "status": "open"
     },
     {
+      "commit": null,
       "status": "open"
     },
     {
+      "commit": null,
       "status": "open"
     },
     {
+      "commit": null,
       "status": "open"
     },
     {
+      "commit": null,
       "status": "open"
     },
     {
+      "commit": null,
       "status": "open"
     },
     {
+      "commit": null,
       "status": "open"
+    },
+    {
+      "commit": null,
+      "status": "open"
+    },
+    {
+      "commit": null,
+      "status": "open"
+    },
+    {
+      "commit": null,
+      "status": "open"
+    },
+    {
+      "commit": "Analyse Gesprächsextrakte",
+      "status": "offen"
+    },
+    {
+      "commit": "Erzeuge initiale Aufgaben",
+      "status": "offen"
+    },
+    {
+      "commit": "Verzweige in Unteraufgaben",
+      "status": "offen"
+    },
+    {
+      "commit": "Bewerte CREP und depth",
+      "status": "offen"
+    },
+    {
+      "commit": "Commitiere Ergebnisse",
+      "status": "offen"
     }
   ],
   "progress": [

--- a/tasks/fractal_tasks.yaml
+++ b/tasks/fractal_tasks.yaml
@@ -1,26 +1,89 @@
-# tasks/fractal_tasks.yaml
-# ⚠️ Diese Datei wird von Fraktalrun generiert/überschrieben.
 tasks:
-  - id: "adv-001"
-    title: "Adapter: ERA5 + OISST – Zeitreihen-Utils harmonisieren"
-    description: "Implementiere ERA5/OISST Adapter und unify utils in src/utils/time."
-    status: "in-progress"
-    priority: 5
-    owner: "codex"
-    labels: ["climate","adapter","crep"]
-    area: "data"
-    component: "adapters"
-    phase: "PRÄSENZ"
-    trikaya: "Sambhogakāya"
-    crep: { resonance: 0.8, coherence: 0.7, emergence: 0.6, poetics: 0.5 }
-    acceptance:
-      - "ERA5 & OISST liefern identische Normalform (schema v1)"
-      - "Unit-Tests > 80% coverage"
-  - id: "adv-002"
-    title: "FourierMetricsServer → OTel-Tracing end-to-end"
-    description: "Trace-ID Propagation UI→WS→Server; Loglevel + Grafana Panel"
-    status: "open"
-    priority: 4
-    labels: ["observability","otel","crep"]
-    phase: "LEERE"
-    trikaya: "Nirmāṇakāya"
+- id: adv-001
+  title: 'Adapter: ERA5 + OISST – Zeitreihen-Utils harmonisieren'
+  description: Implementiere ERA5/OISST Adapter und unify utils in src/utils/time.
+  status: in-progress
+  priority: 5
+  owner: codex
+  labels:
+  - climate
+  - adapter
+  - crep
+  area: data
+  component: adapters
+  phase: PRÄSENZ
+  trikaya: Sambhogakāya
+  crep:
+    resonance: 0.8
+    coherence: 0.7
+    emergence: 0.6
+    poetics: 0.5
+  acceptance:
+  - ERA5 & OISST liefern identische Normalform (schema v1)
+  - Unit-Tests > 80% coverage
+- id: adv-002
+  title: FourierMetricsServer → OTel-Tracing end-to-end
+  description: Trace-ID Propagation UI→WS→Server; Loglevel + Grafana Panel
+  status: open
+  priority: 4
+  labels:
+  - observability
+  - otel
+  - crep
+  phase: LEERE
+  trikaya: Nirmāṇakāya
+- id: adv-003
+  title: Analyse Gesprächsextrakte
+  description: Analyse Gesprächsextrakte
+  status: open
+  priority: 3
+  owner: codex
+  labels:
+  - advanced
+  - codex-import
+  phase: PRÄSENZ
+  trikaya: Nirmāṇakāya
+- id: adv-004
+  title: Erzeuge initiale Aufgaben
+  description: Erzeuge initiale Aufgaben
+  status: open
+  priority: 3
+  owner: codex
+  labels:
+  - advanced
+  - codex-import
+  phase: PRÄSENZ
+  trikaya: Nirmāṇakāya
+- id: adv-005
+  title: Verzweige in Unteraufgaben
+  description: Verzweige in Unteraufgaben
+  status: open
+  priority: 3
+  owner: codex
+  labels:
+  - advanced
+  - codex-import
+  phase: PRÄSENZ
+  trikaya: Nirmāṇakāya
+- id: adv-006
+  title: Bewerte CREP und depth
+  description: Bewerte CREP und depth
+  status: open
+  priority: 3
+  owner: codex
+  labels:
+  - advanced
+  - codex-import
+  phase: PRÄSENZ
+  trikaya: Nirmāṇakāya
+- id: adv-007
+  title: Commitiere Ergebnisse
+  description: Commitiere Ergebnisse
+  status: open
+  priority: 3
+  owner: codex
+  labels:
+  - advanced
+  - codex-import
+  phase: PRÄSENZ
+  trikaya: Nirmāṇakāya


### PR DESCRIPTION
## Summary
- import fractal path tasks from codex fraktal init sigil into advancedToDo YAML and JSON
- generate corresponding adv-003–adv-007 tasks in tasks/fractal_tasks.yaml
- refresh advancedprogress snapshot with latest commit metadata

## Testing
- `pnpm install` *(fails: No matching version found for react-three-fiber@^8.0.27)*
- `poetry install --with test`
- `npx -y pyright`
- `npx -y tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68af7ddcc1a08322b5b5c0d8c65bd41e