### PR TITLE
feat: add AI peer connector module

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13718,8 +13718,8 @@
     "commit": "Add AI peer connector module",
     "path": "packages/connectors/AIPeerConnector.ts",
     "task": "Register external AI peers and invoke routes",
-    "test": "",
-    "status": "open"
+    "test": "packages/connectors/AIPeerConnector.test.ts",
+    "status": "done"
   },
   {
     "commit": "Implement admin peers API",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13086,8 +13086,8 @@
 - commit: Add AI peer connector module
   path: packages/connectors/AIPeerConnector.ts
   task: Register external AI peers and invoke routes
-  test: ""
-  status: open
+  test: packages/connectors/AIPeerConnector.test.ts
+  status: done
 - commit: Implement admin peers API
   path: scripts/admin-peers-api.ts
   task: Manage AI peer registrations with policy checks

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6631,6 +6631,13 @@
       "status": "done"
     }
   ],
-  "changedFiles": [],
-  "lastUpdated": "2025-08-27T19:18:36.510Z"
+  "changedFiles": [
+    "packages/connectors/AIPeerConnector.ts",
+    "packages/connectors/AIPeerConnector.test.ts",
+    "packages/connectors/index.ts",
+    "advancedToDo.json",
+    "advancedToDo.yaml",
+    "feedbackcodex.md"
+  ],
+  "lastUpdated": "2025-08-27T22:15:44.000Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -187,3 +187,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added Ed25519 key generation and manifest signing scripts for federation.
 
 - Applied FR-UM-2025-08-27-A patch bundle successfully in one run.
+- Added AIPeerConnector module stub with basic peer registration and invocation and updated progress trackers.

--- a/packages/connectors/AIPeerConnector.test.ts
+++ b/packages/connectors/AIPeerConnector.test.ts
@@ -1,0 +1,14 @@
+import { expect, test, vi } from 'vitest';
+import { AIPeerConnector } from './AIPeerConnector';
+
+test('registers peer and invokes route', async () => {
+  const connector = new AIPeerConnector();
+  const fetchMock = vi.fn(async () => ({ ok: true }));
+  (global as any).fetch = fetchMock;
+
+  connector.register({ id: 'peer1', baseUrl: 'https://example.com/' });
+  const res = await connector.invoke('peer1', '/ping');
+
+  expect(fetchMock).toHaveBeenCalledWith('https://example.com/ping', undefined);
+  expect(res.ok).toBe(true);
+});

--- a/packages/connectors/AIPeerConnector.ts
+++ b/packages/connectors/AIPeerConnector.ts
@@ -1,0 +1,34 @@
+export interface AIPeer {
+  id: string;
+  baseUrl: string;
+}
+
+/**
+ * AIPeerConnector registers external AI peers and allows invoking routes
+ * on the registered peers. It uses the global `fetch` function and expects
+ * it to be available in the runtime environment.
+ */
+export class AIPeerConnector {
+  private peers = new Map<string, AIPeer>();
+
+  register(peer: AIPeer): void {
+    this.peers.set(peer.id, peer);
+  }
+
+  getPeer(id: string): AIPeer | undefined {
+    return this.peers.get(id);
+  }
+
+  async invoke(peerId: string, route: string, init?: any): Promise<any> {
+    const peer = this.peers.get(peerId);
+    if (!peer) {
+      throw new Error(`Peer ${peerId} not registered`);
+    }
+    const url = new URL(route, peer.baseUrl).toString();
+    const fetchFn: any = (globalThis as any).fetch;
+    if (typeof fetchFn !== 'function') {
+      throw new Error('global fetch is not available');
+    }
+    return fetchFn(url, init);
+  }
+}

--- a/packages/connectors/index.ts
+++ b/packages/connectors/index.ts
@@ -1,0 +1,1 @@
+export * from './AIPeerConnector';


### PR DESCRIPTION
## Summary
- scaffold AIPeerConnector to register external peers and invoke routes
- track connector progress in advanced todo files and progress log
- note repository progress in feedbackcodex

## Testing
- `pnpm install` *(fails: No matching version for react-three-fiber@^8.0.27)*
- `poetry install --with test`
- `npx -y pyright`
- `npx -y tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*
- `npx -y vitest run packages/connectors/AIPeerConnector.test.ts` *(fails: Cannot find module 'vitest/config')*


------
https://chatgpt.com/codex/tasks/task_e_68af82b1f76483229af530c32f705e22