### PR TITLE
feat: add limit option to advanced todo report

### DIFF
--- a/docs/sigils/advancedprogress-guide.md
+++ b/docs/sigils/advancedprogress-guide.md
@@ -34,6 +34,12 @@ avoid loading massive datasets. Pass `--include-conversations` if you really
 need them. The default text output now also shows how many open tasks exist per
 directory and prints a total at the end.
 
+You can cap the number of tasks shown per directory with `--limit`:
+
+```bash
+node repositorypflege/advanced-todo-report.js --limit 3
+```
+
 For machine-readable output you can add `--json` or `--yaml`:
 
 ```bash

--- a/repositorypflege/advanced-todo-report.js
+++ b/repositorypflege/advanced-todo-report.js
@@ -24,6 +24,8 @@ if (require.main === module) {
   const jsonOutput = process.argv.includes('--json');
   const yamlOutput = process.argv.includes('--yaml');
   const includeConvos = process.argv.includes('--include-conversations');
+  const limitIndex = process.argv.indexOf('--limit');
+  const limit = limitIndex >= 0 ? parseInt(process.argv[limitIndex + 1], 10) : undefined;
 
   const grouped = groupTodosByDir(pattern, todoPaths, exclude, includeConvos);
   if (yamlOutput) {
@@ -35,7 +37,11 @@ if (require.main === module) {
     for (const [dir, tasks] of Object.entries(grouped)) {
       total += tasks.length;
       console.log(`${dir} (${tasks.length}):`);
-      tasks.forEach((t) => console.log(`  - ${t.commit}`));
+      const list = limit ? tasks.slice(0, limit) : tasks;
+      list.forEach((t) => console.log(`  - ${t.commit}`));
+      if (limit && tasks.length > limit) {
+        console.log(`  ...and ${tasks.length - limit} more`);
+      }
     }
     console.log(`Total open tasks: ${total}`);
   }


### PR DESCRIPTION
## Summary
- allow limiting per-directory task display in advanced todo report
- document --limit flag in advanced progress guide

## Testing
- `node repositorypflege/update-advanced-progress.js` *(fails: Cannot find module 'js-yaml')*
- `npx pyright` *(fails: npm error canceled)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68af8c98d48c83229e7663b65deed842