### PR TITLE
Fix test setup and ghostshell config placeholders

### DIFF
--- a/config/nginx/ghostshell.conf
+++ b/config/nginx/ghostshell.conf
@@ -1,5 +1,6 @@
 upstream ghostshell {
-  server ghostshell:8080;
+  server 127.0.0.1:${PORT_BASE:-3000};
+  server 127.0.0.1:${PORT_NEXT:-3001};
 }
 
 server {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,16 @@
 module.exports = {
   transform: { '^.+\\.tsx?$': ['<rootDir>/node_modules/ts-jest', {}] },
   testEnvironment: 'jsdom',
-  testPathIgnorePatterns: ['/dist/', 'packages/agents', 'packages/agents/__tests__', 'packages/vr-integration', 'services/ghost-shell/server.test.ts'],
+  testPathIgnorePatterns: [
+    '/dist/',
+    'packages/agents',
+    'packages/agents/__tests__',
+    'packages/vr-integration',
+    'services/ghost-shell/server.test.ts',
+    'scripts',
+    'packages/pantheon',
+    'packages/gpt-bridges/router'
+  ],
   moduleNameMapper: {
     '^yaml$': '<rootDir>/node_modules/yaml/dist/index.js'
   },


### PR DESCRIPTION
## Summary
- update ghostshell nginx config to use local port placeholders
- skip Vitest-only directories in Jest to avoid execution errors

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68af9f1737508322a92ae620fee49659