### PR TITLE
Include docs test files in vitest configuration

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       'packages/boundary-engine/**/*.{test,spec}.ts',
       'packages/api/**/*.{test,spec}.ts',
       'scripts/**/*.{test,spec,vitest}.ts',
+      'docs/**/*.{test,spec}.ts',
       'packages/wissenschaftliche-versuche/**/*.{test,spec}.ts',
       'packages/consent-mesh/**/*.{test,spec}.ts',
       'packages/federated/**/*.{test,spec}.ts',


### PR DESCRIPTION
## Summary
- expand Vitest include patterns to cover tests under `docs`

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run docs` *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68afaee4d9408322981cfdd327291818