### PR TITLE
feat(admin-ui): add consent timeline component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13873,7 +13873,7 @@
     "path": "packages/admin-ui/ConsentTimeline.tsx",
     "task": "Display active consent records from admin API",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add PeerManager component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13197,7 +13197,7 @@
   path: packages/admin-ui/ConsentTimeline.tsx
   task: Display active consent records from admin API
   test: ""
-  status: open
+  status: done
 - commit: Add PeerManager component
   path: packages/admin-ui/PeerManager.tsx
   task: Show registered AI peers with roles and trust

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6211,7 +6211,9 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "packages/admin-ui/"
+    "codexfeedback.md",
+    "packages/admin-ui/index.ts",
+    "packages/admin-ui/ConsentTimeline.tsx"
   ],
-  "lastUpdated": "2025-08-28T01:28:14.470Z"
+  "lastUpdated": "2025-08-28T04:57:42.097Z"
 }

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -5,3 +5,4 @@
 - FR-UM-2025-08-27-Fraktalrun: Alle Änderungen in einem Lauf umgesetzt – kein zweiter Lauf notwendig.
 - FR-UM-2025-08-27-Fraktalrun-Import: Alle Änderungen in einem Lauf umgesetzt – kein zweiter Lauf notwendig.
 - Implemented admin API gateway script aggregating service statuses and proxying admin commands.
+- Added ConsentTimeline component for displaying consent records.

--- a/packages/admin-ui/ConsentTimeline.tsx
+++ b/packages/admin-ui/ConsentTimeline.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+
+interface ConsentRecord {
+  id: string;
+  subject: string;
+  granted: boolean;
+  grantedAt: string;
+}
+
+/**
+ * ConsentTimeline displays a list of active consent records
+ * fetched from the admin API.
+ */
+export default function ConsentTimeline() {
+  const [records, setRecords] = useState<ConsentRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/admin/consents')
+      .then((r) => r.json())
+      .then((data) => setRecords(data.consents || []))
+      .catch(() => setRecords([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div aria-label="ConsentTimeline">
+      <h2>Consent Timeline</h2>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <ul>
+          {records.map((c) => (
+            <li key={c.id}>
+              {c.subject}: {c.granted ? 'granted' : 'revoked'} at {c.grantedAt}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/admin-ui/index.ts
+++ b/packages/admin-ui/index.ts
@@ -1,1 +1,2 @@
 export { default as AdminConsoleApp } from './AdminConsoleApp';
+export { default as ConsentTimeline } from './ConsentTimeline';


### PR DESCRIPTION
## Summary
- add ConsentTimeline component to display admin consent records
- export new component in admin-ui package
- mark ConsentTimeline todo as complete and sync progress metadata

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68afe1244c108322a3523491079f6a1c