### PR TITLE
fractal-step-1: add streaming conversation analyzer

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -15029,7 +15029,7 @@
     "path": "",
     "task": "Analyse Gesprächsextrakte",
     "test": "",
-    "status": "offen"
+    "status": "done"
   },
   {
     "commit": "Erzeuge initiale Aufgaben",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13998,7 +13998,7 @@
   path: ""
   task: Analyse Gesprächsextrakte
   test: ""
-  status: offen
+  status: done
 - commit: Erzeuge initiale Aufgaben
   path: ""
   task: Erzeuge initiale Aufgaben

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -8,422 +8,29 @@
   "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events | Added JetStream KV/ObjectStore wrappers and tool loader | Added waveform option to CREP sonification | Implemented GermanGrammarAssistant agent | Implemented GeoTIFF ingest | Added ingest demo script | Implemented ReviewerQueue and reviewer API | Added screen capture and UI automation routes | Implemented PatternMapperGPT and TunerGPT agents | Added AdminConsoleApp component",
   "pendingTasks": [
     {
-      "commit": "Implement admin peers API",
+      "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129",
+      "path": "GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json",
       "status": "open"
     },
     {
-      "commit": "Create spaces management module",
+      "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e",
+      "path": "GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json",
       "status": "open"
     },
     {
-      "commit": "Create commons hub app",
+      "commit": "Integrate new GPT teams from Zukunft conversation",
+      "path": "packages/agents",
       "status": "open"
     },
     {
-      "commit": "Introduce task router module",
+      "commit": "feat: add 3D_Universumsstruktur visualization",
+      "path": "packages/universum-visualization/3D_Universumsstruktur.py",
       "status": "open"
     },
     {
-      "commit": "Extend code agent tasks for admin and commons modules",
+      "commit": "feat: add NullmembranDynamics module",
+      "path": "packages/universum-simulationen/modules/NullmembranDynamics.py",
       "status": "open"
-    },
-    {
-      "commit": "Create CoIntel orchestrator service",
-      "status": "open"
-    },
-    {
-      "commit": "Implement collab websocket server",
-      "status": "open"
-    },
-    {
-      "commit": "Add CreditLedger module",
-      "status": "open"
-    },
-    {
-      "commit": "Add AttributionIndex module",
-      "status": "open"
-    },
-    {
-      "commit": "Create peer handshake service",
-      "status": "open"
-    },
-    {
-      "commit": "Create CoauthorCanvas component",
-      "status": "open"
-    },
-    {
-      "commit": "Create TaskBoard component",
-      "status": "open"
-    },
-    {
-      "commit": "Add PeerManager component",
-      "status": "open"
-    },
-    {
-      "commit": "Add ModelRouterEditor component",
-      "status": "open"
-    },
-    {
-      "commit": "Create identity API service",
-      "status": "open"
-    },
-    {
-      "commit": "Define UI templates",
-      "status": "open"
-    },
-    {
-      "commit": "Create instance registry service",
-      "status": "open"
-    },
-    {
-      "commit": "Add ACL API service",
-      "status": "open"
-    },
-    {
-      "commit": "Create InitialAdminPanel component",
-      "status": "open"
-    },
-    {
-      "commit": "Define federation manifest type",
-      "status": "open"
-    },
-    {
-      "commit": "Create federation registry service",
-      "status": "open"
-    },
-    {
-      "commit": "Create federation bridge websocket",
-      "status": "open"
-    },
-    {
-      "commit": "Add collab federation bridge script",
-      "status": "open"
-    },
-    {
-      "commit": "Create GlobalMandalaGraph component",
-      "status": "open"
-    },
-    {
-      "commit": "Add unified AppShell",
-      "status": "open"
-    },
-    {
-      "commit": "Extend code agent tasks for Co-Intelligence services",
-      "status": "open"
-    },
-    {
-      "commit": "Append identity and federation services to code agent tasks",
-      "status": "open"
-    },
-    {
-      "commit": "Add OIDC stub service",
-      "status": "open"
-    },
-    {
-      "commit": "Add UI switchboard service",
-      "status": "open"
-    },
-    {
-      "commit": "Add compose override for UM services",
-      "status": "open"
-    },
-    {
-      "commit": "Add Windows stack start script",
-      "status": "open"
-    },
-    {
-      "commit": "Add Windows services installer",
-      "status": "open"
-    },
-    {
-      "commit": "Add UM integration GitHub workflow",
-      "status": "open"
-    },
-    {
-      "commit": "Expose UM service scripts in package.json",
-      "status": "open"
-    },
-    {
-      "commit": "Provide tsconfig for UM services",
-      "status": "open"
-    },
-    {
-      "commit": "Add production docker compose file",
-      "status": "open"
-    },
-    {
-      "commit": "Create generic Dockerfile for TypeScript services",
-      "status": "open"
-    },
-    {
-      "commit": "Configure NGINX reverse proxy for UM services",
-      "status": "open"
-    },
-    {
-      "commit": "Add Kong gateway configuration",
-      "status": "open"
-    },
-    {
-      "commit": "Create verified federation registry service",
-      "status": "open"
-    },
-    {
-      "commit": "Implement SSO broker service",
-      "status": "open"
-    },
-    {
-      "commit": "Generate systemd unit files script",
-      "status": "open"
-    },
-    {
-      "commit": "Document production setup",
-      "status": "open"
-    },
-    {
-      "commit": "Add Keycloak OIDC dev bundle",
-      "status": "open"
-    },
-    {
-      "commit": "Add Kubernetes manifests with Kustomize overlays",
-      "status": "open"
-    },
-    {
-      "commit": "Add monitoring configuration",
-      "status": "open"
-    },
-    {
-      "commit": "Add Caddy TLS reverse proxy",
-      "status": "open"
-    },
-    {
-      "commit": "Add GitHub Actions workflow for Kubernetes deployment",
-      "status": "open"
-    },
-    {
-      "commit": "Add Helm OIDC bundle",
-      "status": "open"
-    },
-    {
-      "commit": "Add Traefik mTLS ingress",
-      "status": "open"
-    },
-    {
-      "commit": "Add SLO monitoring pack",
-      "status": "open"
-    },
-    {
-      "commit": "Add GitOps manifests and workflow",
-      "status": "open"
-    },
-    {
-      "commit": "Add Go OIDC quickstart",
-      "status": "open"
-    },
-    {
-      "commit": "Add Keycloak auto-import helmfile",
-      "status": "open"
-    },
-    {
-      "commit": "Add Cloudflare DNS01 ClusterIssuer",
-      "status": "open"
-    },
-    {
-      "commit": "Add Argo Rollouts canary stack",
-      "status": "open"
-    },
-    {
-      "commit": "Add GitOps app factory script",
-      "status": "open"
-    },
-    {
-      "commit": "Add Observability++ stack",
-      "status": "open"
-    },
-    {
-      "commit": "Add secret management examples",
-      "status": "open"
-    },
-    {
-      "commit": "Add NetworkPolicy templates",
-      "status": "open"
-    },
-    {
-      "commit": "Add blue/green rollouts with Slack alerts",
-      "status": "open"
-    },
-    {
-      "commit": "Add GitOps golden path template",
-      "status": "open"
-    },
-    {
-      "commit": "Add one-click cluster bootstrap",
-      "status": "open"
-    },
-    {
-      "commit": "Integrate Vault CSI for secret file mounts",
-      "status": "open"
-    },
-    {
-      "commit": "Add ServiceMap-based NetworkPolicy generator",
-      "status": "open"
-    },
-    {
-      "commit": "Set up Cypress UI smoke tests and workflow",
-      "status": "open"
-    },
-    {
-      "commit": "Set up k6 API smoke tests and workflow",
-      "status": "open"
-    },
-    {
-      "commit": "Configure promotion gates for rollouts",
-      "status": "open"
-    },
-    {
-      "commit": "Deploy gate-controller for E2E gating",
-      "status": "open"
-    },
-    {
-      "commit": "Add Playwright synthetics with OTel",
-      "status": "open"
-    },
-    {
-      "commit": "Implement multi-signal quorum gates",
-      "status": "open"
-    },
-    {
-      "commit": "Add Terraform synthetics and alerting",
-      "status": "open"
-    },
-    {
-      "commit": "Enable auto-rollback on SLO violation",
-      "status": "open"
-    },
-    {
-      "commit": "Schedule weekly SLO and error budget reports",
-      "status": "open"
-    },
-    {
-      "commit": "Support multi-tenant E2E gates",
-      "status": "open"
-    },
-    {
-      "commit": "Add Windows E2E workflow",
-      "status": "open"
-    },
-    {
-      "commit": "Track SLO budget consumption",
-      "status": "open"
-    },
-    {
-      "commit": "Capture debug snapshots on aborted rollouts",
-      "status": "open"
-    },
-    {
-      "commit": "Provide tenant admin API and UI",
-      "status": "open"
-    },
-    {
-      "commit": "Automate image builds and Kustomize validation",
-      "status": "open"
-    },
-    {
-      "commit": "Bootstrap GitOps root application",
-      "status": "open"
-    },
-    {
-      "commit": "Introduce multi-cluster ApplicationSet and security policies",
-      "status": "open"
-    },
-    {
-      "commit": "Integrate Kyverno policies with Gatekeeper audit layer",
-      "status": "open"
-    },
-    {
-      "commit": "Apply Cilium default-deny and service allow policies",
-      "status": "open"
-    },
-    {
-      "commit": "Deploy Falco with RBAC-abuse rules and Slack alerts",
-      "status": "open"
-    },
-    {
-      "commit": "Wire OpenTelemetry collector to Tempo and Loki",
-      "status": "open"
-    },
-    {
-      "commit": "Enable Alertmanager night mode routing",
-      "status": "open"
-    },
-    {
-      "commit": "Define per-namespace Cilium FQDN allowlists",
-      "status": "open"
-    },
-    {
-      "commit": "Switch Kyverno verifyImages to enforce",
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "commit": "Analyse Gesprächsextrakte",
-      "status": "offen"
-    },
-    {
-      "commit": "Erzeuge initiale Aufgaben",
-      "status": "offen"
-    },
-    {
-      "commit": "Verzweige in Unteraufgaben",
-      "status": "offen"
-    },
-    {
-      "commit": "Bewerte CREP und depth",
-      "status": "offen"
-    },
-    {
-      "commit": "Commitiere Ergebnisse",
-      "status": "offen"
     }
   ],
   "progress": [
@@ -6609,6 +6216,10 @@
     {
       "commit": "feat: create GeophysikSection component",
       "status": "done"
+    },
+    {
+      "commit": "Analyse Gesprächsextrakte",
+      "status": "done"
     }
   ],
   "fractalTodos": [
@@ -6622,12 +6233,11 @@
     }
   ],
   "changedFiles": [
-    "feedbackcodex.md",
-    "package.json",
-    "packages/shared-utils/jsonFragmenter.test.ts",
-    "packages/shared-utils/jsonFragmenter.ts",
-    "pnpm-lock.yaml",
-    "scripts/parse-newadvanced-conversations.js"
+    "advancedToDo.json",
+    "advancedToDo.yaml",
+    "codexfeedback.md",
+    "scripts/analyze-newadvanced-conversations.test.ts",
+    "scripts/analyze-newadvanced-conversations.ts"
   ],
-  "lastUpdated": "2025-08-28T05:20:27.454Z"
+  "lastUpdated": "2025-08-28T05:43:57.447Z"
 }

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -6,3 +6,4 @@
 - FR-UM-2025-08-27-Fraktalrun-Import: Alle Änderungen in einem Lauf umgesetzt – kein zweiter Lauf notwendig.
 - Implemented admin API gateway script aggregating service statuses and proxying admin commands.
 - Added ConsentTimeline component for displaying consent records.
+- Implemented streaming analyzer for newadvanced conversations to handle large datasets.

--- a/scripts/analyze-newadvanced-conversations.test.ts
+++ b/scripts/analyze-newadvanced-conversations.test.ts
@@ -3,7 +3,10 @@ import path from 'path';
 import fs from 'fs';
 import os from 'os';
 import { execSync } from 'child_process';
-import { analyzeNewAdvancedConversations } from './analyze-newadvanced-conversations';
+import {
+  analyzeNewAdvancedConversations,
+  analyzeNewAdvancedConversationsStream,
+} from './analyze-newadvanced-conversations';
 
 describe('analyzeNewAdvancedConversations', () => {
   it('summarizes sample conversation data', () => {
@@ -46,7 +49,7 @@ describe('analyzeNewAdvancedConversations', () => {
     const file = path.join(__dirname, '../tests/fixtures/newadvanced-sample.json');
     const out = path.join(os.tmpdir(), 'newadvanced-stats.json');
     const script = path.join(__dirname, 'analyze-newadvanced-conversations.ts');
-    execSync(`npx ts-node ${script} ${file} --json ${out}`);
+    execSync(`npx ts-node --transpile-only ${script} ${file} --json ${out}`);
     const written = JSON.parse(fs.readFileSync(out, 'utf8'));
     expect(written.conversationCount).toBe(1);
   });
@@ -56,10 +59,24 @@ describe('analyzeNewAdvancedConversations', () => {
     const out = path.join(os.tmpdir(), 'newadvanced-stats2.json');
     const script = path.join(__dirname, 'analyze-newadvanced-conversations.ts');
     execSync(
-      `npx ts-node ${script} ${file} --start 1 --count 1 --json ${out}`
+      `npx ts-node --transpile-only ${script} ${file} --start 1 --count 1 --json ${out}`
     );
     const written = JSON.parse(fs.readFileSync(out, 'utf8'));
     expect(written.conversationCount).toBe(1);
     expect(written.titles).toEqual(['Second']);
+  });
+
+  it('streams conversation data without loading entire file', async () => {
+    const file = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-multi.json'
+    );
+    const stats = await analyzeNewAdvancedConversationsStream(file);
+    expect(stats.conversationCount).toBe(2);
+    expect(stats.messageCount).toBe(2);
+    expect(stats.authorCounts.user).toBe(1);
+    expect(stats.authorCounts.assistant).toBe(1);
+    expect(stats.todoCount).toBe(1);
+    expect(stats.titles).toEqual(['First', 'Second']);
   });
 });

--- a/scripts/analyze-newadvanced-conversations.ts
+++ b/scripts/analyze-newadvanced-conversations.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env ts-node
 import fs from 'fs';
 import path from 'path';
+import { parser } from 'stream-json';
+import { streamArray } from 'stream-json/streamers/StreamArray';
 
 export interface ConversationStats {
   conversationCount: number;
@@ -63,13 +65,85 @@ export function analyzeNewAdvancedConversations(
   };
 }
 
+export async function analyzeNewAdvancedConversationsStream(
+  filePath: string,
+  filterTitles?: string[],
+  start = 0,
+  count = Infinity
+): Promise<ConversationStats> {
+  return new Promise((resolve, reject) => {
+    const titleSet = filterTitles ? new Set(filterTitles) : undefined;
+    const stats: ConversationStats = {
+      conversationCount: 0,
+      messageCount: 0,
+      authorCounts: {},
+      averageMessagesPerConversation: 0,
+      timeRange: { start: null, end: null },
+      todoCount: 0,
+      titles: [],
+    };
+    let index = -1;
+    const pipeline = fs
+      .createReadStream(filePath, { encoding: 'utf8' })
+      .pipe(parser())
+      .pipe(streamArray());
+    pipeline.on('data', ({ value }: { value: any }) => {
+      index++;
+      if (index < start) return;
+      if (stats.conversationCount >= count) {
+        pipeline.destroy();
+        return;
+      }
+      if (titleSet && !titleSet.has(value.title)) return;
+      stats.conversationCount++;
+      stats.titles.push(value.title || 'Untitled');
+      const nodes = Object.values(value.mapping || {});
+      nodes.forEach((node: any) => {
+        const msg = node.message;
+        if (msg && msg.author) {
+          stats.messageCount++;
+          const role = msg.author.role || 'unknown';
+          stats.authorCounts[role] = (stats.authorCounts[role] || 0) + 1;
+          const ct = (msg as any).create_time;
+          if (typeof ct === 'number') {
+            stats.timeRange.start =
+              stats.timeRange.start === null
+                ? ct
+                : Math.min(stats.timeRange.start, ct);
+            stats.timeRange.end =
+              stats.timeRange.end === null
+                ? ct
+                : Math.max(stats.timeRange.end, ct);
+          }
+          const parts: string[] = msg.content?.parts || [];
+          const text = parts.join(' ');
+          const matches = text.match(/TODO/gi);
+          if (matches) stats.todoCount += matches.length;
+        }
+      });
+    });
+    const finalize = () => {
+      stats.averageMessagesPerConversation = stats.conversationCount
+        ? stats.messageCount / stats.conversationCount
+        : 0;
+      resolve(stats);
+    };
+    pipeline.on('end', finalize);
+    pipeline.on('close', finalize);
+    pipeline.on('error', reject);
+  });
+}
+
 if (require.main === module) {
   const args = process.argv.slice(2);
   const fileArgIndex = args.findIndex((a: string) => !a.startsWith('--'));
   const file =
     fileArgIndex >= 0
       ? args[fileArgIndex]
-      : path.join(__dirname, '../docs/sigils/newadvancedconversations.json');
+      : path.join(
+          __dirname,
+          '../docs/sigils/newadvancedconversations.json'
+        );
   const summaryIndex = args.indexOf('--summary');
   const summaryPath = summaryIndex >= 0 ? args[summaryIndex + 1] : null;
   const jsonIndex = args.indexOf('--json');
@@ -86,31 +160,44 @@ if (require.main === module) {
   const countIndex = args.indexOf('--count');
   const count =
     countIndex >= 0 ? parseInt(args[countIndex + 1], 10) : Infinity;
-  const stats = analyzeNewAdvancedConversations(file, titleList, start, count);
-  console.log(`Conversations: ${stats.conversationCount}`);
-  console.log(`Messages: ${stats.messageCount}`);
-  console.log('Authors:', stats.authorCounts);
-  console.log('Titles:', stats.titles);
-  if (summaryPath) {
-    const lines = [
-      '# New Advanced Conversations Stats',
-      '',
-      `- Conversations: ${stats.conversationCount}`,
-      `- Messages: ${stats.messageCount}`,
-      '- Authors:',
-      ...Object.entries(stats.authorCounts).map(
-        ([role, count]) => `  - ${role}: ${count}`
-      ),
-      '- Titles:',
-      ...stats.titles.map((t) => `  - ${t}`),
-      `- TODOs: ${stats.todoCount}`,
-      `- Time range: ${stats.timeRange.start ?? 'n/a'} - ${stats.timeRange.end ?? 'n/a'}`,
-    ];
-    fs.writeFileSync(summaryPath, lines.join('\n') + '\n');
-    console.log(`Summary written to ${summaryPath}`);
-  }
-  if (jsonPath) {
-    fs.writeFileSync(jsonPath, JSON.stringify(stats, null, 2));
-    console.log(`JSON summary written to ${jsonPath}`);
-  }
+  const useStream = args.includes('--stream');
+
+  (async () => {
+    const stats = useStream
+      ? await analyzeNewAdvancedConversationsStream(
+          file,
+          titleList,
+          start,
+          count
+        )
+      : analyzeNewAdvancedConversations(file, titleList, start, count);
+    console.log(`Conversations: ${stats.conversationCount}`);
+    console.log(`Messages: ${stats.messageCount}`);
+    console.log('Authors:', stats.authorCounts);
+    console.log('Titles:', stats.titles);
+    if (summaryPath) {
+      const lines = [
+        '# New Advanced Conversations Stats',
+        '',
+        `- Conversations: ${stats.conversationCount}`,
+        `- Messages: ${stats.messageCount}`,
+        '- Authors:',
+        ...Object.entries(stats.authorCounts).map(
+          ([role, count]) => `  - ${role}: ${count}`
+        ),
+        '- Titles:',
+        ...stats.titles.map((t) => `  - ${t}`),
+        `- TODOs: ${stats.todoCount}`,
+        `- Time range: ${
+          stats.timeRange.start ?? 'n/a'
+        } - ${stats.timeRange.end ?? 'n/a'}`,
+      ];
+      fs.writeFileSync(summaryPath, lines.join('\n') + '\n');
+      console.log(`Summary written to ${summaryPath}`);
+    }
+    if (jsonPath) {
+      fs.writeFileSync(jsonPath, JSON.stringify(stats, null, 2));
+      console.log(`JSON summary written to ${jsonPath}`);
+    }
+  })();
 }


### PR DESCRIPTION
## Summary
- add streaming analysis function and CLI flag for newadvanced conversations
- cover streaming path with vitest and enable ts-node transpile-only in CLI tests
- mark "Analyse Gesprächsextrakte" as done and sync progress files

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest scripts/analyze-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68afe8cbc3288322acc79b84f3a63a27