### PR TITLE
Add streaming summary parser for large conversation logs

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6237,8 +6237,10 @@
     }
   ],
   "changedFiles": [
-    "scripts/__tests__/parse-newadvanced-conversations.test.ts",
-    "scripts/parse-newadvanced-conversations.js"
+    "codexfeedback.md",
+    "scripts/__tests__/fixtures/",
+    "scripts/__tests__/summarize-newadvanced-conversations.test.ts",
+    "scripts/summarize-newadvanced-conversations.ts"
   ],
-  "lastUpdated": "2025-08-28T11:05:14.252Z"
+  "lastUpdated": "2025-08-28T11:36:11.538Z"
 }

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -7,3 +7,4 @@
 - Implemented admin API gateway script aggregating service statuses and proxying admin commands.
 - Added ConsentTimeline component for displaying consent records.
 - Implemented streaming analyzer for newadvanced conversations to handle large datasets.
+- Added streaming summary script for newadvanced conversations.

--- a/scripts/__tests__/fixtures/newadvancedconversations-small.json
+++ b/scripts/__tests__/fixtures/newadvancedconversations-small.json
@@ -1,0 +1,13 @@
+[
+  {
+    "title": "Session A",
+    "mapping": {
+      "n1": {},
+      "n2": {}
+    }
+  },
+  {
+    "title": "Session B",
+    "mapping": {}
+  }
+]

--- a/scripts/__tests__/summarize-newadvanced-conversations.test.ts
+++ b/scripts/__tests__/summarize-newadvanced-conversations.test.ts
@@ -1,0 +1,19 @@
+import { summarizeNewAdvancedConversations } from '../summarize-newadvanced-conversations';
+import * as path from 'path';
+
+describe('summarizeNewAdvancedConversations', () => {
+  it('summarizes titles and node counts', async () => {
+    const file = path.join(__dirname, 'fixtures/newadvancedconversations-small.json');
+    const summaries = await summarizeNewAdvancedConversations(file);
+    expect(summaries).toEqual([
+      { title: 'Session A', nodes: 2 },
+      { title: 'Session B', nodes: 0 },
+    ]);
+  });
+
+  it('respects limit option', async () => {
+    const file = path.join(__dirname, 'fixtures/newadvancedconversations-small.json');
+    const summaries = await summarizeNewAdvancedConversations(file, 1);
+    expect(summaries).toEqual([{ title: 'Session A', nodes: 2 }]);
+  });
+});

--- a/scripts/summarize-newadvanced-conversations.ts
+++ b/scripts/summarize-newadvanced-conversations.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { parser } from 'stream-json';
+import { streamArray } from 'stream-json/streamers/StreamArray';
+
+export interface ConversationSummary {
+  title: string;
+  nodes: number;
+}
+
+export function summarizeNewAdvancedConversations(filePath: string, limit?: number): Promise<ConversationSummary[]> {
+  return new Promise((resolve, reject) => {
+    const summaries: ConversationSummary[] = [];
+    let resolved = false;
+    const pipeline = fs
+      .createReadStream(filePath, { encoding: 'utf8' })
+      .pipe(parser())
+      .pipe(streamArray());
+
+    pipeline.on('data', ({ value }: { value: any }) => {
+      const title = value.title || 'untitled';
+      const mapping = value.mapping || {};
+      const nodes = Object.keys(mapping).length;
+      summaries.push({ title, nodes });
+      if (limit && summaries.length >= limit) {
+        resolved = true;
+        pipeline.destroy();
+        resolve(summaries);
+      }
+    });
+
+    pipeline.on('end', () => {
+      if (!resolved) resolve(summaries);
+    });
+    pipeline.on('error', reject);
+  });
+}
+
+if (require.main === module) {
+  const args: string[] = process.argv.slice(2);
+  const fileIndex = args.findIndex((a: string) => a === '--file' || a === '-f');
+  const limitIndex = args.findIndex((a: string) => a === '--limit' || a === '-n');
+  const file = fileIndex >= 0 ? path.resolve(args[fileIndex + 1]) : path.join(__dirname, '../docs/sigils/newadvancedconversations.json');
+  const limit = limitIndex >= 0 ? parseInt(args[limitIndex + 1], 10) : undefined;
+  summarizeNewAdvancedConversations(file, limit).then(res => {
+    console.log(JSON.stringify(res, null, 2));
+  });
+}


### PR DESCRIPTION
## Summary
- add `summarize-newadvanced-conversations` script to stream titles and node counts
- add tests and fixtures for summarizing new advanced conversations
- track progress and feedback for the new parser

## Testing
- `npx jest scripts/__tests__/summarize-newadvanced-conversations.test.ts`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68b03df884e08322a2e613ae8cedefdd