### PR TITLE
Add streaming chunk parser for conversation datasets

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6237,10 +6237,11 @@
     }
   ],
   "changedFiles": [
-    "codexfeedback.md",
-    "scripts/__tests__/fixtures/",
-    "scripts/__tests__/summarize-newadvanced-conversations.test.ts",
-    "scripts/summarize-newadvanced-conversations.ts"
+    "packages/shared-utils/jsonFragmenter.js",
+    "packages/shared-utils/jsonFragmenter.test.ts",
+    "packages/shared-utils/jsonFragmenter.ts",
+    "scripts/__tests__/parse-newadvanced-conversations.test.ts",
+    "scripts/parse-newadvanced-conversations.js"
   ],
-  "lastUpdated": "2025-08-28T11:36:11.538Z"
+  "lastUpdated": "2025-08-28T11:53:50.021Z"
 }

--- a/packages/shared-utils/jsonFragmenter.js
+++ b/packages/shared-utils/jsonFragmenter.js
@@ -3,6 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.splitJsonArray = splitJsonArray;
 exports.splitJsonArrayFile = splitJsonArrayFile;
 exports.writeJsonChunks = writeJsonChunks;
+exports.writeJsonChunksStream = writeJsonChunksStream;
 exports.grepJsonArrayFile = grepJsonArrayFile;
 exports.grepJsonArrayFileStream = grepJsonArrayFileStream;
 exports.extractCodeSnippetsFromFile = extractCodeSnippetsFromFile;
@@ -51,6 +52,38 @@ function writeJsonChunks(filePath, destDir, chunkSize) {
     chunks.forEach((chunk, idx) => {
     const outPath = `${destDir}/${base.split('/').pop()}-${idx + 1}.json`;
     fs_1.writeFileSync(outPath, JSON.stringify(chunk, null, 2), 'utf8');
+    });
+}
+
+function writeJsonChunksStream(filePath, destDir, chunkSize) {
+    return new Promise((resolve, reject) => {
+        if (!fs_1.existsSync(destDir))
+            fs_1.mkdirSync(destDir, { recursive: true });
+        const base = filePath.replace(/\.json$/i, '');
+        let buffer = [];
+        let index = 0;
+        const pipeline = fs_1
+            .createReadStream(filePath, { encoding: 'utf8' })
+            .pipe((0, stream_json_1.parser)())
+            .pipe((0, StreamArray_1.streamArray)());
+        pipeline.on('data', ({ value }) => {
+            buffer.push(value);
+            if (buffer.length >= chunkSize) {
+                index++;
+                const outPath = `${destDir}/${(0, path_1.basename)(base)}-${index}.json`;
+                fs_1.writeFileSync(outPath, JSON.stringify(buffer, null, 2), 'utf8');
+                buffer = [];
+            }
+        });
+        pipeline.on('end', () => {
+            if (buffer.length > 0) {
+                index++;
+                const outPath = `${destDir}/${(0, path_1.basename)(base)}-${index}.json`;
+                fs_1.writeFileSync(outPath, JSON.stringify(buffer, null, 2), 'utf8');
+            }
+            resolve();
+        });
+        pipeline.on('error', reject);
     });
 }
 /**

--- a/packages/shared-utils/jsonFragmenter.test.ts
+++ b/packages/shared-utils/jsonFragmenter.test.ts
@@ -1,6 +1,13 @@
 import fs from 'fs';
 import path from 'path';
-import { splitJsonArray, splitJsonArrayFile, writeJsonChunks, grepJsonArrayFile, grepJsonArrayFileStream } from './jsonFragmenter';
+import {
+  splitJsonArray,
+  splitJsonArrayFile,
+  writeJsonChunks,
+  writeJsonChunksStream,
+  grepJsonArrayFile,
+  grepJsonArrayFileStream,
+} from './jsonFragmenter';
 
 describe('jsonFragmenter', () => {
   const tmpDir = path.join(__dirname, '__tmp__');
@@ -30,6 +37,15 @@ describe('jsonFragmenter', () => {
   test('writeJsonChunks writes files', () => {
     const dest = path.join(tmpDir, 'out');
     writeJsonChunks(sampleFile, dest, 2);
+    const files = fs.readdirSync(dest).sort();
+    expect(files.length).toBe(3);
+    const data1 = JSON.parse(fs.readFileSync(path.join(dest, files[0]), 'utf8'));
+    expect(data1).toEqual([1,2]);
+  });
+
+  test('writeJsonChunksStream streams and writes files', async () => {
+    const dest = path.join(tmpDir, 'out-stream');
+    await writeJsonChunksStream(sampleFile, dest, 2);
     const files = fs.readdirSync(dest).sort();
     expect(files.length).toBe(3);
     const data1 = JSON.parse(fs.readFileSync(path.join(dest, files[0]), 'utf8'));

--- a/packages/shared-utils/jsonFragmenter.ts
+++ b/packages/shared-utils/jsonFragmenter.ts
@@ -48,6 +48,51 @@ export function writeJsonChunks(filePath: string, destDir: string, chunkSize: nu
 }
 
 /**
+ * Streams a JSON array file and writes chunks without loading the entire file.
+ * Resulting files are named <basename>-<index>.json in destDir.
+ * @param filePath Input JSON array file.
+ * @param destDir Destination directory for chunk files.
+ * @param chunkSize Number of items per chunk.
+ */
+export function writeJsonChunksStream(
+  filePath: string,
+  destDir: string,
+  chunkSize: number
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!fs.existsSync(destDir)) fs.mkdirSync(destDir, { recursive: true });
+    const base = filePath.replace(/\.json$/i, '');
+    let buffer: any[] = [];
+    let index = 0;
+
+    const pipeline = fs
+      .createReadStream(filePath, { encoding: 'utf8' })
+      .pipe(parser())
+      .pipe(streamArray());
+
+    pipeline.on('data', ({ value }: { value: any }) => {
+      buffer.push(value);
+      if (buffer.length >= chunkSize) {
+        index++;
+        const outPath = `${destDir}/${path.basename(base)}-${index}.json`;
+        fs.writeFileSync(outPath, JSON.stringify(buffer, null, 2), 'utf8');
+        buffer = [];
+      }
+    });
+
+    pipeline.on('end', () => {
+      if (buffer.length > 0) {
+        index++;
+        const outPath = `${destDir}/${path.basename(base)}-${index}.json`;
+        fs.writeFileSync(outPath, JSON.stringify(buffer, null, 2), 'utf8');
+      }
+      resolve();
+    });
+    pipeline.on('error', reject);
+  });
+}
+
+/**
  * Filters a JSON array file by a regex applied to each item's stringified form.
  * Matching items are written to <basename>-grep.json in destDir.
  * @param filePath Input JSON array file.

--- a/scripts/__tests__/parse-newadvanced-conversations.test.ts
+++ b/scripts/__tests__/parse-newadvanced-conversations.test.ts
@@ -1,7 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-const { parseNewAdvancedConversations } = require('../parse-newadvanced-conversations');
+const {
+  parseNewAdvancedConversations,
+  chunkNewAdvancedConversations,
+} = require('../parse-newadvanced-conversations');
 
 test('parseNewAdvancedConversations writes YAML when enabled', async () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'parse-test-'));
@@ -24,4 +27,17 @@ test('parseNewAdvancedConversations streams when requested', async () => {
   expect(matches).toHaveLength(1);
   const base = path.join(dest, 'newadvanced-sample-grep');
   expect(fs.existsSync(`${base}.json`)).toBe(true);
+});
+
+test('chunkNewAdvancedConversations splits file into chunks', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'chunk-'));
+  const input = path.join(tmp, 'input.json');
+  const data = Array.from({ length: 5 }, (_, i) => ({ id: i }));
+  fs.writeFileSync(input, JSON.stringify(data));
+  const dest = path.join(tmp, 'out');
+  await chunkNewAdvancedConversations(input, dest, 2);
+  const files = fs.readdirSync(dest).sort();
+  expect(files).toEqual(['input-1.json', 'input-2.json', 'input-3.json']);
+  const first = JSON.parse(fs.readFileSync(path.join(dest, 'input-1.json'), 'utf8'));
+  expect(first).toEqual([{ id: 0 }, { id: 1 }]);
 });

--- a/scripts/parse-newadvanced-conversations.js
+++ b/scripts/parse-newadvanced-conversations.js
@@ -1,7 +1,11 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
-const { grepJsonArrayFile, grepJsonArrayFileStream } = require('../packages/shared-utils/jsonFragmenter');
+const {
+  grepJsonArrayFile,
+  grepJsonArrayFileStream,
+  writeJsonChunksStream,
+} = require('../packages/shared-utils/jsonFragmenter');
 
 function extractSessionTodos(filePath, titles) {
   const raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -60,6 +64,10 @@ async function parseNewAdvancedConversations(filePath, destDir, keyword = 'TODO'
   return matches;
 }
 
+function chunkNewAdvancedConversations(filePath, destDir, chunkSize) {
+  return writeJsonChunksStream(filePath, destDir, chunkSize);
+}
+
 if (require.main === module) {
   const args = process.argv.slice(2);
   const opts = {
@@ -74,6 +82,7 @@ if (require.main === module) {
     yaml: false,
     limit: undefined,
     stream: undefined,
+    chunkSize: undefined,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -110,13 +119,21 @@ if (require.main === module) {
       case '--stream':
         opts.stream = true;
         break;
+      case '--chunk':
+      case '--chunk-size':
+        opts.chunkSize = parseInt(args[++i], 10);
+        break;
       default:
         // legacy positional keyword
         if (!arg.startsWith('-')) opts.keyword = arg;
     }
   }
 
-  if (opts.extract) {
+  if (opts.chunkSize) {
+    chunkNewAdvancedConversations(opts.file, opts.dest, opts.chunkSize).then(() => {
+      console.log(`Chunked ${opts.file} into ${opts.dest}`);
+    });
+  } else if (opts.extract) {
     const tasks = extractSessionTodos(opts.file, opts.titles);
     const outJson = path.join(opts.dest, 'advancedToDo.part6.json');
     const outYaml = path.join(opts.dest, 'advancedToDo.part6.yaml');
@@ -135,4 +152,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { parseNewAdvancedConversations, extractSessionTodos };
+module.exports = { parseNewAdvancedConversations, extractSessionTodos, chunkNewAdvancedConversations };


### PR DESCRIPTION
## Summary
- add writeJsonChunksStream to process huge JSON arrays without loading into memory
- extend newadvanced conversation parser with chunking CLI option
- cover streaming chunking with tests

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/shared-utils/jsonFragmenter.test.ts scripts/__tests__/parse-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b04241144c832280d6cde51e06bb5f