### PR TITLE
Add admin peers API and connector utilities

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-28, in der Zeit des Morgen.
+Am 2025-08-28, in der Zeit des Tag.
 
-Symbolphase: Initiation (Fokus: C)
+Symbolphase: Aktivierung (Fokus: R)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13726,7 +13726,7 @@
     "path": "scripts/admin-peers-api.ts",
     "task": "Manage AI peer registrations with policy checks",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create spaces management module",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13092,7 +13092,7 @@
   path: scripts/admin-peers-api.ts
   task: Manage AI peer registrations with policy checks
   test: ""
-  status: open
+  status: done
 - commit: Create spaces management module
   path: packages/commons/Spaces.ts
   task: Manage collaboration spaces, members, and invites

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "fractal-step-1: finalize progress",
+  "lastCommit": "Merge pull request #1538 from GenesisAeon/codex/investigate-failing-checks-in-ci/cd-pipeline",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -5298,6 +5298,10 @@
     {
       "commit": "Analyse Gesprächsextrakte",
       "status": "done"
+    },
+    {
+      "commit": "Implement admin peers API",
+      "status": "done"
     }
   ],
   "completed": [
@@ -6237,11 +6241,8 @@
     }
   ],
   "changedFiles": [
-    "packages/shared-utils/jsonFragmenter.js",
-    "packages/shared-utils/jsonFragmenter.test.ts",
-    "packages/shared-utils/jsonFragmenter.ts",
-    "scripts/__tests__/parse-newadvanced-conversations.test.ts",
-    "scripts/parse-newadvanced-conversations.js"
+    "CHRONOPOEM.md",
+    "scripts/admin-peers-api.ts"
   ],
-  "lastUpdated": "2025-08-28T11:53:50.021Z"
+  "lastUpdated": "2025-08-28T12:10:56.786Z"
 }

--- a/packages/connectors/AIPeerConnector.test.ts
+++ b/packages/connectors/AIPeerConnector.test.ts
@@ -1,14 +1,34 @@
-import { expect, test, vi } from 'vitest';
+import { expect, test } from 'vitest';
 import { AIPeerConnector } from './AIPeerConnector';
 
 test('registers peer and invokes route', async () => {
   const connector = new AIPeerConnector();
-  const fetchMock = vi.fn(async () => ({ ok: true }));
+  let calledWith: any;
+  const fetchMock = async (...args: any[]) => {
+    calledWith = args;
+    return { ok: true } as any;
+  };
   (global as any).fetch = fetchMock;
 
   connector.register({ id: 'peer1', baseUrl: 'https://example.com/' });
   const res = await connector.invoke('peer1', '/ping');
 
-  expect(fetchMock).toHaveBeenCalledWith('https://example.com/ping', undefined);
+  expect(calledWith).toEqual(['https://example.com/ping', undefined]);
   expect(res.ok).toBe(true);
+});
+
+test('lists and unregisters peers', () => {
+  const connector = new AIPeerConnector();
+  connector.register({ id: 'peer1', baseUrl: 'https://example.com/' });
+  connector.register({ id: 'peer2', baseUrl: 'https://example.org/' });
+
+  expect(connector.list()).toEqual([
+    { id: 'peer1', baseUrl: 'https://example.com/' },
+    { id: 'peer2', baseUrl: 'https://example.org/' }
+  ]);
+
+  expect(connector.unregister('peer1')).toBe(true);
+  expect(connector.list()).toEqual([
+    { id: 'peer2', baseUrl: 'https://example.org/' }
+  ]);
 });

--- a/packages/connectors/AIPeerConnector.ts
+++ b/packages/connectors/AIPeerConnector.ts
@@ -15,6 +15,20 @@ export class AIPeerConnector {
     this.peers.set(peer.id, peer);
   }
 
+  /**
+   * Returns all registered peers as an array.
+   */
+  list(): AIPeer[] {
+    return Array.from(this.peers.values());
+  }
+
+  /**
+   * Unregister a peer by id. Returns true if the peer existed.
+   */
+  unregister(id: string): boolean {
+    return this.peers.delete(id);
+  }
+
   getPeer(id: string): AIPeer | undefined {
     return this.peers.get(id);
   }

--- a/scripts/admin-peers-api.ts
+++ b/scripts/admin-peers-api.ts
@@ -1,0 +1,64 @@
+import express from 'express';
+import { AIPeer, AIPeerConnector } from '../packages/connectors/AIPeerConnector';
+
+const app = express();
+app.use(express.json());
+
+const connector = new AIPeerConnector();
+
+// simple bearer token check using ADMIN_TOKEN env var
+function auth(req: express.Request, res: express.Response, next: express.NextFunction) {
+  const token = process.env.ADMIN_TOKEN;
+  if (token && req.headers.authorization !== `Bearer ${token}`) {
+    res.status(403).json({ error: 'forbidden' });
+    return;
+  }
+  next();
+}
+
+app.use(auth);
+
+app.post('/peers', (req, res) => {
+  const peer = req.body as AIPeer;
+  if (!peer || !peer.id || !peer.baseUrl) {
+    res.status(400).json({ error: 'invalid peer' });
+    return;
+  }
+  connector.register(peer);
+  res.status(201).json({ status: 'registered' });
+});
+
+app.get('/peers', (_req, res) => {
+  res.json({ peers: connector.list() });
+});
+
+app.delete('/peers/:id', (req, res) => {
+  const ok = connector.unregister(req.params.id);
+  if (!ok) {
+    res.status(404).json({ error: 'peer not found' });
+    return;
+  }
+  res.json({ status: 'removed' });
+});
+
+app.all('/peers/:id/*', async (req, res) => {
+  const { id } = req.params;
+  const extra = (req.params as any)[0] as string | undefined;
+  const path = extra ? `/${extra}` : '';
+  try {
+    const resp = await connector.invoke(id, path, {
+      method: req.method,
+      headers: { 'Content-Type': 'application/json' },
+      body: req.method === 'GET' || req.method === 'HEAD' ? undefined : JSON.stringify(req.body)
+    });
+    const text = await resp.text();
+    res.status(resp.status).send(text);
+  } catch (err) {
+    res.status(500).json({ error: String(err) });
+  }
+});
+
+const port = Number(process.env.PORT) || 4011;
+app.listen(port, () => {
+  console.log(`Admin peers API listening on :${port}`);
+});


### PR DESCRIPTION
## Summary
- extend AIPeerConnector with listing and unregistering helpers
- create `admin-peers-api.ts` service for registering and proxying AI peers
- mark admin peers API tasks done and update progress tracking

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json --noEmit --extendedDiagnostics`
- `pnpm test packages/connectors/AIPeerConnector.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b045db7c9c832290c0b9b11cad5dfb