### PR TITLE
Add start/count options to newadvanced parser

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6238,11 +6238,18 @@
     {
       "commit": "Add streaming parser for newadvancedconversations",
       "status": "done"
+    },
+    {
+      "commit": "feat: add start and count options to newadvanced parser",
+      "status": "done"
     }
   ],
   "changedFiles": [
-    "CHRONOPOEM.md",
-    "scripts/admin-peers-api.ts"
+    "packages/shared-utils/jsonFragmenter.js",
+    "packages/shared-utils/jsonFragmenter.test.ts",
+    "packages/shared-utils/jsonFragmenter.ts",
+    "scripts/__tests__/parse-newadvanced-conversations.test.ts",
+    "scripts/parse-newadvanced-conversations.js"
   ],
-  "lastUpdated": "2025-08-28T12:10:56.786Z"
+  "lastUpdated": "2025-08-28T12:21:49.791Z"
 }

--- a/packages/shared-utils/jsonFragmenter.js
+++ b/packages/shared-utils/jsonFragmenter.js
@@ -94,14 +94,15 @@ function writeJsonChunksStream(filePath, destDir, chunkSize) {
  * @param pattern Regular expression used to match items.
  * @param limit Optional maximum number of matches to return.
  */
-function grepJsonArrayFile(filePath, destDir, pattern, limit) {
+function grepJsonArrayFile(filePath, destDir, pattern, limit, start = 0, count = Infinity) {
     const raw = fs_1.readFileSync(filePath, 'utf8');
     const data = JSON.parse(raw);
     if (!Array.isArray(data)) {
         throw new Error('Input JSON must be an array');
     }
     const matches = [];
-    for (const item of data) {
+    const slice = data.slice(start, start + count);
+    for (const item of slice) {
         if (pattern.test(JSON.stringify(item))) {
             matches.push(item);
             if (limit && matches.length >= limit)
@@ -125,30 +126,40 @@ function grepJsonArrayFile(filePath, destDir, pattern, limit) {
  * @param pattern Regular expression to test each item.
  * @param limit Optional maximum number of matches to return.
  */
-function grepJsonArrayFileStream(filePath, destDir, pattern, limit) {
+function grepJsonArrayFileStream(filePath, destDir, pattern, limit, start = 0, count = Infinity) {
     return new Promise((resolve, reject) => {
         const matches = [];
         if (!fs_1.existsSync(destDir))
             fs_1.mkdirSync(destDir, { recursive: true });
         const base = filePath.replace(/\.json$/i, '');
         const outPath = `${destDir}/${path_1.basename(base)}-grep.json`;
-        const pipeline = fs_1
+    let index = -1;
+    const pipeline = fs_1
             .createReadStream(filePath, { encoding: 'utf8' })
             .pipe((0, stream_json_1.parser)())
             .pipe((0, StreamArray_1.streamArray)());
-        pipeline.on('data', ({ value }) => {
-            if (pattern.test(JSON.stringify(value))) {
-                matches.push(value);
-                if (limit && matches.length >= limit) {
-                    pipeline.destroy();
-                }
+    pipeline.on('data', ({ value }) => {
+        index++;
+        if (index < start)
+            return;
+        if (index >= start + count) {
+            pipeline.destroy();
+            return;
+        }
+        if (pattern.test(JSON.stringify(value))) {
+            matches.push(value);
+            if (limit && matches.length >= limit) {
+                pipeline.destroy();
             }
-        });
-    pipeline.on('end', () => {
+        }
+    });
+    const finalize = () => {
         fs_1.writeFileSync(outPath, JSON.stringify(matches, null, 2), 'utf8');
         resolve(matches);
-    });
-        pipeline.on('error', reject);
+    };
+    pipeline.on('end', finalize);
+    pipeline.on('close', finalize);
+    pipeline.on('error', reject);
     });
 }
 /**

--- a/packages/shared-utils/jsonFragmenter.test.ts
+++ b/packages/shared-utils/jsonFragmenter.test.ts
@@ -69,4 +69,16 @@ describe('jsonFragmenter', () => {
     const written = JSON.parse(fs.readFileSync(outPath, 'utf8'));
     expect(written).toEqual([4,5]);
   });
+
+  test('grepJsonArrayFile respects start and count', () => {
+    const dest = path.join(tmpDir, 'grep-start');
+    const matches = grepJsonArrayFile(sampleFile, dest, /1|2|3/, undefined, 1, 2);
+    expect(matches).toEqual([2,3]);
+  });
+
+  test('grepJsonArrayFileStream respects start and count', async () => {
+    const dest = path.join(tmpDir, 'grep-stream-start');
+    const matches = await grepJsonArrayFileStream(sampleFile, dest, /4|5/, undefined, 3, 1);
+    expect(matches).toEqual([4]);
+  });
 });

--- a/packages/shared-utils/jsonFragmenter.ts
+++ b/packages/shared-utils/jsonFragmenter.ts
@@ -104,7 +104,9 @@ export function grepJsonArrayFile<T>(
   filePath: string,
   destDir: string,
   pattern: RegExp,
-  limit?: number
+  limit?: number,
+  start = 0,
+  count = Infinity
 ): T[] {
   const raw = fs.readFileSync(filePath, 'utf8');
   const data: T[] = JSON.parse(raw);
@@ -112,7 +114,8 @@ export function grepJsonArrayFile<T>(
     throw new Error('Input JSON must be an array');
   }
   const matches: T[] = [];
-  for (const item of data) {
+  const slice = data.slice(start, start + count);
+  for (const item of slice) {
     if (pattern.test(JSON.stringify(item))) {
       matches.push(item);
       if (limit && matches.length >= limit) break;
@@ -139,20 +142,28 @@ export function grepJsonArrayFileStream<T>(
   filePath: string,
   destDir: string,
   pattern: RegExp,
-  limit?: number
+  limit?: number,
+  start = 0,
+  count = Infinity
 ): Promise<T[]> {
   return new Promise((resolve, reject) => {
     const matches: T[] = [];
     if (!fs.existsSync(destDir)) fs.mkdirSync(destDir, { recursive: true });
     const base = filePath.replace(/\.json$/i, '');
     const outPath = `${destDir}/${path.basename(base)}-grep.json`;
-
+    let index = -1;
     const pipeline = fs
       .createReadStream(filePath, { encoding: 'utf8' })
       .pipe(parser())
       .pipe(streamArray());
 
     pipeline.on('data', ({ value }: { value: T }) => {
+      index++;
+      if (index < start) return;
+      if (index >= start + count) {
+        pipeline.destroy();
+        return;
+      }
       if (pattern.test(JSON.stringify(value))) {
         matches.push(value);
         if (limit && matches.length >= limit) {
@@ -161,10 +172,12 @@ export function grepJsonArrayFileStream<T>(
       }
     });
 
-    pipeline.on('end', () => {
+    const finalize = () => {
       fs.writeFileSync(outPath, JSON.stringify(matches, null, 2), 'utf8');
       resolve(matches);
-    });
+    };
+    pipeline.on('end', finalize);
+    pipeline.on('close', finalize);
     pipeline.on('error', reject);
   });
 }

--- a/scripts/__tests__/parse-newadvanced-conversations.test.ts
+++ b/scripts/__tests__/parse-newadvanced-conversations.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { test, expect } from 'vitest';
 const {
   parseNewAdvancedConversations,
   chunkNewAdvancedConversations,
@@ -40,4 +41,16 @@ test('chunkNewAdvancedConversations splits file into chunks', async () => {
   expect(files).toEqual(['input-1.json', 'input-2.json', 'input-3.json']);
   const first = JSON.parse(fs.readFileSync(path.join(dest, 'input-1.json'), 'utf8'));
   expect(first).toEqual([{ id: 0 }, { id: 1 }]);
+});
+
+test('parseNewAdvancedConversations honors start and count', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'parse-start-'));
+  const fixture = path.join(__dirname, '../../tests/fixtures/newadvanced-multi.json');
+  const dest = path.join(tmp, 'out');
+  const matches = await parseNewAdvancedConversations(fixture, dest, 'TODO', {
+    stream: true,
+    start: 1,
+    count: 1,
+  });
+  expect(matches).toHaveLength(0);
 });

--- a/scripts/parse-newadvanced-conversations.js
+++ b/scripts/parse-newadvanced-conversations.js
@@ -42,7 +42,7 @@ function extractSessionTodos(filePath, titles) {
 }
 
 async function parseNewAdvancedConversations(filePath, destDir, keyword = 'TODO', options = {}) {
-  let { writeYaml = false, limit, stream } = options;
+  let { writeYaml = false, limit, stream, start = 0, count = Infinity } = options;
   if (stream === undefined) {
     try {
       const size = fs.statSync(filePath).size;
@@ -54,8 +54,8 @@ async function parseNewAdvancedConversations(filePath, destDir, keyword = 'TODO'
   }
   const regex = new RegExp(keyword, 'i');
   const matches = stream
-    ? await grepJsonArrayFileStream(filePath, destDir, regex, limit)
-    : grepJsonArrayFile(filePath, destDir, regex, limit);
+    ? await grepJsonArrayFileStream(filePath, destDir, regex, limit, start, count)
+    : grepJsonArrayFile(filePath, destDir, regex, limit, start, count);
   if (writeYaml) {
     const base = filePath.replace(/\.json$/i, '');
     const outPath = path.join(destDir, `${path.basename(base)}-grep.yaml`);
@@ -82,6 +82,8 @@ if (require.main === module) {
     yaml: false,
     limit: undefined,
     stream: undefined,
+    start: 0,
+    count: Infinity,
     chunkSize: undefined,
   };
 
@@ -119,6 +121,12 @@ if (require.main === module) {
       case '--stream':
         opts.stream = true;
         break;
+      case '--start':
+        opts.start = parseInt(args[++i], 10);
+        break;
+      case '--count':
+        opts.count = parseInt(args[++i], 10);
+        break;
       case '--chunk':
       case '--chunk-size':
         opts.chunkSize = parseInt(args[++i], 10);
@@ -146,6 +154,8 @@ if (require.main === module) {
       writeYaml: opts.yaml,
       limit: opts.limit,
       stream: opts.stream,
+      start: opts.start,
+      count: opts.count,
     }).then(matches => {
       console.log(`Parsed ${matches.length} fragments containing '${opts.keyword}'. Output: ${opts.dest}`);
     });


### PR DESCRIPTION
## Summary
- extend jsonFragmenter grep helpers to support start and count offsets
- add CLI and options for start/count in parse-newadvanced-conversations script
- cover new parsing behaviour with tests and update progress log

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx vitest run scripts/__tests__/parse-newadvanced-conversations.test.ts`
- `npx jest packages/shared-utils/jsonFragmenter.test.ts`
- `pnpm install`
- `poetry install --with test`


------
https://chatgpt.com/codex/tasks/task_e_68b04936b6248322a6472324478bb3d7