### PR TITLE
Fix training data test import

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6245,11 +6245,7 @@
     }
   ],
   "changedFiles": [
-    "packages/shared-utils/jsonFragmenter.js",
-    "packages/shared-utils/jsonFragmenter.test.ts",
-    "packages/shared-utils/jsonFragmenter.ts",
-    "scripts/__tests__/parse-newadvanced-conversations.test.ts",
-    "scripts/parse-newadvanced-conversations.js"
+    "scripts/__tests__/extract-training-data.vitest.ts"
   ],
-  "lastUpdated": "2025-08-28T12:21:49.791Z"
+  "lastUpdated": "2025-08-28T12:37:49.948Z"
 }

--- a/scripts/__tests__/extract-training-data.vitest.ts
+++ b/scripts/__tests__/extract-training-data.vitest.ts
@@ -3,7 +3,10 @@ import { promises as fs, constants as fsConstants } from 'fs';
 import path from 'path';
 import os from 'os';
 import yaml from 'js-yaml';
-import { extractTrainingData } from '../extract-training-data';
+// ts-jest allows requiring TypeScript files directly; using `require` avoids
+// issues with ESM syntax in the generated .js file.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { extractTrainingData } = require('../extract-training-data.ts');
 import { SelfReflectionAgent } from '../../packages/self-reflection/src';
 
 async function exists(p: string) {


### PR DESCRIPTION
## Summary
- require TypeScript source in `extract-training-data` test to avoid ESM parsing errors
- sync `advancedprogress.json` after updating tests

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test scripts/__tests__/extract-training-data.vitest.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b04bcae4548322b63acd46866fec97