### PR TITLE
fractal-step-3: add commons hub app

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13754,7 +13754,7 @@
     "path": "packages/commons-ui/CommonsApp.tsx",
     "task": "Human-first interface integrating research and voice panels",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add system overview widget",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13112,7 +13112,7 @@
   path: packages/commons-ui/CommonsApp.tsx
   task: Human-first interface integrating research and voice panels
   test: ""
-  status: open
+  status: done
 - commit: Add system overview widget
   path: packages/unifiedmandala-ui/components/SystemOverview.tsx
   task: Display health status of core services

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -5306,6 +5306,10 @@
     {
       "commit": "Create spaces management module",
       "status": "done"
+    },
+    {
+      "commit": "Create commons hub app",
+      "status": "done"
     }
   ],
   "completed": [
@@ -6252,6 +6256,11 @@
       "status": "done"
     }
   ],
-  "changedFiles": [],
-  "lastUpdated": "2025-08-28T15:01:18.856Z"
+  "changedFiles": [
+    "advancedToDo.json",
+    "advancedToDo.yaml",
+    "feedbackcodex.md",
+    "packages/commons-ui/"
+  ],
+  "lastUpdated": "2025-08-28T16:53:54.426Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -189,3 +189,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Applied FR-UM-2025-08-27-A patch bundle successfully in one run.
 - Added AIPeerConnector module stub with basic peer registration and invocation and updated progress trackers.
 - Added streaming utilities for parsing large newadvancedconversations dataset.
+- Implemented CommonsApp component unifying ResearchHub and VoicePanel.

--- a/packages/commons-ui/CommonsApp.test.tsx
+++ b/packages/commons-ui/CommonsApp.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CommonsApp from './CommonsApp';
+
+jest.mock('../unifiedmandala-ui/components/ResearchHub', () => () => <div aria-label="ResearchHub" />);
+jest.mock('../unifiedmandala-ui/components/VoicePanel', () => () => <div aria-label="VoicePanel" />);
+
+test('renders research and voice panels', () => {
+  render(<CommonsApp />);
+  expect(screen.getByLabelText('CommonsApp')).toBeInTheDocument();
+  expect(screen.getByLabelText('ResearchHub')).toBeInTheDocument();
+  expect(screen.getByLabelText('VoicePanel')).toBeInTheDocument();
+});

--- a/packages/commons-ui/CommonsApp.tsx
+++ b/packages/commons-ui/CommonsApp.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ResearchHub from '../unifiedmandala-ui/components/ResearchHub';
+import VoicePanel from '../unifiedmandala-ui/components/VoicePanel';
+
+/**
+ * CommonsApp combines research and voice panels into a human-first hub.
+ */
+export default function CommonsApp() {
+  return (
+    <div aria-label="CommonsApp">
+      <h1>Commons Hub</h1>
+      <ResearchHub />
+      <VoicePanel />
+    </div>
+  );
+}

--- a/packages/commons-ui/index.ts
+++ b/packages/commons-ui/index.ts
@@ -1,0 +1,1 @@
+export { default as CommonsApp } from './CommonsApp';


### PR DESCRIPTION
## Summary
- implement CommonsApp combining ResearchHub and VoicePanel
- mark commons hub app task as done and sync advanced progress
- record component addition in feedback codex

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/commons-ui/CommonsApp.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b088f418b08322b3f7339c4a217efc