### PR TITLE
fractal-step-3: add streaming JSON array iterator

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -7,6 +7,13 @@
     "status": "done"
   },
   {
+    "commit": "Add streaming JSON array iterator",
+    "path": "packages/shared-utils/jsonFragmenter.ts",
+    "task": "Provide memory-efficient callback-based streaming for large datasets",
+    "test": "packages/shared-utils/jsonFragmenter.test.ts",
+    "status": "done"
+  },
+  {
     "commit": "Add summary generator to training data extraction",
     "path": "scripts/extract-training-data.ts",
     "task": "Replace placeholder with generated conversation summaries",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -3,6 +3,11 @@
   task: Simulate basic fusion-based population evolution
   test: packages/universum-simulationen/fusion_evolution_test.py
   status: done
+- commit: Add streaming JSON array iterator
+  path: packages/shared-utils/jsonFragmenter.ts
+  task: Provide memory-efficient callback-based streaming for large datasets
+  test: packages/shared-utils/jsonFragmenter.test.ts
+  status: done
 - commit: Add summary generator to training data extraction
   path: scripts/extract-training-data.ts
   task: Replace placeholder with generated conversation summaries

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "fractal-step-2: add spaces management module",
+  "lastCommit": "fractal-step-3: add streaming JSON array iterator",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events | Added JetStream KV/ObjectStore wrappers and tool loader | Added waveform option to CREP sonification | Implemented GermanGrammarAssistant agent | Implemented GeoTIFF ingest | Added ingest demo script | Implemented ReviewerQueue and reviewer API | Added screen capture and UI automation routes | Implemented PatternMapperGPT and TunerGPT agents | Added AdminConsoleApp component",
+  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events | Added JetStream KV/ObjectStore wrappers and tool loader | Added waveform option to CREP sonification | Implemented GermanGrammarAssistant agent | Implemented GeoTIFF ingest | Added ingest demo script | Implemented ReviewerQueue and reviewer API | Added screen capture and UI automation routes | Implemented PatternMapperGPT and TunerGPT agents | Added AdminConsoleApp component | Added streaming JSON array iterator",
   "pendingTasks": [
     {
       "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129",

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -7,6 +7,7 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Implemented `log_triggers` script to collect latest trigger phrases and open ToDos for chat migration.
 - Implemented `export_sigillin` script to aggregate active Sigillin into JSON and YAML for chat migration.
 - Added `init_modules` script to verify presence of key modules for new chat bootstrap.
+- Added streaming JSON iterator in `jsonFragmenter` for processing large conversation datasets without high memory usage.
 
 - Added onboarding service catalog and agent service mapping configurations.
 - Added CSV output option to repository-map-summary script for spreadsheet-friendly module counts.

--- a/packages/shared-utils/jsonFragmenter.js
+++ b/packages/shared-utils/jsonFragmenter.js
@@ -6,6 +6,7 @@ exports.writeJsonChunks = writeJsonChunks;
 exports.writeJsonChunksStream = writeJsonChunksStream;
 exports.grepJsonArrayFile = grepJsonArrayFile;
 exports.grepJsonArrayFileStream = grepJsonArrayFileStream;
+exports.streamJsonArrayFile = streamJsonArrayFile;
 exports.extractCodeSnippetsFromFile = extractCodeSnippetsFromFile;
 exports.mergeJsonChunks = mergeJsonChunks;
 const fs_1 = require("fs");
@@ -160,6 +161,45 @@ function grepJsonArrayFileStream(filePath, destDir, pattern, limit, start = 0, c
     pipeline.on('end', finalize);
     pipeline.on('close', finalize);
     pipeline.on('error', reject);
+    });
+}
+
+/**
+ * Streams a JSON array file and invokes a callback for each item without
+ * loading the entire file into memory.
+ * @param {string} filePath Path to the JSON array file.
+ * @param {(item:any,index:number)=>void|Promise<void>} onItem Callback executed per element.
+ * @param {number} [start=0] Index to begin processing.
+ * @param {number} [count=Infinity] Maximum number of items to process.
+ * @returns {Promise<void>}
+ */
+function streamJsonArrayFile(filePath, onItem, start = 0, count = Infinity) {
+    return new Promise((resolve, reject) => {
+        let index = -1;
+        const pipeline = (0, fs_1
+            .createReadStream)(filePath, { encoding: 'utf8' })
+            .pipe((0, stream_json_1.parser)())
+            .pipe((0, StreamArray_1.streamArray)());
+        const finalize = () => resolve();
+        pipeline.on('data', async ({ value }) => {
+            index++;
+            if (index < start)
+                return;
+            if (index >= start + count) {
+                pipeline.destroy();
+                return;
+            }
+            try {
+                await onItem(value, index);
+            }
+            catch (err) {
+                pipeline.destroy();
+                reject(err);
+            }
+        });
+        pipeline.on('end', finalize);
+        pipeline.on('close', finalize);
+        pipeline.on('error', reject);
     });
 }
 /**

--- a/packages/shared-utils/jsonFragmenter.test.ts
+++ b/packages/shared-utils/jsonFragmenter.test.ts
@@ -7,6 +7,7 @@ import {
   writeJsonChunksStream,
   grepJsonArrayFile,
   grepJsonArrayFileStream,
+  streamJsonArrayFile,
 } from './jsonFragmenter';
 
 describe('jsonFragmenter', () => {
@@ -80,5 +81,13 @@ describe('jsonFragmenter', () => {
     const dest = path.join(tmpDir, 'grep-stream-start');
     const matches = await grepJsonArrayFileStream(sampleFile, dest, /4|5/, undefined, 3, 1);
     expect(matches).toEqual([4]);
+  });
+
+  test('streamJsonArrayFile invokes callback per item', async () => {
+    const collected: number[] = [];
+    await streamJsonArrayFile<number>(sampleFile, (item) => {
+      collected.push(item);
+    });
+    expect(collected).toEqual([1,2,3,4,5]);
   });
 });

--- a/packages/shared-utils/jsonFragmenter.ts
+++ b/packages/shared-utils/jsonFragmenter.ts
@@ -183,6 +183,51 @@ export function grepJsonArrayFileStream<T>(
 }
 
 /**
+ * Streams a JSON array file and invokes a callback for each item without
+ * loading the entire file into memory.
+ *
+ * @param filePath Path to the JSON array file.
+ * @param onItem   Callback executed for every array element.
+ * @param start    Optional index to begin processing.
+ * @param count    Optional number of items to process.
+ */
+export function streamJsonArrayFile<T>(
+  filePath: string,
+  onItem: (item: T, index: number) => void | Promise<void>,
+  start = 0,
+  count = Infinity
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let index = -1;
+    const pipeline = fs
+      .createReadStream(filePath, { encoding: 'utf8' })
+      .pipe(parser())
+      .pipe(streamArray());
+
+    const finalize = () => resolve();
+
+    pipeline.on('data', async ({ value }: { value: T }) => {
+      index++;
+      if (index < start) return;
+      if (index >= start + count) {
+        pipeline.destroy();
+        return;
+      }
+      try {
+        await onItem(value, index);
+      } catch (err) {
+        pipeline.destroy();
+        reject(err);
+      }
+    });
+
+    pipeline.on('end', finalize);
+    pipeline.on('close', finalize);
+    pipeline.on('error', reject);
+  });
+}
+
+/**
  * Extracts code snippets (```code```) from a JSON array file and writes them to individual files.
  * @param filePath Path to JSON array file.
  * @param destDir Output directory for snippets.


### PR DESCRIPTION
## Summary
- add `streamJsonArrayFile` utility for processing large JSON arrays without loading into memory
- cover new iterator with unit test
- track streaming utility in advanced ToDo and progress files

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/shared-utils/jsonFragmenter.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b095d000348322a2f4c122ae03a4b2