### PR TITLE
Add YAML output test for newadvanced conversations parser

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "fractal-step-1: stream extract-training-data",
+  "lastCommit": "fractal-step-2: add YAML output test",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events | Added JetStream KV/ObjectStore wrappers and tool loader | Added waveform option to CREP sonification | Implemented GermanGrammarAssistant agent | Implemented GeoTIFF ingest | Added ingest demo script | Implemented ReviewerQueue and reviewer API | Added screen capture and UI automation routes | Implemented PatternMapperGPT and TunerGPT agents | Added AdminConsoleApp component | Added streaming JSON array iterator",
+  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events | Added JetStream KV/ObjectStore wrappers and tool loader | Added waveform option to CREP sonification | Implemented GermanGrammarAssistant agent | Implemented GeoTIFF ingest | Added ingest demo script | Implemented ReviewerQueue and reviewer API | Added screen capture and UI automation routes | Implemented PatternMapperGPT and TunerGPT agents | Added AdminConsoleApp component | Added streaming JSON array iterator | Added YAML output test for conversation parser",
   "pendingTasks": [
     {
       "commit": "Introduce task router module",
@@ -6641,10 +6641,6 @@
       "status": "done"
     }
   ],
-  "changedFiles": [
-    "scripts/__tests__/extract-training-data.vitest.ts",
-    "scripts/extract-training-data.js",
-    "scripts/extract-training-data.ts"
-  ],
-  "lastUpdated": "2025-08-28T19:23:16.748Z"
+  "changedFiles": [],
+  "lastUpdated": "2025-08-28T19:55:09.726Z"
 }

--- a/feedbackcodex.md
+++ b/feedbackcodex.md
@@ -192,3 +192,4 @@ Dev-Agents prüfen zu Beginn eines Laufs auf diese Dateien und priorisieren dere
 - Added streaming utilities for parsing large newadvancedconversations dataset.
 - Implemented CommonsApp component unifying ResearchHub and VoicePanel.
 - Added tests for parse-newadvanced-conversations script verifying streaming and range options.
+- Added YAML output test for parse-newadvanced-conversations to confirm optional YAML generation.

--- a/scripts/__tests__/parse-newadvanced-conversations.test.ts
+++ b/scripts/__tests__/parse-newadvanced-conversations.test.ts
@@ -24,6 +24,13 @@ describe('parseNewAdvancedConversations', () => {
     expect(written).toEqual(matches);
   });
 
+  it('writes YAML output when enabled', async () => {
+    await parseNewAdvancedConversations(file, dest, 'Session', { stream: false, writeYaml: true });
+    const yamlPath = path.join(dest, 'newadvancedconversations-small-grep.yaml');
+    const content = fs.readFileSync(yamlPath, 'utf8');
+    expect(content).toMatch(/Session A/);
+  });
+
   it('respects start and count in streaming mode', async () => {
     const matches = await parseNewAdvancedConversations(file, dest, 'Session', { stream: true, start: 1, count: 1 });
     expect(matches).toEqual([{ title: 'Session B', mapping: {} }]);


### PR DESCRIPTION
## Summary
- test: add YAML generation test for parse-newadvanced-conversations script
- docs: log YAML test in feedback codex
- chore: update advanced progress tracker

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json` *(fails: TS5097, TS2441, TS1343)*
- `pnpm test scripts/__tests__/parse-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0b346912c83229a1907719687dacf