### PR TITLE
fractal-step-1: stream newadvanced conversation splitter

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-28, in der Zeit des Abend.
+Am 2025-08-28, in der Zeit des Nacht.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Reflexion (Fokus: P)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,11 +1,11 @@
 {
-  "lastCommit": "fractal-step-2: add YAML output test",
+  "lastCommit": "fractal-step-1: update progress feedback",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
   ],
   "mergeConflicts": [],
-  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events | Added JetStream KV/ObjectStore wrappers and tool loader | Added waveform option to CREP sonification | Implemented GermanGrammarAssistant agent | Implemented GeoTIFF ingest | Added ingest demo script | Implemented ReviewerQueue and reviewer API | Added screen capture and UI automation routes | Implemented PatternMapperGPT and TunerGPT agents | Added AdminConsoleApp component | Added streaming JSON array iterator | Added YAML output test for conversation parser",
+  "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events | Added JetStream KV/ObjectStore wrappers and tool loader | Added waveform option to CREP sonification | Implemented GermanGrammarAssistant agent | Implemented GeoTIFF ingest | Added ingest demo script | Implemented ReviewerQueue and reviewer API | Added screen capture and UI automation routes | Implemented PatternMapperGPT and TunerGPT agents | Added AdminConsoleApp component | Added streaming JSON array iterator | Added YAML output test for conversation parser | Added streaming mode to split-newadvanced-conversations",
   "pendingTasks": [
     {
       "commit": "Introduce task router module",
@@ -6641,6 +6641,10 @@
       "status": "done"
     }
   ],
-  "changedFiles": [],
-  "lastUpdated": "2025-08-28T19:55:09.726Z"
+  "changedFiles": [
+    "scripts/split-newadvanced-conversations.test.ts",
+    "scripts/split-newadvanced-conversations.ts",
+    "repositorypflege/feedback.md"
+  ],
+  "lastUpdated": "2025-08-28T23:48:29.183Z"
 }

--- a/repositorypflege/feedback.md
+++ b/repositorypflege/feedback.md
@@ -1,0 +1,3 @@
+# Repository Feedback
+
+- Added streaming mode to `scripts/split-newadvanced-conversations.ts` to handle large datasets efficiently.

--- a/scripts/split-newadvanced-conversations.test.ts
+++ b/scripts/split-newadvanced-conversations.test.ts
@@ -5,10 +5,13 @@ import os from 'os';
 import { splitNewAdvancedConversations } from './split-newadvanced-conversations';
 
 describe('splitNewAdvancedConversations', () => {
-  it('splits conversations into separate files', () => {
-    const src = path.join(__dirname, '../tests/fixtures/newadvanced-multi.json');
+  it('splits conversations into separate files', async () => {
+    const src = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-multi.json'
+    );
     const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'split-convo-'));
-    const files = splitNewAdvancedConversations(src, outDir);
+    const files = await splitNewAdvancedConversations(src, outDir);
     expect(files.length).toBe(2);
     const first = JSON.parse(fs.readFileSync(files[0], 'utf8'));
     expect(first.title).toBe('First');
@@ -16,10 +19,15 @@ describe('splitNewAdvancedConversations', () => {
     expect(fs.existsSync(yamlFile)).toBe(true);
   });
 
-  it('supports start index and count', () => {
-    const src = path.join(__dirname, '../tests/fixtures/newadvanced-multi.json');
+  it('supports start index and count in streaming mode', async () => {
+    const src = path.join(
+      __dirname,
+      '../tests/fixtures/newadvanced-multi.json'
+    );
     const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'split-convo-'));
-    const files = splitNewAdvancedConversations(src, outDir, 1, 1);
+    const files = await splitNewAdvancedConversations(src, outDir, 1, 1, {
+      stream: true,
+    });
     expect(files.length).toBe(1);
     const second = JSON.parse(fs.readFileSync(files[0], 'utf8'));
     expect(second.title).toBe('Second');

--- a/scripts/split-newadvanced-conversations.ts
+++ b/scripts/split-newadvanced-conversations.ts
@@ -2,40 +2,101 @@
 import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
+import { parser } from 'stream-json';
+import { streamArray } from 'stream-json/streamers/StreamArray';
 
-export function splitNewAdvancedConversations(
+export async function splitNewAdvancedConversations(
   srcPath: string,
   outDir: string,
   start = 0,
-  count = Infinity
-): string[] {
-  const data = JSON.parse(fs.readFileSync(srcPath, 'utf8'));
-  if (!Array.isArray(data)) {
-    throw new Error('Expected an array of conversations');
+  count = Infinity,
+  opts: { stream?: boolean } = {}
+): Promise<string[]> {
+  let useStream = opts.stream;
+  if (useStream === undefined) {
+    try {
+      const size = fs.statSync(srcPath).size;
+      useStream = size > 10 * 1024 * 1024; // default to stream for files >10MB
+    } catch {
+      useStream = false;
+    }
   }
-  if (!fs.existsSync(outDir)) {
-    fs.mkdirSync(outDir, { recursive: true });
+
+  if (!useStream) {
+    const data = JSON.parse(fs.readFileSync(srcPath, 'utf8'));
+    if (!Array.isArray(data)) {
+      throw new Error('Expected an array of conversations');
+    }
+    if (!fs.existsSync(outDir)) {
+      fs.mkdirSync(outDir, { recursive: true });
+    }
+    return data.slice(start, start + count).map((conv: any, idx: number) => {
+      const index = start + idx + 1;
+      const base = path.join(outDir, `conversation-${index}`);
+      const jsonFile = `${base}.json`;
+      const yamlFile = `${base}.yaml`;
+      fs.writeFileSync(jsonFile, JSON.stringify(conv, null, 2));
+      fs.writeFileSync(yamlFile, yaml.dump(conv));
+      return jsonFile;
+    });
   }
-  return data.slice(start, start + count).map((conv: any, idx: number) => {
-    const index = start + idx + 1;
-    const base = path.join(outDir, `conversation-${index}`);
-    const jsonFile = `${base}.json`;
-    const yamlFile = `${base}.yaml`;
-    fs.writeFileSync(jsonFile, JSON.stringify(conv, null, 2));
-    fs.writeFileSync(yamlFile, yaml.dump(conv));
-    return jsonFile;
+
+  return new Promise((resolve, reject) => {
+    const files: string[] = [];
+    if (!fs.existsSync(outDir)) {
+      fs.mkdirSync(outDir, { recursive: true });
+    }
+    let index = -1;
+    const pipeline = fs
+      .createReadStream(srcPath, { encoding: 'utf8' })
+      .pipe(parser())
+      .pipe(streamArray());
+
+    pipeline.on('data', ({ value }: { value: any }) => {
+      index++;
+      if (index < start) return;
+      if (index >= start + count) {
+        pipeline.destroy();
+        return;
+      }
+      const current = index + 1;
+      const base = path.join(outDir, `conversation-${current}`);
+      const jsonFile = `${base}.json`;
+      const yamlFile = `${base}.yaml`;
+      fs.writeFileSync(jsonFile, JSON.stringify(value, null, 2));
+      fs.writeFileSync(yamlFile, yaml.dump(value));
+      files.push(jsonFile);
+    });
+
+    const finalize = () => resolve(files);
+    pipeline.on('end', finalize);
+    pipeline.on('close', finalize);
+    pipeline.on('error', reject);
   });
 }
 
 if (require.main === module) {
+  const args = process.argv.slice(2);
+  const positional = args.filter((a: string) => !a.startsWith('--'));
+  const flags = new Set(args.filter((a: string) => a.startsWith('--')));
   const src =
-    process.argv[2] ||
+    positional[0] ||
     path.join(__dirname, '../docs/sigils/newadvancedconversations.json');
   const out =
-    process.argv[3] ||
-    path.join(__dirname, '../docs/sigils/newadvancedconversations_fragments');
-  const start = parseInt(process.argv[4] || '0', 10);
-  const count = parseInt(process.argv[5] || `${Number.POSITIVE_INFINITY}`, 10);
-  const files = splitNewAdvancedConversations(src, out, start, count);
-  console.log(`Wrote ${files.length} fragments to ${out}`);
+    positional[1] ||
+    path.join(
+      __dirname,
+      '../docs/sigils/newadvancedconversations_fragments'
+    );
+  const start = parseInt(positional[2] || '0', 10);
+  const count = parseInt(positional[3] || `${Number.POSITIVE_INFINITY}`, 10);
+  const stream = flags.has('--stream');
+  splitNewAdvancedConversations(src, out, start, count, { stream })
+    .then(files => {
+      console.log(`Wrote ${files.length} fragments to ${out}`);
+    })
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
 }


### PR DESCRIPTION
## Summary
- stream `split-newadvanced-conversations` for large JSON datasets with auto-switch and `--stream` flag
- add tests covering streaming and range options
- log parser upgrade in repository feedback and refresh advanced progress tracker

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json` *(fails: TS5097 import path must end with .js, TS2441 duplicate identifier 'require', TS1343 import.meta, from existing scripts)*
- `pnpm test scripts/split-newadvanced-conversations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0e9f7eaec8322869b85ba54677f5f