### PR TITLE
Add extractSessionTodos unit test

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-28, in der Zeit des Nacht.
+Am 2025-08-29, in der Zeit des Morgen.
 
-Symbolphase: Reflexion (Fokus: P)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "fractal-step-1: update progress feedback",
+  "lastCommit": "fractal-step-4: sync progress after test addition",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -5314,6 +5314,10 @@
     {
       "commit": "Add streaming JSON array iterator",
       "status": "done"
+    },
+    {
+      "commit": "Add extractSessionTodos unit test",
+      "status": "done"
     }
   ],
   "completed": [
@@ -6268,8 +6272,6 @@
       "status": "done"
     }
   ],
-  "changedFiles": [
-    "scripts/__tests__/chunk-newadvanced-conversations.test.ts"
-  ],
-  "lastUpdated": "2025-08-29T05:15:38.176Z"
+  "changedFiles": [],
+  "lastUpdated": "2025-08-29T06:24:23.491Z"
 }

--- a/scripts/__tests__/extract-session-todos.test.ts
+++ b/scripts/__tests__/extract-session-todos.test.ts
@@ -1,0 +1,26 @@
+import * as path from 'path';
+const { extractSessionTodos } = require('../parse-newadvanced-conversations');
+
+describe('extractSessionTodos', () => {
+  const file = path.join(__dirname, 'fixtures/newadvancedconversations-todos.json');
+
+  it('extracts TODO lines from specified session titles', () => {
+    const tasks = extractSessionTodos(file, ['Todo Session']);
+    expect(tasks).toEqual([
+      {
+        commit: 'TODO: implement feature',
+        path: '',
+        task: 'TODO: implement feature',
+        test: '',
+        status: 'planned'
+      },
+      {
+        commit: '- TODO: fix bug',
+        path: '',
+        task: 'TODO: fix bug',
+        test: '',
+        status: 'planned'
+      }
+    ]);
+  });
+});

--- a/scripts/__tests__/fixtures/newadvancedconversations-todos.json
+++ b/scripts/__tests__/fixtures/newadvancedconversations-todos.json
@@ -1,0 +1,41 @@
+[
+  {
+    "title": "Todo Session",
+    "mapping": {
+      "a": {
+        "message": {
+          "content": {
+            "parts": [
+              "TODO: implement feature",
+              "Some other line"
+            ]
+          }
+        }
+      },
+      "b": {
+        "message": {
+          "content": {
+            "parts": [
+              "- TODO: fix bug",
+              "Nothing here"
+            ]
+          }
+        }
+      }
+    }
+  },
+  {
+    "title": "Other Session",
+    "mapping": {
+      "x": {
+        "message": {
+          "content": {
+            "parts": [
+              "TODO: ignore this"
+            ]
+          }
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- test: verify `extractSessionTodos` handles TODO entries from conversation fragments
- chore: sync advanced progress tracker

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json` *(fails: TS5097, TS2441, TS1343)*
- `pnpm test scripts/__tests__/extract-session-todos.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b146370f4c8322948e7c41cd6d15e7