### PR TITLE
feat(repositorypflege): recurse advanced todo directories

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add admin and commons tasks",
+  "lastCommit": "Merge pull request #1553 from GenesisAeon/codex/optimize-repo-structure-and-implement-features-gcw7v0",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -6650,8 +6650,8 @@
     }
   ],
   "changedFiles": [
-    "advancedToDo.yaml",
-    "code-agent-tasks.yaml"
+    "repositorypflege/__tests__/list-open-advanced-todos.test.js",
+    "repositorypflege/list-open-advanced-todos.js"
   ],
-  "lastUpdated": "2025-08-29T07:47:26.515Z"
+  "lastUpdated": "2025-08-29T17:53:53.759Z"
 }

--- a/repositorypflege/__tests__/list-open-advanced-todos.test.js
+++ b/repositorypflege/__tests__/list-open-advanced-todos.test.js
@@ -54,6 +54,19 @@ test('reads tasks from directory of part files', () => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
+test('recurses into nested directories', () => {
+  const tmpDir = path.join(__dirname, 'tmp-nested');
+  const nested = path.join(tmpDir, 'inner');
+  fs.mkdirSync(nested, { recursive: true });
+  const sample = [{ commit: 'Nested Task', path: 'inner/task', status: 'open' }];
+  fs.writeFileSync(path.join(nested, 'todo.json'), JSON.stringify(sample, null, 2));
+
+  const todos = listOpenAdvancedTodos(undefined, tmpDir);
+  expect(todos).toEqual([{ commit: 'Nested Task', path: 'inner/task' }]);
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
 test('excludes tasks matching pattern', () => {
   const tmp = path.join(__dirname, 'tmp-exclude.json');
   const sample = [

--- a/repositorypflege/list-open-advanced-todos.js
+++ b/repositorypflege/list-open-advanced-todos.js
@@ -10,19 +10,23 @@ function readTodoFile(file) {
 
 function collectFiles(inputPaths) {
   const files = [];
-  for (const p of inputPaths) {
-    if (!fs.existsSync(p)) continue;
+
+  function walk(p) {
+    if (!fs.existsSync(p)) return;
     const stat = fs.statSync(p);
     if (stat.isDirectory()) {
       for (const f of fs.readdirSync(p)) {
-        if (/\.(json|ya?ml)$/i.test(f)) {
-          files.push(path.join(p, f));
-        }
+        walk(path.join(p, f));
       }
-    } else {
+    } else if (/\.(json|ya?ml)$/i.test(p)) {
       files.push(p);
     }
   }
+
+  for (const p of inputPaths) {
+    walk(p);
+  }
+
   return files;
 }
 


### PR DESCRIPTION
## Summary
- enable recursive directory traversal when gathering advanced todo files
- cover nested directory parsing with new unit test
- refresh advanced progress snapshot

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json` *(fails: TS5097, TS2441, TS1343)*
- `npx jest repositorypflege/__tests__/list-open-advanced-todos.test.js`
- `node repositorypflege/update-advanced-progress.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1e83fd3308322b040e3df12a64122