### PR TITLE
feat(progress): optional conversations tasks

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6277,10 +6277,9 @@
     }
   ],
   "changedFiles": [
-    "advancedToDo.json",
-    "advancedToDo.yaml",
+    "docs/sigils/advancedprogress-guide.md",
     "repositorypflege/feedback.md",
-    "packages/hub/"
+    "repositorypflege/update-advanced-progress.js"
   ],
-  "lastUpdated": "2025-08-29T20:14:01.000Z"
+  "lastUpdated": "2025-08-29T23:06:49.734Z"
 }

--- a/docs/sigils/advancedprogress-guide.md
+++ b/docs/sigils/advancedprogress-guide.md
@@ -15,6 +15,14 @@ and every fragment in `advancedToDo_parts/`. It also records a `changedFiles`
 list capturing the files currently modified in the working tree and stamps a
 `lastUpdated` timestamp. This helps trace fractal updates across commits.
 
+By default tasks that reference conversation datasets are skipped. Pass
+`--include-conversations` to include them in the generated progress file when
+needed:
+
+```bash
+node repositorypflege/update-advanced-progress.js --include-conversations
+```
+
 To write progress to an alternative file, pass the `--file` flag:
 
 ```bash

--- a/repositorypflege/feedback.md
+++ b/repositorypflege/feedback.md
@@ -4,3 +4,4 @@
 - Added chunking test for new advanced conversations parser to ensure large files can be split safely.
 - Replaced placeholder `example.com` domains in agents with `noaa.gov` to satisfy domain audit.
 - Implemented initial TaskRouter module to assign tasks to humans or AI based on role and score.
+- Added `--include-conversations` flag to `update-advanced-progress.js` and documented usage.

--- a/repositorypflege/update-advanced-progress.js
+++ b/repositorypflege/update-advanced-progress.js
@@ -15,12 +15,23 @@ function getChangedFiles() {
   }
 }
 
-function updateAdvancedProgress(limit = 5, progressFile, pattern, todoPaths, excludePattern) {
+function updateAdvancedProgress(
+  limit = 5,
+  progressFile,
+  pattern,
+  todoPaths,
+  excludePattern,
+  { includeConversations = false } = {}
+) {
   const progressPath = progressFile || path.resolve(__dirname, '..', 'advancedprogress.json');
   const progress = JSON.parse(fs.readFileSync(progressPath, 'utf8'));
-  const todos = listOpenAdvancedTodos(pattern, todoPaths, excludePattern).slice(0, limit);
+  const todos = listOpenAdvancedTodos(pattern, todoPaths, excludePattern, {
+    includeConversations
+  }).slice(0, limit);
   progress.pendingTasks = todos.map((t) => ({ commit: t.commit, path: t.path, status: 'open' }));
-  const changed = getChangedFiles().filter((f) => f !== path.relative(path.resolve(__dirname, '..'), progressPath));
+  const changed = getChangedFiles().filter(
+    (f) => f !== path.relative(path.resolve(__dirname, '..'), progressPath)
+  );
   progress.changedFiles = changed;
   progress.lastUpdated = new Date().toISOString();
   fs.writeFileSync(progressPath, JSON.stringify(progress, null, 2));
@@ -38,7 +49,10 @@ if (require.main === module) {
   const exclude = exclIndex >= 0 ? process.argv[exclIndex + 1] : undefined;
   const fileIndex = process.argv.indexOf('--file');
   const progressFile = fileIndex >= 0 ? process.argv[fileIndex + 1] : undefined;
-  updateAdvancedProgress(limit, progressFile, pattern, todoPaths, exclude);
+  const includeConvos = process.argv.includes('--include-conversations');
+  updateAdvancedProgress(limit, progressFile, pattern, todoPaths, exclude, {
+    includeConversations: includeConvos
+  });
 }
 
 module.exports = { updateAdvancedProgress };


### PR DESCRIPTION
## Summary
- allow including conversation-related tasks when syncing advancedprogress
- document new flag in advancedprogress guide and record feedback note
- update progress manifest with latest files

## Testing
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json` *(fails: import path must end with .ts, duplicate identifier 'require')*


------
https://chatgpt.com/codex/tasks/task_e_68b231b48fb0832295f89617622bf147