### PR TITLE
feat: add sorting option to advanced todo report

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add CoIntel orchestrator service",
+  "lastCommit": "feat: add sort option to advanced todo report",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -6650,10 +6650,9 @@
     }
   ],
   "changedFiles": [
-    "advancedToDo.json",
-    "advancedToDo.yaml",
-    "repositorypflege/feedback.md",
-    "scripts/cointel-orchestrator.ts"
+    "docs/sigils/advancedprogress-guide.md",
+    "repositorypflege/advanced-todo-report.js",
+    "repositorypflege/feedback.md"
   ],
-  "lastUpdated": "2025-08-30T08:24:10.338Z"
+  "lastUpdated": "2025-08-30T08:45:48.823Z"
 }

--- a/docs/sigils/advancedprogress-guide.md
+++ b/docs/sigils/advancedprogress-guide.md
@@ -55,6 +55,13 @@ node repositorypflege/advanced-todo-report.js --json
 node repositorypflege/advanced-todo-report.js --yaml
 ```
 
+To sort directories by the number of open tasks, pass `--sort count`. The
+default alphabetical order can be made explicit with `--sort alpha`:
+
+```bash
+node repositorypflege/advanced-todo-report.js --sort count
+```
+
 ## Handling Large Conversation Files
 
 Datasets such as `newadvancedconversations.json` in this directory are

--- a/repositorypflege/advanced-todo-report.js
+++ b/repositorypflege/advanced-todo-report.js
@@ -26,6 +26,8 @@ if (require.main === module) {
   const includeConvos = process.argv.includes('--include-conversations');
   const limitIndex = process.argv.indexOf('--limit');
   const limit = limitIndex >= 0 ? parseInt(process.argv[limitIndex + 1], 10) : undefined;
+  const sortIndex = process.argv.indexOf('--sort');
+  const sortMode = sortIndex >= 0 ? process.argv[sortIndex + 1] : 'alpha';
 
   const grouped = groupTodosByDir(pattern, todoPaths, exclude, includeConvos);
   if (yamlOutput) {
@@ -34,7 +36,14 @@ if (require.main === module) {
     console.log(JSON.stringify(grouped, null, 2));
   } else {
     let total = 0;
-    for (const [dir, tasks] of Object.entries(grouped)) {
+    const entries = Object.entries(grouped);
+    entries.sort((a, b) => {
+      if (sortMode === 'count') {
+        return b[1].length - a[1].length;
+      }
+      return a[0].localeCompare(b[0]);
+    });
+    for (const [dir, tasks] of entries) {
       total += tasks.length;
       console.log(`${dir} (${tasks.length}):`);
       const list = limit ? tasks.slice(0, limit) : tasks;

--- a/repositorypflege/feedback.md
+++ b/repositorypflege/feedback.md
@@ -6,3 +6,4 @@
 - Implemented initial TaskRouter module to assign tasks to humans or AI based on role and score.
 - Added `--include-conversations` flag to `update-advanced-progress.js` and documented usage.
 - Implemented initial CoIntel orchestrator service to route tasks to human or AI endpoints.
+- Added `--sort` flag to `advanced-todo-report.js` for directory ordering by task count.


### PR DESCRIPTION
## Summary
- allow `advanced-todo-report.js` to sort directories by count with new `--sort` flag
- document sorting option in advanced progress guide
- note new flag in repository feedback and sync advanced progress tracking

## Testing
- `node repositorypflege/advanced-todo-report.js --limit 2 --sort count`
- `node repositorypflege/update-advanced-progress.js`
- `npx pyright` *(warnings: Import "fastapi" could not be resolved, etc.)*
- `npx tsc -p tsconfig.json` *(errors: Import path can only end with '.ts', Duplicate identifier 'require', etc.)*
- `pnpm install` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b9d5f7588322b19d773cc76e892f