### PR TITLE
feat: add echo agent with golden test

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6292,6 +6292,10 @@
       "status": "done"
     }
   ],
-  "changedFiles": [],
-  "lastUpdated": "2025-08-30T13:42:24.541Z"
+  "changedFiles": [
+    "agents/registry.yaml",
+    "agents/echo/",
+    "tests/agents/golden/echo/"
+  ],
+  "lastUpdated": "2025-08-30T14:10:12.999Z"
 }

--- a/agents/echo/index.ts
+++ b/agents/echo/index.ts
@@ -1,0 +1,13 @@
+import type { Agent, AgentHealth, AgentContext } from "../_shared/types";
+
+const EchoAgent: Agent<any, any> = {
+  id: "echo",
+  async health(): Promise<AgentHealth> {
+    return { id: "echo", ok: true };
+  },
+  async run(input: any, _ctx: AgentContext): Promise<any> {
+    return { echo: input };
+  }
+};
+
+export default EchoAgent;

--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -1,5 +1,8 @@
 # Liste registrierter Agenten (opt-in). Beispiel-Einträge auskommentiert.
-agents: []
+agents:
+  - id: "echo"
+    entry: "agents/echo/index.ts"
+    description: "Echoes back input for testing"
 # Beispiel:
 #  - id: "hydro.cso"
 #    entry: "agents/hydro.cso/index.ts"
@@ -7,4 +10,3 @@ agents: []
 #  - id: "climate.risk"
 #    entry: "agents/climate.risk/index.ts"
 #    description: "Klimarisiko-Synthese (ERA5/OISST/EFFIS)"
-

--- a/tests/agents/golden/echo/expected.json
+++ b/tests/agents/golden/echo/expected.json
@@ -1,0 +1,1 @@
+{"echo":{"message":"hello"}}

--- a/tests/agents/golden/echo/input.json
+++ b/tests/agents/golden/echo/input.json
@@ -1,0 +1,1 @@
+{"message":"hello"}


### PR DESCRIPTION
## Summary
- add simple echo agent and register it
- provide golden test for echo agent
- sync advanced progress metadata

## Testing
- `pnpm agents:test:golden`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `node repositorypflege/update-advanced-progress.js`


------
https://chatgpt.com/codex/tasks/task_e_68b305458e2083229a8bb4934890c38c