### PR TITLE
feat: render climate KPIs from YAML config

### DIFF
--- a/apps/ui/src/components/KpiBoard.tsx
+++ b/apps/ui/src/components/KpiBoard.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import type { KpiConfig } from "../config/useClimateConfig";
+import { pollKpis, type KpiValue } from "../services/kpi-engine";
+
+function Badge({ status }: { status: KpiValue["status"] }) {
+  const color = status === "alarm" ? "#c62828" : status === "warn" ? "#ef6c00" : "#2e7d32";
+  const label = status === "alarm" ? "ALARM" : status === "warn" ? "WARN" : "OK";
+  return (
+    <span style={{ background: color, color: "#fff", padding: "2px 6px", borderRadius: 6, fontSize: 12 }}>
+      {label}
+    </span>
+  );
+}
+
+function KpiCard({ cfg, val }: { cfg: KpiConfig; val?: KpiValue }) {
+  return (
+    <div
+      style={{
+        border: "1px solid #ddd",
+        borderRadius: 12,
+        padding: 12,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <div style={{ fontWeight: 600 }}>{cfg.label}</div>
+        {val && <Badge status={val.status} />}
+      </div>
+      <div style={{ fontSize: 24, fontWeight: 700 }}>{val ? `${val.value} ${cfg.unit}` : "…"}</div>
+      <div style={{ fontSize: 12, color: "#555" }}>
+        Warn: {cfg.warn} · Alarm: {cfg.threshold} {cfg.unit}
+      </div>
+    </div>
+  );
+}
+
+export default function KpiBoard({ kpis }: { kpis: KpiConfig[] }) {
+  const [values, setValues] = useState<Record<string, KpiValue>>({});
+  useEffect(() => {
+    let stop = false;
+    async function tick() {
+      try {
+        const vals = await pollKpis(kpis);
+        if (stop) return;
+        const map: Record<string, KpiValue> = {};
+        for (const v of vals) map[v.id] = v;
+        setValues(map);
+      } catch (e) {
+        console.error("KPI poll error", e);
+      }
+    }
+    tick();
+    const id = setInterval(tick, 10_000); // alle 10s
+    return () => {
+      stop = true;
+      clearInterval(id);
+    };
+  }, [JSON.stringify(kpis)]);
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill,minmax(240px,1fr))", gap: 12 }}>
+      {kpis.map(k => (
+        <KpiCard key={k.id} cfg={k} val={values[k.id]} />
+      ))}
+    </div>
+  );
+}

--- a/apps/ui/src/config/useClimateConfig.ts
+++ b/apps/ui/src/config/useClimateConfig.ts
@@ -1,0 +1,28 @@
+import { useMemo } from "react";
+import YAML from "yaml";
+// Vite: '?raw' importiert Datei als String
+// Pfad: UI → (../../..) → src/config/...
+// @ts-ignore
+import raw from "../../../../src/config/climate-dashboard.yaml?raw";
+
+export type KpiConfig = {
+  id: string;
+  label: string;
+  threshold: number;
+  warn: number;
+  unit: string;
+};
+export type ClimateConfig = { kpis: KpiConfig[] };
+
+export function useClimateConfig(): ClimateConfig {
+  return useMemo(() => {
+    try {
+      const parsed = YAML.parse(String(raw)) as ClimateConfig;
+      if (!parsed?.kpis?.length) throw new Error("missing kpis");
+      return parsed;
+    } catch (e) {
+      console.error("Failed to parse climate-dashboard.yaml", e);
+      return { kpis: [] };
+    }
+  }, []);
+}

--- a/apps/ui/src/services/kpi-engine.ts
+++ b/apps/ui/src/services/kpi-engine.ts
@@ -1,0 +1,45 @@
+import type { KpiConfig } from "../config/useClimateConfig";
+// Adapters liegen im Repo-Root unter src/adapters/*
+// Pfad aus UI: ../../../..
+import { ERA5Adapter } from "../../../../src/adapters/era5";
+import { PegelAdapter } from "../../../../src/adapters/pegel";
+
+export type KpiValue = { id: string; value: number; status: "ok" | "warn" | "alarm"; unit?: string };
+
+// sehr einfache Heuristiken für Demo/Light:
+async function computeKpi(k: KpiConfig): Promise<KpiValue> {
+  if (k.id === "t2m_anomaly") {
+    const s = await ERA5Adapter.fetchSeries({});
+    const lastK = s.points.at(-1)?.v ?? 285; // Kelvin
+    const lastC = lastK - 273.15;
+    const anomaly = lastC - 15; // Dummy-Baseline 15°C (nur Demo!)
+    return score(k, anomaly);
+  }
+  if (k.id === "underground_water") {
+    const s = await PegelAdapter.fetchSeries({ station: "KOLN" });
+    const last = s.points.at(-1)?.v ?? 300; // cm
+    const delta = last - 300; // Dummy-Nullpunkt 300 cm (nur Demo!)
+    return score(k, delta);
+  }
+  if (k.id === "wildfire_risk") {
+    // Proxy über Temperatur-Anomalie → 0..1 (Dummy)
+    const base = await computeKpi({ id: "t2m_anomaly", label: "", threshold: 2, warn: 1, unit: "°C" });
+    const idx = Math.max(0, Math.min(1, (base.value - 0) / 4)); // 0..~4°C → 0..1
+    return score(k, idx);
+  }
+  // Fallback: 0
+  return score(k, 0);
+}
+
+function score(k: KpiConfig, val: number): KpiValue {
+  let status: "ok" | "warn" | "alarm" = "ok";
+  if (val >= k.threshold) status = "alarm";
+  else if (val >= k.warn) status = "warn";
+  return { id: k.id, value: Number(val.toFixed(2)), status, unit: k.unit };
+}
+
+// Polling-Hook für React-Komponenten
+export async function pollKpis(kpis: KpiConfig[]): Promise<KpiValue[]> {
+  // parallel berechnen, aber leichtgewichtig
+  return await Promise.all(kpis.map(computeKpi));
+}

--- a/apps/ui/src/shell/App.tsx
+++ b/apps/ui/src/shell/App.tsx
@@ -1,30 +1,13 @@
-import React, { useEffect, useState } from "react";
-type Kpi = { id: string; label: string; threshold?: number; warn?: number; unit?: string };
-type ClimateConfig = { kpis: Kpi[] };
+import { useClimateConfig } from "../config/useClimateConfig";
+import KpiBoard from "../components/KpiBoard";
 
 export default function App() {
-  const [cfg, setCfg] = useState<ClimateConfig | null>(null);
-  useEffect(() => {
-    fetch("/config/climate-dashboard.yaml")
-      .then(res => res.text())
-      .then(txt => {
-        const kpis = [...txt.matchAll(/^- id:\s*(.*)\s*[\r\n]+.*label:\s*(.*)$/gm)]
-          .map(m => ({ id: m[1].trim(), label: m[2].trim() }));
-        setCfg({ kpis });
-      })
-      .catch(() => setCfg({ kpis: [] }));
-  }, []);
+  const cfg = useClimateConfig();
   return (
-    <div style={{ fontFamily: "system-ui, sans-serif", padding: 24 }}>
-      <h1>Mandala Climate Dashboard</h1>
-      <p style={{ opacity: 0.7 }}>Wiring-Check: Config → UI</p>
-      <h2>KPIs</h2>
-      <ul>
-        {(cfg?.kpis ?? []).map(k => (
-          <li key={k.id}><strong>{k.id}</strong> — {k.label}</li>
-        ))}
-      </ul>
-      {!cfg && <p>Lade Konfiguration …</p>}
+    <div style={{ padding: 16 }}>
+      <h1 style={{ margin: "8px 0 16px" }}>Mandala Climate Dashboard</h1>
+      <h2 style={{ margin: "0 0 8px", fontSize: 16, color: "#333" }}>KPIs (live, aus Config)</h2>
+      <KpiBoard kpis={cfg.kpis} />
     </div>
   );
 }

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -12,3 +12,4 @@
 - Provided seven deep-dive analyses (GenesisAeonAdvancedAi, agents, GenesisAeonZIPMEM, orchestrator, unifiedmandala-orchestrator, unifiedmandala-neural, .github/.husky) with patch proposals; further fractal runs recommended for implementation.
 - FR-UM-2025-08-30-OFFLINE-PERF-A: Proposed light static server with precompressed assets and TTFB smoke test to fix offline response times; awaiting application.
 - FR-UM-2025-08-30-OFFLINE-PERF-B: Implemented start scripts, light static server, and TTFB smoke test; kein weiterer Lauf notwendig.
+- FR-UM-2025-08-30-CLIMATE-WIRING-A: YAML-Config mit Live-KPI-Engine und Kachel-Board verdrahtet – kein weiterer Lauf notwendig.

--- a/docs/runbooks/wiring-config-ui.md
+++ b/docs/runbooks/wiring-config-ui.md
@@ -1,0 +1,9 @@
+# Wiring: Config → UI (KPIs)
+- Quelle: `src/config/climate-dashboard.yaml`
+- Loader: `apps/ui/src/config/useClimateConfig.ts` (YAML via `?raw` & `yaml.parse`)
+- Engine: `apps/ui/src/services/kpi-engine.ts` (Light/Mock zieht Werte aus ERA5/Pegel-Adaptern)
+- UI: `apps/ui/src/components/KpiBoard.tsx`
+## Test
+1) YAML anpassen (Warn/Alarm/Label/Unit)
+2) `pnpm dev:ui` (HMR) **oder** `pnpm build:ui && pnpm dev` (Port 3000)
+3) Kacheln aktualisieren sich automatisch; Werte werden alle 10 s neu gepollt


### PR DESCRIPTION
## Summary
- load climate dashboard YAML at runtime and expose typed hook
- add mock KPI engine and polling board rendering with status badges
- document wiring from config to UI and note run instructions

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68b3367082ac83228c5017d4b427527d