### PR TITLE
feat: add peer handshake service

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13853,7 +13853,7 @@
     "path": "scripts/peer-handshake.ts",
     "task": "Receive peer hello messages and record attestation",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add setup wizard script",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13183,7 +13183,7 @@
   path: scripts/peer-handshake.ts
   task: Receive peer hello messages and record attestation
   test: ""
-  status: open
+  status: done
 - commit: Add setup wizard script
   path: scripts/setup-wizard.ts
   task: Automate space creation and peer registration workflow

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6293,9 +6293,9 @@
     }
   ],
   "changedFiles": [
-    "agents/registry.yaml",
-    "agents/echo/",
-    "tests/agents/golden/echo/"
+    "advancedToDo.json",
+    "advancedToDo.yaml",
+    "scripts/peer-handshake.ts"
   ],
-  "lastUpdated": "2025-08-30T14:10:12.999Z"
+  "lastUpdated": "2025-08-30T22:31:56.627Z"
 }

--- a/scripts/peer-handshake.ts
+++ b/scripts/peer-handshake.ts
@@ -1,0 +1,25 @@
+import express from 'express';
+import fs from 'fs';
+import path from 'path';
+
+const app = express();
+app.use(express.json());
+
+const HANDSHAKE_FILE = path.resolve(__dirname, '../data/peer-handshakes.jsonl');
+
+app.post('/handshake', (req, res) => {
+  const { peerId, attestation } = req.body || {};
+  if (!peerId || !attestation) {
+    res.status(400).json({ error: 'peerId and attestation required' });
+    return;
+  }
+  const entry = { peerId, attestation, received: new Date().toISOString() };
+  fs.mkdirSync(path.dirname(HANDSHAKE_FILE), { recursive: true });
+  fs.appendFileSync(HANDSHAKE_FILE, JSON.stringify(entry) + '\n');
+  res.json({ status: 'ok' });
+});
+
+const port = Number(process.env.PORT) || 3040;
+app.listen(port, () => {
+  console.log(`Peer handshake service listening on ${port}`);
+});


### PR DESCRIPTION
## Summary
- add lightweight peer handshake HTTP service to record peer attestations
- mark peer handshake task as complete in advanced TODO files
- refresh advanced progress tracking

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json --noEmit`
- `node repositorypflege/update-advanced-progress.js`


------
https://chatgpt.com/codex/tasks/task_e_68b37b34c6e88322b6310c05297b849d