### PR TITLE
chore: mark credits tasks done

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13831,15 +13831,15 @@
     "commit": "Add CreditLedger module",
     "path": "packages/credits/CreditLedger.ts",
     "task": "Track contribution line counts and weights per actor",
-    "test": "",
-    "status": "open"
+    "test": "packages/credits/CreditLedger.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add AttributionIndex module",
     "path": "packages/credits/AttributionIndex.ts",
     "task": "Map artifacts to contributor shares and licenses",
-    "test": "",
-    "status": "open"
+    "test": "packages/credits/AttributionIndex.test.ts",
+    "status": "done"
   },
   {
     "commit": "Add Provenance hashing utilities",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13167,13 +13167,13 @@
 - commit: Add CreditLedger module
   path: packages/credits/CreditLedger.ts
   task: Track contribution line counts and weights per actor
-  test: ""
-  status: open
+  test: packages/credits/CreditLedger.test.ts
+  status: done
 - commit: Add AttributionIndex module
   path: packages/credits/AttributionIndex.ts
   task: Map artifacts to contributor shares and licenses
-  test: ""
-  status: open
+  test: packages/credits/AttributionIndex.test.ts
+  status: done
 - commit: Add Provenance hashing utilities
   path: packages/provenance/Provenance.ts
   task: Provide SHA-256 hashing for strings and buffers

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6295,7 +6295,7 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "scripts/peer-handshake.ts"
+    "repositorypflege/feedback.md"
   ],
-  "lastUpdated": "2025-08-30T22:31:56.627Z"
+  "lastUpdated": "2025-08-31T18:50:36.390Z"
 }

--- a/repositorypflege/feedback.md
+++ b/repositorypflege/feedback.md
@@ -7,3 +7,4 @@
 - Added `--include-conversations` flag to `update-advanced-progress.js` and documented usage.
 - Implemented initial CoIntel orchestrator service to route tasks to human or AI endpoints.
 - Added `--sort` flag to `advanced-todo-report.js` for directory ordering by task count.
+- Marked CreditLedger and AttributionIndex tasks as complete in `advancedToDo` files.


### PR DESCRIPTION
## Summary
- mark CreditLedger and AttributionIndex tasks as complete in advanced todo files
- record progress sync and note completion in repository feedback

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json --pretty false && echo "tsc completed"`
- `npx jest packages/credits/CreditLedger.test.ts packages/credits/AttributionIndex.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b4971a1220832289a48297ff96b7e0