### PR TITLE
chore: register additional agents

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6293,9 +6293,7 @@
     }
   ],
   "changedFiles": [
-    "advancedToDo.json",
-    "advancedToDo.yaml",
-    "repositorypflege/feedback.md"
+    "agents/registry.yaml"
   ],
-  "lastUpdated": "2025-08-31T18:50:36.390Z"
+  "lastUpdated": "2025-08-31T19:38:42.575Z"
 }

--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -3,6 +3,12 @@ agents:
   - id: "echo"
     entry: "agents/echo/index.ts"
     description: "Echoes back input for testing"
+  - id: "desert_tracker"
+    entry: "agents/desert_tracker/main.py"
+    description: "Tracks desertification indicators"
+  - id: "digital_twin"
+    entry: "agents/digital_twin/main.py"
+    description: "Synchronizes digital twin simulations"
 # Beispiel:
 #  - id: "hydro.cso"
 #    entry: "agents/hydro.cso/index.ts"


### PR DESCRIPTION
## Summary
- register `desert_tracker` and `digital_twin` in agents registry
- sync advanced progress metadata

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: venvPath .venv is not a valid directory)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68b4a458431c832289ac989cf5739926