### PR TITLE
feat: add instance registry service

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-31, in der Zeit des Abend.
+Am 2025-08-31, in der Zeit des Nacht.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Reflexion (Fokus: P)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13923,14 +13923,14 @@
     "path": "packages/instances/Templates.ts",
     "task": "Provide admin-console and commons-hub UI templates",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create instance registry service",
     "path": "scripts/instance-registry.ts",
     "task": "Clone UI instances from templates and list them",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add ACL API service",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13233,12 +13233,12 @@
   path: packages/instances/Templates.ts
   task: Provide admin-console and commons-hub UI templates
   test: ""
-  status: open
+  status: done
 - commit: Create instance registry service
   path: scripts/instance-registry.ts
   task: Clone UI instances from templates and list them
   test: ""
-  status: open
+  status: done
 - commit: Add ACL API service
   path: scripts/acl-api.ts
   task: Manage per-instance role grants

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "chore: refresh progress metadata",
+  "lastCommit": "feat: add instance registry service",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -25,14 +25,6 @@
     },
     {
       "commit": "Create identity API service",
-      "status": "open"
-    },
-    {
-      "commit": "Define UI templates",
-      "status": "open"
-    },
-    {
-      "commit": "Create instance registry service",
       "status": "open"
     },
     {
@@ -5696,6 +5688,14 @@
     {
       "commit": "Create peer handshake service",
       "status": "done"
+    },
+    {
+      "commit": "Define UI templates",
+      "status": "done"
+    },
+    {
+      "commit": "Create instance registry service",
+      "status": "done"
     }
   ],
   "completed": [
@@ -6650,6 +6650,11 @@
       "status": "done"
     }
   ],
-  "changedFiles": [],
-  "lastUpdated": "2025-08-31T21:41:06.094Z"
+  "changedFiles": [
+    "advancedToDo.json",
+    "advancedToDo.yaml",
+    "packages/instances/",
+    "scripts/instance-registry.ts"
+  ],
+  "lastUpdated": "2025-08-31T22:30:32.920Z"
 }

--- a/packages/instances/Templates.ts
+++ b/packages/instances/Templates.ts
@@ -1,0 +1,40 @@
+import path from 'path';
+
+export interface UITemplate {
+  /**
+   * Unique identifier of the template.
+   */
+  id: string;
+  /**
+   * Absolute path to the template source directory.
+   */
+  source: string;
+  /**
+   * Optional human readable description.
+   */
+  description?: string;
+}
+
+/**
+ * Available UI templates that can be cloned by the instance registry.
+ *
+ * Templates currently point to existing packages inside the repository.
+ */
+export const templates: Record<string, UITemplate> = {
+  adminConsole: {
+    id: 'adminConsole',
+    source: path.resolve(__dirname, '..', 'admin-ui'),
+    description: 'Admin console UI template'
+  },
+  commonsHub: {
+    id: 'commonsHub',
+    source: path.resolve(__dirname, '..', 'commons-ui'),
+    description: 'Commons hub UI template'
+  }
+};
+
+export type TemplateName = keyof typeof templates;
+
+export function getTemplate(name: TemplateName): UITemplate {
+  return templates[name];
+}

--- a/scripts/instance-registry.ts
+++ b/scripts/instance-registry.ts
@@ -1,0 +1,64 @@
+import fs from 'fs';
+import path from 'path';
+import { templates, TemplateName } from '../packages/instances/Templates';
+
+const instancesDir = path.resolve(__dirname, '..', 'instances');
+
+function ensureDir(dir: string) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function clone(templateName: TemplateName, instanceName: string) {
+  const template = templates[templateName];
+  if (!template) {
+    throw new Error(`Unknown template: ${templateName}`);
+  }
+  ensureDir(instancesDir);
+  const target = path.join(instancesDir, instanceName);
+  fs.cpSync(template.source, target, { recursive: true });
+  console.log(`Cloned ${templateName} to ${target}`);
+}
+
+function list() {
+  if (!fs.existsSync(instancesDir)) {
+    console.log('No instances available');
+    return;
+  }
+  const entries = fs
+    .readdirSync(instancesDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+  if (entries.length === 0) {
+    console.log('No instances available');
+  } else {
+    console.log(entries.join('\n'));
+  }
+}
+
+function usage() {
+  console.log('Usage: node scripts/instance-registry.ts <clone|list> [args]');
+  console.log('  clone <template> <instance>  Clone template into instances directory');
+  console.log('  list                         List existing instances');
+}
+
+const [cmd, tmpl, name] = process.argv.slice(2) as [string, TemplateName, string];
+
+try {
+  if (cmd === 'clone') {
+    if (!tmpl || !name) {
+      usage();
+      process.exit(1);
+    }
+    clone(tmpl, name);
+  } else if (cmd === 'list') {
+    list();
+  } else {
+    usage();
+    process.exit(1);
+  }
+} catch (err) {
+  console.error((err as Error).message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- define reusable admin and commons UI templates
- add instance registry script for cloning and listing UI instances
- update advanced ToDo and progress tracking

## Testing
- `node repositorypflege/update-advanced-progress.js`
- `poetry install --with test`
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx ts-node scripts/instance-registry.ts list`

------
https://chatgpt.com/codex/tasks/task_e_68b4cc8a725c832299b9a4cf46d81a58