### PR TITLE
feat(report): add markdown output option

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-08-31, in der Zeit des Nacht.
+Am 2025-09-01, in der Zeit des Morgen.
 
-Symbolphase: Reflexion (Fokus: P)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo_parts/advancedToDo.part10.yaml
+++ b/advancedToDo_parts/advancedToDo.part10.yaml
@@ -33,3 +33,8 @@
   task: Multi-user resonance module for VR meeting spaces
   test: packages/unifiedmandala-vr/VRResonanceHub.test.ts
   status: done
+- commit: Add Markdown output option to advanced-todo-report script
+  path: repositorypflege/advanced-todo-report.js
+  task: Allow advanced-todo-report to output grouped tasks as Markdown when --md flag is used
+  test: repositorypflege/__tests__/advanced-todo-report.test.js
+  status: done

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add instance registry service",
+  "lastCommit": "Merge pull request #1570 from GenesisAeon/codex/optimize-repo-structure-and-codebase",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -8,29 +8,367 @@
   "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events | Added JetStream KV/ObjectStore wrappers and tool loader | Added waveform option to CREP sonification | Implemented GermanGrammarAssistant agent | Implemented GeoTIFF ingest | Added ingest demo script | Implemented ReviewerQueue and reviewer API | Added screen capture and UI automation routes | Implemented PatternMapperGPT and TunerGPT agents | Added AdminConsoleApp component | Added streaming JSON array iterator | Added YAML output test for conversation parser | Added streaming mode to split-newadvanced-conversations",
   "pendingTasks": [
     {
-      "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129",
-      "path": "GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json",
+      "commit": "Create CoauthorCanvas component",
       "status": "open"
     },
     {
-      "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e",
-      "path": "GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json",
+      "commit": "Create TaskBoard component",
       "status": "open"
     },
     {
-      "commit": "Integrate new GPT teams from Zukunft conversation",
-      "path": "packages/agents",
+      "commit": "Add PeerManager component",
       "status": "open"
     },
     {
-      "commit": "feat: add 3D_Universumsstruktur visualization",
-      "path": "packages/universum-visualization/3D_Universumsstruktur.py",
+      "commit": "Add ModelRouterEditor component",
       "status": "open"
     },
     {
-      "commit": "feat: add NullmembranDynamics module",
-      "path": "packages/universum-simulationen/modules/NullmembranDynamics.py",
+      "commit": "Create identity API service",
       "status": "open"
+    },
+    {
+      "commit": "Add ACL API service",
+      "status": "open"
+    },
+    {
+      "commit": "Create InitialAdminPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Define federation manifest type",
+      "status": "open"
+    },
+    {
+      "commit": "Create federation registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Create federation bridge websocket",
+      "status": "open"
+    },
+    {
+      "commit": "Add collab federation bridge script",
+      "status": "open"
+    },
+    {
+      "commit": "Create GlobalMandalaGraph component",
+      "status": "open"
+    },
+    {
+      "commit": "Add unified AppShell",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for Co-Intelligence services",
+      "status": "open"
+    },
+    {
+      "commit": "Append identity and federation services to code agent tasks",
+      "status": "open"
+    },
+    {
+      "commit": "Add OIDC stub service",
+      "status": "open"
+    },
+    {
+      "commit": "Add UI switchboard service",
+      "status": "open"
+    },
+    {
+      "commit": "Add compose override for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows stack start script",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows services installer",
+      "status": "open"
+    },
+    {
+      "commit": "Add UM integration GitHub workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Expose UM service scripts in package.json",
+      "status": "open"
+    },
+    {
+      "commit": "Provide tsconfig for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add production docker compose file",
+      "status": "open"
+    },
+    {
+      "commit": "Create generic Dockerfile for TypeScript services",
+      "status": "open"
+    },
+    {
+      "commit": "Configure NGINX reverse proxy for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add Kong gateway configuration",
+      "status": "open"
+    },
+    {
+      "commit": "Create verified federation registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Implement SSO broker service",
+      "status": "open"
+    },
+    {
+      "commit": "Generate systemd unit files script",
+      "status": "open"
+    },
+    {
+      "commit": "Document production setup",
+      "status": "open"
+    },
+    {
+      "commit": "Add Keycloak OIDC dev bundle",
+      "status": "open"
+    },
+    {
+      "commit": "Add Kubernetes manifests with Kustomize overlays",
+      "status": "open"
+    },
+    {
+      "commit": "Add monitoring configuration",
+      "status": "open"
+    },
+    {
+      "commit": "Add Caddy TLS reverse proxy",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitHub Actions workflow for Kubernetes deployment",
+      "status": "open"
+    },
+    {
+      "commit": "Add Helm OIDC bundle",
+      "status": "open"
+    },
+    {
+      "commit": "Add Traefik mTLS ingress",
+      "status": "open"
+    },
+    {
+      "commit": "Add SLO monitoring pack",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps manifests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Add Go OIDC quickstart",
+      "status": "open"
+    },
+    {
+      "commit": "Add Keycloak auto-import helmfile",
+      "status": "open"
+    },
+    {
+      "commit": "Add Cloudflare DNS01 ClusterIssuer",
+      "status": "open"
+    },
+    {
+      "commit": "Add Argo Rollouts canary stack",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps app factory script",
+      "status": "open"
+    },
+    {
+      "commit": "Add Observability++ stack",
+      "status": "open"
+    },
+    {
+      "commit": "Add secret management examples",
+      "status": "open"
+    },
+    {
+      "commit": "Add NetworkPolicy templates",
+      "status": "open"
+    },
+    {
+      "commit": "Add blue/green rollouts with Slack alerts",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps golden path template",
+      "status": "open"
+    },
+    {
+      "commit": "Add one-click cluster bootstrap",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Vault CSI for secret file mounts",
+      "status": "open"
+    },
+    {
+      "commit": "Add ServiceMap-based NetworkPolicy generator",
+      "status": "open"
+    },
+    {
+      "commit": "Set up Cypress UI smoke tests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Set up k6 API smoke tests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Configure promotion gates for rollouts",
+      "status": "open"
+    },
+    {
+      "commit": "Deploy gate-controller for E2E gating",
+      "status": "open"
+    },
+    {
+      "commit": "Add Playwright synthetics with OTel",
+      "status": "open"
+    },
+    {
+      "commit": "Implement multi-signal quorum gates",
+      "status": "open"
+    },
+    {
+      "commit": "Add Terraform synthetics and alerting",
+      "status": "open"
+    },
+    {
+      "commit": "Enable auto-rollback on SLO violation",
+      "status": "open"
+    },
+    {
+      "commit": "Schedule weekly SLO and error budget reports",
+      "status": "open"
+    },
+    {
+      "commit": "Support multi-tenant E2E gates",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows E2E workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Track SLO budget consumption",
+      "status": "open"
+    },
+    {
+      "commit": "Capture debug snapshots on aborted rollouts",
+      "status": "open"
+    },
+    {
+      "commit": "Provide tenant admin API and UI",
+      "status": "open"
+    },
+    {
+      "commit": "Automate image builds and Kustomize validation",
+      "status": "open"
+    },
+    {
+      "commit": "Bootstrap GitOps root application",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce multi-cluster ApplicationSet and security policies",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Kyverno policies with Gatekeeper audit layer",
+      "status": "open"
+    },
+    {
+      "commit": "Apply Cilium default-deny and service allow policies",
+      "status": "open"
+    },
+    {
+      "commit": "Deploy Falco with RBAC-abuse rules and Slack alerts",
+      "status": "open"
+    },
+    {
+      "commit": "Wire OpenTelemetry collector to Tempo and Loki",
+      "status": "open"
+    },
+    {
+      "commit": "Enable Alertmanager night mode routing",
+      "status": "open"
+    },
+    {
+      "commit": "Define per-namespace Cilium FQDN allowlists",
+      "status": "open"
+    },
+    {
+      "commit": "Switch Kyverno verifyImages to enforce",
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "commit": "Erzeuge initiale Aufgaben",
+      "status": "offen"
+    },
+    {
+      "commit": "Verzweige in Unteraufgaben",
+      "status": "offen"
+    },
+    {
+      "commit": "Bewerte CREP und depth",
+      "status": "offen"
+    },
+    {
+      "commit": "Commitiere Ergebnisse",
+      "status": "offen"
     }
   ],
   "progress": [
@@ -5358,6 +5696,10 @@
     {
       "commit": "Create instance registry service",
       "status": "done"
+    },
+    {
+      "commit": "Add Markdown output option to advanced-todo-report script",
+      "status": "done"
     }
   ],
   "completed": [
@@ -6313,9 +6655,9 @@
     }
   ],
   "changedFiles": [
-    "docs/sigils/advancedprogress-guide.md",
-    "repositorypflege/__tests__/update-advanced-progress.test.js",
-    "repositorypflege/update-advanced-progress.js"
+    "advancedToDo_parts/advancedToDo.part10.yaml",
+    "repositorypflege/__tests__/advanced-todo-report.test.js",
+    "repositorypflege/advanced-todo-report.js"
   ],
-  "lastUpdated": "2025-08-31T23:30:24.756Z"
+  "lastUpdated": "2025-09-01T00:05:33.948Z"
 }

--- a/repositorypflege/__tests__/advanced-todo-report.test.js
+++ b/repositorypflege/__tests__/advanced-todo-report.test.js
@@ -69,3 +69,23 @@ test('cli outputs yaml when --yaml flag is provided', () => {
 
   fs.unlinkSync(tmp);
 });
+
+test('cli outputs markdown when --md flag is provided', () => {
+  const tmp = path.join(__dirname, 'tmp-report.json');
+  const sample = [
+    { commit: 'Task A', path: 'a/file1', status: 'open' },
+    { commit: 'Task C', path: 'b/file3', status: 'open' }
+  ];
+  fs.writeFileSync(tmp, JSON.stringify(sample, null, 2));
+
+  const script = path.join(__dirname, '..', 'advanced-todo-report.js');
+  const out = execSync(`node ${script} --path ${tmp} --md`, {
+    encoding: 'utf8'
+  });
+  expect(out).toContain('### a (1)');
+  expect(out).toContain('- Task A');
+  expect(out).toContain('### b (1)');
+  expect(out).toContain('- Task C');
+
+  fs.unlinkSync(tmp);
+});

--- a/repositorypflege/advanced-todo-report.js
+++ b/repositorypflege/advanced-todo-report.js
@@ -23,6 +23,8 @@ if (require.main === module) {
   const exclude = exclIndex >= 0 ? process.argv[exclIndex + 1] : undefined;
   const jsonOutput = process.argv.includes('--json');
   const yamlOutput = process.argv.includes('--yaml');
+  const markdownOutput =
+    process.argv.includes('--markdown') || process.argv.includes('--md');
   const includeConvos = process.argv.includes('--include-conversations');
   const limitIndex = process.argv.indexOf('--limit');
   const limit = limitIndex >= 0 ? parseInt(process.argv[limitIndex + 1], 10) : undefined;
@@ -34,6 +36,26 @@ if (require.main === module) {
     console.log(yaml.dump(grouped));
   } else if (jsonOutput) {
     console.log(JSON.stringify(grouped, null, 2));
+  } else if (markdownOutput) {
+    let total = 0;
+    const entries = Object.entries(grouped);
+    entries.sort((a, b) => {
+      if (sortMode === 'count') {
+        return b[1].length - a[1].length;
+      }
+      return a[0].localeCompare(b[0]);
+    });
+    for (const [dir, tasks] of entries) {
+      total += tasks.length;
+      console.log(`### ${dir} (${tasks.length})`);
+      const list = limit ? tasks.slice(0, limit) : tasks;
+      list.forEach((t) => console.log(`- ${t.commit}`));
+      if (limit && tasks.length > limit) {
+        console.log(`- ...and ${tasks.length - limit} more`);
+      }
+      console.log('');
+    }
+    console.log(`Total open tasks: ${total}`);
   } else {
     let total = 0;
     const entries = Object.entries(grouped);


### PR DESCRIPTION
## Summary
- add markdown output capability to advanced-todo-report script
- test markdown flag and document task completion entry
- sync advanced progress tracking

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest repositorypflege/__tests__/advanced-todo-report.test.js`
- `node repositorypflege/update-advanced-progress.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4e27fa7108322a047c7622a974e9c