### PR TITLE
feat: add OIDC stub service

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -14007,7 +14007,7 @@
     "path": "scripts/oidc-stub.ts",
     "task": "Serve JWKS and token endpoints for development",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add UI switchboard service",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13293,7 +13293,7 @@
   path: scripts/oidc-stub.ts
   task: Serve JWKS and token endpoints for development
   test: ""
-  status: open
+  status: done
 - commit: Add UI switchboard service
   path: scripts/ui-switchboard.ts
   task: List cloned UIs via instance registry proxy

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1570 from GenesisAeon/codex/optimize-repo-structure-and-codebase",
+  "lastCommit": "feat: add OIDC stub service",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -65,10 +65,6 @@
     },
     {
       "commit": "Append identity and federation services to code agent tasks",
-      "status": "open"
-    },
-    {
-      "commit": "Add OIDC stub service",
       "status": "open"
     },
     {
@@ -5700,6 +5696,10 @@
     {
       "commit": "Add Markdown output option to advanced-todo-report script",
       "status": "done"
+    },
+    {
+      "commit": "Add OIDC stub service",
+      "status": "done"
     }
   ],
   "completed": [
@@ -6655,9 +6655,9 @@
     }
   ],
   "changedFiles": [
-    "advancedToDo_parts/advancedToDo.part10.yaml",
-    "repositorypflege/__tests__/advanced-todo-report.test.js",
-    "repositorypflege/advanced-todo-report.js"
+    "advancedToDo.json",
+    "advancedToDo.yaml",
+    "scripts/oidc-stub.ts"
   ],
-  "lastUpdated": "2025-09-01T00:05:33.948Z"
+  "lastUpdated": "2025-09-01T05:45:30.021Z"
 }

--- a/scripts/oidc-stub.ts
+++ b/scripts/oidc-stub.ts
@@ -1,0 +1,32 @@
+import express from 'express';
+import { generateKeyPairSync } from 'crypto';
+import jwt from 'jsonwebtoken';
+
+const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const jwk = publicKey.export({ format: 'jwk' }) as any;
+jwk.use = 'sig';
+jwk.alg = 'RS256';
+jwk.kid = 'dev-key';
+
+const app = express();
+app.use(express.json());
+
+app.get('/.well-known/jwks.json', (_req, res) => {
+  res.json({ keys: [jwk] });
+});
+
+app.post('/token', (req, res) => {
+  const sub = (req.body && req.body.sub) || 'dev-user';
+  const token = jwt.sign({ sub }, privateKey, {
+    algorithm: 'RS256',
+    expiresIn: '1h',
+    keyid: jwk.kid,
+    issuer: 'oidc-stub'
+  });
+  res.json({ access_token: token, token_type: 'Bearer', expires_in: 3600 });
+});
+
+const port = Number(process.env.PORT) || 4009;
+app.listen(port, () => {
+  console.log(`OIDC stub listening on :${port}`);
+});


### PR DESCRIPTION
## Summary
- add development OIDC stub with JWKS and token endpoints
- mark OIDC stub task complete in advanced todo and progress log

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright` *(fails: venvPath /workspace/unified-mandala/.venv is not a valid directory)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68b5326a21a08322aac828a8b08fdf4a