### PR TITLE
feat: record commit hash in progress updates

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-09-01, in der Zeit des Morgen.
+Am 2025-09-01, in der Zeit des Abend.
 
-Symbolphase: Initiation (Fokus: C)
+Symbolphase: Integration (Fokus: E)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add OIDC stub service",
+  "lastCommit": "Merge pull request #1572 from GenesisAeon/codex/optimize-repo-structure-and-code-dfmtmz",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -6655,9 +6655,10 @@
     }
   ],
   "changedFiles": [
-    "advancedToDo.json",
-    "advancedToDo.yaml",
-    "scripts/oidc-stub.ts"
+    "docs/sigils/advancedprogress-guide.md",
+    "repositorypflege/__tests__/update-advanced-progress.test.js",
+    "repositorypflege/update-advanced-progress.js"
   ],
-  "lastUpdated": "2025-09-01T05:45:30.021Z"
+  "lastUpdated": "2025-09-01T19:12:43.938Z",
+  "commitHash": "7399e5be1ee7e0f22e6cb148f15b5c313d6c1a06"
 }

--- a/docs/sigils/advancedprogress-guide.md
+++ b/docs/sigils/advancedprogress-guide.md
@@ -13,7 +13,9 @@ node repositorypflege/update-advanced-progress.js
 The script collects open items from `advancedToDo.json`, `advancedToDo.yaml`
 and every fragment in `advancedToDo_parts/`. It also records a `changedFiles`
 list capturing the files currently modified in the working tree and stamps a
-`lastUpdated` timestamp. This helps trace fractal updates across commits.
+`lastUpdated` timestamp. The current Git `commitHash` is stored as well, which
+anchors the progress snapshot to a specific revision. This helps trace fractal
+updates across commits.
 
 By default tasks that reference conversation datasets are skipped. Pass
 `--include-conversations` to include them in the generated progress file when

--- a/repositorypflege/__tests__/update-advanced-progress.test.js
+++ b/repositorypflege/__tests__/update-advanced-progress.test.js
@@ -25,6 +25,7 @@ test('updates pendingTasks with limited todos', () => {
   ]);
   expect(typeof updated.lastUpdated).toBe('string');
   expect(isNaN(Date.parse(updated.lastUpdated))).toBe(false);
+  expect(updated.commitHash).toMatch(/^[0-9a-f]{40}$/);
 });
 
 test('forwards exclude pattern to listOpenAdvancedTodos', () => {
@@ -52,6 +53,7 @@ test('dry run prints without modifying file', () => {
   const updated = JSON.parse(fs.readFileSync(tmp, 'utf8'));
   expect(updated.pendingTasks).toEqual([]);
   expect(spy).toHaveBeenCalled();
+  expect(updated.commitHash).toBeUndefined();
   spy.mockRestore();
 });
 
@@ -69,6 +71,7 @@ test('cli writes to provided progress file', () => {
   expect(updated.pendingTasks).toEqual([
     { commit: 'CLI Task', path: 'cli', status: 'open' }
   ]);
+  expect(updated.commitHash).toMatch(/^[0-9a-f]{40}$/);
   fs.unlinkSync(tmpProgress);
   fs.unlinkSync(tmpTodo);
 });

--- a/repositorypflege/update-advanced-progress.js
+++ b/repositorypflege/update-advanced-progress.js
@@ -15,6 +15,14 @@ function getChangedFiles() {
   }
 }
 
+function getCommitHash() {
+  try {
+    return execSync('git rev-parse HEAD').toString().trim();
+  } catch {
+    return null;
+  }
+}
+
 function updateAdvancedProgress(
   limit = 5,
   progressFile,
@@ -34,6 +42,10 @@ function updateAdvancedProgress(
   );
   progress.changedFiles = changed;
   progress.lastUpdated = new Date().toISOString();
+  const commit = getCommitHash();
+  if (commit) {
+    progress.commitHash = commit;
+  }
   const output = JSON.stringify(progress, null, 2);
   if (dryRun) {
     console.log(output);


### PR DESCRIPTION
## Summary
- track the current git commit when syncing advanced progress
- document new commit hash metadata
- test update script and sync generated progress file

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test repositorypflege/__tests__/update-advanced-progress.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5ec5652a4832299b033ef0ea3ce27