### PR TITLE
feat: add advanced progress summary script

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-09-01, in der Zeit des Abend.
+Am 2025-09-03, in der Zeit des Morgen.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -15066,5 +15066,12 @@
     "task": "Commitiere Ergebnisse",
     "test": "",
     "status": "offen"
+  },
+  {
+    "commit": "Add advanced progress summary script",
+    "path": "repositorypflege/advanced-progress-summary.js",
+    "task": "Summarize advanced progress file",
+    "test": "",
+    "status": "done"
   }
 ]

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -14005,6 +14005,11 @@
   task: Analyse Gesprächsextrakte
   test: ""
   status: done
+- commit: Add advanced progress summary script
+  path: repositorypflege/advanced-progress-summary.js
+  task: Summarize advanced progress file
+  test: ""
+  status: done
 - commit: Erzeuge initiale Aufgaben
   path: ""
   task: Erzeuge initiale Aufgaben

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6322,8 +6322,9 @@
   ],
   "changedFiles": [
     "advancedToDo.json",
-    "advancedToDo.yaml"
+    "advancedToDo.yaml",
+    "repositorypflege/advanced-progress-summary.js"
   ],
-  "lastUpdated": "2025-09-02T09:24:26.240Z",
-  "commitHash": "a533f35e19cf389f8f22eeab4655c370a0efba3b"
+  "lastUpdated": "2025-09-03T11:29:51.534Z",
+  "commitHash": "ca8dbf9f458035d69cce7d1f8e0e882e2978efc3"
 }

--- a/repositorypflege/advanced-progress-summary.js
+++ b/repositorypflege/advanced-progress-summary.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+const fs = require('fs');
+try {
+  const data = JSON.parse(fs.readFileSync('advancedprogress.json', 'utf8'));
+  const count = (arr) => Array.isArray(arr) ? arr.length : 0;
+  const summary = {
+    pending: count(data.pendingTasks),
+    done: count(data.progress),
+    fractalTodos: count(data.fractalTodos),
+    lastUpdated: data.lastUpdated,
+    commitHash: data.commitHash,
+  };
+  console.log('Advanced Progress Summary');
+  console.log(`Pending Tasks: ${summary.pending}`);
+  console.log(`Completed Tasks: ${summary.done}`);
+  console.log(`Fractal Todos: ${summary.fractalTodos}`);
+  if (summary.lastUpdated) console.log(`Last Updated: ${summary.lastUpdated}`);
+  if (summary.commitHash) console.log(`Commit: ${summary.commitHash}`);
+} catch (err) {
+  console.error('Failed to read advancedprogress.json', err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add `advanced-progress-summary` utility to quickly view task counts from `advancedprogress.json`
- track the utility in `advancedToDo` files and refresh progress snapshot
- refresh Chronopoem metadata

## Testing
- `node repositorypflege/advanced-progress-summary.js`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68b823b0bb80832292c0dcb31a3a0a62