### PR TITLE
feat: add flexible progress summary output

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6321,10 +6321,9 @@
     }
   ],
   "changedFiles": [
-    "advancedToDo.json",
-    "advancedToDo.yaml",
-    "repositorypflege/advanced-progress-summary.js"
+    "repositorypflege/advanced-progress-summary.js",
+    "repositorypflege/__tests__/advanced-progress-summary.test.js"
   ],
-  "lastUpdated": "2025-09-03T11:29:51.534Z",
-  "commitHash": "ca8dbf9f458035d69cce7d1f8e0e882e2978efc3"
+  "lastUpdated": "2025-09-03T12:07:50.323Z",
+  "commitHash": "e0fccf519f95157fce551ce696efcb601ba91378"
 }

--- a/repositorypflege/__tests__/advanced-progress-summary.test.js
+++ b/repositorypflege/__tests__/advanced-progress-summary.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+test('outputs JSON summary for custom file', () => {
+  const tmp = path.join(__dirname, 'tmp-progress.json');
+  fs.writeFileSync(
+    tmp,
+    JSON.stringify(
+      {
+        pendingTasks: [{}],
+        progress: [{}],
+        fractalTodos: [{}],
+        lastUpdated: '2025-01-01T00:00:00.000Z',
+        commitHash: '0123456789abcdef0123456789abcdef01234567'
+      },
+      null,
+      2
+    )
+  );
+
+  const script = path.join(__dirname, '..', 'advanced-progress-summary.js');
+  const output = execSync(`node ${script} --json --file ${tmp}`, { encoding: 'utf8' });
+  const summary = JSON.parse(output);
+  expect(summary).toEqual({
+    pending: 1,
+    done: 1,
+    fractalTodos: 1,
+    lastUpdated: '2025-01-01T00:00:00.000Z',
+    commitHash: '0123456789abcdef0123456789abcdef01234567'
+  });
+
+  fs.unlinkSync(tmp);
+});

--- a/repositorypflege/advanced-progress-summary.js
+++ b/repositorypflege/advanced-progress-summary.js
@@ -1,8 +1,21 @@
 #!/usr/bin/env node
 const fs = require('fs');
+
+// Basic argv parsing without extra dependencies
+const args = process.argv.slice(2);
+const format = args.includes('--json')
+  ? 'json'
+  : args.includes('--markdown')
+    ? 'markdown'
+    : 'text';
+const fileIdx = args.indexOf('--file');
+const progressFile = fileIdx !== -1 && args[fileIdx + 1]
+  ? args[fileIdx + 1]
+  : 'advancedprogress.json';
+
 try {
-  const data = JSON.parse(fs.readFileSync('advancedprogress.json', 'utf8'));
-  const count = (arr) => Array.isArray(arr) ? arr.length : 0;
+  const data = JSON.parse(fs.readFileSync(progressFile, 'utf8'));
+  const count = (arr) => (Array.isArray(arr) ? arr.length : 0);
   const summary = {
     pending: count(data.pendingTasks),
     done: count(data.progress),
@@ -10,6 +23,25 @@ try {
     lastUpdated: data.lastUpdated,
     commitHash: data.commitHash,
   };
+
+  if (format === 'json') {
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  if (format === 'markdown') {
+    console.log('| Metric | Value |');
+    console.log('| --- | --- |');
+    console.log(`| Pending Tasks | ${summary.pending} |`);
+    console.log(`| Completed Tasks | ${summary.done} |`);
+    console.log(`| Fractal Todos | ${summary.fractalTodos} |`);
+    if (summary.lastUpdated)
+      console.log(`| Last Updated | ${summary.lastUpdated} |`);
+    if (summary.commitHash)
+      console.log(`| Commit | ${summary.commitHash} |`);
+    return;
+  }
+
   console.log('Advanced Progress Summary');
   console.log(`Pending Tasks: ${summary.pending}`);
   console.log(`Completed Tasks: ${summary.done}`);
@@ -17,6 +49,6 @@ try {
   if (summary.lastUpdated) console.log(`Last Updated: ${summary.lastUpdated}`);
   if (summary.commitHash) console.log(`Commit: ${summary.commitHash}`);
 } catch (err) {
-  console.error('Failed to read advancedprogress.json', err);
+  console.error(`Failed to read ${progressFile}`, err);
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- support JSON and Markdown formats in `advanced-progress-summary.js`
- allow specifying custom progress file for summaries
- add test for JSON output and update progress snapshot

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest repositorypflege/__tests__/advanced-progress-summary.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b82f31465c8322b868c655353c1800