### PR TITLE
feat: extend advanced todo lister with structured output

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add NullmembranDynamics module",
+  "lastCommit": "Merge pull request #1579 from GenesisAeon/codex/optimize-repository-structure-and-features-qlcmah",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -6328,9 +6328,7 @@
       "status": "done"
     }
   ],
-  "changedFiles": [
-    "advancedToDo.json"
-  ],
-  "lastUpdated": "2025-09-03T14:28:27.952Z",
-  "commitHash": "7c7d016c97a60356533e01becaeb269bb9846ec4"
+  "changedFiles": [],
+  "lastUpdated": "2025-09-03T14:46:29.109Z",
+  "commitHash": "f6f2901a6a453de6d3e2efa9b877cffbaf8915da"
 }

--- a/repositorypflege/__tests__/list-open-advanced-todos.test.js
+++ b/repositorypflege/__tests__/list-open-advanced-todos.test.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
+const { execSync } = require('child_process');
 const { listOpenAdvancedTodos } = require('../list-open-advanced-todos');
 
 test('lists and filters open advanced todos', () => {
@@ -92,5 +93,24 @@ test('deduplicates tasks with same commit and path', () => {
   const todos = listOpenAdvancedTodos(undefined, tmp);
   expect(todos).toEqual([{ commit: 'Task A', path: 'a' }]);
 
+  fs.unlinkSync(tmp);
+});
+
+test('CLI outputs JSON format', () => {
+  const tmp = path.join(__dirname, 'tmp-cli.json');
+  const sample = [
+    { commit: 'Task A', path: 'a', status: 'open' },
+    { commit: 'Task B', path: 'b', status: 'open' }
+  ];
+  fs.writeFileSync(tmp, JSON.stringify(sample, null, 2));
+  const script = path.join(__dirname, '..', 'list-open-advanced-todos.js');
+  const output = execSync(`node ${script} 5 --path ${tmp} --json`, {
+    encoding: 'utf8'
+  });
+  const parsed = JSON.parse(output);
+  expect(parsed.todos).toEqual([
+    { commit: 'Task A', path: 'a' },
+    { commit: 'Task B', path: 'b' }
+  ]);
   fs.unlinkSync(tmp);
 });

--- a/repositorypflege/feedback.md
+++ b/repositorypflege/feedback.md
@@ -9,3 +9,4 @@
 - Added `--sort` flag to `advanced-todo-report.js` for directory ordering by task count.
 - Marked CreditLedger and AttributionIndex tasks as complete in `advancedToDo` files.
 - Added `--yaml` option to `advanced-progress-summary.js` for flexible report formats.
+- Added JSON/YAML/Markdown output options to `list-open-advanced-todos.js` for easier automation.

--- a/repositorypflege/list-open-advanced-todos.js
+++ b/repositorypflege/list-open-advanced-todos.js
@@ -91,19 +91,40 @@ if (require.main === module) {
   const exclIndex = process.argv.indexOf('--exclude');
   const exclude = exclIndex >= 0 ? process.argv[exclIndex + 1] : undefined;
   const includeConvos = process.argv.includes('--include-conversations');
+  const jsonOutput = process.argv.includes('--json');
+  const yamlOutput = process.argv.includes('--yaml');
+  const markdownOutput =
+    process.argv.includes('--markdown') || process.argv.includes('--md');
   const open = listOpenAdvancedTodos(pattern, todoPaths, exclude, {
     includeConversations: includeConvos
   });
   const display = open.slice(0, limit);
-  display.forEach((t) => {
-    const commitText =
-      typeof t.commit === 'string' && t.commit.length > 120
-        ? t.commit.slice(0, 117) + '...'
-        : t.commit;
-    console.log(`- ${commitText} (${t.path})`);
-  });
-  if (open.length > limit) {
-    console.log(`...and ${open.length - limit} more`);
+  if (jsonOutput) {
+    console.log(
+      JSON.stringify(
+        { todos: display, remaining: open.length - display.length },
+        null,
+        2
+      )
+    );
+  } else if (yamlOutput) {
+    console.log(
+      yaml.dump({ todos: display, remaining: open.length - display.length })
+    );
+  } else {
+    display.forEach((t) => {
+      const commitText =
+        markdownOutput || typeof t.commit !== 'string'
+          ? t.commit
+          : t.commit.length > 120
+            ? t.commit.slice(0, 117) + '...'
+            : t.commit;
+      console.log(`- ${commitText} (${t.path})`);
+    });
+    if (open.length > limit) {
+      const moreLine = `...and ${open.length - limit} more`;
+      console.log(markdownOutput ? `- ${moreLine}` : moreLine);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- support JSON, YAML and Markdown output in `list-open-advanced-todos.js`
- cover new output option with CLI test
- document advanced todo lister output formats in repository feedback
- refresh advanced progress snapshot

## Testing
- `npx jest repositorypflege/__tests__/list-open-advanced-todos.test.js`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `node repositorypflege/update-advanced-progress.js`


------
https://chatgpt.com/codex/tasks/task_e_68b853c1c5ac83229642f2e86d180248