### PR TITLE
feat: add federation manifest type

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13952,7 +13952,7 @@
     "path": "packages/federation/Manifest.ts",
     "task": "Describe global registry entries for Mandala peers",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create federation registry service",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13254,7 +13254,7 @@
   path: packages/federation/Manifest.ts
   task: Describe global registry entries for Mandala peers
   test: ""
-  status: open
+  status: done
 - commit: Create federation registry service
   path: scripts/federation-registry.ts
   task: Register and list Mandala manifests

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1579 from GenesisAeon/codex/optimize-repository-structure-and-features-qlcmah",
+  "lastCommit": "Merge pull request #1580 from GenesisAeon/codex/optimize-repo-structure-and-implement-features-sc70xf",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -8,29 +8,356 @@
   "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events | Added JetStream KV/ObjectStore wrappers and tool loader | Added waveform option to CREP sonification | Implemented GermanGrammarAssistant agent | Implemented GeoTIFF ingest | Added ingest demo script | Implemented ReviewerQueue and reviewer API | Added screen capture and UI automation routes | Implemented PatternMapperGPT and TunerGPT agents | Added AdminConsoleApp component | Added streaming JSON array iterator | Added YAML output test for conversation parser | Added streaming mode to split-newadvanced-conversations",
   "pendingTasks": [
     {
-      "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129",
-      "path": "GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json",
+      "commit": "Create CoauthorCanvas component",
       "status": "open"
     },
     {
-      "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e",
-      "path": "GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json",
+      "commit": "Create TaskBoard component",
       "status": "open"
     },
     {
-      "commit": "Integrate new GPT teams from Zukunft conversation",
-      "path": "packages/agents",
+      "commit": "Add PeerManager component",
       "status": "open"
     },
     {
-      "commit": "feat: add 3D_Universumsstruktur visualization",
-      "path": "packages/universum-visualization/3D_Universumsstruktur.py",
+      "commit": "Add ModelRouterEditor component",
       "status": "open"
     },
     {
-      "commit": "feat: add TheoryDatabase service",
-      "path": "packages/universum-simulationen/modules/TheoryDatabase.ts",
+      "commit": "Create identity API service",
       "status": "open"
+    },
+    {
+      "commit": "Add ACL API service",
+      "status": "open"
+    },
+    {
+      "commit": "Create InitialAdminPanel component",
+      "status": "open"
+    },
+    {
+      "commit": "Create federation registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Create federation bridge websocket",
+      "status": "open"
+    },
+    {
+      "commit": "Add collab federation bridge script",
+      "status": "open"
+    },
+    {
+      "commit": "Create GlobalMandalaGraph component",
+      "status": "open"
+    },
+    {
+      "commit": "Add unified AppShell",
+      "status": "open"
+    },
+    {
+      "commit": "Extend code agent tasks for Co-Intelligence services",
+      "status": "open"
+    },
+    {
+      "commit": "Append identity and federation services to code agent tasks",
+      "status": "open"
+    },
+    {
+      "commit": "Add UI switchboard service",
+      "status": "open"
+    },
+    {
+      "commit": "Add compose override for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows stack start script",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows services installer",
+      "status": "open"
+    },
+    {
+      "commit": "Add UM integration GitHub workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Expose UM service scripts in package.json",
+      "status": "open"
+    },
+    {
+      "commit": "Provide tsconfig for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add production docker compose file",
+      "status": "open"
+    },
+    {
+      "commit": "Create generic Dockerfile for TypeScript services",
+      "status": "open"
+    },
+    {
+      "commit": "Configure NGINX reverse proxy for UM services",
+      "status": "open"
+    },
+    {
+      "commit": "Add Kong gateway configuration",
+      "status": "open"
+    },
+    {
+      "commit": "Create verified federation registry service",
+      "status": "open"
+    },
+    {
+      "commit": "Implement SSO broker service",
+      "status": "open"
+    },
+    {
+      "commit": "Generate systemd unit files script",
+      "status": "open"
+    },
+    {
+      "commit": "Document production setup",
+      "status": "open"
+    },
+    {
+      "commit": "Add Keycloak OIDC dev bundle",
+      "status": "open"
+    },
+    {
+      "commit": "Add Kubernetes manifests with Kustomize overlays",
+      "status": "open"
+    },
+    {
+      "commit": "Add monitoring configuration",
+      "status": "open"
+    },
+    {
+      "commit": "Add Caddy TLS reverse proxy",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitHub Actions workflow for Kubernetes deployment",
+      "status": "open"
+    },
+    {
+      "commit": "Add Helm OIDC bundle",
+      "status": "open"
+    },
+    {
+      "commit": "Add Traefik mTLS ingress",
+      "status": "open"
+    },
+    {
+      "commit": "Add SLO monitoring pack",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps manifests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Add Go OIDC quickstart",
+      "status": "open"
+    },
+    {
+      "commit": "Add Keycloak auto-import helmfile",
+      "status": "open"
+    },
+    {
+      "commit": "Add Cloudflare DNS01 ClusterIssuer",
+      "status": "open"
+    },
+    {
+      "commit": "Add Argo Rollouts canary stack",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps app factory script",
+      "status": "open"
+    },
+    {
+      "commit": "Add Observability++ stack",
+      "status": "open"
+    },
+    {
+      "commit": "Add secret management examples",
+      "status": "open"
+    },
+    {
+      "commit": "Add NetworkPolicy templates",
+      "status": "open"
+    },
+    {
+      "commit": "Add blue/green rollouts with Slack alerts",
+      "status": "open"
+    },
+    {
+      "commit": "Add GitOps golden path template",
+      "status": "open"
+    },
+    {
+      "commit": "Add one-click cluster bootstrap",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Vault CSI for secret file mounts",
+      "status": "open"
+    },
+    {
+      "commit": "Add ServiceMap-based NetworkPolicy generator",
+      "status": "open"
+    },
+    {
+      "commit": "Set up Cypress UI smoke tests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Set up k6 API smoke tests and workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Configure promotion gates for rollouts",
+      "status": "open"
+    },
+    {
+      "commit": "Deploy gate-controller for E2E gating",
+      "status": "open"
+    },
+    {
+      "commit": "Add Playwright synthetics with OTel",
+      "status": "open"
+    },
+    {
+      "commit": "Implement multi-signal quorum gates",
+      "status": "open"
+    },
+    {
+      "commit": "Add Terraform synthetics and alerting",
+      "status": "open"
+    },
+    {
+      "commit": "Enable auto-rollback on SLO violation",
+      "status": "open"
+    },
+    {
+      "commit": "Schedule weekly SLO and error budget reports",
+      "status": "open"
+    },
+    {
+      "commit": "Support multi-tenant E2E gates",
+      "status": "open"
+    },
+    {
+      "commit": "Add Windows E2E workflow",
+      "status": "open"
+    },
+    {
+      "commit": "Track SLO budget consumption",
+      "status": "open"
+    },
+    {
+      "commit": "Capture debug snapshots on aborted rollouts",
+      "status": "open"
+    },
+    {
+      "commit": "Provide tenant admin API and UI",
+      "status": "open"
+    },
+    {
+      "commit": "Automate image builds and Kustomize validation",
+      "status": "open"
+    },
+    {
+      "commit": "Bootstrap GitOps root application",
+      "status": "open"
+    },
+    {
+      "commit": "Introduce multi-cluster ApplicationSet and security policies",
+      "status": "open"
+    },
+    {
+      "commit": "Integrate Kyverno policies with Gatekeeper audit layer",
+      "status": "open"
+    },
+    {
+      "commit": "Apply Cilium default-deny and service allow policies",
+      "status": "open"
+    },
+    {
+      "commit": "Deploy Falco with RBAC-abuse rules and Slack alerts",
+      "status": "open"
+    },
+    {
+      "commit": "Wire OpenTelemetry collector to Tempo and Loki",
+      "status": "open"
+    },
+    {
+      "commit": "Enable Alertmanager night mode routing",
+      "status": "open"
+    },
+    {
+      "commit": "Define per-namespace Cilium FQDN allowlists",
+      "status": "open"
+    },
+    {
+      "commit": "Switch Kyverno verifyImages to enforce",
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "status": "open"
+    },
+    {
+      "commit": "Erzeuge initiale Aufgaben",
+      "status": "offen"
+    },
+    {
+      "commit": "Verzweige in Unteraufgaben",
+      "status": "offen"
+    },
+    {
+      "commit": "Bewerte CREP und depth",
+      "status": "offen"
+    },
+    {
+      "commit": "Commitiere Ergebnisse",
+      "status": "offen"
     }
   ],
   "progress": [
@@ -5374,6 +5701,10 @@
     {
       "commit": "feat: add NullmembranDynamics module",
       "status": "done"
+    },
+    {
+      "commit": "Define federation manifest type",
+      "status": "done"
     }
   ],
   "completed": [
@@ -6328,7 +6659,11 @@
       "status": "done"
     }
   ],
-  "changedFiles": [],
-  "lastUpdated": "2025-09-03T14:46:29.109Z",
-  "commitHash": "f6f2901a6a453de6d3e2efa9b877cffbaf8915da"
+  "changedFiles": [
+    "advancedToDo.json",
+    "advancedToDo.yaml",
+    "packages/federation/"
+  ],
+  "lastUpdated": "2025-09-03T15:20:40.283Z",
+  "commitHash": "cbed99c6524c6b4df94f31630b376837be90ab82"
 }

--- a/packages/federation/Manifest.ts
+++ b/packages/federation/Manifest.ts
@@ -1,0 +1,40 @@
+/**
+ * Describes a Mandala peer in the global federation registry.
+ * Each peer exposes a manifest so other instances can
+ * discover available capabilities and contact information.
+ */
+export interface FederationManifest {
+  /** Unique identifier for the peer, e.g. a UUID or hash. */
+  id: string;
+  /** Human readable label for the peer. */
+  name: string;
+  /** Base URL where the peer can be reached. */
+  url: string;
+  /** Public key used for signed messages. */
+  publicKey: string;
+  /** List of capabilities that this peer provides. */
+  capabilities: string[];
+  /** Optional geographic or logical region description. */
+  region?: string;
+  /** Timestamp in ISO format when manifest was created. */
+  createdAt: string;
+  /** Timestamp in ISO format when manifest was last updated. */
+  updatedAt?: string;
+}
+
+/**
+ * Type guard to ensure an arbitrary object is a FederationManifest.
+ */
+export function isFederationManifest(value: unknown): value is FederationManifest {
+  if (typeof value !== 'object' || value === null) return false;
+  const m = value as Record<string, unknown>;
+  return (
+    typeof m.id === 'string' &&
+    typeof m.name === 'string' &&
+    typeof m.url === 'string' &&
+    typeof m.publicKey === 'string' &&
+    Array.isArray(m.capabilities) &&
+    m.capabilities.every((c) => typeof c === 'string') &&
+    typeof m.createdAt === 'string'
+  );
+}


### PR DESCRIPTION
## Summary
- define `FederationManifest` interface and type guard for Mandala peers
- mark federation manifest task done and refresh advanced progress snapshot

## Testing
- `pnpm install`
- `poetry install --with test`
- `node repositorypflege/update-advanced-progress.js`
- `npx pyright`
- `npx tsc -p tsconfig.json --noEmit && echo "tsc passed"`


------
https://chatgpt.com/codex/tasks/task_e_68b85c4771088322a57dca3a2cb09b0b