### PR TITLE
feat: add TaskBoard component

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-09-03, in der Zeit des Tag.
+Am 2025-09-03, in der Zeit des Abend.
 
-Symbolphase: Aktivierung (Fokus: R)
+Symbolphase: Integration (Fokus: E)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13875,7 +13875,7 @@
     "path": "packages/commons-ui/TaskBoard.tsx",
     "task": "List and enqueue tasks via orchestrator API",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add ConsentTimeline component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13199,7 +13199,7 @@
   path: packages/commons-ui/TaskBoard.tsx
   task: List and enqueue tasks via orchestrator API
   test: ""
-  status: open
+  status: done
 - commit: Add ConsentTimeline component
   path: packages/admin-ui/ConsentTimeline.tsx
   task: Display active consent records from admin API

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "Merge pull request #1580 from GenesisAeon/codex/optimize-repo-structure-and-implement-features-sc70xf",
+  "lastCommit": "feat: add TaskBoard component",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -8,356 +8,29 @@
   "notes": "Added FusionEvolution module | Added FieldQuantization module and marked NullmembranQuantization complete | Added ModelRouter and open-source providers | Added Red Team Day exercise scripts | Added RAG API deployment manifest | Implemented AgentHeartbeat module | Added unified security Grafana dashboard | Exposed agent health API | Implemented ReviewerHotkeys UI hook | Added AgentHealthPanel component | Added Personhood Protocol documentation | Provide Prometheus scrape config | Added JetStreamBus for persistent events | Added JetStream KV/ObjectStore wrappers and tool loader | Added waveform option to CREP sonification | Implemented GermanGrammarAssistant agent | Implemented GeoTIFF ingest | Added ingest demo script | Implemented ReviewerQueue and reviewer API | Added screen capture and UI automation routes | Implemented PatternMapperGPT and TunerGPT agents | Added AdminConsoleApp component | Added streaming JSON array iterator | Added YAML output test for conversation parser | Added streaming mode to split-newadvanced-conversations",
   "pendingTasks": [
     {
-      "commit": "Create CoauthorCanvas component",
+      "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json - a0cddb53-12d4-44b8-b881-4fbfad63f129",
+      "path": "GenesisAeonZIPMEM/Aeon_Uebergabe-Sigil_Prozess_part2.json",
       "status": "open"
     },
     {
-      "commit": "Create TaskBoard component",
+      "commit": "TODO from GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json - bbb21f74-3a0f-45b2-8e8c-25e45e32861e",
+      "path": "GenesisAeonZIPMEM/Aeon_Uebergabe_und_Zyklus_part1.json",
       "status": "open"
     },
     {
-      "commit": "Add PeerManager component",
+      "commit": "Integrate new GPT teams from Zukunft conversation",
+      "path": "packages/agents",
       "status": "open"
     },
     {
-      "commit": "Add ModelRouterEditor component",
+      "commit": "feat: add 3D_Universumsstruktur visualization",
+      "path": "packages/universum-visualization/3D_Universumsstruktur.py",
       "status": "open"
     },
     {
-      "commit": "Create identity API service",
+      "commit": "feat: add TheoryDatabase service",
+      "path": "packages/universum-simulationen/modules/TheoryDatabase.ts",
       "status": "open"
-    },
-    {
-      "commit": "Add ACL API service",
-      "status": "open"
-    },
-    {
-      "commit": "Create InitialAdminPanel component",
-      "status": "open"
-    },
-    {
-      "commit": "Create federation registry service",
-      "status": "open"
-    },
-    {
-      "commit": "Create federation bridge websocket",
-      "status": "open"
-    },
-    {
-      "commit": "Add collab federation bridge script",
-      "status": "open"
-    },
-    {
-      "commit": "Create GlobalMandalaGraph component",
-      "status": "open"
-    },
-    {
-      "commit": "Add unified AppShell",
-      "status": "open"
-    },
-    {
-      "commit": "Extend code agent tasks for Co-Intelligence services",
-      "status": "open"
-    },
-    {
-      "commit": "Append identity and federation services to code agent tasks",
-      "status": "open"
-    },
-    {
-      "commit": "Add UI switchboard service",
-      "status": "open"
-    },
-    {
-      "commit": "Add compose override for UM services",
-      "status": "open"
-    },
-    {
-      "commit": "Add Windows stack start script",
-      "status": "open"
-    },
-    {
-      "commit": "Add Windows services installer",
-      "status": "open"
-    },
-    {
-      "commit": "Add UM integration GitHub workflow",
-      "status": "open"
-    },
-    {
-      "commit": "Expose UM service scripts in package.json",
-      "status": "open"
-    },
-    {
-      "commit": "Provide tsconfig for UM services",
-      "status": "open"
-    },
-    {
-      "commit": "Add production docker compose file",
-      "status": "open"
-    },
-    {
-      "commit": "Create generic Dockerfile for TypeScript services",
-      "status": "open"
-    },
-    {
-      "commit": "Configure NGINX reverse proxy for UM services",
-      "status": "open"
-    },
-    {
-      "commit": "Add Kong gateway configuration",
-      "status": "open"
-    },
-    {
-      "commit": "Create verified federation registry service",
-      "status": "open"
-    },
-    {
-      "commit": "Implement SSO broker service",
-      "status": "open"
-    },
-    {
-      "commit": "Generate systemd unit files script",
-      "status": "open"
-    },
-    {
-      "commit": "Document production setup",
-      "status": "open"
-    },
-    {
-      "commit": "Add Keycloak OIDC dev bundle",
-      "status": "open"
-    },
-    {
-      "commit": "Add Kubernetes manifests with Kustomize overlays",
-      "status": "open"
-    },
-    {
-      "commit": "Add monitoring configuration",
-      "status": "open"
-    },
-    {
-      "commit": "Add Caddy TLS reverse proxy",
-      "status": "open"
-    },
-    {
-      "commit": "Add GitHub Actions workflow for Kubernetes deployment",
-      "status": "open"
-    },
-    {
-      "commit": "Add Helm OIDC bundle",
-      "status": "open"
-    },
-    {
-      "commit": "Add Traefik mTLS ingress",
-      "status": "open"
-    },
-    {
-      "commit": "Add SLO monitoring pack",
-      "status": "open"
-    },
-    {
-      "commit": "Add GitOps manifests and workflow",
-      "status": "open"
-    },
-    {
-      "commit": "Add Go OIDC quickstart",
-      "status": "open"
-    },
-    {
-      "commit": "Add Keycloak auto-import helmfile",
-      "status": "open"
-    },
-    {
-      "commit": "Add Cloudflare DNS01 ClusterIssuer",
-      "status": "open"
-    },
-    {
-      "commit": "Add Argo Rollouts canary stack",
-      "status": "open"
-    },
-    {
-      "commit": "Add GitOps app factory script",
-      "status": "open"
-    },
-    {
-      "commit": "Add Observability++ stack",
-      "status": "open"
-    },
-    {
-      "commit": "Add secret management examples",
-      "status": "open"
-    },
-    {
-      "commit": "Add NetworkPolicy templates",
-      "status": "open"
-    },
-    {
-      "commit": "Add blue/green rollouts with Slack alerts",
-      "status": "open"
-    },
-    {
-      "commit": "Add GitOps golden path template",
-      "status": "open"
-    },
-    {
-      "commit": "Add one-click cluster bootstrap",
-      "status": "open"
-    },
-    {
-      "commit": "Integrate Vault CSI for secret file mounts",
-      "status": "open"
-    },
-    {
-      "commit": "Add ServiceMap-based NetworkPolicy generator",
-      "status": "open"
-    },
-    {
-      "commit": "Set up Cypress UI smoke tests and workflow",
-      "status": "open"
-    },
-    {
-      "commit": "Set up k6 API smoke tests and workflow",
-      "status": "open"
-    },
-    {
-      "commit": "Configure promotion gates for rollouts",
-      "status": "open"
-    },
-    {
-      "commit": "Deploy gate-controller for E2E gating",
-      "status": "open"
-    },
-    {
-      "commit": "Add Playwright synthetics with OTel",
-      "status": "open"
-    },
-    {
-      "commit": "Implement multi-signal quorum gates",
-      "status": "open"
-    },
-    {
-      "commit": "Add Terraform synthetics and alerting",
-      "status": "open"
-    },
-    {
-      "commit": "Enable auto-rollback on SLO violation",
-      "status": "open"
-    },
-    {
-      "commit": "Schedule weekly SLO and error budget reports",
-      "status": "open"
-    },
-    {
-      "commit": "Support multi-tenant E2E gates",
-      "status": "open"
-    },
-    {
-      "commit": "Add Windows E2E workflow",
-      "status": "open"
-    },
-    {
-      "commit": "Track SLO budget consumption",
-      "status": "open"
-    },
-    {
-      "commit": "Capture debug snapshots on aborted rollouts",
-      "status": "open"
-    },
-    {
-      "commit": "Provide tenant admin API and UI",
-      "status": "open"
-    },
-    {
-      "commit": "Automate image builds and Kustomize validation",
-      "status": "open"
-    },
-    {
-      "commit": "Bootstrap GitOps root application",
-      "status": "open"
-    },
-    {
-      "commit": "Introduce multi-cluster ApplicationSet and security policies",
-      "status": "open"
-    },
-    {
-      "commit": "Integrate Kyverno policies with Gatekeeper audit layer",
-      "status": "open"
-    },
-    {
-      "commit": "Apply Cilium default-deny and service allow policies",
-      "status": "open"
-    },
-    {
-      "commit": "Deploy Falco with RBAC-abuse rules and Slack alerts",
-      "status": "open"
-    },
-    {
-      "commit": "Wire OpenTelemetry collector to Tempo and Loki",
-      "status": "open"
-    },
-    {
-      "commit": "Enable Alertmanager night mode routing",
-      "status": "open"
-    },
-    {
-      "commit": "Define per-namespace Cilium FQDN allowlists",
-      "status": "open"
-    },
-    {
-      "commit": "Switch Kyverno verifyImages to enforce",
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "status": "open"
-    },
-    {
-      "commit": "Erzeuge initiale Aufgaben",
-      "status": "offen"
-    },
-    {
-      "commit": "Verzweige in Unteraufgaben",
-      "status": "offen"
-    },
-    {
-      "commit": "Bewerte CREP und depth",
-      "status": "offen"
-    },
-    {
-      "commit": "Commitiere Ergebnisse",
-      "status": "offen"
     }
   ],
   "progress": [
@@ -5705,6 +5378,10 @@
     {
       "commit": "Define federation manifest type",
       "status": "done"
+    },
+    {
+      "commit": "Create TaskBoard component",
+      "status": "done"
     }
   ],
   "completed": [
@@ -6659,11 +6336,7 @@
       "status": "done"
     }
   ],
-  "changedFiles": [
-    "advancedToDo.json",
-    "advancedToDo.yaml",
-    "packages/federation/"
-  ],
-  "lastUpdated": "2025-09-03T15:20:40.283Z",
-  "commitHash": "cbed99c6524c6b4df94f31630b376837be90ab82"
+  "changedFiles": [],
+  "lastUpdated": "2025-09-03T18:03:53.651Z",
+  "commitHash": "cfcac19d6130816e89582444b0fd4a61bfa3727a"
 }

--- a/packages/commons-ui/TaskBoard.test.tsx
+++ b/packages/commons-ui/TaskBoard.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TaskBoard from './TaskBoard';
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({ json: () => Promise.resolve([]) })
+) as unknown as typeof fetch;
+
+test('renders task board heading', () => {
+  render(<TaskBoard />);
+  expect(screen.getByLabelText('TaskBoard')).toBeInTheDocument();
+  expect(screen.getByText('Task Board')).toBeInTheDocument();
+});

--- a/packages/commons-ui/TaskBoard.tsx
+++ b/packages/commons-ui/TaskBoard.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+
+interface Task {
+  id: string;
+  title: string;
+}
+
+/**
+ * TaskBoard lists tasks from the orchestrator API and allows enqueueing new ones.
+ * This lightweight component demonstrates basic interaction without depending on
+ * a specific backend implementation.
+ */
+export default function TaskBoard() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [title, setTitle] = useState('');
+
+  useEffect(() => {
+    fetch('/api/tasks')
+      .then((res) => res.json())
+      .then((data) => setTasks(Array.isArray(data) ? data : []))
+      .catch(() => setTasks([]));
+  }, []);
+
+  async function addTask() {
+    if (!title.trim()) return;
+    const newTask = { title };
+    setTitle('');
+    try {
+      await fetch('/api/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(newTask)
+      });
+      setTasks((prev) => [
+        ...prev,
+        { id: Math.random().toString(36).slice(2), title: newTask.title }
+      ]);
+    } catch {
+      /* ignore network errors in demo */
+    }
+  }
+
+  return (
+    <div aria-label="TaskBoard">
+      <h2>Task Board</h2>
+      <ul>
+        {tasks.map((task) => (
+          <li key={task.id}>{task.title}</li>
+        ))}
+      </ul>
+      <input
+        aria-label="new-task"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="New task"
+      />
+      <button onClick={addTask}>Add Task</button>
+    </div>
+  );
+}

--- a/packages/commons-ui/index.ts
+++ b/packages/commons-ui/index.ts
@@ -1,1 +1,2 @@
 export { default as CommonsApp } from './CommonsApp';
+export { default as TaskBoard } from './TaskBoard';


### PR DESCRIPTION
## Summary
- add TaskBoard React component for listing and enqueueing tasks via orchestrator API
- export TaskBoard in commons-ui package
- mark TaskBoard entry complete in advanced ToDo trackers and refresh progress snapshot

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx jest packages/commons-ui/TaskBoard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b881be8b4c8322872e17fe8a1f59a1