### PR TITLE
feat: generate initial tasks list

### DIFF
--- a/CHRONOPOEM.md
+++ b/CHRONOPOEM.md
@@ -1,9 +1,9 @@
 # 🜂 Chronopoem
 
 Im Kreis der Genesis erwacht das Mandala,
-Am 2025-09-03, in der Zeit des Abend.
+Am 2025-09-04, in der Zeit des Morgen.
 
-Symbolphase: Integration (Fokus: E)
+Symbolphase: Initiation (Fokus: C)
 
 CREP-Strahl: ?, ?, ?, ? – das Lied der Struktur (C=Quelle, R=Klang, E=Flamme, P=Pfad)
 CREP-Zustand: 

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -1,5 +1,5 @@
 {
-  "lastCommit": "feat: add UI switchboard service",
+  "lastCommit": "Merge pull request #1585 from GenesisAeon/codex/optimize-repository-structure-and-code-x8iv0l",
   "fractalStep": "implementiert",
   "openBranches": [
     "work"
@@ -6660,8 +6660,10 @@
     }
   ],
   "changedFiles": [
-    "scripts/ui-switchboard.ts"
+    "package.json",
+    "repositorypflege/generate-initial-tasks.js",
+    "repositorypflege/initial-tasks.json"
   ],
-  "lastUpdated": "2025-09-03T20:20:55.394Z",
-  "commitHash": "eca9518309d64b88f990d82b2470c1d3138361f6"
+  "lastUpdated": "2025-09-04T06:07:08.487Z",
+  "commitHash": "029ec8c63f76efab39edeac510d9cf6a63a8690a"
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "update:fractal-todo": "node scripts/update-fractal-todo.js",
     "update:todo-sigil": "node scripts/update-todo-sigil.js",
     "update:advanced-progress": "node repositorypflege/update-advanced-progress.js",
+    "generate:initial-tasks": "node repositorypflege/generate-initial-tasks.js",
     "validate:todos": "node scripts/validate-implicit-todos.js",
     "validate:advancedtodo": "node scripts/validate-advancedtodo.js",
     "export:crep-docs": "node scripts/export-crep-docs.js",

--- a/repositorypflege/generate-initial-tasks.js
+++ b/repositorypflege/generate-initial-tasks.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+function readData(file) {
+  const ext = path.extname(file).toLowerCase();
+  try {
+    const raw = fs.readFileSync(file, 'utf8');
+    return ext === '.json' ? JSON.parse(raw) : yaml.load(raw);
+  } catch (err) {
+    console.error(`Failed to parse ${file}:`, err.message);
+    return [];
+  }
+}
+
+function collectFiles(dir) {
+  let files = [];
+  if (!fs.existsSync(dir)) return files;
+  const stat = fs.statSync(dir);
+  if (stat.isDirectory()) {
+    for (const entry of fs.readdirSync(dir)) {
+      files = files.concat(collectFiles(path.join(dir, entry)));
+    }
+  } else if (/\.(json|ya?ml)$/i.test(dir)) {
+    files.push(dir);
+  }
+  return files;
+}
+
+function gatherTasks() {
+  const repoRoot = path.resolve(__dirname, '..');
+  const sources = [
+    path.join(repoRoot, 'advancedToDo.json'),
+    path.join(repoRoot, 'advancedToDo.yaml'),
+    path.join(repoRoot, 'advancedToDo_parts')
+  ];
+  let tasks = [];
+  for (const src of sources) {
+    const files = collectFiles(src);
+    for (const file of files) {
+      const data = readData(file);
+      if (Array.isArray(data)) tasks = tasks.concat(data);
+    }
+  }
+  return tasks;
+}
+
+function isOpen(status) {
+  const s = String(status || '').toLowerCase();
+  return s && s !== 'done' && s !== 'closed' && s !== 'fertig';
+}
+
+const args = process.argv.slice(2);
+const limitIdx = args.indexOf('--limit');
+const limit = limitIdx >= 0 ? parseInt(args[limitIdx + 1], 10) : Infinity;
+const outIdx = args.indexOf('--out');
+const outFile = outIdx >= 0 ? args[outIdx + 1] : path.join(__dirname, 'initial-tasks.json');
+const includeConvos = args.includes('--include-conversations');
+
+const allTasks = gatherTasks();
+const openTasks = [];
+for (const t of allTasks) {
+  if (isOpen(t.status)) {
+    const commit = t.commit || t.title || '';
+    const p = t.path || null;
+    if (!includeConvos) {
+      const text = `${commit} ${p || ''}`;
+      if (/conversations/i.test(text)) continue;
+    }
+    openTasks.push({ commit, path: p, task: t.task || t.title || '' });
+  }
+}
+
+const sliced = openTasks.slice(0, limit);
+const output = { generatedAt: new Date().toISOString(), tasks: sliced };
+fs.writeFileSync(outFile, JSON.stringify(output, null, 2));
+console.log(`Initial tasks written to ${path.relative(process.cwd(), outFile)} (${sliced.length} items)`);

--- a/repositorypflege/initial-tasks.json
+++ b/repositorypflege/initial-tasks.json
@@ -1,0 +1,105 @@
+{
+  "generatedAt": "2025-09-04T06:06:59.561Z",
+  "tasks": [
+    {
+      "commit": "Create CoauthorCanvas component",
+      "path": "packages/commons-ui/CoauthorCanvas.tsx",
+      "task": "Collaboratively edit documents over collab-ws"
+    },
+    {
+      "commit": "Add PeerManager component",
+      "path": "packages/admin-ui/PeerManager.tsx",
+      "task": "Show registered AI peers with roles and trust"
+    },
+    {
+      "commit": "Add ModelRouterEditor component",
+      "path": "packages/admin-ui/ModelRouterEditor.tsx",
+      "task": "Edit model routing policies in admin console"
+    },
+    {
+      "commit": "Create identity API service",
+      "path": "scripts/identity-api.ts",
+      "task": "Issue JWTs and manage tenants and instances"
+    },
+    {
+      "commit": "Add ACL API service",
+      "path": "scripts/acl-api.ts",
+      "task": "Manage per-instance role grants"
+    },
+    {
+      "commit": "Create InitialAdminPanel component",
+      "path": "packages/unifiedmandala-ui/components/InitialAdminPanel.tsx",
+      "task": "Clone UIs and assign roles for tenants and instances"
+    },
+    {
+      "commit": "Create federation registry service",
+      "path": "scripts/federation-registry.ts",
+      "task": "Register and list Mandala manifests"
+    },
+    {
+      "commit": "Create federation bridge websocket",
+      "path": "scripts/federation-bridge-ws.ts",
+      "task": "Broadcast presence and activity across instances"
+    },
+    {
+      "commit": "Add collab federation bridge script",
+      "path": "scripts/collab-federation-bridge.ts",
+      "task": "Relay CRDT patches between local collab server and federation bridge"
+    },
+    {
+      "commit": "Add unified AppShell",
+      "path": "packages/unifiedmandala-ui/AppShell.tsx",
+      "task": "Compose admin panels and global network graph"
+    },
+    {
+      "commit": "Extend code agent tasks for Co-Intelligence services",
+      "path": "code-agent-tasks.yaml",
+      "task": "Add orchestrator, collab, peer handshake and setup wizard commands"
+    },
+    {
+      "commit": "Append identity and federation services to code agent tasks",
+      "path": "code-agent-tasks.yaml",
+      "task": "Include identity, instance, ACL and federation service run commands"
+    },
+    {
+      "commit": "Add compose override for UM services",
+      "path": "compose.override.yml",
+      "task": "Define containers for identity, federation, collab and admin services"
+    },
+    {
+      "commit": "Add Windows stack start script",
+      "path": "windows/Start-UMStack.ps1",
+      "task": "Launch all UM services as background processes on Windows"
+    },
+    {
+      "commit": "Add Windows services installer",
+      "path": "windows/Install-UMServices.ps1",
+      "task": "Register UM services with Task Scheduler or NSSM"
+    },
+    {
+      "commit": "Add UM integration GitHub workflow",
+      "path": ".github/workflows/um-integration.yml",
+      "task": "Run type check and smoke test for UM services"
+    },
+    {
+      "commit": "Expose UM service scripts in package.json",
+      "path": "package.json",
+      "task": "Add dev commands for identity, registry, collab and admin APIs"
+    },
+    {
+      "commit": "Provide tsconfig for UM services",
+      "path": "tsconfig.json",
+      "task": "Configure ES2020 modules and ts-node options"
+    },
+    {
+      "commit": "Add production docker compose file",
+      "path": "compose.prod.yml",
+      "task": "Provide dist-first multi-service builds with ts-node fallback"
+    },
+    {
+      "commit": "Create generic Dockerfile for TypeScript services",
+      "path": "docker/Dockerfile.service",
+      "task": "Add multi-stage build template using SERVICE_ENTRY arg"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add script to collect open advanced TODOs into an initial task list
- expose generator via new package.json script
- update progress snapshot and Chronopoem

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68b92c09762883229762bbff2cdc5755