### PR TITLE
feat: display changed files in progress summary

### DIFF
--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6344,7 +6344,12 @@
       "status": "done"
     }
   ],
-  "changedFiles": [],
-  "lastUpdated": "2025-09-04T06:21:24.068Z",
-  "commitHash": "61b9c30b5d68f8ea1f5933c4f46c017acf3b113f"
+  "changedFiles": [
+    "docs/sigils/advancedprogress-guide.md",
+    "repositorypflege/__tests__/advanced-progress-summary.test.js",
+    "repositorypflege/advanced-progress-summary.js",
+    "repositorypflege/feedback.md"
+  ],
+  "lastUpdated": "2025-09-04T06:56:44.217Z",
+  "commitHash": "21cb35960497c16e2b7b962bd53186bf81d3648d"
 }

--- a/docs/sigils/advancedprogress-guide.md
+++ b/docs/sigils/advancedprogress-guide.md
@@ -78,9 +78,9 @@ Use the summary script for a quick overview of repository progress:
 node repositorypflege/advanced-progress-summary.js
 ```
 
-Pass `--details` to include the last commit, current fractal step, and branch
-information. Output can be formatted with `--json`, `--yaml`, or
-`--markdown`.
+Pass `--details` to include the last commit, changed files, current fractal
+step, and branch information. Output can be formatted with `--json`, `--yaml`,
+or `--markdown`.
 
 ## Handling Large Conversation Files
 

--- a/repositorypflege/__tests__/advanced-progress-summary.test.js
+++ b/repositorypflege/__tests__/advanced-progress-summary.test.js
@@ -98,3 +98,29 @@ test('outputs CSV summary for custom file', () => {
 
   fs.unlinkSync(tmp);
 });
+
+test('includes changed files when details flag is used', () => {
+  const tmp = path.join(__dirname, 'tmp-progress-details.json');
+  fs.writeFileSync(
+    tmp,
+    JSON.stringify(
+      {
+        pendingTasks: [],
+        progress: [],
+        fractalTodos: [],
+        changedFiles: ['a.js', 'docs/readme.md']
+      },
+      null,
+      2
+    )
+  );
+
+  const script = path.join(__dirname, '..', 'advanced-progress-summary.js');
+  const output = execSync(`node ${script} --json --details --file ${tmp}`, {
+    encoding: 'utf8'
+  });
+  const summary = JSON.parse(output);
+  expect(summary.changedFiles).toEqual(['a.js', 'docs/readme.md']);
+
+  fs.unlinkSync(tmp);
+});

--- a/repositorypflege/advanced-progress-summary.js
+++ b/repositorypflege/advanced-progress-summary.js
@@ -35,6 +35,9 @@ try {
     summary.fractalStep = data.fractalStep;
     summary.openBranches = data.openBranches;
     summary.mergeConflicts = data.mergeConflicts;
+    if (data.changedFiles && data.changedFiles.length) {
+      summary.changedFiles = data.changedFiles;
+    }
   }
 
   if (format === 'json') {
@@ -66,6 +69,8 @@ try {
         console.log(`| Open Branches | ${summary.openBranches.join(', ')} |`);
       if (summary.mergeConflicts && summary.mergeConflicts.length)
         console.log(`| Merge Conflicts | ${summary.mergeConflicts.join(', ')} |`);
+      if (summary.changedFiles && summary.changedFiles.length)
+        console.log(`| Changed Files | ${summary.changedFiles.join(', ')} |`);
     }
     return;
   }
@@ -98,6 +103,10 @@ try {
         headers.push('Merge Conflicts');
         values.push(summary.mergeConflicts.join('|'));
       }
+      if (summary.changedFiles && summary.changedFiles.length) {
+        headers.push('Changed Files');
+        values.push(summary.changedFiles.join('|'));
+      }
     }
     console.log(headers.join(','));
     console.log(values.join(','));
@@ -117,6 +126,8 @@ try {
       console.log(`Open Branches: ${summary.openBranches.join(', ')}`);
     if (summary.mergeConflicts && summary.mergeConflicts.length)
       console.log(`Merge Conflicts: ${summary.mergeConflicts.join(', ')}`);
+    if (summary.changedFiles && summary.changedFiles.length)
+      console.log(`Changed Files: ${summary.changedFiles.join(', ')}`);
   }
 } catch (err) {
   console.error(`Failed to read ${progressFile}`, err);

--- a/repositorypflege/feedback.md
+++ b/repositorypflege/feedback.md
@@ -13,3 +13,4 @@
 - Added GlobalMandalaGraph component to visualize Mandala nodes and capabilities.
 - Added `--details` option to `advanced-progress-summary.js` and documented usage.
 - Added `--csv` option to `advanced-progress-summary.js` for spreadsheet-friendly reports.
+- Added changed file listing to `advanced-progress-summary.js` when using `--details`.


### PR DESCRIPTION
## Summary
- track changed files in progress summary when using `--details`
- document new `--details` behavior in advanced progress guide
- test `advanced-progress-summary.js` for changed file support and record update in repository feedback

## Testing
- `npx jest repositorypflege/__tests__/advanced-progress-summary.test.js`
- `pnpm install --frozen-lockfile`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json --noEmit && echo tsc succeeded`


------
https://chatgpt.com/codex/tasks/task_e_68b9377f416c83229aceed7d79945080