### PR TITLE
feat(admin-ui): add peer manager and model router editor

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13889,14 +13889,14 @@
     "path": "packages/admin-ui/PeerManager.tsx",
     "task": "Show registered AI peers with roles and trust",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Add ModelRouterEditor component",
     "path": "packages/admin-ui/ModelRouterEditor.tsx",
     "task": "Edit model routing policies in admin console",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Introduce Tenant and Instance types",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13209,12 +13209,12 @@
   path: packages/admin-ui/PeerManager.tsx
   task: Show registered AI peers with roles and trust
   test: ""
-  status: open
+  status: done
 - commit: Add ModelRouterEditor component
   path: packages/admin-ui/ModelRouterEditor.tsx
   task: Edit model routing policies in admin console
   test: ""
-  status: open
+  status: done
 - commit: Introduce Tenant and Instance types
   path: packages/identity/Tenant.ts
   task: Define multi-tenant IDs and membership structures

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6345,11 +6345,12 @@
     }
   ],
   "changedFiles": [
-    "docs/sigils/advancedprogress-guide.md",
-    "repositorypflege/__tests__/advanced-progress-summary.test.js",
-    "repositorypflege/advanced-progress-summary.js",
-    "repositorypflege/feedback.md"
+    "advancedToDo.json",
+    "advancedToDo.yaml",
+    "packages/admin-ui/index.ts",
+    "packages/admin-ui/ModelRouterEditor.tsx",
+    "packages/admin-ui/PeerManager.tsx"
   ],
-  "lastUpdated": "2025-09-04T06:56:44.217Z",
-  "commitHash": "21cb35960497c16e2b7b962bd53186bf81d3648d"
+  "lastUpdated": "2025-09-04T12:04:32.436Z",
+  "commitHash": "959ce6302cfded5052d722fec6ec7fb688b61165"
 }

--- a/packages/admin-ui/ModelRouterEditor.tsx
+++ b/packages/admin-ui/ModelRouterEditor.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+
+export interface Route {
+  model: string;
+  target: string;
+}
+
+export interface ModelRouterEditorProps {
+  initialRoutes?: Route[];
+  onChange?: (routes: Route[]) => void;
+}
+
+/**
+ * ModelRouterEditor allows editing of simple model routing rules.
+ * Routes can be added dynamically and emit changes via the onChange callback.
+ */
+const ModelRouterEditor: React.FC<ModelRouterEditorProps> = ({ initialRoutes = [], onChange }) => {
+  const [routes, setRoutes] = useState<Route[]>(initialRoutes);
+
+  const updateRoute = (index: number, key: keyof Route, value: string) => {
+    const next = routes.slice();
+    next[index] = { ...next[index], [key]: value };
+    setRoutes(next);
+    onChange?.(next);
+  };
+
+  const addRoute = () => {
+    const next = [...routes, { model: '', target: '' }];
+    setRoutes(next);
+    onChange?.(next);
+  };
+
+  return (
+    <div>
+      <h2>Model Router Editor</h2>
+      {routes.map((r, i) => (
+        <div key={i}>
+          <input
+            placeholder="Model"
+            value={r.model}
+            onChange={(e) => updateRoute(i, 'model', e.target.value)}
+          />
+          <input
+            placeholder="Target"
+            value={r.target}
+            onChange={(e) => updateRoute(i, 'target', e.target.value)}
+          />
+        </div>
+      ))}
+      <button onClick={addRoute}>Add Route</button>
+    </div>
+  );
+};
+
+export default ModelRouterEditor;

--- a/packages/admin-ui/PeerManager.tsx
+++ b/packages/admin-ui/PeerManager.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+export interface Peer {
+  id: string;
+  role: string;
+  trust: number;
+}
+
+export interface PeerManagerProps {
+  peers: Peer[];
+}
+
+/**
+ * PeerManager renders a simple table of registered AI peers.
+ * Each peer displays its id, assigned role and trust score.
+ */
+const PeerManager: React.FC<PeerManagerProps> = ({ peers }) => (
+  <div>
+    <h2>Peer Manager</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Peer</th>
+          <th>Role</th>
+          <th>Trust</th>
+        </tr>
+      </thead>
+      <tbody>
+        {peers.map((p) => (
+          <tr key={p.id}>
+            <td>{p.id}</td>
+            <td>{p.role}</td>
+            <td>{p.trust}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default PeerManager;

--- a/packages/admin-ui/index.ts
+++ b/packages/admin-ui/index.ts
@@ -1,2 +1,4 @@
 export { default as AdminConsoleApp } from './AdminConsoleApp';
 export { default as ConsentTimeline } from './ConsentTimeline';
+export { default as PeerManager } from './PeerManager';
+export { default as ModelRouterEditor } from './ModelRouterEditor';


### PR DESCRIPTION
## Summary
- implement `PeerManager` to list AI peers in admin console
- add `ModelRouterEditor` for editing routing rules
- mark related advanced TODO items as completed and refresh progress snapshot

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json` *(fails: npm warn Unknown env config "http-proxy", process interrupted)*
- `npx pyright` *(fails: venvPath /workspace/unified-mandala/.venv is not a valid directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b97fa29f888322b53ed73740a64fe7