### PR TITLE
feat: add CoauthorCanvas component

### DIFF
--- a/advancedToDo.json
+++ b/advancedToDo.json
@@ -13868,7 +13868,7 @@
     "path": "packages/commons-ui/CoauthorCanvas.tsx",
     "task": "Collaboratively edit documents over collab-ws",
     "test": "",
-    "status": "open"
+    "status": "done"
   },
   {
     "commit": "Create TaskBoard component",

--- a/advancedToDo.yaml
+++ b/advancedToDo.yaml
@@ -13194,7 +13194,7 @@
   path: packages/commons-ui/CoauthorCanvas.tsx
   task: Collaboratively edit documents over collab-ws
   test: ""
-  status: open
+  status: done
 - commit: Create TaskBoard component
   path: packages/commons-ui/TaskBoard.tsx
   task: List and enqueue tasks via orchestrator API

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -6347,10 +6347,13 @@
   "changedFiles": [
     "advancedToDo.json",
     "advancedToDo.yaml",
-    "packages/admin-ui/index.ts",
-    "packages/admin-ui/ModelRouterEditor.tsx",
-    "packages/admin-ui/PeerManager.tsx"
+    "package.json",
+    "packages/commons-ui/index.ts",
+    "pnpm-lock.yaml",
+    "scripts/collab-ws.ts",
+    "packages/commons-ui/CoauthorCanvas.test.tsx",
+    "packages/commons-ui/CoauthorCanvas.tsx"
   ],
-  "lastUpdated": "2025-09-04T12:04:32.436Z",
-  "commitHash": "959ce6302cfded5052d722fec6ec7fb688b61165"
+  "lastUpdated": "2025-09-04T12:58:49.486Z",
+  "commitHash": "f18dd6b268d28ccb52b0abdda6446a0aec06dba4"
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "ajv": "^8.0.0",
     "ajv-formats": "^3.0.1",
     "axios": "^1.10.0",
+    "@automerge/automerge": "^3.1.1",
     "chokidar": "^3.5.3",
     "commander": "^11.0.0",
     "d3": "^7.8.5",

--- a/packages/commons-ui/CoauthorCanvas.test.tsx
+++ b/packages/commons-ui/CoauthorCanvas.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CoauthorCanvas from './CoauthorCanvas';
+
+class MockWebSocket {
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  readyState = 1;
+  constructor(url: string) {
+    this.url = url;
+  }
+  url: string;
+  send() {/* noop */}
+  close() {/* noop */}
+  addEventListener() {/* noop */}
+  removeEventListener() {/* noop */}
+}
+
+(global as any).WebSocket = MockWebSocket as any;
+
+test('renders coauthor canvas', () => {
+  render(<CoauthorCanvas />);
+  expect(screen.getByLabelText('CoauthorCanvas')).toBeInTheDocument();
+  expect(screen.getByLabelText('coauthor-editor')).toBeInTheDocument();
+});

--- a/packages/commons-ui/CoauthorCanvas.tsx
+++ b/packages/commons-ui/CoauthorCanvas.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as Automerge from '@automerge/automerge';
+
+interface Doc {
+  text: string;
+}
+
+/**
+ * CoauthorCanvas provides a minimal collaborative text editor.
+ * It syncs document changes through a simple Automerge-based
+ * WebSocket protocol compatible with the `collab-ws` script.
+ */
+export default function CoauthorCanvas({ docId = 'default' }: { docId?: string }) {
+  const [value, setValue] = useState('');
+  const docRef = useRef(Automerge.init<Doc>());
+  const wsRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    const ws = new WebSocket(`ws://${window.location.host}/collab`);
+    wsRef.current = ws;
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data.toString());
+        if (msg.id !== docId) return;
+        const [updated] = Automerge.applyChanges(docRef.current, msg.changes);
+        docRef.current = updated;
+        setValue(updated.text || '');
+      } catch {
+        /* ignore malformed messages */
+      }
+    };
+    return () => {
+      ws.close();
+    };
+  }, [docId]);
+
+  function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    const newText = e.target.value;
+    const newDoc = Automerge.change(docRef.current, (d) => {
+      d.text = newText;
+    });
+    const changes = Automerge.getChanges(docRef.current, newDoc);
+    docRef.current = newDoc;
+    setValue(newText);
+    wsRef.current?.send(JSON.stringify({ id: docId, changes }));
+  }
+
+  return (
+    <div aria-label="CoauthorCanvas">
+      <h2>Coauthor Canvas</h2>
+      <textarea
+        aria-label="coauthor-editor"
+        value={value}
+        onChange={handleChange}
+        rows={10}
+        cols={40}
+      />
+    </div>
+  );
+}

--- a/packages/commons-ui/index.ts
+++ b/packages/commons-ui/index.ts
@@ -1,2 +1,3 @@
 export { default as CommonsApp } from './CommonsApp';
 export { default as TaskBoard } from './TaskBoard';
+export { default as CoauthorCanvas } from './CoauthorCanvas';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@automerge/automerge':
+        specifier: ^3.1.1
+        version: 3.1.1
       '@grpc/grpc-js':
         specifier: ^1.9.10
         version: 1.13.4
@@ -315,6 +318,9 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@automerge/automerge@3.1.1':
+    resolution: {integrity: sha512-x7tZiMBLk4/SKYimVEVl1/wPntT9buGvLOWCey9ZcH8JUsB0dgm49C0S7Ojzgvflcs2hc/YjiXRPcFeFkinIgw==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -6424,6 +6430,8 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@automerge/automerge@3.1.1': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:

--- a/scripts/collab-ws.ts
+++ b/scripts/collab-ws.ts
@@ -1,5 +1,5 @@
 import { WebSocketServer, WebSocket } from 'ws';
-import * as Automerge from 'automerge';
+import * as Automerge from '@automerge/automerge';
 
 interface ChangeMessage {
   id: string;


### PR DESCRIPTION
## Summary
- add CoauthorCanvas collaborative editor using Automerge and websockets
- expose CoauthorCanvas in commons-ui package and update collab server
- mark CoauthorCanvas task as complete in advancedToDo lists

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test packages/commons-ui/CoauthorCanvas.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b98c27cb888322bbbbf10154c4e810