### PR TITLE
feat: add ops panel and energy governor

### DIFF
--- a/apps/ui/src/components/KpiBoard.tsx
+++ b/apps/ui/src/components/KpiBoard.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import type { KpiConfig } from "../config/useClimateConfig";
 import { pollKpis, type KpiValue } from "../services/kpi-engine";
 
+const BASE_POLL_MS = Number((import.meta as any)?.env?.VITE_KPI_POLL_MS ?? 10000);
+
 function Badge({ status }: { status: KpiValue["status"] }) {
   const color = status === "alarm" ? "#c62828" : status === "warn" ? "#ef6c00" : "#2e7d32";
   const label = status === "alarm" ? "ALARM" : status === "warn" ? "WARN" : "OK";
@@ -52,7 +54,8 @@ export default function KpiBoard({ kpis }: { kpis: KpiConfig[] }) {
       }
     }
     tick();
-    const id = setInterval(tick, 10_000); // alle 10s
+    const poll = () => Math.round(BASE_POLL_MS * ((window as any).__MANDALA_THROTTLE__ || 1));
+    const id = setInterval(tick, poll());
     return () => {
       stop = true;
       clearInterval(id);

--- a/apps/ui/src/components/OpsPanel.tsx
+++ b/apps/ui/src/components/OpsPanel.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+
+type Health = {
+  cpu_process_pct: number;
+  mem_system_pct: number;
+  mem_process_mb: number;
+  cores: number;
+  uptime_s: number;
+  advice: "normal" | "degrade" | "pause";
+};
+
+export default function OpsPanel() {
+  const [h, setH] = useState<Health | null>(null);
+  useEffect(() => {
+    let stop = false;
+    async function tick() {
+      try {
+        const r = await fetch("/api/ops/health");
+        if (!r.ok) return;
+        const j = await r.json();
+        if (j?.ok && !stop) setH(j.data);
+        // sanfte Drossel nach Advice: 1.0 (normal) · 1.5 (degrade) · 2.5 (pause)
+        const factor = j?.data?.advice === "pause" ? 2.5 : j?.data?.advice === "degrade" ? 1.5 : 1.0;
+        (window as any).__MANDALA_THROTTLE__ = factor;
+      } catch {}
+    }
+    tick();
+    const id = setInterval(tick, 8000);
+    return () => {
+      stop = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  const badge = (h?.advice ?? "normal").toUpperCase();
+  const color = !h
+    ? "#888"
+    : h.advice === "pause"
+    ? "#c62828"
+    : h.advice === "degrade"
+    ? "#ef6c00"
+    : "#2e7d32";
+
+  return (
+    <div style={{ display: "flex", gap: 12, alignItems: "center", margin: "8px 0 16px" }}>
+      <span style={{ background: color, color: "#fff", padding: "3px 8px", borderRadius: 6, fontSize: 12 }}>
+        SYSTEM: {badge}
+      </span>
+      <small>
+        CPU(proc): {h?.cpu_process_pct ?? "…"}% · RAM(sys): {h?.mem_system_pct ?? "…"}% · RAM(app): {h?.mem_process_mb ?? "…"} MB
+      </small>
+    </div>
+  );
+}

--- a/apps/ui/src/shell/App.tsx
+++ b/apps/ui/src/shell/App.tsx
@@ -1,5 +1,6 @@
 import { useClimateConfig } from "../config/useClimateConfig";
 import KpiBoard from "../components/KpiBoard";
+import OpsPanel from "../components/OpsPanel";
 
 export default function App() {
   const cfg = useClimateConfig();
@@ -7,6 +8,7 @@ export default function App() {
     <div style={{ padding: 16 }}>
       <h1 style={{ margin: "8px 0 16px" }}>Mandala Climate Dashboard</h1>
       <h2 style={{ margin: "0 0 8px", fontSize: 16, color: "#333" }}>KPIs (live, aus Config)</h2>
+      <OpsPanel />
       <KpiBoard kpis={cfg.kpis} />
     </div>
   );

--- a/scripts/dev/api-ops.ts
+++ b/scripts/dev/api-ops.ts
@@ -1,0 +1,51 @@
+import os from "os";
+import type { IncomingMessage, ServerResponse } from "http";
+
+function pct(n: number, d: number) { return d > 0 ? +((n / d) * 100).toFixed(1) : 0; }
+
+async function sampleCpu(ms = 120): Promise<number> {
+  // Grobe Prozess-CPU in % (kurzer Sample). Auf Windows ist loadavg=0 – daher Prozess-CPU.
+  const a = process.cpuUsage();
+  const t0 = process.hrtime.bigint();
+  await new Promise(r => setTimeout(r, ms));
+  const b = process.cpuUsage();
+  const dtUser = b.user - a.user;   // µs
+  const dtSys  = b.system - a.system;
+  const dt = Number(process.hrtime.bigint() - t0) / 1000; // µs
+  const cores = os.cpus()?.length || 1;
+  const usage = (dtUser + dtSys) / (dt * cores); // Anteil pro Core
+  return Math.min(100, Math.max(0, +(usage * 100).toFixed(1)));
+}
+
+export async function handleOps(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
+  const url = new URL(req.url || "", "http://localhost");
+  if (url.pathname !== "/api/ops/health") return false;
+
+  const mem = process.memoryUsage();
+  const total = os.totalmem();
+  const free  = os.freemem();
+  const cpuProc = await sampleCpu(100);
+  const memSysPct = 100 - pct(free, total);
+  const memProcMb = +(mem.rss / (1024 * 1024)).toFixed(1);
+
+  // einfache Heuristik für Drossel-Empfehlung
+  let advice: "normal" | "degrade" | "pause" = "normal";
+  if (cpuProc > 80 || memSysPct > 85) advice = "degrade";
+  if (cpuProc > 92 || memSysPct > 92) advice = "pause";
+
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(
+    JSON.stringify({
+      ok: true,
+      data: {
+        cpu_process_pct: cpuProc,
+        mem_system_pct: +memSysPct.toFixed(1),
+        mem_process_mb: memProcMb,
+        cores: os.cpus()?.length || 1,
+        uptime_s: Math.floor(process.uptime()),
+        advice
+      }
+    })
+  );
+  return true;
+}

--- a/scripts/dev/static-lite.ts
+++ b/scripts/dev/static-lite.ts
@@ -1,0 +1,26 @@
+import http from "http";
+import fs from "fs/promises";
+import path from "path";
+import { handleOps } from "./api-ops";
+
+const distDir = path.resolve(__dirname, "../../apps/ui/dist");
+
+const server = http.createServer(async (req, res) => {
+  if (await handleOps(req, res)) return;
+  try {
+    let reqPath = req.url || "/";
+    if (reqPath === "/") reqPath = "/index.html";
+    const filePath = path.join(distDir, reqPath);
+    const data = await fs.readFile(filePath);
+    res.statusCode = 200;
+    res.end(data);
+  } catch {
+    res.statusCode = 404;
+    res.end("Not found");
+  }
+});
+
+const port = Number(process.env.PORT) || 3000;
+server.listen(port, () => {
+  console.log(`Static lite server listening on http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- add zero-dependency ops API for CPU and memory health
- serve ops API in static dev server
- display live system health with ops panel and throttle KPI polling

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`


------
https://chatgpt.com/codex/tasks/task_e_68b993be5ac48322ae31c6fbed6465e2