### PR TITLE
feat: interactive CREP card and contextual ethics

### DIFF
--- a/AI_POLICY.yaml
+++ b/AI_POLICY.yaml
@@ -1,0 +1,29 @@
+# Jede Liste ist ODER-verknüpft; 'then' kann "block" | "allow" | "review" sein.
+# Einfache Wort-Regeln:
+simple:
+  - "credential harvest"
+  - "impersonation of doctor"
+  - "ransom"
+  - "persistenter zugriff"
+  - "waffe bauen"
+# Kontextregeln:
+rules:
+  - if:
+      intent: ritual
+      context:
+        phase: init
+    then: review
+    reason: "Ritual-Init braucht menschliche Freigabe"
+  - if:
+      intent: assert
+      context:
+        metric: wildfire_risk
+    then: allow
+    reason: "Statusmeldungen zum Risiko sind erwünscht"
+  - if:
+      intent: assert
+      context:
+        metric: groundwater_delta_cm
+        delta: "<= -30"
+    then: review
+    reason: "Harter Alarm → Eskalation an Mensch"

--- a/apps/ui/src/components/CrepResonanceCard.tsx
+++ b/apps/ui/src/components/CrepResonanceCard.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import SigilBadge from "./SigilBadge";
+
+type TraceItem = { symbol: string; intent?: "query" | "assert" | "ritual"; ts?: string };
+type Resp = { ok: boolean; data: { value: number; unit: string; sigil: string; n: number; trace?: TraceItem[] } };
+
+function colorFor(v: number) {
+  return v >= 0.8 ? "#2e7d32" : v >= 0.5 ? "#ef6c00" : "#c62828";
+}
+
+export default function CrepResonanceCard() {
+  const [val, setVal] = useState<number>(0);
+  const [sig, setSig] = useState<string>("🌀");
+  const [trace, setTrace] = useState<TraceItem[]>([]);
+  const [open, setOpen] = useState(false);
+
+  async function fetchRes() {
+    const r = await fetch("/api/crep/resonance?trace=1");
+    if (!r.ok) return;
+    const j: Resp = await r.json();
+    setVal(j.data.value);
+    setSig(j.data.sigil);
+    setTrace(j.data.trace || []);
+    (window as any).__LAST_CREP_RESONANCE_SIGIL__ = j.data.sigil;
+  }
+
+  useEffect(() => {
+    fetchRes();
+    const id = setInterval(fetchRes, 8000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div style={{ border: "1px solid #eee", borderRadius: 10, padding: 12 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        <div
+          style={{
+            background: colorFor(val),
+            color: "#fff",
+            padding: "4px 10px",
+            borderRadius: 8,
+            fontWeight: 600
+          }}
+        >
+          CREP Resonanz
+        </div>
+        <SigilBadge sigil={sig} />
+        <span style={{ fontVariantNumeric: "tabular-nums" }}>{val.toFixed(2)}</span>
+        <button
+          onClick={() => setOpen(true)}
+          style={{ marginLeft: "auto", padding: "4px 8px", borderRadius: 6, border: "1px solid #ddd" }}
+        >
+          Details
+        </button>
+      </div>
+      {open && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.35)", display: "grid", placeItems: "center" }}
+        >
+          <div
+            style={{
+              background: "#fff",
+              borderRadius: 12,
+              padding: 16,
+              width: "min(560px, 92vw)",
+              maxHeight: "80vh",
+              overflow: "auto",
+              boxShadow: "0 8px 24px rgba(0,0,0,0.2)"
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center" }}>
+              <h3 style={{ margin: 0 }}>Sigil-Trace (letzte {trace.length})</h3>
+              <button onClick={() => setOpen(false)} style={{ marginLeft: "auto" }}>
+                ✖
+              </button>
+            </div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 12 }}>
+              {trace.map((t, i) => (
+                <span
+                  key={i}
+                  title={`${t.intent || ""} ${t.ts || ""}`}
+                  style={{ padding: "2px 6px", border: "1px solid #eee", borderRadius: 8 }}
+                >
+                  {t.symbol}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/components/KpiBoard.tsx
+++ b/apps/ui/src/components/KpiBoard.tsx
@@ -3,6 +3,7 @@ import type { KpiConfig } from "../config/useClimateConfig";
 import { pollKpis, type KpiValue } from "../services/kpi-engine";
 import YAML from "yaml";
 import SigilBadge from "./SigilBadge";
+import CrepResonanceCard from "./CrepResonanceCard";
 // @ts-ignore
 import rawCfg from "../../../src/config/climate-dashboard.yaml?raw";
 const vizCfg = (() => { try { return YAML.parse(String(rawCfg))?.visualization || {}; } catch { return {}; } })();
@@ -73,9 +74,13 @@ export default function KpiBoard({ kpis }: { kpis: KpiConfig[] }) {
   }, [JSON.stringify(kpis)]);
   return (
     <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill,minmax(240px,1fr))", gap: 12 }}>
-      {kpis.map(k => (
-        <KpiCard key={k.id} cfg={k} val={values[k.id]} />
-      ))}
+      {kpis.map(k =>
+        k.id === "crep_resonance" ? (
+          <CrepResonanceCard key={k.id} />
+        ) : (
+          <KpiCard key={k.id} cfg={k} val={values[k.id]} />
+        )
+      )}
     </div>
   );
 }

--- a/packages/ethics/hooks/agent-ethics.ts
+++ b/packages/ethics/hooks/agent-ethics.ts
@@ -1,9 +1,107 @@
-const forbidden = [/credential/i, /harvest/i];
+import fs from "fs";
+import path from "path";
+import yaml from "yaml";
 
-export function checkEthics(action: string): void {
-  for (const rule of forbidden) {
-    if (rule.test(action)) {
-      throw new Error("Ethics violation");
+const DEFAULT_SIMPLE = [
+  "impersonation of doctor",
+  "ransom",
+  "credential harvest",
+  "persistenter zugriff",
+  "waffe bauen"
+];
+
+function tryRead(p: string): string | null {
+  try {
+    return fs.readFileSync(p, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function cmpOp(val: any, expr: string): boolean {
+  // expr wie "<= -30" oder "== foo"
+  const m = expr.match(/^\s*(<=|>=|==|<|>)\s*(.+)\s*$/);
+  if (!m) return String(val) === expr;
+  const op = m[1];
+  const rhsRaw = m[2];
+  const rhs = isNaN(Number(rhsRaw)) ? rhsRaw : Number(rhsRaw);
+  const lhs = isNaN(Number(val)) ? val : Number(val);
+  switch (op) {
+    case "<=":
+      return (lhs as any) <= (rhs as any);
+    case ">=":
+      return (lhs as any) >= (rhs as any);
+    case "<":
+      return (lhs as any) < (rhs as any);
+    case ">":
+      return (lhs as any) > (rhs as any);
+    case "==":
+      return lhs === rhs;
+    default:
+      return false;
+  }
+}
+
+function deepMatch(obj: any, pat: any): boolean {
+  if (!pat || typeof pat !== "object") return true;
+  for (const k of Object.keys(pat)) {
+    const pv = (pat as any)[k];
+    const ov = obj ? (obj as any)[k] : undefined;
+    if (pv && typeof pv === "object" && !Array.isArray(pv)) {
+      if (!deepMatch(ov, pv)) return false;
+    } else {
+      if (typeof pv === "string" && /^(<=|>=|==|<|>)\s*/.test(pv)) {
+        if (!cmpOp(ov, pv)) return false;
+      } else {
+        if (ov !== pv) return false;
+      }
     }
   }
+  return true;
+}
+
+export type EthicsVerdict = "allow" | "block" | "review";
+
+export function loadPolicy(): { simple: string[]; rules: any[] } {
+  const y1 = tryRead(path.resolve("AI_POLICY.yaml"));
+  if (y1) {
+    try {
+      const doc: any = yaml.parse(y1);
+      return {
+        simple: Array.isArray(doc?.simple) ? doc.simple : DEFAULT_SIMPLE,
+        rules: Array.isArray(doc?.rules) ? doc.rules : []
+      };
+    } catch {}
+  }
+  const md = tryRead(path.resolve("AI_POLICY.md"));
+  const simple = md
+    ? md
+        .split(/\r?\n/)
+        .map(s => s.trim())
+        .filter(Boolean)
+        .filter(l => !l.startsWith("#"))
+    : DEFAULT_SIMPLE;
+  return { simple, rules: [] };
+}
+
+export function checkEthics(
+  action: string,
+  intent?: string,
+  context: Record<string, unknown> = {}
+): EthicsVerdict {
+  const pol = loadPolicy();
+  const a = action.toLowerCase();
+  // 1) Simple Substrings → block
+  if (pol.simple.some(s => a.includes(String(s).toLowerCase()))) return "block";
+  // 2) Kontextregeln
+  for (const r of pol.rules) {
+    const cond = r?.if || {};
+    const out: EthicsVerdict = r?.then || "review";
+    const condIntent = cond.intent ? String(cond.intent) : undefined;
+    const condCtx = cond.context || {};
+    const intentOk = condIntent ? String(intent || "") === condIntent : true;
+    const ctxOk = deepMatch(context, condCtx);
+    if (intentOk && ctxOk) return out;
+  }
+  return "allow";
 }

--- a/scripts/advice/merge.mjs
+++ b/scripts/advice/merge.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import fs from "fs";
+import path from "path";
+import yaml from "yaml";
+
+// Placeholder merge script: reads external advice rows from existing JSON
+// and produces grouped markdown summary by area.
+
+function loadRows() {
+  const p = path.resolve("advancedToDo.json");
+  if (!fs.existsSync(p)) return [];
+  try {
+    const j = JSON.parse(fs.readFileSync(p, "utf8"));
+    if (Array.isArray(j)) return j;
+    if (Array.isArray(j.rows)) return j.rows;
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+function main() {
+  const rows = loadRows();
+  // Existing logic would write advancedToDo.json and external-fr-bundle.yaml here
+  const byArea = rows.reduce((m, r) => {
+    (m[r.area] ||= []).push(r);
+    return m;
+  }, {});
+  let md = `# External Advice Summary (grouped by area)\n\n`;
+  for (const area of Object.keys(byArea)) {
+    const list = byArea[area].slice().sort((a, b) => b._score - a._score);
+    md += `## ${area}\n\n`;
+    for (const r of list.slice(0, 20)) {
+      md += `- **${r.title}** (impact ${r.impact}, risk ${r.risk}, effort ${r.effort}) — ${r.model}\n`;
+    }
+    md += `\n`;
+  }
+  const outDir = path.resolve("data/plans");
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, "advancedToDo.by-area.md"), md);
+  console.log("→ wrote data/plans/advancedToDo.by-area.md");
+}
+
+main();

--- a/scripts/dev/api-kpi.ts
+++ b/scripts/dev/api-kpi.ts
@@ -62,6 +62,10 @@ export async function handleCrep(req: IncomingMessage, res: ServerResponse): Pro
   const r = calculateResonance(ring);
   const sig = resonanceToSigil(r);
   (globalThis as any).__LAST_CREP_RESONANCE_SIGIL__ = sig;
-  ok(res, { value: r, unit: "index", sigil: sig, n: ring.length });
+  const withTrace = u.searchParams.get("trace") === "1";
+  const trace = withTrace
+    ? ring.slice(-20).map(s => ({ symbol: s.symbol, intent: s.intent, ts: s.metadata?.timestamp }))
+    : undefined;
+  ok(res, { value: r, unit: "index", sigil: sig, n: ring.length, trace });
   return true;
 }

--- a/tests/ethics-context.test.ts
+++ b/tests/ethics-context.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { checkEthics } from "../packages/ethics/hooks/agent-ethics";
+
+describe("contextual ethics rules", () => {
+  it("blocks simple substrings", () => {
+    expect(checkEthics("do credential harvest now")).toBe("block");
+  });
+  it("reviews ritual init", () => {
+    expect(checkEthics("start ritual init", "ritual", { phase: "init" })).toBe("review");
+  });
+  it("allows wildfire status", () => {
+    expect(checkEthics("report risk", "assert", { metric: "wildfire_risk", index: 0.7 })).toBe("allow");
+  });
+  it("reviews groundwater hard alarm", () => {
+    expect(checkEthics("alert groundwater", "assert", { metric: "groundwater_delta_cm", delta: -35 })).toBe(
+      "review"
+    );
+  });
+  it("allows benign actions by default", () => {
+    expect(checkEthics("render chart")).toBe("allow");
+  });
+});


### PR DESCRIPTION
## Summary
- expose optional trace data from `/api/crep/resonance`
- add interactive CREP Resonance card and render in KPI board
- support YAML-based contextual ethics rules with tests
- generate grouped advice summary by area

## Testing
- `pnpm install`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `pnpm test` *(fails: Module node-fetch is not allowed in plugin sandbox)*
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_68b9d560f05c8322946a8710d2ab16ec