### PR TITLE
feat(ui): add time axis to CREP trace

### DIFF
--- a/apps/ui/src/components/CrepResonanceCard.tsx
+++ b/apps/ui/src/components/CrepResonanceCard.tsx
@@ -76,15 +76,15 @@ export default function CrepResonanceCard() {
                 ✖
               </button>
             </div>
-            <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 12 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, marginTop: 12 }}>
               {trace.map((t, i) => (
-                <span
-                  key={i}
-                  title={`${t.intent || ""} ${t.ts || ""}`}
-                  style={{ padding: "2px 6px", border: "1px solid #eee", borderRadius: 8 }}
-                >
-                  {t.symbol}
-                </span>
+                <div key={i} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <span style={{ width: 80, textAlign: "right", opacity: 0.6 }}>
+                    {t.ts ? new Date(t.ts).toLocaleTimeString().slice(0, 5) : `T-${trace.length - i}`}
+                  </span>
+                  <SigilBadge sigil={t.symbol} />
+                  <span style={{ fontSize: "0.8em", color: "#666" }}>{t.intent}</span>
+                </div>
               ))}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- show timestamped Sigil history in CREP resonance dialog

## Testing
- `pnpm install`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `pnpm test`
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_68b9ebc5344c83228fe4f039930610d8