### PR TITLE
feat: harden logging, locks, readiness, and bus

### DIFF
--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -7,3 +7,12 @@
 ## Env
 - `LOG_LEVEL=debug`
 - `REDIS_URL=redis://localhost:6379` (optional)
+
+## ALS & Logging
+- Steuerung: `LOG_CONTEXT=off` (deaktiviert), `LOG_CONTEXT_SAMPLE=0.25` (25% Sampling)
+## Readiness
+- `/readyz` prüft Redis, wenn `REDIS_URL` gesetzt ist.
+## Locks
+- Stale-Cleanup beim Start (älter als 5 Min).
+## Event Bus
+- `onSafe()` fängt Handler-Fehler ab → `packages/bus/dlq`.

--- a/packages/bus/index.ts
+++ b/packages/bus/index.ts
@@ -5,6 +5,14 @@ type Events = {
   "kpi.update": { id: string; value: number; ts: string };
 };
 export const bus = mitt<Events>();
+export const dlq: { type: string; data: any; err: string; ts: string }[] = [];
+export function onSafe<T extends keyof Events>(type: T, handler: (data: Events[T]) => void) {
+  bus.on(type, (data: any) => {
+    try { handler(data); } catch (e:any) {
+      dlq.push({ type: String(type), data, err: String(e?.message || e), ts: new Date().toISOString() });
+    }
+  });
+}
 export function bridgeRedis(sub: Redis, pub: Redis, channel = "um:bus") {
   sub.subscribe(channel, (err)=>{ if (err) console.error("redis sub error", err); });
   sub.on("message", (_ch, msg) => {

--- a/packages/lock/index.ts
+++ b/packages/lock/index.ts
@@ -3,6 +3,19 @@ import fsp from "fs/promises";
 import path from "path";
 import { randomUUID } from "crypto";
 import type { Redis } from "ioredis";
+
+export async function cleanupStaleLocks(maxAgeMs = 5*60*1000) {
+  const dir = path.resolve(".locks");
+  if (!fs.existsSync(dir)) return;
+  const now = Date.now();
+  for (const entry of fs.readdirSync(dir)) {
+    const kdir = path.join(dir, entry);
+    try {
+      const st = fs.statSync(kdir);
+      if (now - st.mtimeMs > maxAgeMs) await fsp.rm(kdir, { recursive: true, force: true });
+    } catch {}
+  }
+}
 export interface ILock {
   acquire(key: string, ttlMs?: number): Promise<string>;
   release(key: string, token: string): Promise<void>;

--- a/packages/logging/logger.ts
+++ b/packages/logging/logger.ts
@@ -6,3 +6,4 @@ export function logWithContext() {
   const c = getCtx();
   return logger.child({ reqId: c.requestId, agent: c.agent, user: c.user, ...c.extra });
 }
+export async function shutdownLogger(){ await new Promise<void>(res => (logger as any).flush ? (logger as any).flush(res) : res()); }

--- a/scripts/dev/api-health.ts
+++ b/scripts/dev/api-health.ts
@@ -1,12 +1,22 @@
 import type { IncomingMessage, ServerResponse } from "http";
 import fs from "fs";
 import { logWithContext } from "../../packages/logging/logger";
+import Redis from "ioredis";
+
 export async function handleHealth(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
   const u = new URL(req.url || "", "http://localhost");
   if (u.pathname !== "/healthz" && u.pathname !== "/readyz") return false;
   const log = logWithContext();
   const version = (fs.existsSync("package.json") ? JSON.parse(fs.readFileSync("package.json","utf8")).version : "0.0.0") || "0.0.0";
-  const data = { ok: true, service: "unified-mandala", version, ts: new Date().toISOString(), ready: true };
+  let ready = true; let redisOk: boolean | undefined;
+  const url = process.env.REDIS_URL;
+  if (url) {
+    try {
+      const r = new Redis(url, { lazyConnect: true, connectTimeout: 300 });
+      await r.connect(); await r.ping(); await r.quit(); redisOk = true;
+    } catch { redisOk = false; ready = false; }
+  }
+  const data = { ok: true, service: "unified-mandala", version, ts: new Date().toISOString(), ready, dependencies: { redis: redisOk } };
   res.setHeader("Content-Type","application/json; charset=utf-8"); res.end(JSON.stringify(data));
   log.info({ path: u.pathname }, "health");
   return true;

--- a/scripts/dev/static-lite.ts
+++ b/scripts/dev/static-lite.ts
@@ -5,6 +5,10 @@ import { handleOps } from "./api-ops";
 import { handleKpi, handleCrep } from "./api-kpi";
 import { requestLogger } from "../../src/middleware/request-logger";
 import { handleHealth } from "./api-health";
+import { cleanupStaleLocks } from "../../packages/lock";
+import { shutdownLogger } from "../../packages/logging/logger";
+
+cleanupStaleLocks().catch(()=>{});
 
 const distDir = path.resolve(__dirname, "../../apps/ui/dist");
 
@@ -32,3 +36,6 @@ const port = Number(process.env.PORT) || 3000;
 server.listen(port, () => {
   console.log(`Static lite server listening on http://localhost:${port}`);
 });
+
+const graceful = async () => { try { await shutdownLogger(); } catch {} process.exit(0); };
+process.on("SIGTERM", graceful); process.on("SIGINT", graceful);

--- a/src/middleware/request-logger.ts
+++ b/src/middleware/request-logger.ts
@@ -2,10 +2,15 @@ import { runWithCtx } from "../../packages/logging/context";
 import { logWithContext } from "../../packages/logging/logger";
 import { randomUUID } from "crypto";
 import type { IncomingMessage, ServerResponse } from "http";
+
+const SAMPLE = Math.min(1, Math.max(0, Number(process.env.LOG_CONTEXT_SAMPLE ?? "1")));
+const DISABLED = String(process.env.LOG_CONTEXT ?? "").toLowerCase() === "off";
+
 export function requestLogger(req: IncomingMessage, res: ServerResponse, next: () => void) {
   const reqId = (req.headers["x-request-id"] as string) || randomUUID();
   const start = Date.now();
-  runWithCtx({ requestId: reqId }, () => {
+  const run = (fn: () => void) => DISABLED || Math.random() > SAMPLE ? fn() : runWithCtx({ requestId: reqId }, fn);
+  run(() => {
     const log = logWithContext();
     log.info({ method: req.method, url: req.url }, "req:start");
     const done = () => {


### PR DESCRIPTION
## Summary
- add sampling and disable env controls to request logger
- clean up stale file locks and flush logger on shutdown
- check Redis in /readyz, add dev server signal hooks and bus dead-letter queue

## Testing
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm test` *(fails: Module node-fetch is not allowed in plugin sandbox; many missing test globals)*
- `pnpm dev` *(manually tested /healthz and /readyz)*
- `pnpm advice:validate data/external-advice/2025-09-04-logging-locks.jsonl` *(fails: Command "advice:validate" not found)*
- `pnpm advice:merge data/external-advice/2025-09-04-logging-locks.jsonl` *(fails: Command "advice:merge" not found)*
- `poetry install --with test` *(incomplete: repeated nvidia file install messages; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bad555f7c08322b414f8762016f368