### PR TITLE
Refactor CREP resonance and document repository flows

### DIFF
--- a/packages/crep/resonance.ts
+++ b/packages/crep/resonance.ts
@@ -8,9 +8,12 @@ export function calculateResonance(sigils: SigilMessage[]): number {
   const n = intents.length;
   const k = counts.size;
   if (k <= 1) return 1;
-  const entropy = Array.from(counts.values()).reduce((sum, c) => sum - (c / n) * Math.log2(c / n), 0);
+  const entropy = Array.from(counts.values()).reduce(
+    (sum, c) => sum - (c / n) * Math.log2(c / n),
+    0
+  );
   const res = 1 - entropy / Math.log2(k);
-  return Math.max(0, Math.min(1, res));
+  return isFinite(res) ? Math.max(0, Math.min(1, res)) : 0;
 }
 
 export function resonanceToSigil(r: number): SigilMessage {


### PR DESCRIPTION
## Summary
- refine CREP kernel resonance metric with entropy guardrails and normalized output
- codify sigil grammar, repository map layers, program flows, pre-start rituals, and codex task mapping
- add vitest for CREP resonance behavior

## Testing
- `pnpm install`
- `npx pyright`
- `npx tsc -p tsconfig.json --diagnostics`
- `pnpm maps:all` *(fails: Could not find Chrome)*
- `pnpm maps:validate`
- `pnpm test` *(fails: multiple failing tests)
- `pnpm test tests/crep.resonance.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68baec36529c83229a9b1ff89e3a4328