### PR TITLE
feat: add event bus schema and personhood gate

### DIFF
--- a/fixtures/events/example_bad_gate.json
+++ b/fixtures/events/example_bad_gate.json
@@ -1,0 +1,12 @@
+{
+  "topic": "governance.override",
+  "payload": { "action": "test" },
+  "crep_resonance": 0.4,
+  "sigil": "🚫",
+  "governance": {
+    "level": "P1",
+    "compliant": false,
+    "ethics_approval": false,
+    "notes": "bad"
+  }
+}

--- a/fixtures/events/example_ok.json
+++ b/fixtures/events/example_ok.json
@@ -1,0 +1,12 @@
+{
+  "topic": "research.update",
+  "payload": { "value": 1 },
+  "crep_resonance": 0.8,
+  "sigil": "✨",
+  "governance": {
+    "level": "P1",
+    "compliant": true,
+    "ethics_approval": true,
+    "notes": "ok"
+  }
+}

--- a/packages/mandala-sdk/ts/index.ts
+++ b/packages/mandala-sdk/ts/index.ts
@@ -1,0 +1,53 @@
+import Ajv from 'ajv';
+import schema from '../../../schemas/eventbus.message.schema.json';
+import personhoodPolicies from '../../../policies/personhood-levels.json';
+import { EventMessage, PersonhoodLevel } from './types';
+
+const ajv = new Ajv();
+const validate = ajv.compile<EventMessage>(schema);
+
+type Handler<T = any> = (payload: T) => void;
+const handlers: Record<string, Handler[]> = {};
+
+const LEVELS: PersonhoodLevel[] = ['P0', 'P1', 'P2', 'P3'];
+
+function levelAllowed(provided: PersonhoodLevel, required: PersonhoodLevel) {
+  return LEVELS.indexOf(provided) >= LEVELS.indexOf(required);
+}
+
+export function on(topic: string, handler: Handler) {
+  handlers[topic] = handlers[topic] || [];
+  handlers[topic].push(handler);
+}
+
+interface EmitOptions {
+  personhood?: PersonhoodLevel;
+  crep_resonance?: number;
+  sigil?: string;
+  governance?: EventMessage['governance'];
+}
+
+export function emit<T>(topic: string, payload: T, options: EmitOptions = {}) {
+  const message: EventMessage<T> = {
+    topic,
+    payload,
+    crep_resonance: options.crep_resonance,
+    sigil: options.sigil,
+    governance: options.governance,
+  };
+
+  if (!validate(message)) {
+    throw new Error('schema validation failed: ' + ajv.errorsText(validate.errors));
+  }
+
+  const required = (personhoodPolicies as Record<string, PersonhoodLevel>)[topic] || 'P0';
+  const provided = options.personhood || 'P0';
+  if (!levelAllowed(provided, required)) {
+    throw new Error(`personhood level ${provided} insufficient for topic ${topic}`);
+  }
+
+  (handlers[topic] || []).forEach((h) => h(payload));
+  return message;
+}
+
+export type { EventMessage, GovernanceInfo, PersonhoodLevel } from './types';

--- a/packages/mandala-sdk/ts/types.ts
+++ b/packages/mandala-sdk/ts/types.ts
@@ -1,0 +1,16 @@
+export type PersonhoodLevel = 'P0' | 'P1' | 'P2' | 'P3';
+
+export interface GovernanceInfo {
+  level: PersonhoodLevel;
+  compliant: boolean;
+  ethics_approval: boolean;
+  notes?: string;
+}
+
+export interface EventMessage<T = any> {
+  topic: string;
+  payload: T;
+  crep_resonance?: number;
+  sigil?: string;
+  governance?: GovernanceInfo;
+}

--- a/policies/personhood-levels.json
+++ b/policies/personhood-levels.json
@@ -1,0 +1,3 @@
+{
+  "governance.override": "P3"
+}

--- a/schemas/eventbus.message.schema.json
+++ b/schemas/eventbus.message.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "EventBusMessage",
+  "type": "object",
+  "properties": {
+    "topic": { "type": "string" },
+    "payload": {},
+    "crep_resonance": { "type": "number", "minimum": 0, "maximum": 1 },
+    "sigil": { "type": "string" },
+    "governance": {
+      "type": "object",
+      "properties": {
+        "level": { "type": "string", "enum": ["P0", "P1", "P2", "P3"] },
+        "compliant": { "type": "boolean" },
+        "ethics_approval": { "type": "boolean" },
+        "notes": { "type": "string" }
+      },
+      "required": ["level", "compliant", "ethics_approval"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["topic", "payload"],
+  "additionalProperties": false
+}

--- a/tests/gate_smoke.ts
+++ b/tests/gate_smoke.ts
@@ -1,0 +1,26 @@
+import assert from 'assert';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { emit } from '../packages/mandala-sdk/ts/index';
+
+const base = path.resolve(__dirname, '..');
+
+const ok = JSON.parse(readFileSync(path.join(base, 'fixtures/events/example_ok.json'), 'utf8'));
+emit(ok.topic, ok.payload, {
+  personhood: ok.governance.level,
+  crep_resonance: ok.crep_resonance,
+  sigil: ok.sigil,
+  governance: ok.governance,
+});
+
+const bad = JSON.parse(readFileSync(path.join(base, 'fixtures/events/example_bad_gate.json'), 'utf8'));
+assert.throws(() => {
+  emit(bad.topic, bad.payload, {
+    personhood: bad.governance.level,
+    crep_resonance: bad.crep_resonance,
+    sigil: bad.sigil,
+    governance: bad.governance,
+  });
+});
+
+console.log('gate_smoke passed');


### PR DESCRIPTION
## Summary
- add JSON schema for event bus messages with governance metadata
- implement TypeScript SDK with schema validation and personhood gate
- include example fixtures and smoke test

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `npx ts-node tests/gate_smoke.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bdb67981c08322b2fa8c2b6e148cbf