### PR TITLE
feat: NATS transport with tracing and policy checks

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -1,0 +1,13 @@
+name: Governance & Schema
+on: [pull_request, push]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm i ajv
+      - run: node tools/schema-validate.mjs
+      - run: node tools/governance-check.mjs

--- a/config/bus.yaml
+++ b/config/bus.yaml
@@ -1,0 +1,4 @@
+server: "nats://127.0.0.1:4222"
+subject_prefix: "mandala"
+queue_group: "mandala-workers"
+durable: "mandala-durable"

--- a/fixtures/events/example_bad_gate.json
+++ b/fixtures/events/example_bad_gate.json
@@ -1,12 +1,8 @@
 {
-  "topic": "governance.override",
-  "payload": { "action": "test" },
-  "crep_resonance": 0.4,
-  "sigil": "🚫",
-  "governance": {
-    "level": "P1",
-    "compliant": false,
-    "ethics_approval": false,
-    "notes": "bad"
-  }
+  "id":"00000000-0000-4000-8000-000000000000",
+  "topic":"governance.override",
+  "actor":{"id":"fixture","role":"test"},
+  "ts":"2025-01-01T00:00:00Z",
+  "personhood":"P1",
+  "payload":{"op":"force"}
 }

--- a/fixtures/events/example_ok.json
+++ b/fixtures/events/example_ok.json
@@ -1,12 +1,8 @@
 {
-  "topic": "research.update",
-  "payload": { "value": 1 },
-  "crep_resonance": 0.8,
-  "sigil": "✨",
-  "governance": {
-    "level": "P1",
-    "compliant": true,
-    "ethics_approval": true,
-    "notes": "ok"
-  }
+  "id":"00000000-0000-4000-8000-000000000000",
+  "topic":"data.ingest",
+  "actor":{"id":"fixture","role":"test"},
+  "ts":"2025-01-01T00:00:00Z",
+  "personhood":"P1",
+  "payload":{"sha256":"abc"}
 }

--- a/infrastructure/nats/docker-compose.yml
+++ b/infrastructure/nats/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  nats:
+    image: nats:2.10
+    command: ["-js"]
+    ports:
+      - "4222:4222"
+      - "8222:8222"

--- a/package.json
+++ b/package.json
@@ -113,7 +113,12 @@
     "ws": "^8.17.0",
     "yaml": "^2.8.0",
     "ioredis": "^5.4.1",
-    "@um/health": "workspace:*"
+    "@um/health": "workspace:*",
+    "@opentelemetry/sdk-trace-node": "^1.30.1",
+    "@opentelemetry/sdk-trace-base": "^1.30.1",
+    "@opentelemetry/resources": "^1.30.1",
+    "@opentelemetry/semantic-conventions": "^1.37.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.49.1"
   },
   "devDependencies": {
     "@cypress/react": "^9.0.1",

--- a/packages/mandala-sdk/ts/index.ts
+++ b/packages/mandala-sdk/ts/index.ts
@@ -1,53 +1,66 @@
-import Ajv from 'ajv';
-import schema from '../../../schemas/eventbus.message.schema.json';
-import personhoodPolicies from '../../../policies/personhood-levels.json';
-import { EventMessage, PersonhoodLevel } from './types';
+import fs from "fs";
+import path from "path";
+import Ajv from "ajv";
+import { MandalaEvent } from "./types.js";
 
-const ajv = new Ajv();
-const validate = ajv.compile<EventMessage>(schema);
+const ajv = new Ajv({allErrors:true, strict:false});
+const schemaPath = path.join(process.cwd(), "schemas", "eventbus.message.schema.json");
+const schema = JSON.parse(fs.readFileSync(schemaPath,"utf-8"));
+const validate = ajv.compile(schema as any);
 
-type Handler<T = any> = (payload: T) => void;
-const handlers: Record<string, Handler[]> = {};
-
-const LEVELS: PersonhoodLevel[] = ['P0', 'P1', 'P2', 'P3'];
-
-function levelAllowed(provided: PersonhoodLevel, required: PersonhoodLevel) {
-  return LEVELS.indexOf(provided) >= LEVELS.indexOf(required);
+function uuid() {
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, c => {
+    const r = Math.random()*16|0, v = c=="x" ? r : (r&0x3|0x8);
+    return v.toString(16);
+  });
 }
 
-export function on(topic: string, handler: Handler) {
-  handlers[topic] = handlers[topic] || [];
-  handlers[topic].push(handler);
+function loadGate() {
+  const p = path.join(process.cwd(), "policies", "personhood-levels.json");
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf-8"));
+  } catch {
+    return {gates:[]};
+  }
 }
 
-interface EmitOptions {
-  personhood?: PersonhoodLevel;
-  crep_resonance?: number;
-  sigil?: string;
-  governance?: EventMessage['governance'];
+function checkGate(topic: string, personhood?: string) {
+  const policy = loadGate();
+  const gate = (policy.gates||[]).find((g:any)=> {
+    if (g.topic.endsWith(".*")) {
+      const prefix = g.topic.slice(0,-2);
+      return topic.startsWith(prefix);
+    }
+    return g.topic === topic;
+  });
+  if (!gate) return;
+  const levels = ["P0","P1","P2","P3"];
+  const have = levels.indexOf((personhood||"P0") as string);
+  const need = levels.indexOf(gate.min_level);
+  if (have < need) throw new Error(`Personhood gate: topic '${topic}' requires >= ${gate.min_level}, have ${personhood||"P0"}`);
 }
 
-export function emit<T>(topic: string, payload: T, options: EmitOptions = {}) {
-  const message: EventMessage<T> = {
+const handlers = new Map<string, Array<(e: MandalaEvent)=>void>>();
+
+export async function emit<T=any>(topic: string, payload: T, opts?: {personhood?: string, actor?: {id:string, role:string}}): Promise<MandalaEvent<T>> {
+  checkGate(topic, opts?.personhood);
+  const evt: MandalaEvent<T> = {
+    id: uuid(),
     topic,
-    payload,
-    crep_resonance: options.crep_resonance,
-    sigil: options.sigil,
-    governance: options.governance,
+    actor: opts?.actor || { id: "system", role: "agent" },
+    ts: new Date().toISOString(),
+    personhood: (opts?.personhood as any),
+    payload
   };
-
-  if (!validate(message)) {
-    throw new Error('schema validation failed: ' + ajv.errorsText(validate.errors));
+  const ok = validate(evt);
+  if (!ok) {
+    throw new Error("Event schema invalid: " + JSON.stringify((validate as any).errors, null, 2));
   }
-
-  const required = (personhoodPolicies as Record<string, PersonhoodLevel>)[topic] || 'P0';
-  const provided = options.personhood || 'P0';
-  if (!levelAllowed(provided, required)) {
-    throw new Error(`personhood level ${provided} insufficient for topic ${topic}`);
-  }
-
-  (handlers[topic] || []).forEach((h) => h(payload));
-  return message;
+  (handlers.get(topic)||[]).forEach(fn => fn(evt));
+  return evt;
 }
 
-export type { EventMessage, GovernanceInfo, PersonhoodLevel } from './types';
+export function on<T=any>(topic: string, fn: (e: MandalaEvent<T>)=>void) {
+  const list = handlers.get(topic) || [];
+  list.push(fn as any); handlers.set(topic, list);
+}

--- a/packages/mandala-sdk/ts/memory-bus.ts
+++ b/packages/mandala-sdk/ts/memory-bus.ts
@@ -1,0 +1,31 @@
+import { BusTransport, EmitOptions } from "./transport.js";
+import { validateEvent, checkPersonhood } from "./util.ts";
+
+function uuid() {
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, c => {
+    const r = Math.random()*16|0, v = c=="x" ? r : (r&0x3|0x8);
+    return v.toString(16);
+  });
+}
+
+const handlers = new Map<string, Array<(e:any)=>void>>();
+
+export class MemoryBus implements BusTransport {
+  async emit(topic: string, payload: any, options?: EmitOptions): Promise<void> {
+    checkPersonhood(topic, options?.personhood);
+    const evt = {
+      id: uuid(),
+      topic,
+      actor: options?.actor || { id: "system", role: "agent" },
+      ts: new Date().toISOString(),
+      personhood: options?.personhood,
+      payload
+    };
+    validateEvent(evt);
+    (handlers.get(topic)||[]).forEach(fn => fn(evt));
+  }
+  on(topic: string, handler: (evt: any)=>void): void {
+    const list = handlers.get(topic) || [];
+    list.push(handler); handlers.set(topic, list);
+  }
+}

--- a/packages/mandala-sdk/ts/nats-bus.ts
+++ b/packages/mandala-sdk/ts/nats-bus.ts
@@ -1,0 +1,57 @@
+import { BusTransport, EmitOptions } from "./transport.js";
+import { validateEvent, checkPersonhood } from "./util.ts";
+import { connect, StringCodec, NatsConnection } from "nats";
+
+function uuid() {
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, c => {
+    const r = Math.random()*16|0, v = c=="x" ? r : (r&0x3|0x8);
+    return v.toString(16);
+  });
+}
+
+export class NatsBus implements BusTransport {
+  private nc!: NatsConnection;
+  private sc = StringCodec();
+  private prefix: string;
+
+  constructor(prefix = "mandala") {
+    this.prefix = prefix;
+  }
+
+  async connect(url = process.env.NATS_SERVER_URL || "nats://127.0.0.1:4222") {
+    if (!this.nc) this.nc = await connect({ servers: url });
+  }
+
+  private subj(topic: string) { return `${this.prefix}.${topic}`; }
+
+  async emit(topic: string, payload: any, options?: EmitOptions): Promise<void> {
+    await this.connect();
+    checkPersonhood(topic, options?.personhood);
+    const evt = {
+      id: uuid(),
+      topic,
+      actor: options?.actor || { id: "system", role: "agent" },
+      ts: new Date().toISOString(),
+      personhood: options?.personhood,
+      payload
+    };
+    validateEvent(evt);
+    await this.nc.publish(this.subj(topic), this.sc.encode(JSON.stringify(evt)));
+  }
+
+  on(topic: string, handler: (evt: any)=>void): void {
+    this.connect().then(()=>{
+      const sub = this.nc.subscribe(this.subj(topic));
+      (async () => {
+        for await (const m of sub) {
+          try {
+            const evt = JSON.parse(this.sc.decode(m.data));
+            handler(evt);
+          } catch(e) {
+            // ignore bad payloads
+          }
+        }
+      })();
+    });
+  }
+}

--- a/packages/mandala-sdk/ts/tracing.ts
+++ b/packages/mandala-sdk/ts/tracing.ts
@@ -1,0 +1,24 @@
+import { diag, DiagConsoleLogger, DiagLogLevel } from "@opentelemetry/api";
+import { Resource } from "@opentelemetry/resources";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { SimpleSpanProcessor, BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+
+diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ERROR);
+
+const provider = new NodeTracerProvider({
+  resource: new Resource({
+    [SemanticResourceAttributes.SERVICE_NAME]: "mandala-bus",
+  }),
+});
+
+const endpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+if (endpoint) {
+  provider.addSpanProcessor(new BatchSpanProcessor(new OTLPTraceExporter({ url: `${endpoint}/v1/traces` })));
+} else {
+  class ConsoleExporter { export(spans:any, result:any){ console.log("otel spans:", spans.length); result.success(); } shutdown(){} }
+  provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleExporter() as any));
+}
+provider.register();
+export { provider };

--- a/packages/mandala-sdk/ts/transport.ts
+++ b/packages/mandala-sdk/ts/transport.ts
@@ -1,0 +1,9 @@
+export interface EmitOptions {
+  personhood?: "P0"|"P1"|"P2"|"P3";
+  actor?: { id: string; role: string };
+}
+
+export interface BusTransport {
+  emit(topic: string, payload: any, options?: EmitOptions): Promise<void>;
+  on(topic: string, handler: (evt: any)=>void): void;
+}

--- a/packages/mandala-sdk/ts/types.ts
+++ b/packages/mandala-sdk/ts/types.ts
@@ -1,16 +1,25 @@
-export type PersonhoodLevel = 'P0' | 'P1' | 'P2' | 'P3';
+export type Personhood = "P0"|"P1"|"P2"|"P3";
 
-export interface GovernanceInfo {
-  level: PersonhoodLevel;
-  compliant: boolean;
-  ethics_approval: boolean;
+export interface Governance {
+  level?: Personhood;
+  compliant?: boolean;
+  ethics_approval?: boolean;
   notes?: string;
 }
 
-export interface EventMessage<T = any> {
+export interface ActorRef {
+  id: string;
+  role: string;
+}
+
+export interface MandalaEvent<T=any> {
+  id: string;
   topic: string;
-  payload: T;
-  crep_resonance?: number;
+  actor: ActorRef;
+  ts: string;
+  personhood?: Personhood;
+  governance?: Governance;
   sigil?: string;
-  governance?: GovernanceInfo;
+  crep_resonance?: number;
+  payload: T;
 }

--- a/packages/mandala-sdk/ts/util.ts
+++ b/packages/mandala-sdk/ts/util.ts
@@ -1,0 +1,43 @@
+import fs from "fs";
+import path from "path";
+import Ajv from "ajv";
+import yaml from "js-yaml";
+
+const ajv = new Ajv({allErrors:true, strict:false});
+
+export function loadSchema() {
+  const p = path.join(process.cwd(), "schemas", "eventbus.message.schema.json");
+  return JSON.parse(fs.readFileSync(p, "utf-8"));
+}
+
+export function validateEvent(evt: any) {
+  const schema = loadSchema();
+  const validate = ajv.compile(schema as any);
+  const ok = validate(evt);
+  if (!ok) throw new Error("Event schema invalid: " + JSON.stringify((validate as any).errors, null, 2));
+}
+
+export function loadPolicies() {
+  const y = path.join(process.cwd(), "policies", "personhood-levels.yaml");
+  const j = path.join(process.cwd(), "policies", "personhood-levels.json");
+  if (fs.existsSync(y)) return yaml.load(fs.readFileSync(y, "utf-8")) as any;
+  if (fs.existsSync(j)) return JSON.parse(fs.readFileSync(j, "utf-8"));
+  return { gates: [] };
+}
+
+export function checkPersonhood(topic: string, personhood?: string) {
+  const policy = loadPolicies();
+  const gates = policy.gates || [];
+  const gate = gates.find((g:any)=> {
+    if (g.topic?.endsWith(".*")) {
+      const prefix = g.topic.slice(0,-2);
+      return topic.startsWith(prefix);
+    }
+    return g.topic === topic;
+  });
+  if (!gate) return;
+  const levels = ["P0","P1","P2","P3"];
+  const have = levels.indexOf((personhood||"P0"));
+  const need = levels.indexOf(gate.min_level);
+  if (have < need) throw new Error(`Personhood gate: '${topic}' requires >= ${gate.min_level}, have ${personhood||"P0"}`);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,24 @@ importers:
       '@opentelemetry/auto-instrumentations-node':
         specifier: ^0.46.0
         version: 0.46.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.49.1
+        version: 0.49.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources':
+        specifier: ^1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-node':
         specifier: ^0.46.0
         version: 0.46.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.37.0
+        version: 1.37.0
       '@react-three/fiber':
         specifier: ^9.1.4
         version: 9.1.4(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.161.0)
@@ -1370,6 +1385,10 @@ packages:
     resolution: {integrity: sha512-+9BcqfiEDGPXEIo+o3tso/aqGM5dGbGwAkGVp3FPpZ8GlkK1YlaKRd9gMVyPaeRATwvO5wYGGnCsAc/sMMM9Qw==}
     engines: {node: '>=14'}
 
+  '@opentelemetry/api-logs@0.49.1':
+    resolution: {integrity: sha512-kaNl/T7WzyMUQHQlVq7q0oV4Kev6+0xFwqzofryC66jgGMacd0QH5TwfpbUwSTby+SdAdprAe5UKMvBw4tKS5Q==}
+    engines: {node: '>=14'}
+
   '@opentelemetry/api-logs@0.51.1':
     resolution: {integrity: sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==}
     engines: {node: '>=14'}
@@ -1396,11 +1415,23 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.9.0'
 
+  '@opentelemetry/context-async-hooks@1.30.1':
+    resolution: {integrity: sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/core@1.19.0':
     resolution: {integrity: sha512-w42AukJh3TP8R0IZZOVJVM/kMWu8g+lm4LzT70WtuKqhwq7KVhcDzZZuZinWZa6TtQCl7Smt2wolEYzpHabOgw==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.8.0'
+
+  '@opentelemetry/core@1.22.0':
+    resolution: {integrity: sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
 
   '@opentelemetry/core@1.24.1':
     resolution: {integrity: sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==}
@@ -1428,6 +1459,12 @@ packages:
 
   '@opentelemetry/exporter-trace-otlp-http@0.46.0':
     resolution: {integrity: sha512-vZ2pYOB+qrQ+jnKPY6Gnd58y1k/Ti//Ny6/XsSX7/jED0X77crtSVgC6N5UA0JiGJOh6QB2KE9gaH99010XHzg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.49.1':
+    resolution: {integrity: sha512-KOLtZfZvIrpGZLVvblKsiVQT7gQUZNKcUUH24Zz6Xbi7LJb9Vt6xtUZFYdR5IIjvt47PIqBKDWUQlU0o1wAsRw==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
@@ -1708,6 +1745,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
 
+  '@opentelemetry/otlp-exporter-base@0.49.1':
+    resolution: {integrity: sha512-z6sHliPqDgJU45kQatAettY9/eVF58qVPaTuejw9YWfSRqid9pXPYeegDCSdyS47KAUgAtm+nC28K3pfF27HWg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
   '@opentelemetry/otlp-exporter-base@0.51.1':
     resolution: {integrity: sha512-UYlnOYyDdzo1Gw559EHCzru0RwhvuXCwoH8jGo9J4gO1TE58GjnEmIjomMsKBCym3qWNJfIQXw+9SZCV0DdQNg==}
     engines: {node: '>=14'}
@@ -1744,6 +1787,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.8.0'
 
+  '@opentelemetry/otlp-transformer@0.49.1':
+    resolution: {integrity: sha512-Z+koA4wp9L9e3jkFacyXTGphSWTbOKjwwXMpb0CxNb0kjTHGUxhYRN8GnkLFsFo5NbZPjP07hwAqeEG/uCratQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.9.0'
+
   '@opentelemetry/otlp-transformer@0.51.1':
     resolution: {integrity: sha512-OppYOXwV9LQqqtYUCywqoOqX/JT9LQ5/FMuPZ//eTkvuHdUC4ZMwz2c6uSoT2R90GWvvGnF1iEqTGyTT3xAt2Q==}
     engines: {node: '>=14'}
@@ -1774,6 +1823,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.9.0'
 
+  '@opentelemetry/propagator-b3@1.30.1':
+    resolution: {integrity: sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/propagator-jaeger@1.19.0':
     resolution: {integrity: sha512-dedkOoTzKg+nYoLWCMp0Im+wo+XkTRW6aXhi8VQRtMW/9SNJGOllCJSu8llToLxMDF0+6zu7OCrKkevAof2tew==}
     engines: {node: '>=14'}
@@ -1785,6 +1840,12 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.9.0'
+
+  '@opentelemetry/propagator-jaeger@1.30.1':
+    resolution: {integrity: sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
   '@opentelemetry/redis-common@0.36.2':
     resolution: {integrity: sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==}
@@ -1826,6 +1887,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.8.0'
 
+  '@opentelemetry/resources@1.22.0':
+    resolution: {integrity: sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+
   '@opentelemetry/resources@1.24.1':
     resolution: {integrity: sha512-cyv0MwAaPF7O86x5hk3NNgenMObeejZFLJJDVuSeSMIsknlsj3oOZzRv3qSzlwYomXsICfBeFFlxwHQte5mGXQ==}
     engines: {node: '>=14'}
@@ -1845,6 +1912,13 @@ packages:
       '@opentelemetry/api': '>=1.4.0 <1.8.0'
       '@opentelemetry/api-logs': '>=0.39.1'
 
+  '@opentelemetry/sdk-logs@0.49.1':
+    resolution: {integrity: sha512-gCzYWsJE0h+3cuh3/cK+9UwlVFyHvj3PReIOCDOmdeXOp90ZjKRoDOJBc3mvk1LL6wyl1RWIivR8Rg9OToyesw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.9.0'
+      '@opentelemetry/api-logs': '>=0.39.1'
+
   '@opentelemetry/sdk-logs@0.51.1':
     resolution: {integrity: sha512-ULQQtl82b673PpZc5/0EtH4V+BrwVOgKJZEB7tYZnGTG3I98tQVk89S9/JSixomDr++F4ih+LSJTCqIKBz+MQQ==}
     engines: {node: '>=14'}
@@ -1857,6 +1931,12 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.8.0'
+
+  '@opentelemetry/sdk-metrics@1.22.0':
+    resolution: {integrity: sha512-k6iIx6H3TZ+BVMr2z8M16ri2OxWaljg5h8ihGJxi/KQWcjign6FEaEzuigXt5bK9wVEhqAcWLCfarSftaNWkkg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.9.0'
 
   '@opentelemetry/sdk-metrics@1.24.1':
     resolution: {integrity: sha512-FrAqCbbGao9iKI+Mgh+OsC9+U2YMoXnlDHe06yH7dvavCKzE3S892dGtX54+WhSFVxHR/TMRVJiK/CV93GR0TQ==}
@@ -1888,11 +1968,23 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.8.0'
 
+  '@opentelemetry/sdk-trace-base@1.22.0':
+    resolution: {integrity: sha512-pfTuSIpCKONC6vkTpv6VmACxD+P1woZf4q0K46nSUvXFvOFqjBYKFaAMkKD3M1mlKUUh0Oajwj35qNjMl80m1Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+
   '@opentelemetry/sdk-trace-base@1.24.1':
     resolution: {integrity: sha512-zz+N423IcySgjihl2NfjBf0qw1RWe11XIAWVrTNOSSI6dtSPJiVom2zipFB2AEEtJWpv0Iz6DY6+TjnyTV5pWg==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.9.0'
+
+  '@opentelemetry/sdk-trace-base@1.30.1':
+    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
   '@opentelemetry/sdk-trace-node@1.19.0':
     resolution: {integrity: sha512-TCiEq/cUjM15RFqBRwWomTVbOqzndWL4ILa7ZCu0zbjU1/XY6AgHkgrgAc7vGP6TjRqH4Xryuglol8tcIfbBUQ==}
@@ -1906,8 +1998,18 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.9.0'
 
+  '@opentelemetry/sdk-trace-node@1.30.1':
+    resolution: {integrity: sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/semantic-conventions@1.19.0':
     resolution: {integrity: sha512-14jRpC8f5c0gPSwoZ7SbEJni1PqI+AhAE8m1bMz6v+RPM4OlP1PT2UHBJj5Qh/ALLPjhVU/aZUK3YyjTUqqQVg==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.22.0':
+    resolution: {integrity: sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw==}
     engines: {node: '>=14'}
 
   '@opentelemetry/semantic-conventions@1.24.1':
@@ -1918,8 +2020,8 @@ packages:
     resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
     engines: {node: '>=14'}
 
-  '@opentelemetry/semantic-conventions@1.34.0':
-    resolution: {integrity: sha512-aKcOkyrorBGlajjRdVoJWHTxfxO1vCNHLJVlSDaRHDIdjU+pX8IYQPvPDkYiujKLbRnWU+1TBwEt0QRgSm4SGA==}
+  '@opentelemetry/semantic-conventions@1.37.0':
+    resolution: {integrity: sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==}
     engines: {node: '>=14'}
 
   '@opentelemetry/sql-common@0.40.1':
@@ -7664,6 +7766,10 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
 
+  '@opentelemetry/api-logs@0.49.1':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/api-logs@0.51.1':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -7731,10 +7837,19 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
 
+  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/core@1.19.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.19.0
+
+  '@opentelemetry/core@1.22.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.22.0
 
   '@opentelemetry/core@1.24.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -7774,6 +7889,15 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.46.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.19.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.19.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.49.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.49.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.49.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/exporter-trace-otlp-http@0.51.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -7825,7 +7949,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7835,7 +7959,7 @@ snapshots:
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/propagator-aws-xray': 1.26.2(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
       '@types/aws-lambda': 8.10.122
     transitivePeerDependencies:
       - supports-color
@@ -7846,7 +7970,7 @@ snapshots:
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/propagation-utils': 0.30.16(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7863,7 +7987,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7872,7 +7996,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
       '@types/connect': 3.4.36
     transitivePeerDependencies:
       - supports-color
@@ -7881,7 +8005,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7896,7 +8020,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
       semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
@@ -7906,7 +8030,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7915,7 +8039,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7931,7 +8055,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7955,7 +8079,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7974,7 +8098,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/redis-common': 0.36.2
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7982,7 +8106,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7991,7 +8115,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
       '@types/koa': 2.14.0
       '@types/koa__router': 12.0.3
     transitivePeerDependencies:
@@ -8008,7 +8132,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
       '@types/memcached': 2.2.10
     transitivePeerDependencies:
       - supports-color
@@ -8018,7 +8142,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8027,7 +8151,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8035,7 +8159,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
       '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - supports-color
@@ -8044,7 +8168,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
       '@types/mysql': 2.15.22
     transitivePeerDependencies:
       - supports-color
@@ -8053,7 +8177,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8061,7 +8185,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8069,7 +8193,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
       '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.0)
       '@types/pg': 8.6.1
       '@types/pg-pool': 2.0.4
@@ -8088,7 +8212,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/redis-common': 0.36.2
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8097,7 +8221,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/redis-common': 0.36.2
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8106,7 +8230,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8114,7 +8238,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8122,7 +8246,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8130,7 +8254,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
       '@types/tedious': 4.0.14
     transitivePeerDependencies:
       - supports-color
@@ -8179,6 +8303,11 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.19.0(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/otlp-exporter-base@0.49.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/otlp-exporter-base@0.51.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -8224,6 +8353,16 @@ snapshots:
       '@opentelemetry/sdk-metrics': 1.19.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.19.0(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/otlp-transformer@0.49.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.49.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 1.22.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/otlp-transformer@0.51.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -8252,6 +8391,11 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.24.1(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/propagator-b3@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/propagator-jaeger@1.19.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -8262,40 +8406,45 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.24.1(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/propagator-jaeger@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/redis-common@0.36.2': {}
 
   '@opentelemetry/resource-detector-alibaba-cloud@0.28.10(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
 
   '@opentelemetry/resource-detector-aws@1.12.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
 
   '@opentelemetry/resource-detector-azure@0.2.12(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
 
   '@opentelemetry/resource-detector-container@0.3.11(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
 
   '@opentelemetry/resource-detector-gcp@0.29.13(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.34.0
+      '@opentelemetry/semantic-conventions': 1.37.0
       gcp-metadata: 6.1.1
     transitivePeerDependencies:
       - encoding
@@ -8306,6 +8455,12 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.19.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.19.0
+
+  '@opentelemetry/resources@1.22.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.22.0
 
   '@opentelemetry/resources@1.24.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -8326,6 +8481,13 @@ snapshots:
       '@opentelemetry/core': 1.19.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.19.0(@opentelemetry/api@1.9.0)
 
+  '@opentelemetry/sdk-logs@0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.49.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/sdk-logs@0.51.1(@opentelemetry/api-logs@0.51.1)(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -8338,6 +8500,13 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.19.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.19.0(@opentelemetry/api@1.9.0)
+      lodash.merge: 4.6.2
+
+  '@opentelemetry/sdk-metrics@1.22.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.9.0)
       lodash.merge: 4.6.2
 
   '@opentelemetry/sdk-metrics@1.24.1(@opentelemetry/api@1.9.0)':
@@ -8398,12 +8567,26 @@ snapshots:
       '@opentelemetry/resources': 1.19.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.19.0
 
+  '@opentelemetry/sdk-trace-base@1.22.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.22.0
+
   '@opentelemetry/sdk-trace-base@1.24.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.24.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.24.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.24.1
+
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.28.0
 
   '@opentelemetry/sdk-trace-node@1.19.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -8425,13 +8608,25 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 1.24.1(@opentelemetry/api@1.9.0)
       semver: 7.7.2
 
+  '@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      semver: 7.7.2
+
   '@opentelemetry/semantic-conventions@1.19.0': {}
+
+  '@opentelemetry/semantic-conventions@1.22.0': {}
 
   '@opentelemetry/semantic-conventions@1.24.1': {}
 
   '@opentelemetry/semantic-conventions@1.28.0': {}
 
-  '@opentelemetry/semantic-conventions@1.34.0': {}
+  '@opentelemetry/semantic-conventions@1.37.0': {}
 
   '@opentelemetry/sql-common@0.40.1(@opentelemetry/api@1.9.0)':
     dependencies:

--- a/policies/personhood-levels.json
+++ b/policies/personhood-levels.json
@@ -1,3 +1,7 @@
 {
-  "governance.override": "P3"
+  "gates": [
+    {"topic":"governance.override","min_level":"P3"},
+    {"topic":"admin.*","min_level":"P3"},
+    {"topic":"data.ingest","min_level":"P1"}
+  ]
 }

--- a/runners/mandala_research_runner.ts
+++ b/runners/mandala_research_runner.ts
@@ -1,0 +1,68 @@
+import { writeFileSync } from 'fs';
+
+type UniverseTree = Record<string, string[]>;
+type SeedModelResults = { modelName: string; crepResonance: number }[];
+type UtopiaAdapterData = { source: string; sigil: string; value: number; timestamp: string }[];
+
+function generateMermaidTree(tree: UniverseTree): string {
+  const lines: string[] = ["graph TD;"];
+  for (const [node, children] of Object.entries(tree)) {
+    if (!children || children.length===0) { lines.push(node); continue; }
+    lines.push(`${node}-->${children.join(`\n${node}-->`)}`);
+  }
+  return lines.join("\n");
+}
+
+(async function main() {
+  const tree: UniverseTree = { "R0": ["R1","R2"], "R1": ["R1a","R1b"], "R2": ["R2a"] };
+  const seed: SeedModelResults = [
+    { modelName:"emergence_predictor", crepResonance:0.72 },
+    { modelName:"consent_mesh_sim", crepResonance:0.64 }
+  ];
+  const utopia: UtopiaAdapterData = [
+    { source:"mobility_2030", sigil:"sigil:mobility-2030", value:0.8, timestamp:new Date().toISOString() }
+  ];
+
+  const html = `<!DOCTYPE html>
+<html><head>
+  <meta charset="utf-8"/>
+  <title>Mandala Research Report</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <style>
+    body { font-family: Inter, Arial, sans-serif; margin: 24px; }
+    .chart { width: 80%; margin: 24px auto; }
+    table { border-collapse: collapse; width: 90%; }
+    th, td { border: 1px solid #ddd; padding: 8px; }
+    th { background: #f6f6f6; }
+    .mermaid { margin: 24px auto; max-width: 90%; }
+  </style>
+</head>
+<body>
+  <h1>Mandala Research Report</h1>
+  <h2>Universe Tree</h2>
+  <div class="mermaid">${generateMermaidTree(tree)}</div>
+  <h2>Seed Model Results</h2>
+  <div class="chart"><canvas id="resonanceChart"></canvas></div>
+  <script>
+    const ctx = document.getElementById('resonanceChart').getContext('2d');
+    new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: ${JSON.stringify(["emergence_predictor","consent_mesh_sim"])},
+        datasets: [{ label: 'CREP Resonance', data: ${JSON.stringify([0.72,0.64])} }]
+      },
+      options: { responsive:true, scales: { y: { beginAtZero: true, max: 1 } } }
+    });
+  </script>
+  <h2>Utopia Adapter Data</h2>
+  <table>
+    <tr><th>Source</th><th>Sigil</th><th>Value</th><th>Timestamp</th></tr>
+    ${`<tr><td>mobility_2030</td><td>sigil:mobility-2030</td><td>0.8</td><td>${new Date().toISOString()}</td></tr>`}
+  </table>
+  <script>mermaid.initialize({ startOnLoad: true });</script>
+</body></html>`;
+
+  writeFileSync('runs/report.html', html);
+  console.log('Report generated at runs/report.html');
+})().catch(e=>{ console.error(e); process.exit(1); });

--- a/schemas/eventbus.message.schema.json
+++ b/schemas/eventbus.message.schema.json
@@ -1,24 +1,34 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "EventBusMessage",
+  "title": "MandalaEvent",
   "type": "object",
   "properties": {
-    "topic": { "type": "string" },
-    "payload": {},
-    "crep_resonance": { "type": "number", "minimum": 0, "maximum": 1 },
-    "sigil": { "type": "string" },
-    "governance": {
+    "id": {"type": "string"},
+    "topic": {"type": "string"},
+    "actor": {
       "type": "object",
       "properties": {
-        "level": { "type": "string", "enum": ["P0", "P1", "P2", "P3"] },
-        "compliant": { "type": "boolean" },
-        "ethics_approval": { "type": "boolean" },
-        "notes": { "type": "string" }
+        "id": {"type": "string"},
+        "role": {"type": "string"}
       },
-      "required": ["level", "compliant", "ethics_approval"],
+      "required": ["id","role"]
+    },
+    "ts": {"type": "string", "format": "date-time"},
+    "personhood": {"type": "string", "enum": ["P0","P1","P2","P3"]},
+    "governance": {
+      "type":"object",
+      "properties": {
+        "level": {"type":"string","enum":["P0","P1","P2","P3"]},
+        "compliant": {"type":"boolean"},
+        "ethics_approval": {"type":"boolean"},
+        "notes": {"type":"string"}
+      },
       "additionalProperties": false
-    }
+    },
+    "sigil": {"type":"string"},
+    "crep_resonance": {"type":"number","minimum":0,"maximum":1},
+    "payload": {}
   },
-  "required": ["topic", "payload"],
-  "additionalProperties": false
+  "required": ["id","topic","ts","payload"],
+  "additionalProperties": true
 }

--- a/scripts/aeon.ps1
+++ b/scripts/aeon.ps1
@@ -1,0 +1,14 @@
+param([Parameter(Position=0)][string]$cmd)
+
+function nats_up { docker compose -f infrastructure/nats/docker-compose.yml up -d }
+function nats_down { docker compose -f infrastructure/nats/docker-compose.yml down }
+function bus_smoke_memory { node --loader ts-node/esm tools/bus-smoke.ts }
+function bus_smoke_nats { $env:BUS_MODE="nats"; node --loader ts-node/esm tools/bus-smoke.ts }
+
+switch ($cmd) {
+  "nats_up" { nats_up }
+  "nats_down" { nats_down }
+  "bus_smoke" { bus_smoke_memory }
+  "bus_smoke_nats" { bus_smoke_nats }
+  default { Write-Host "Usage: .\scripts\aeon.ps1 [nats_up|nats_down|bus_smoke|bus_smoke_nats]" }
+}

--- a/tests/gate_smoke.ts
+++ b/tests/gate_smoke.ts
@@ -1,26 +1,13 @@
-import assert from 'assert';
-import { readFileSync } from 'fs';
-import path from 'path';
-import { emit } from '../packages/mandala-sdk/ts/index';
+import { emit, on } from "../packages/mandala-sdk/ts/index.js";
 
-const base = path.resolve(__dirname, '..');
-
-const ok = JSON.parse(readFileSync(path.join(base, 'fixtures/events/example_ok.json'), 'utf8'));
-emit(ok.topic, ok.payload, {
-  personhood: ok.governance.level,
-  crep_resonance: ok.crep_resonance,
-  sigil: ok.sigil,
-  governance: ok.governance,
-});
-
-const bad = JSON.parse(readFileSync(path.join(base, 'fixtures/events/example_bad_gate.json'), 'utf8'));
-assert.throws(() => {
-  emit(bad.topic, bad.payload, {
-    personhood: bad.governance.level,
-    crep_resonance: bad.crep_resonance,
-    sigil: bad.sigil,
-    governance: bad.governance,
-  });
-});
-
-console.log('gate_smoke passed');
+(async () => {
+  let threw = false;
+  try {
+    await emit("governance.override", {op:"force"}, { personhood: "P1" as any });
+  } catch(e:any) {
+    threw = /Personhood gate/.test(e.message);
+    console.log("gate threw:", e.message);
+  }
+  if (!threw) { console.error("Gate did not throw on insufficient level!"); process.exit(1); }
+  console.log("OK: gate throws for governance.override @ P1");
+})().catch(e=>{ console.error(e); process.exit(1); });

--- a/tools/bus-smoke.ts
+++ b/tools/bus-smoke.ts
@@ -1,0 +1,23 @@
+import { MemoryBus } from "../packages/mandala-sdk/ts/memory-bus.ts";
+import { NatsBus } from "../packages/mandala-sdk/ts/nats-bus.ts";
+
+const mode = process.env.BUS_MODE || "memory";
+const bus = mode==="nats" ? new NatsBus() : new MemoryBus();
+
+bus.on("demo.hello", (evt:any)=> console.log("[sub] received:", evt.topic, evt.id));
+
+(async () => {
+  try {
+    await bus.emit("demo.hello", { msg: "world" }, { personhood: "P2" as any });
+    let threw = false;
+    try {
+      await bus.emit("governance.override", { op: "force" }, { personhood: "P1" as any });
+    } catch(e:any) {
+      threw = /requires/.test(e.message); console.log("gate ok:", e.message);
+    }
+    if (!threw) { console.error("Gate failed!"); process.exit(1); }
+    console.log("SMOKE OK – mode:", mode);
+  } catch(e) {
+    console.error(e); process.exit(1);
+  }
+})();

--- a/tools/governance-check.mjs
+++ b/tools/governance-check.mjs
@@ -1,0 +1,12 @@
+import fs from "fs";
+const p = "policies/personhood-levels.json";
+if (!fs.existsSync(p)) { console.error("Missing policies/personhood-levels.json"); process.exit(1); }
+const doc = JSON.parse(fs.readFileSync(p,"utf-8"));
+if (!Array.isArray(doc.gates)) { console.error("gates[] missing in policies/personhood-levels.json"); process.exit(1); }
+const topics = new Set();
+for (const g of doc.gates) {
+  if (!g.topic || !g.min_level) { console.error("gate missing topic/min_level", g); process.exit(1); }
+  if (topics.has(g.topic)) { console.error("duplicate gate topic:", g.topic); process.exit(1); }
+  topics.add(g.topic);
+}
+console.log("Governance policy looks sane.");

--- a/tools/schema-validate.mjs
+++ b/tools/schema-validate.mjs
@@ -1,0 +1,26 @@
+import fs from "fs";
+import path from "path";
+import Ajv from "ajv";
+
+const ajv = new Ajv({allErrors:true, strict:false});
+const schema = JSON.parse(fs.readFileSync(path.join("schemas","eventbus.message.schema.json"),"utf-8"));
+const validate = ajv.compile(schema);
+
+const fxDir = "fixtures/events";
+const files = fs.readdirSync(fxDir).filter(f=>f.endsWith(".json"));
+
+let failed = 0;
+for (const f of files) {
+  const p = path.join(fxDir, f);
+  const data = JSON.parse(fs.readFileSync(p, "utf-8"));
+  const ok = validate(data);
+  if (!ok) {
+    failed++;
+    console.error("[INVALID]", f, JSON.stringify(validate.errors,null,2));
+  } else {
+    console.log("[OK]", f);
+  }
+}
+
+if (failed) { process.exit(1); }
+console.log("All fixtures validate.");


### PR DESCRIPTION
## Summary
- extend event schema and SDK with personhood gating
- add governance & schema validation workflow
- generate research HTML report with Mermaid and Chart.js
- implement NATS transport with OpenTelemetry tracing and YAML policy loader

## Testing
- `npx tsc -p tsconfig.json --pretty false`
- `npx pyright`
- `node tools/schema-validate.mjs`
- `node tools/governance-check.mjs`
- `npx ts-node tools/bus-smoke.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bdbd277da483228125ace1ac4e3324