### PR TITLE
chore: add LLM orchestration prompts and feedback tooling

### DIFF
--- a/policies/merge-guardrails.yaml
+++ b/policies/merge-guardrails.yaml
@@ -1,0 +1,12 @@
+# Leichte, menschlich-verständliche Guardrails (zusätzlich zu CI)
+rules:
+  - id: "no-gate-widening-without-issue"
+    description: "Gates (personhood-levels) dürfen nicht erweitert werden ohne referenziertes Issue/ADR."
+    check:
+      files: ["policies/personhood-levels.yaml","policies/personhood-levels.json"]
+      pattern_disallow: ["min_level: P0", "admin.*"]
+      require_issue_ref: true
+  - id: "docs-for-governance-changes"
+    description: "Governance-Änderungen erfordern DOC Patch mit Migrationshinweisen."
+    require_doc_touch:
+      paths: ["docs/","README.md","Handbuch.md"]

--- a/tools/feedback/apply.mjs
+++ b/tools/feedback/apply.mjs
@@ -1,0 +1,34 @@
+import fs from "fs";
+import cp from "child_process";
+import os from "os";
+const csPath = process.argv[2] || "CHANGESET.yaml";
+if (!fs.existsSync(csPath)) { console.error("missing", csPath); process.exit(1); }
+const raw = fs.readFileSync(csPath, "utf-8");
+// naive YAML parse just for blocks
+function parseBlocks(y) {
+  const blocks = [];
+  const re = /patch:\s*\|\n([\s\S]*?)(?=\n\s*[a-z]+\:|\nchangespecs\:|\n- from\:|$)/gmi;
+  let m;
+  while ((m = re.exec(y))) blocks.push(m[1].replace(/\n {6}/g, "\n").replace(/^ {6}/, ""));
+  return blocks;
+}
+const patches = parseBlocks(raw);
+if (!patches.length) {
+  console.log("No patches found in", csPath);
+  process.exit(0);
+}
+for (let i=0;i<patches.length;i++) {
+  const p = patches[i];
+  const tmp = os.tmpdir()+`/mandala-patch-${Date.now()}-${i}.patch`;
+  fs.writeFileSync(tmp, p);
+  console.log("Applying", tmp);
+  try {
+    cp.execFileSync("git", ["apply", tmp], { stdio: "inherit" });
+    cp.execFileSync("git", ["add", "-A"], { stdio: "inherit" });
+    cp.execFileSync("git", ["commit", "-m", `chore: apply LLM patch ${i+1}`], { stdio: "inherit" });
+  } catch (e) {
+    console.error("Patch failed; leaving tmp:", tmp);
+    process.exit(1);
+  }
+}
+console.log("All patches applied & committed.");

--- a/tools/feedback/ingest.mjs
+++ b/tools/feedback/ingest.mjs
@@ -1,0 +1,44 @@
+import fs from "fs";
+const inputs = process.argv.slice(2);
+if (!inputs.length) {
+  console.error("usage: node tools/feedback/ingest.mjs feedback/claude.md feedback/mistral.md");
+  process.exit(1);
+}
+function parseBlocks(md) {
+  const blocks = [];
+  const fence = /```(\w+)(?:\s+title=([^\n]+))?\n([\s\S]*?)```/g;
+  let m;
+  while ((m = fence.exec(md))) {
+    blocks.push({ lang: m[1], title: m[2] || "", content: m[3] });
+  }
+  return blocks;
+}
+function splitSections(md) {
+  const out = {};
+  const re = /^##\s+([A-Z\/]+)\s*$/gmi;
+  let last = "ROOT", idx = 0, match, prevIndex = 0;
+  const sections = [];
+  const lines = md.split(/\r?\n/);
+  for (let i=0;i<lines.length;i++) {
+    const L = lines[i];
+    const m = /^##\s+([A-Z\/]+)\s*$/.exec(L);
+    if (m) {
+      sections.push({ name: m[1], start: i });
+    }
+  }
+  sections.push({ name: "EOF", start: lines.length });
+  for (let i=0;i<sections.length-1;i++) {
+    const s = sections[i], e = sections[i+1];
+    const body = lines.slice(s.start+1, e.start).join("\n");
+    out[s.name] = body;
+  }
+  return out;
+}
+const aggregated = [];
+for (const p of inputs) {
+  const md = fs.readFileSync(p, "utf-8");
+  const sections = splitSections(md);
+  const blocks = parseBlocks(md);
+  aggregated.push({ file: p, sections, blocks });
+}
+process.stdout.write(JSON.stringify(aggregated, null, 2));

--- a/tools/feedback/plan.mjs
+++ b/tools/feedback/plan.mjs
@@ -1,0 +1,50 @@
+import fs from "fs";
+const input = process.argv[2] || "feedback/aggregated.json";
+const agg = JSON.parse(fs.readFileSync(input, "utf-8"));
+function collectChangespecYamls() {
+  const list = [];
+  for (const doc of agg) {
+    for (const b of doc.blocks) {
+      if (b.lang === "yaml" && /changes:/.test(b.content)) {
+        list.push({ from: doc.file, yaml: b.content });
+      }
+    }
+  }
+  return list;
+}
+function collectDiffs() {
+  const list = [];
+  for (const doc of agg) {
+    for (const b of doc.blocks) {
+      if (b.lang === "diff") {
+        list.push({ from: doc.file, title: b.title, diff: b.content });
+      }
+    }
+  }
+  return list;
+}
+const cs = {
+  meta: {
+    generated_at: new Date().toISOString(),
+    sources: agg.map(a => a.file)
+  },
+  diffs: collectDiffs(),
+  changespecs: collectChangespecYamls()
+};
+fs.writeFileSync("CHANGESET.yaml", [
+  "meta:",
+  `  generated_at: "${cs.meta.generated_at}"`,
+  `  sources:`,
+  ...cs.meta.sources.map(s => `    - "${s}"`),
+  "diffs:",
+  ...cs.diffs.map(d => {
+    const patch = d.diff.split("\n").map(l => "      " + l).join("\n");
+    return `  - from: "${d.from}"\n    title: "${d.title || ""}"\n    patch: |\n${patch}`;
+  }),
+  "changespecs:",
+  ...cs.changespecs.map(c => {
+    const spec = c.yaml.split("\n").map(l => "      " + l).join("\n");
+    return `  - from: "${c.from}"\n    spec: |\n${spec}`;
+  })
+].join("\n") + "\n");
+console.log("Wrote CHANGESET.yaml");

--- a/tools/llm-review-prompts/claude.md
+++ b/tools/llm-review-prompts/claude.md
@@ -1,0 +1,25 @@
+# Mandala Review – Claude Focus (Ethics/Docs/Onboarding/UX)
+## Kontext (kurz)
+Wir haben Governance (P0–P3), Personhood-Gates, CI-Checks, Reports & Runner-Brücke.
+## Bitte liefere:
+1) **DOC-PATCHES** als Diff-Hunks (Markdown/YAML):
+   ```diff title=docs/agents/QualityAssuranceAgent.md
+   @@ ...
+   + New section: Personhood escalation appeal flow
+```
+2. **RITUALS** (Markdown) als *fenced blocks*:
+   ```markdown title=docs/rituals/ethics-escalation.md
+   # Ethics Escalation Ritual
+   ...
+   ```
+3. **CHANGESPEC** (YAML, maschinenlesbar; s. Format aus Mistral-Prompt)
+## Review-Schwerpunkte
+* **Ethik-Governance**: appeal/override Pfade klar & mensch-zentriert
+* **Onboarding**: „erste 30 Minuten“ Guide
+* **UX-Text**: knappe, verständliche Beschriftungen / Tooltips
+* **Doku-Kohärenz**: Linkpfade, Glossar-Einträge
+## Output-Format
+Bitte **nur** in drei Abschnitten antworten – exakt so:
+* `## DIFFS`
+* `## DOCS/RITUALS`
+* `## CHANGESPEC`

--- a/tools/llm-review-prompts/mistral.md
+++ b/tools/llm-review-prompts/mistral.md
@@ -1,0 +1,42 @@
+# Mandala Review – Mistral Focus (Architektur/Policy/Tests)
+## Kontext (kurz)
+- EventBus schema + SDK Gate + Governance CI + NATS/OTEL + YAML Policies
+- Ziel: präzise Patches (git-ready), testbare Änderungen, klare Acceptance Criteria
+## Bitte liefere:
+1) **DIFF-HUNKS** als _fenced blocks_ mit Header:
+   ```diff title=path/to/file
+   @@ ...
+   + additions
+   - removals
+```
+2. **TESTCASES** (Jest/Vitest oder Node scripts) als *fenced blocks*:
+   ```ts title=tests/<name>.test.ts
+   // ...
+   ```
+3. **CHANGESPEC** – kompaktes YAML (ein Block), maschinenlesbar:
+   ```yaml
+   changes:
+     - kind: file_patch
+       path: "packages/mandala-sdk/ts/nats-bus.ts"
+       rationale: "Subject-collision fix + retry + backpressure"
+       risk: "low"
+       acceptance:
+         - "bus-smoke passes in nats+memory"
+         - "no duplicate subjects observed in 30s soak"
+     - kind: policy_update
+       path: "policies/personhood-levels.yaml"
+       rationale: "Narrow admin.* to admin.control.*"
+       risk: "medium"
+       acceptance:
+         - "governance-check.mjs still green"
+   ```
+## Review-Schwerpunkte
+* **NATS Robustness**: Retries, Subject-Namespace, Backpressure Hinweise
+* **OTEL**: Span-Kontexte, sinnvolle Service-Namen
+* **Governance**: präzise Topics, kein Overreach in Gates
+* **CI**: schnelle, deterministische Checks
+## Output-Format
+Bitte **nur** in drei Abschnitten antworten – exakt so:
+* `## DIFFS`
+* `## TESTS`
+* `## CHANGESPEC`


### PR DESCRIPTION
## Summary
- add Mistral and Claude review prompt templates
- add feedback ingestion, planning, and patch application scripts
- define merge guardrails policy for governance changes

## Testing
- `pnpm install`
- `poetry install --with test`
- `docker compose -f infrastructure/nats/docker-compose.yml up -d || true` *(fails: command not found)*
- `docker compose -f infrastructure/otel/docker-compose.yml up -d || true` *(fails: command not found)*
- `node tools/bus-smoke.ts` *(fails: Cannot find module '/workspace/unified-mandala/packages/mandala-sdk/ts/transport.js')*
- `BUS_MODE=nats node tools/bus-smoke.ts` *(fails: Cannot find module '/workspace/unified-mandala/packages/mandala-sdk/ts/transport.js')*
- `node tools/governance-check.mjs`
- `node tools/schema-validate.mjs` *(fails: missing required property 'id' etc.)*
- `npx pyright`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68bde9b295448322a538630f0081fe12