### PR TITLE
feat: add llm orchestration templates and guardrails

### DIFF
--- a/.backportrc.yml
+++ b/.backportrc.yml
@@ -1,0 +1,4 @@
+branches:
+  - name: "stable/0.4.x"
+    labels: ["backport-to-0.4"]
+title_pattern: "^\\[Backport\\].+"

--- a/.github/ISSUE_TEMPLATE/llm-review.yml
+++ b/.github/ISSUE_TEMPLATE/llm-review.yml
@@ -1,0 +1,27 @@
+name: "🤖 LLM Review Request"
+description: "Request a review cycle from Claude/Mistral"
+title: "[LLM] Review: <short description>"
+labels: ["llm-orchestration","review"]
+body:
+  - type: markdown
+    attributes:
+      value: "## Ziel\nMerge-fähige DIFF-Patches + TESTS + CHANGESPEC (risk/acceptance)."
+  - type: textarea
+    id: context
+    attributes:
+      label: "Kontext / Scope"
+      placeholder: |
+        - EventBus (NATS + OTEL), Governance (OPA), Runner-Brücke
+        - Links: PR #123, Design-Doc
+    validations: { required: true }
+  - type: checkboxes
+    id: acceptance
+    attributes:
+      label: "Acceptance"
+      options:
+        - label: "DIFFs git-apply-fähig"          # required
+          required: true
+        - label: "TESTS decken Edge-Cases ab"     # required
+          required: true
+        - label: "CHANGESPEC mit risk + acceptance"
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE/llm-patch.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/llm-patch.yml
@@ -1,0 +1,25 @@
+name: "🤖 LLM Patch"
+title: "[LLM] <short description>"
+labels: ["llm-patch"]
+body:
+  - type: markdown
+    attributes:
+      value: "Quelle: feedback/claude.md, feedback/mistral.md • CHANGESET.yaml im Root"
+  - type: textarea
+    id: changes
+    attributes:
+      label: "Zusammenfassung"
+      placeholder: |
+        - nats-bus.ts: Retry/Backpressure (risk: low)
+        - docs/rituals: Ethics Escalation (risk: medium)
+    validations: { required: true }
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: "Pre-Merge"
+      options:
+        - label: "`git apply --check` sauber"         # required
+          required: true
+        - label: "`pnpm guardrails:check` grün"       # required
+          required: true
+        - label: "Release-Notes aktualisiert"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,17 @@
+name: "Auto-Backport"
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+jobs:
+  backport:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Cherry-pick
+        run: |
+          git checkout stable/0.4.x
+          git cherry-pick -x ${{ github.event.pull_request.merge_commit_sha }} || true
+          git push || true

--- a/.github/workflows/label-risk.yml
+++ b/.github/workflows/label-risk.yml
@@ -1,0 +1,24 @@
+name: "LLM: Auto Risk Labels"
+on:
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  risk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: pnpm add yaml
+      - run: node -e "const fs=require('fs');const YAML=require('yaml');const y=YAML.parse(fs.readFileSync('CHANGESET.yaml','utf-8'));const r=new Set();(y.changespecs||[]).forEach(c=>{try{const s=YAML.parse(c.spec);(s.changes||[]).forEach(ch=>r.add(`risk:${(ch.risk||'low').toLowerCase()}`));}catch{}});fs.writeFileSync('RISK_LABELS.txt',Array.from(r).join(','));"
+      - name: Apply labels
+        if: hashFiles('RISK_LABELS.txt') != ''
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: ${{ steps.parse.outputs.labels }}
+        id: parse
+        env:
+          INPUT_LABELS: ${{ steps.parse.outputs.labels }}
+      - id: parse
+        run: echo "labels=$(cat RISK_LABELS.txt)" >> $GITHUB_OUTPUT

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "feedback:plan": "node tools/feedback/plan.mjs feedback/aggregated.json",
     "feedback:apply": "node tools/feedback/apply2.mjs CHANGESET.yaml",
     "guardrails:check": "node tools/governance-guardrails.mjs",
-    "release:notes": "node tools/release/notes2.mjs"
+    "release:notes": "node tools/release/notes2.mjs",
+    "metrics:serve": "node tools/metrics/patch-metrics.mjs"
   },
   "dependencies": {
     "@automerge/automerge": "^3.1.1",
@@ -128,7 +129,8 @@
     "undici": "^7.15.0",
     "ws": "^8.17.0",
     "yaml": "^2.8.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@cypress/react": "^9.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       d3:
         specifier: ^7.8.5
         version: 7.9.0
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
       express:
         specifier: ^4.19.2
         version: 4.21.2
@@ -3750,6 +3753,10 @@ packages:
 
   dompurify@3.2.6:
     resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -10428,6 +10435,8 @@ snapshots:
   dompurify@3.2.6:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  dotenv@16.6.1: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/policies/merge-guardrails.yaml
+++ b/policies/merge-guardrails.yaml
@@ -1,12 +1,4 @@
-# Leichte, menschlich-verständliche Guardrails (zusätzlich zu CI)
 rules:
-  - id: "no-gate-widening-without-issue"
-    description: "Gates (personhood-levels) dürfen nicht erweitert werden ohne referenziertes Issue/ADR."
-    check:
-      files: ["policies/personhood-levels.yaml","policies/personhood-levels.json"]
-      pattern_disallow: ["min_level: P0", "admin.*"]
-      require_issue_ref: true
-  - id: "docs-for-governance-changes"
-    description: "Governance-Änderungen erfordern DOC Patch mit Migrationshinweisen."
-    require_doc_touch:
-      paths: ["docs/","README.md","Handbuch.md"]
+  - id: docs-for-governance-changes
+  - id: no-gate-widening-without-issue
+  - id: llm-env-secrets-present

--- a/tools/governance-guardrails.mjs
+++ b/tools/governance-guardrails.mjs
@@ -1,48 +1,35 @@
-import fs from "fs";
-import YAML from "yaml";
+import 'dotenv/config';
+import fs from "fs"; import YAML from "yaml"; import cp from "child_process";
+const cfgPath="policies/merge-guardrails.yaml"; if(!fs.existsSync(cfgPath)){console.log("No guardrails config");process.exit(0);}
+const cfg=YAML.parse(fs.readFileSync(cfgPath,"utf-8")); let ok=true;
+const git=(cmd)=>cp.execSync(cmd,{encoding:"utf-8"});
+const touched=git(`git diff --name-only HEAD~1..HEAD`).split("\n").filter(Boolean);
 
-const cfgPath = "policies/merge-guardrails.yaml";
-if (!fs.existsSync(cfgPath)) {
-  console.log("No merge-guardrails.yaml — skipping");
-  process.exit(0);
-}
-const cfg = YAML.parse(fs.readFileSync(cfgPath, "utf-8"));
-let ok = true;
-
-function fileTouched(path) {
-  try {
-    const out = require("child_process").execSync(`git diff --name-only HEAD~1..HEAD`, { encoding: "utf-8" });
-    return out.split("\n").filter(Boolean).includes(path);
-  } catch { return false; }
-}
-
-for (const rule of cfg.rules || []) {
-  if (rule.id === "no-gate-widening-without-issue") {
-    const files = rule.check?.files || [];
-    for (const f of files) {
-      if (!fileTouched(f)) continue;
-      const txt = fs.readFileSync(f, "utf-8");
-      if ((rule.check.pattern_disallow || []).some(p => txt.includes(p))) {
-        if (rule.check.require_issue_ref) {
-          const msg = require("child_process").execSync(`git log -1 --pretty=%B`, { encoding: "utf-8" });
-          if (!/#\d+/.test(msg)) {
-            ok = false;
-            console.error(`[Guardrail] ${rule.id}: Disallowed pattern in ${f} without issue reference.`);
-          }
-        }
-      }
-    }
+function requiresDocForPolicyChange() {
+  const policyTouched = touched.some(f => f.startsWith("policies/personhood-levels"));
+  if (policyTouched) {
+    const docsTouched = touched.some(f => f.startsWith("docs/")) || touched.includes("README.md") || touched.includes("Handbuch.md");
+    if (!docsTouched) { console.error("[Guardrail] Policy change without docs"); ok=false; }
   }
-  if (rule.id === "docs-for-governance-changes") {
-    const touchedPolicy = fileTouched("policies/personhood-levels.yaml") || fileTouched("policies/personhood-levels.json");
-    if (touchedPolicy) {
-      const touchedDocs = ["docs/","README.md","Handbuch.md"].some(p => fileTouched(p) || p.endsWith(".md") && fileTouched(p));
-      if (!touchedDocs) {
-        ok = false;
-        console.error("[Guardrail] docs-for-governance-changes: Policy change requires doc patch.");
-      }
+}
+function requireIssueForGateWidening() {
+  const files = ["policies/personhood-levels.yaml","policies/personhood-levels.json"].filter(f=>touched.includes(f));
+  for (const f of files) {
+    const txt=fs.readFileSync(f,"utf-8");
+    if (/min_level:\s*P0|admin\.*/.test(txt)) {
+      const msg=git(`git log -1 --pretty=%B`);
+      if(!/#\d+/.test(msg)){ console.error("[Guardrail] Gate widening without issue ref"); ok=false; }
     }
   }
 }
-
-process.exit(ok ? 0 : 1);
+function envSecretsPresent() {
+  if (touched.includes("tools/llm/send-claude.mjs") || touched.includes("tools/llm/send-mistral.mjs")) {
+    if (!process.env.ANTHROPIC_API_KEY || !process.env.MISTRAL_API_KEY) {
+      console.error("[Guardrail] Missing API keys (.env not set)"); ok=false;
+    }
+  }
+}
+requiresDocForPolicyChange();
+requireIssueForGateWidening();
+envSecretsPresent();
+process.exit(ok?0:1);

--- a/tools/llm/mock.mjs
+++ b/tools/llm/mock.mjs
@@ -1,0 +1,30 @@
+import fs from "fs";
+const kind = process.argv[2] || "mistral"; // "claude"|"mistral"
+const lines = [
+  `## ${kind==="claude"?"DOCS/RITUALS":"DIFFS"}`,
+  "```diff title=packages/mandala-sdk/ts/nats-bus.ts",
+  "@@",
+  "+ // mock patch: no-op for offline test",
+  "```",
+  kind==="claude"?"## CHANGESPEC":"## TESTS",
+  "```yaml",
+  "changes:",
+  "  - kind: file_patch",
+  "    path: \"packages/mandala-sdk/ts/nats-bus.ts\"",
+  "    rationale: \"offline smoke\"",
+  "    risk: \"low\"",
+  "    acceptance:",
+  "      - \"git apply --check passes\"",
+  "```",
+  kind==="claude"?"":"## CHANGESPEC",
+  "```yaml",
+  "changes:",
+  "  - kind: doc_note",
+  "    path: \"docs/notes.md\"",
+  "    rationale: \"offline smoke\"",
+  "    risk: \"low\"",
+  "```",
+];
+const out = lines.join("\n");
+fs.writeFileSync(`feedback/${kind}.md`, out);
+console.log("mock feedback →", `feedback/${kind}.md`);

--- a/tools/llm/round-trip.mjs
+++ b/tools/llm/round-trip.mjs
@@ -1,29 +1,15 @@
+import 'dotenv/config';
 import { spawnSync } from "child_process";
 import { mkdirSync } from "fs";
+const run=(c,a,e={})=>{const r=spawnSync(c,a,{stdio:"inherit",env:{...process.env,...e}}); if(r.status!==0)throw new Error(`${c} ${a.join(" ")} failed`);};
 
-function run(cmd, args, env = {}) {
-  const r = spawnSync(cmd, args, { stdio: "inherit", env: { ...process.env, ...env } });
-  if (r.status !== 0) throw new Error(`${cmd} ${args.join(" ")} failed`);
-}
-
-mkdirSync("feedback", { recursive: true });
-
-// 1) Prompts senden
-run("node", ["tools/llm/send-claude.mjs", "tools/llm-review-prompts/claude.md", "feedback/claude.md"]);
-run("node", ["tools/llm/send-mistral.mjs", "tools/llm-review-prompts/mistral.md", "feedback/mistral.md"]);
-
-// 2) Aggregieren + planen
-run("node", ["tools/feedback/ingest.mjs", "feedback/claude.md", "feedback/mistral.md"], { });
-run("node", ["tools/feedback/plan.mjs", "feedback/aggregated.json"]);
-
-// 3) Risk-aware apply
-run("node", ["tools/feedback/apply2.mjs", "CHANGESET.yaml"]);
-
-// 4) Smokes
-run("node", ["tools/bus-smoke.ts"]);
-run("node", ["tools/governance-check.mjs"]);
-
-// 5) Release Notes
-run("node", ["tools/release/notes2.mjs"]);
-
+mkdirSync("feedback",{recursive:true});
+run("node",["tools/llm/send-claude.mjs","tools/llm-review-prompts/claude.md","feedback/claude.md"]);
+run("node",["tools/llm/send-mistral.mjs","tools/llm-review-prompts/mistral.md","feedback/mistral.md"]);
+run("node",["tools/feedback/ingest.mjs","feedback/claude.md","feedback/mistral.md"]);
+run("node",["tools/feedback/plan.mjs","feedback/aggregated.json"]);
+run("node",["tools/feedback/apply2.mjs","CHANGESET.yaml"]);
+run("node",["tools/bus-smoke.ts"]);
+run("node",["tools/governance-check.mjs"]);
+run("node",["tools/release/notes2.mjs"]);
 console.log("✅ Round-trip completed.");

--- a/tools/llm/send-claude.mjs
+++ b/tools/llm/send-claude.mjs
@@ -1,35 +1,23 @@
+import 'dotenv/config';
 import { readFile } from "fs/promises";
 import { writeFileSync } from "fs";
 import { fetch } from "undici";
 
 const inPath = process.argv[2] || "tools/llm-review-prompts/claude.md";
 const outPath = process.argv[3] || "feedback/claude.md";
-
 const API_KEY = process.env.ANTHROPIC_API_KEY;
 const MODEL = process.env.ANTHROPIC_MODEL || "claude-3-5-sonnet-latest";
-if (!API_KEY) throw new Error("Set ANTHROPIC_API_KEY");
+if (!API_KEY) throw new Error("Set ANTHROPIC_API_KEY in .env");
 
 const prompt = await readFile(inPath, "utf-8");
-const body = {
-  model: MODEL,
-  max_tokens: 4000,
-  messages: [{ role: "user", content: prompt }]
-};
+const body = { model: MODEL, max_tokens: 4000, messages: [{ role: "user", content: prompt }] };
 
 const resp = await fetch("https://api.anthropic.com/v1/messages", {
   method: "POST",
-  headers: {
-    "content-type": "application/json",
-    "x-api-key": API_KEY,
-    "anthropic-version": "2023-06-01"
-  },
+  headers: { "content-type":"application/json", "x-api-key":API_KEY, "anthropic-version":"2023-06-01" },
   body: JSON.stringify(body)
 });
-if (!resp.ok) {
-  const t = await resp.text();
-  throw new Error(`Claude API error ${resp.status}: ${t}`);
-}
+if (!resp.ok) throw new Error(`Claude API error ${resp.status}: ${await resp.text()}`);
 const data = await resp.json();
-const text = data?.content?.[0]?.text ?? "";
-writeFileSync(outPath, text);
-console.log("Claude feedback written:", outPath);
+writeFileSync(outPath, data?.content?.[0]?.text ?? "");
+console.log("Claude feedback:", outPath);

--- a/tools/llm/send-mistral.mjs
+++ b/tools/llm/send-mistral.mjs
@@ -1,35 +1,21 @@
+import 'dotenv/config';
 import { readFile } from "fs/promises";
 import { writeFileSync } from "fs";
 import { fetch } from "undici";
 
 const inPath = process.argv[2] || "tools/llm-review-prompts/mistral.md";
 const outPath = process.argv[3] || "feedback/mistral.md";
-
 const API_KEY = process.env.MISTRAL_API_KEY;
 const MODEL = process.env.MISTRAL_MODEL || "mistral-large-latest";
-if (!API_KEY) throw new Error("Set MISTRAL_API_KEY");
+if (!API_KEY) throw new Error("Set MISTRAL_API_KEY in .env");
 
 const prompt = await readFile(inPath, "utf-8");
-const body = {
-  model: MODEL,
-  messages: [{ role: "user", content: prompt }],
-  temperature: 0.2,
-  max_tokens: 4000
-};
+const body = { model: MODEL, messages: [{ role:"user", content: prompt }], temperature:0.2, max_tokens:4000 };
 
 const resp = await fetch("https://api.mistral.ai/v1/chat/completions", {
-  method: "POST",
-  headers: {
-    "content-type": "application/json",
-    "authorization": `Bearer ${API_KEY}`
-  },
-  body: JSON.stringify(body)
+  method:"POST", headers:{ "content-type":"application/json","authorization":`Bearer ${API_KEY}` }, body: JSON.stringify(body)
 });
-if (!resp.ok) {
-  const t = await resp.text();
-  throw new Error(`Mistral API error ${resp.status}: ${t}`);
-}
+if (!resp.ok) throw new Error(`Mistral API error ${resp.status}: ${await resp.text()}`);
 const data = await resp.json();
-const text = data?.choices?.[0]?.message?.content ?? "";
-writeFileSync(outPath, text);
-console.log("Mistral feedback written:", outPath);
+writeFileSync(outPath, data?.choices?.[0]?.message?.content ?? "");
+console.log("Mistral feedback:", outPath);

--- a/tools/metrics/patch-metrics.mjs
+++ b/tools/metrics/patch-metrics.mjs
@@ -1,0 +1,19 @@
+import { collectDefaultMetrics, register } from 'prom-client';
+import http from 'http';
+
+collectDefaultMetrics();
+
+const server = http.createServer(async (req, res) => {
+  if (req.url === '/metrics') {
+    res.setHeader('Content-Type', register.contentType);
+    res.end(await register.metrics());
+  } else {
+    res.statusCode = 404;
+    res.end('not found');
+  }
+});
+
+const port = process.env.PORT || 9100;
+server.listen(port, () => {
+  console.log(`Metrics server listening on ${port}`);
+});


### PR DESCRIPTION
## Summary
- add LLM review & patch templates and automation workflows
- expand LLM round-trip scripts with dotenv support and offline mock
- implement governance guardrails and metrics helper

## Testing
- `pnpm install`
- `poetry install --with test`
- `npx tsc -p tsconfig.json`
- `npx pyright`
- `ANTHROPIC_API_KEY=dummy MISTRAL_API_KEY=dummy pnpm guardrails:check`


------
https://chatgpt.com/codex/tasks/task_e_68bdf465fff88322b43601cce2136450