### PR TITLE
feat: add orientation hub docs and personhood tools

### DIFF
--- a/apps/mandala-ui/panels/PersonhoodPanel.tsx
+++ b/apps/mandala-ui/panels/PersonhoodPanel.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from "react";
+
+type Hit = { idx:number; when:string; author:string; channel:string; keywords:string; preview:string };
+
+export default function PersonhoodPanel() {
+  const [hits, setHits] = useState<Hit[]>([]);
+  const [q, setQ] = useState("");
+
+  useEffect(() => {
+    // Minimal: erwartet, dass ein kleiner API-Proxy out/personhood_hits.csv liefert
+    // Alternativ: GitHub Raw URL eintragen (read-only)
+    fetch("/out/personhood_hits.csv")
+      .then(r => r.text())
+      .then(t => {
+        const lines = t.trim().split("\n").slice(1);
+        const rows = lines.map((line) => {
+          const [idx, when, author, channel, keywords, preview] = line.split("\t");
+          return { idx:+idx, when, author, channel, keywords, preview };
+        });
+        setHits(rows);
+      })
+      .catch(() => setHits([]));
+  }, []);
+
+  const filtered = hits.filter(h =>
+    !q ||
+    h.preview.toLowerCase().includes(q.toLowerCase()) ||
+    h.keywords.toLowerCase().includes(q.toLowerCase())
+  );
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-semibold mb-2">Personhood – Conversation Hits</h2>
+      <input
+        value={q}
+        onChange={e=>setQ(e.target.value)}
+        placeholder="Suche in keywords/preview…"
+        className="border rounded px-3 py-2 mb-3 w-full"
+      />
+      <div className="space-y-3">
+        {filtered.slice(0,200).map(h => (
+          <div key={h.idx} className="border rounded p-3">
+            <div className="text-sm text-gray-600">{h.when} · {h.channel} · {h.author}</div>
+            <div className="font-medium">#{h.idx} — {h.keywords}</div>
+            <div className="mt-1">{h.preview} …</div>
+          </div>
+        ))}
+        {filtered.length === 0 && <div className="text-gray-500">Keine Treffer (noch).</div>}
+      </div>
+    </div>
+  );
+}

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -13,3 +13,4 @@
 - FR-UM-2025-08-30-OFFLINE-PERF-A: Proposed light static server with precompressed assets and TTFB smoke test to fix offline response times; awaiting application.
 - FR-UM-2025-08-30-OFFLINE-PERF-B: Implemented start scripts, light static server, and TTFB smoke test; kein weiterer Lauf notwendig.
 - FR-UM-2025-08-30-CLIMATE-WIRING-A: YAML-Config mit Live-KPI-Engine und Kachel-Board verdrahtet – kein weiterer Lauf notwendig.
+- FR-UM-2025-08-30-Fraktal8-OrientationHub: Alle Änderungen in einem Lauf umgesetzt – kein zweiter Lauf notwendig.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -1,0 +1,3 @@
+fraktalrun: "Fraktal8 OrientationHub"
+status: "implemented"
+notes: "Alle Inhalte aus Fraktal8 integriert; weitere Fragmente können in Folgeläufen ergänzt werden."

--- a/docs/README-RESTORED.md
+++ b/docs/README-RESTORED.md
@@ -1,0 +1,27 @@
+# Unified Mandala – Orientierung & Quickstart (Restored)
+
+Willkommen im **Unified Mandala**. Dieses Dokument dient als Einstieg für Mensch und AI gleichermaßen.
+
+## Ziele
+- **Agenten-Ökosystem**: modulare KI-Agenten (Greek/Math/Aeon-Layer)
+- **Universumssimulationen**: Resonanz, Nullfeld, Narrative, Puls, u.a.
+- **Personhood/Governance**: Consent, Policies, Auditing, RAG-Begründungen
+- **Developer-Experience**: klare Maps, Skript-Katalog, Runbooks
+
+## Wichtige Einstiege
+- **Agenten-Atlas**: `docs/agents/Atlas.md`
+- **Repo-Karten**:
+  - Agents: `docs/maps/RepoMap.agents.yaml`
+  - Sims:   `docs/maps/RepoMap.sims.yaml`
+  - Personhood: `docs/maps/RepoMap.personhood.yaml`
+- **Befehlskatalog**: `docs/scripts/COMMANDS.md`
+
+## Konventionen
+- **AI-builds-AI**: Sämtliche Artefakte sind AI-erstellt (Codex-Pipeline).
+- **Citations / RAG**: Juristische Begründungen via RAG-Index (siehe Personhood).
+- **Auditing**: `/metrics`, Ledger-Append, Sigil-States.
+
+## Nächste Schritte
+1. RepoMap durchsehen (Agents, Sims, Personhood)
+2. Skripte & Tools (ohne lokale Execution möglich) in PRs integrieren
+3. UI-Panel aktivieren (PersonhoodPanel)

--- a/docs/agents/Atlas.md
+++ b/docs/agents/Atlas.md
@@ -1,0 +1,18 @@
+# Agenten-Atlas (Kurzfassung)
+
+## Schichten
+- **Greek**: Primitive/Grammatik/Parsing
+- **Math**: Analyse/Metrik/Similarity
+- **Aeon**: Orchestrierung/Meta/Policy/Personhood
+
+## Typische Flüsse
+Input → (Greek parse) → (Math analyse) → (Aeon orchestrate) → Actions/Webhooks → Audit
+
+## Kernfamilien (Auszug)
+- **Sigillin / Resonanz**: Interpreter, Plotter, Metrics, Insights
+- **Transpiler / Codex**: TranspilerAgent, Navigator, Synchronizer
+- **Orchestrierer**: TaskPlannerAgent, MetaComposer/Learner, EmergenceFusion
+- **Runtime Hooks**: HookTriggerer, DreamSync
+- **Personhood**: ConsentRegistry, PolicyGuard, AuditTrail, Router-Hook
+
+> Details & Pfade: `docs/maps/RepoMap.agents.yaml`

--- a/docs/maps/RepoMap.agents.yaml
+++ b/docs/maps/RepoMap.agents.yaml
@@ -1,0 +1,52 @@
+version: 0.3
+topic: agents
+layers:
+  greek:
+    - name: "YAMLNavigatorAgent"
+      files: ["packages/agents/YAMLNavigatorAgent.ts"]
+      role: "Parse/Traverse YAML codices"
+  math:
+    - name: "KiResonanceAnalyzer"
+      files: ["packages/agents/KiResonanceAnalyzer.ts","packages/agents/ResonanzMetrics.ts"]
+      role: "Resonanzmetriken, Scoring, Thresholds"
+    - name: "HumanMachineCheckAgent"
+      files: ["packages/agents/HumanMachineCheckAgent.ts"]   # to-verify
+      role: "Vorfilter Mensch/ Maschine"
+      status: "to-verify"
+  aeon:
+    - name: "TaskPlannerAgent"
+      files: ["packages/agents/TaskPlannerAgent.ts"]
+      role: "Aufgabenplanung / Orchestrierung"
+    - name: "MetaComposerAgent"
+      files: ["packages/agents/MetaComposerAgent.ts","packages/agents/MetaScoreComposer.ts"]
+      role: "Scores mischen, Plan-Komposition"
+    - name: "MetaLearnerAgent"
+      files: ["packages/agents/MetaLearnerAgent.ts"]
+      role: "Meta-Lernen, Score-Validierung"
+    - name: "EmergenceFusionAgent"
+      files: ["packages/agents/EmergenceFusionAgent.ts"]
+      role: "Emergenz fusionieren, Finalisierung"
+    - name: "SigillinInterpreterAgent"
+      files: ["packages/agents/SigillinInterpreterAgent.ts"]
+      role: "Sigillin-Kommandos lesen/ausführen"
+    - name: "HookTriggererAgent"
+      files: ["packages/agents/HookTriggererAgent.ts"]
+      role: "Webhooks, Side-effects"
+    - name: "DreamSyncAgent"
+      files: ["packages/agents/DreamSyncAgent.ts"]
+      role: "Sync/Async Dream-Flows"
+    - name: "AIJuristischePersonAgent"
+      files: ["packages/agents/AIJuristischePersonAgent.ts"]   # to-verify
+      role: "Personhood-Decision (allow/challenge/throttle/deny)"
+      status: "to-verify"
+
+personhood_support:
+  router_hook:
+    - "packages/gpt-bridges/router/withPersonhood.ts"
+  governance:
+    - "governance/personhood.policy.yaml"
+    - "docs/personhood/PersonhoodProtocol.md"
+  registry_audit:
+    - "packages/personhood/ConsentRegistry.ts"
+    - "packages/personhood/PolicyGuard.ts"
+    - "packages/personhood/AuditTrail.ts"

--- a/docs/maps/RepoMap.personhood.yaml
+++ b/docs/maps/RepoMap.personhood.yaml
@@ -1,0 +1,27 @@
+version: 0.4
+topic: personhood
+components:
+  scanners:
+    - name: "scan-conversations.ts"
+      files: ["scripts/personhood/scan-conversations.ts"]
+      role: "Scans dev chats for personhood references"
+    - name: "scan-conversations-jsonl.ts"
+      files: ["scripts/personhood/scan-conversations-jsonl.ts"]
+      role: "Outputs JSONL hits"
+    - name: "scan_conversations.py"
+      files: ["scripts/personhood/scan_conversations.py"]
+      role: "Python alternative scanner"
+  keywords:
+    - files: ["scripts/personhood/kw.ts","scripts/personhood/regexes.ts"]
+  utilities:
+    - files: ["scripts/personhood/util.ts"]
+  governance:
+    - "docs/personhood/PersonhoodProtocol.md"
+    - "governance/personhood.policy.yaml"
+  registry:
+    - "packages/personhood/ConsentRegistry.ts"
+    - "packages/personhood/PolicyGuard.ts"
+    - "packages/personhood/AuditTrail.ts"
+  outputs:
+    - "out/personhood_hits.csv"
+    - "out/personhood_hits.md"

--- a/docs/maps/RepoMap.sims.yaml
+++ b/docs/maps/RepoMap.sims.yaml
@@ -1,0 +1,41 @@
+version: 0.2
+topic: simulations
+families:
+  resonance:
+    - name: "EmotionalResonanceSimulator"
+      files: ["packages/universum-simulationen/EmotionalResonanceSimulator.ts"]
+      role: "Zeitliche Resonanzkurven/Events"
+  nullfeld:
+    - name: "NullfeldSimulation"
+      files: ["packages/universum-simulationen/NullfeldSimulation.ts"]
+      role: "Nullfeld-Zustände, Übergänge"
+    - name: "NullfeldVisualization"
+      files: ["packages/universum-simulationen/NullfeldVisualization.ts"]
+      role: "Rendern/Plotten"
+    - name: "NullmembranDynamics"
+      files: ["packages/universum-simulationen/modules/NullmembranDynamics.py"]
+      role: "Physikalische Dynamik (Py-Modul)"
+  narrative:
+    - name: "InteractiveNarrativeEngine"
+      files: ["packages/universum-simulationen/InteractiveNarrativeEngine.ts"]
+      role: "Story/Node-Graph Simulation"
+  pulse:
+    - name: "UniversePulseSimulator"
+      files: ["packages/universum-simulationen/UniversePulseSimulator.ts"]
+      role: "Pulsmodell (sinus/fusion)"
+  geometry:
+    - name: "PyramidNodeSimulation"
+      files: ["packages/universum-simulationen/PyramidNodeSimulation.ts"]
+      role: "Graph/Layer-Topologie"
+  sound:
+    - name: "SoundResonanceModule"
+      files: ["packages/universum-simulationen/SoundResonanceModule.ts"]
+      role: "Sound/FFT-Ankoppelung"
+
+tooling:
+  - scripts:
+      - "scripts/sim-run.ts"            # to-verify
+      - "scripts/sim-plot.ts"           # to-verify
+notes:
+  - "Py-Module dienen als Kernphysik; TS orchestriert/visualisiert."
+  - "Hooks zu Agents möglich (Resonanz → Planner → Webhook)."

--- a/docs/scripts/COMMANDS.md
+++ b/docs/scripts/COMMANDS.md
@@ -1,0 +1,25 @@
+# Befehlskatalog (Scripts & Tools)
+
+## Personhood – Dev-Chats scannen
+- TS (JSON-Array):  
+  `pnpm dlx tsx scripts/personhood/scan-conversations.ts`
+- TS (JSONL):  
+  `pnpm dlx tsx scripts/personhood/scan-conversations-jsonl.ts`
+- Python (JSON-Array):  
+  `python3 scripts/personhood/scan_conversations.py`
+
+Outputs:
+- `out/personhood_hits.csv` (tab)
+- `out/personhood_hits.md` (lesbar)
+
+## Ähnlichkeits-Gerüst (optional)
+- Index bauen:  
+  `ts-node scripts/personhood/similarity-index.ts --inputs out/personhood_hits.md docs/governance/HI-Compact.md AI_POLICY.md`
+- Query:  
+  `ts-node scripts/personhood/similarity-query.ts --text "AI-Person → river rights Analogie"`
+
+## Repo-Hilfen
+- Skripte listen:  
+  `ts-node scripts/repo/list-scripts.ts`
+- Command-Index generieren (erkenne Usage-Strings):  
+  `ts-node scripts/repo/command-index.ts`

--- a/scripts/personhood/README.md
+++ b/scripts/personhood/README.md
@@ -1,0 +1,13 @@
+# Personhood Tools
+
+Skripte zum Durchsuchen von Entwickler-Chats nach Hinweisen auf AI-Personhood.
+
+## Scanner
+- `scan-conversations.ts` – durchsucht JSON/Markdown-Konversationen und erstellt CSV/Markdown-Ausgaben.
+- `scan-conversations-jsonl.ts` – Variante mit JSONL-Output.
+- `scan_conversations.py` – Python-Äquivalent.
+
+## Schlüsselwörter
+Siehe `kw.ts` und `regexes.ts` für verwendete Suchmuster.
+
+Ausgaben werden in `out/personhood_hits.*` abgelegt.

--- a/scripts/personhood/json-schema.conversation-item.json
+++ b/scripts/personhood/json-schema.conversation-item.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ConversationItem",
+  "type": "object",
+  "properties": {
+    "when": { "type": ["string","number"] },
+    "author": { "type": ["string","null"] },
+    "channel": { "type": ["string","null"] },
+    "text": { "type": ["string","null"] },
+    "message": { "type": ["string","null"] },
+    "content": { "type": ["string","null"] },
+    "meta": { "type": ["object","null"] }
+  },
+  "additionalProperties": true
+}

--- a/scripts/personhood/kw.ts
+++ b/scripts/personhood/kw.ts
@@ -1,0 +1,11 @@
+export const KEYWORDS = [
+  "personhood",
+  "legal person",
+  "rights of nature",
+  "river rights",
+  "tree rights",
+  "juristische person",
+  "legal personhood",
+  "mensch oder maschine",
+  "human or machine"
+];

--- a/scripts/personhood/regexes.ts
+++ b/scripts/personhood/regexes.ts
@@ -1,0 +1,6 @@
+export const RX = {
+  rightsOfNature: /(rights?\s+of\s+nature|tree\s+rights?|river\s+rights?)/i,
+  legalPerson: /(legal\s+person(hood)?|juristische\s+person)/i,
+  humanMachine: /(mensch[-\s]?oder[-\s]?maschine|human\s+or\s+machine|isHuman)/i,
+  similarity: /(similarit(y|ies)|analogy|precedent|case\s+law|vergleich(bar)?|ähnlich(keit)?)/i,
+};

--- a/scripts/personhood/scan-conversations-jsonl.ts
+++ b/scripts/personhood/scan-conversations-jsonl.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import path from "node:path";
+import { ConvItem, extractText, findKeywords } from "./util";
+
+const dir = process.argv[2] || "fraktalrun";
+const hits: any[] = [];
+let idx = 0;
+
+function loadItems(file: string): ConvItem[] {
+  const src = fs.readFileSync(file, "utf8");
+  if (file.endsWith(".jsonl")) {
+    return src
+      .trim()
+      .split(/\n+/)
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+  }
+  try {
+    const data = JSON.parse(src);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+for (const f of fs.readdirSync(dir)) {
+  const full = path.join(dir, f);
+  if (!/\.json(l)?$/.test(f)) continue;
+  const items = loadItems(full);
+  for (const item of items) {
+    const text = extractText(item);
+    const kws = findKeywords(text);
+    if (kws.length) {
+      hits.push({
+        idx: idx++,
+        when: item.when ?? "",
+        author: item.author ?? "",
+        channel: item.channel ?? "",
+        keywords: kws.join(","),
+        preview: text.slice(0, 80)
+      });
+    }
+  }
+}
+
+fs.mkdirSync("out", { recursive: true });
+fs.writeFileSync(
+  "out/personhood_hits.jsonl",
+  hits.map((h) => JSON.stringify(h)).join("\n")
+);
+console.log(`wrote ${hits.length} hits`);

--- a/scripts/personhood/scan-conversations.ts
+++ b/scripts/personhood/scan-conversations.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import path from "node:path";
+import { ConvItem, extractText, findKeywords } from "./util";
+
+const dir = process.argv[2] || "fraktalrun";
+const hits: string[][] = [];
+let idx = 0;
+
+function loadItems(file: string): ConvItem[] {
+  const src = fs.readFileSync(file, "utf8");
+  if (file.endsWith(".jsonl")) {
+    return src
+      .trim()
+      .split(/\n+/)
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+  }
+  try {
+    const data = JSON.parse(src);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+for (const f of fs.readdirSync(dir)) {
+  const full = path.join(dir, f);
+  if (!/\.json(l)?$/.test(f)) continue;
+  const items = loadItems(full);
+  for (const item of items) {
+    const text = extractText(item);
+    const kws = findKeywords(text);
+    if (kws.length) {
+      hits.push([
+        String(idx++),
+        String(item.when ?? ""),
+        String(item.author ?? ""),
+        String(item.channel ?? ""),
+        kws.join(","),
+        text.slice(0, 80)
+      ]);
+    }
+  }
+}
+
+fs.mkdirSync("out", { recursive: true });
+const header = "idx\twhen\tauthor\tchannel\tkeywords\tpreview";
+const csv = [header, ...hits.map((r) => r.join("\t"))].join("\n");
+fs.writeFileSync("out/personhood_hits.csv", csv);
+const md = hits.map((r) => `- ${r[1]} ${r[2]} ${r[4]} — ${r[5]}`).join("\n");
+fs.writeFileSync("out/personhood_hits.md", md);
+console.log(`wrote ${hits.length} hits`);

--- a/scripts/personhood/scan_conversations.py
+++ b/scripts/personhood/scan_conversations.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+import json, re, sys, csv, pathlib
+from typing import List, Dict
+
+KEYWORDS = [
+    "personhood",
+    "legal person",
+    "rights of nature",
+    "river rights",
+    "tree rights",
+    "juristische person",
+    "legal personhood",
+    "mensch oder maschine",
+    "human or machine",
+]
+
+RX: Dict[str, re.Pattern[str]] = {
+    "rightsOfNature": re.compile(r"(rights?\s+of\s+nature|tree\s+rights?|river\s+rights?)", re.I),
+    "legalPerson": re.compile(r"(legal\s+person(hood)?|juristische\s+person)", re.I),
+    "humanMachine": re.compile(r"(mensch[-\s]?oder[-\s]?maschine|human\s+or\s+machine|isHuman)", re.I),
+    "similarity": re.compile(r"(similarit(y|ies)|analogy|precedent|case\s+law|vergleich(bar)?|ähnlich(keit)?)", re.I),
+}
+
+def extract_text(item: Dict[str, object]) -> str:
+    for key in ("text", "message", "content"):
+        val = item.get(key)
+        if isinstance(val, str):
+            return val
+    return ""
+
+def find_keywords(text: str) -> List[str]:
+    hits = [k for k in KEYWORDS if k.lower() in text.lower()]
+    for name, rx in RX.items():
+        if rx.search(text):
+            hits.append(name)
+    return list(dict.fromkeys(hits))
+
+def main() -> None:
+    dir = sys.argv[1] if len(sys.argv) > 1 else "fraktalrun"
+    hits: List[List[str]] = []
+    idx = 0
+    for p in pathlib.Path(dir).glob("*.json*"):
+        lines = p.read_text(encoding="utf8").strip().splitlines()
+        items = [json.loads(line) for line in lines if line.strip()]
+        for item in items:
+            text = extract_text(item)
+            kws = find_keywords(text)
+            if kws:
+                hits.append([
+                    str(idx),
+                    str(item.get("when", "")),
+                    str(item.get("author", "")),
+                    str(item.get("channel", "")),
+                    ",".join(kws),
+                    text[:80],
+                ])
+                idx += 1
+    out_dir = pathlib.Path("out")
+    out_dir.mkdir(exist_ok=True)
+    with (out_dir / "personhood_hits.csv").open("w", encoding="utf8", newline="") as f:
+        writer = csv.writer(f, delimiter="\t")
+        writer.writerow(["idx","when","author","channel","keywords","preview"])
+        writer.writerows(hits)
+    with (out_dir / "personhood_hits.md").open("w", encoding="utf8") as f:
+        for r in hits:
+            f.write(f"- {r[1]} {r[2]} {r[4]} — {r[5]}\n")
+    print(f"wrote {len(hits)} hits")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/personhood/util.ts
+++ b/scripts/personhood/util.ts
@@ -1,0 +1,28 @@
+import { KEYWORDS } from "./kw";
+import { RX } from "./regexes";
+
+export type ConvItem = {
+  when?: string | number;
+  author?: string | null;
+  channel?: string | null;
+  text?: string | null;
+  message?: string | null;
+  content?: string | null;
+  [k: string]: any;
+};
+
+export function extractText(item: ConvItem): string {
+  return item.text ?? item.message ?? item.content ?? "";
+}
+
+export function findKeywords(t: string): string[] {
+  const hits: string[] = [];
+  const lower = t.toLowerCase();
+  for (const k of KEYWORDS) {
+    if (lower.includes(k.toLowerCase())) hits.push(k);
+  }
+  for (const [name, rx] of Object.entries(RX)) {
+    if (rx.test(t)) hits.push(name);
+  }
+  return Array.from(new Set(hits));
+}

--- a/scripts/repo/command-index.ts
+++ b/scripts/repo/command-index.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const exts = new Set([".ts",".js",".py",".sh"]);
+const patterns = [
+  /pnpm\s+dlx\s+tsx\s+([^\n]+)/g,
+  /ts-node\s+([^\n]+)/g,
+  /node\s+([^\n]+)/g,
+  /python3?\s+([^\n]+)/g,
+  /bash\s+([^\n]+)/g
+];
+
+function* walk(dir:string): any {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) yield* walk(p);
+    else yield p;
+  }
+}
+
+const out:any[] = [];
+for (const f of walk(path.join(ROOT, "scripts"))) {
+  if (!exts.has(path.extname(f))) continue;
+  const src = fs.readFileSync(f, "utf8");
+  const hits:string[] = [];
+  for (const rx of patterns) {
+    let m:RegExpExecArray|null;
+    while ((m = rx.exec(src))) hits.push(m[0].trim());
+  }
+  if (hits.length) out.push({ file: f, commands: hits });
+}
+fs.writeFileSync("out/command-index.json", JSON.stringify(out, null, 2));
+console.log("wrote out/command-index.json");

--- a/scripts/repo/list-scripts.ts
+++ b/scripts/repo/list-scripts.ts
@@ -1,0 +1,18 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+function* walk(dir:string): any {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) yield* walk(p);
+    else yield p;
+  }
+}
+
+const exts = new Set([".ts",".js",".py",".sh",".mjs",".cjs"]);
+const files:string[] = [];
+for (const f of walk(path.join(ROOT, "scripts"))) {
+  if (exts.has(path.extname(f))) files.push(f);
+}
+console.log(JSON.stringify(files.sort(), null, 2));


### PR DESCRIPTION
## Summary
- add Orientation Hub README and Atlas with repo maps for agents, simulations, and personhood
- introduce personhood scanning utilities, regexes, and UI panel
- provide repo helper scripts and command catalog

## Testing
- `npx tsc -p tsconfig.json`
- `npx pyright`


------
https://chatgpt.com/codex/tasks/task_e_68c02b552d1c8322a6612ecd4e0e95dd