### PR TITLE
feat: build agents and add sigillin index panel

### DIFF
--- a/codexfeedback.json
+++ b/codexfeedback.json
@@ -1,0 +1,19 @@
+{
+  "runs": [
+    {
+      "fraktalrun": "Fraktal8 OrientationHub",
+      "status": "implemented",
+      "notes": "Alle Inhalte aus Fraktal8 integriert; weitere Fragmente können in Folgeläufen ergänzt werden."
+    },
+    {
+      "fraktalrun": "Fraktal10 SigillinIndex",
+      "status": "implemented",
+      "notes": "Sigillin-Index-Skript hinzugefügt; nächster Schritt Personhood-UI."
+    },
+    {
+      "fraktalrun": "Fraktal11 PersonhoodBuild",
+      "status": "implemented",
+      "notes": "Personhood-Build und SigillinIndexPanel umgesetzt; Tests grün."
+    }
+  ]
+}

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -16,3 +16,4 @@
 - FR-UM-2025-08-30-Fraktal8-OrientationHub: Alle Änderungen in einem Lauf umgesetzt – kein zweiter Lauf notwendig.
 - FR-UM-2025-08-31-Fraktal9: Alle Änderungen in einem Lauf umgesetzt – kein zweiter Lauf notwendig.
 - FR-UM-2025-09-01-Fraktal10: Sigillin-Index-Skript hinzugefügt und ausgeführt; nächster Schritt Personhood-UI.
+- FR-UM-2025-09-02-Fraktal11: Personhood-Buildfix und SigillinIndexPanel umgesetzt – kein weiterer Lauf notwendig.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -5,3 +5,6 @@ runs:
   - fraktalrun: "Fraktal10 SigillinIndex"
     status: "implemented"
     notes: "Sigillin-Index-Skript hinzugefügt; nächster Schritt Personhood-UI."
+  - fraktalrun: "Fraktal11 PersonhoodBuild"
+    status: "implemented"
+    notes: "Personhood-Build und SigillinIndexPanel umgesetzt; Tests grün."

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "apps/*"
   ],
   "scripts": {
-    "build": "tsc -b",
+    "build:agents": "tsc -p tsconfig.agents.json && node -e \"const fs=require('fs'),p='dist/agents/personhood/AIJuristicAgent.js';if(fs.existsSync(p))fs.renameSync(p,p.replace(/\\.js$/,'.cjs'));\"",
+    "build": "tsc -p tsconfig.json && pnpm build:agents",
     "build:ui": "pnpm -F mandala-ui build",
     "lint": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
@@ -72,7 +73,7 @@
     "conversations:grep": "ts-node scripts/parse-newadvancedconversations.ts",
     "sigils:index": "ts-node scripts/build-sigillin-index.ts",
     "orchestrator:dev": "ts-node unifiedmandala-orchestrator/src/server.ts",
-    "personhood:test": "node -e \"import('file://'+process.cwd()+'/dist/agents/personhood/AIJuristicAgent.js').then(m=>console.log(JSON.stringify((m.default||m).analyze({subject:'ai',claims:['autonomy','contractual capacity']})))).catch(err=>console.error(err))\"",
+    "personhood:test": "pnpm build:agents && node -e \"console.log(require('./dist/agents/personhood/AIJuristicAgent.cjs').analyze({subject:'ai',claims:['autonomy','contractual capacity']}))\"",
     "maps:all": "pnpm maps:build",
     "llm:send:claude": "node tools/llm/send-claude.mjs",
     "llm:send:mistral": "node tools/llm/send-mistral.mjs",

--- a/packages/unifiedmandala-ui/components/SigillinIndexPanel.tsx
+++ b/packages/unifiedmandala-ui/components/SigillinIndexPanel.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+type SigilEntry = {
+  id: string;
+  title?: string;
+  tags?: string[];
+  crep?: number;
+  path?: string;
+  summary?: string;
+};
+
+export default function SigillinIndexPanel() {
+  const [data, setData] = useState<SigilEntry[]>([]);
+  const [q, setQ] = useState("");
+  const [tag, setTag] = useState("");
+
+  useEffect(() => {
+    // passe den Pfad an deinen Output an (z.B. out/sigillin_index.json)
+    fetch("/out/sigillin_index.json")
+      .then(r => r.json())
+      .then(setData)
+      .catch(() => setData([]));
+  }, []);
+
+  const tags = useMemo(() => {
+    const set = new Set<string>();
+    data.forEach(d => (d.tags || []).forEach(t => set.add(t)));
+    return Array.from(set).sort();
+  }, [data]);
+
+  const filtered = useMemo(() => {
+    const qq = q.trim().toLowerCase();
+    return data.filter(d => {
+      const qHit =
+        !qq ||
+        (d.title && d.title.toLowerCase().includes(qq)) ||
+        (d.summary && d.summary.toLowerCase().includes(qq)) ||
+        (d.id && d.id.toLowerCase().includes(qq));
+      const tHit = !tag || (d.tags || []).includes(tag);
+      return qHit && tHit;
+    });
+  }, [data, q, tag]);
+
+  return (
+    <div style={{ display: "grid", gap: 8 }}>
+      <h3>Sigillin Index</h3>
+      <div style={{ display: "flex", gap: 8 }}>
+        <input
+          placeholder="Suche (Titel, ID, Summary)…"
+          value={q}
+          onChange={e => setQ(e.target.value)}
+          style={{ flex: 1 }}
+        />
+        <select value={tag} onChange={e => setTag(e.target.value)}>
+          <option value="">Alle Tags</option>
+          {tags.map(t => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div style={{ display: "grid", gap: 6 }}>
+        {filtered.map(d => (
+          <div
+            key={d.id}
+            style={{ padding: 8, border: "1px solid #333", borderRadius: 8 }}
+          >
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                gap: 8,
+              }}
+            >
+              <strong>{d.title || d.id}</strong>
+              {typeof d.crep === "number" && (
+                <span title="CREP" style={{ opacity: 0.8 }}>
+                  CREP: {d.crep.toFixed(2)}
+                </span>
+              )}
+            </div>
+            {d.summary && (
+              <div style={{ opacity: 0.85, marginTop: 4 }}>{d.summary}</div>
+            )}
+            <div
+              style={{
+                marginTop: 6,
+                display: "flex",
+                gap: 6,
+                flexWrap: "wrap",
+              }}
+            >
+              {(d.tags || []).map(t => (
+                <span
+                  key={t}
+                  style={{
+                    fontSize: 12,
+                    border: "1px solid #555",
+                    padding: "2px 6px",
+                    borderRadius: 12,
+                  }}
+                >
+                  {t}
+                </span>
+              ))}
+            </div>
+            {d.path && (
+              <div style={{ marginTop: 6, fontSize: 12, opacity: 0.7 }}>
+                {d.path}
+              </div>
+            )}
+          </div>
+        ))}
+        {!filtered.length && (
+          <div style={{ opacity: 0.7 }}>Keine Einträge.</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -13,6 +13,7 @@ export { default as AeonTrigger } from './components/AeonTrigger';
 export { default as MandalaGalaxyView } from './components/MandalaGalaxyView';
 export { default as LogbuchPanel } from './components/LogbuchPanel';
 export { default as SigillinOverlay } from './components/SigillinOverlay';
+export { default as SigillinIndexPanel } from './components/SigillinIndexPanel';
 export * from './hooks/useCREPManager';
 export * from './hooks/useCREPHistory';
 export { default as MandalaCREPCircle } from './components/MandalaCREPCircle';

--- a/tsconfig.agents.json
+++ b/tsconfig.agents.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "commonjs",
+    "target": "ES2020",
+    "declaration": false,
+    "sourceMap": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": false,
+    "allowImportingTsExtensions": false,
+    "rootDir": "."
+  },
+  "include": ["agents/personhood/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add dedicated tsconfig and build scripts for personhood agents
- surface sigillin index in UI via new SigillinIndexPanel
- track Fraktal11 progress in codex feedback files

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm sigils:index`
- `pnpm maps:build`
- `pnpm audit:ui-vr`
- `pnpm personhood:test`


------
https://chatgpt.com/codex/tasks/task_e_68c0a13c2cb08322aeadaac8b6d4d2b9