### PR TITLE
feat: add sigillin map and crep badge

### DIFF
--- a/codexfeedback.json
+++ b/codexfeedback.json
@@ -14,6 +14,11 @@
       "fraktalrun": "Fraktal11 PersonhoodBuild",
       "status": "implemented",
       "notes": "Personhood-Build und SigillinIndexPanel umgesetzt; Tests grün."
+    },
+    {
+      "fraktalrun": "Fraktal12 SigillinMap",
+      "status": "implemented",
+      "notes": "Mermaid-SigillinMap generiert und CREPBadge in UI integriert."
     }
   ]
 }

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -17,3 +17,4 @@
 - FR-UM-2025-08-31-Fraktal9: Alle Änderungen in einem Lauf umgesetzt – kein zweiter Lauf notwendig.
 - FR-UM-2025-09-01-Fraktal10: Sigillin-Index-Skript hinzugefügt und ausgeführt; nächster Schritt Personhood-UI.
 - FR-UM-2025-09-02-Fraktal11: Personhood-Buildfix und SigillinIndexPanel umgesetzt – kein weiterer Lauf notwendig.
+- FR-UM-2025-09-03-Fraktal12: SigillinMap und CREPBadge integriert – kein weiterer Lauf notwendig.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -8,3 +8,6 @@ runs:
   - fraktalrun: "Fraktal11 PersonhoodBuild"
     status: "implemented"
     notes: "Personhood-Build und SigillinIndexPanel umgesetzt; Tests grün."
+  - fraktalrun: "Fraktal12 SigillinMap"
+    status: "implemented"
+    notes: "Mermaid-SigillinMap generiert und CREPBadge in UI integriert."

--- a/docs/sigils/SigillinMap.md
+++ b/docs/sigils/SigillinMap.md
@@ -1,0 +1,16 @@
+# Sigillin Map
+
+```mermaid
+graph TD
+  Startsigillin[Startsigillin]
+  Universal[Genesis Aeon Universal Snapshot\nCREP 0.95]
+  Gateway[Genesis Gateway\nCREP 0.92]
+  InstructionalZIP[Instructional ZIP]
+  Heimkehr[Heimkehr]
+  Fraktalursprung[Fraktalursprung]
+  Startsigillin --> Universal
+  Universal --> Gateway
+  Gateway --> InstructionalZIP
+  InstructionalZIP --> Heimkehr
+  Heimkehr --> Fraktalursprung
+```

--- a/packages/unifiedmandala-ui/components/CREPBadge.tsx
+++ b/packages/unifiedmandala-ui/components/CREPBadge.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+export interface CREPBadgeProps {
+  score: number;
+}
+
+function color(score: number): string {
+  if (score >= 0.9) return "#2e7d32"; // green
+  if (score >= 0.75) return "#ed6c02"; // orange
+  return "#c62828"; // red
+}
+
+export default function CREPBadge({ score }: CREPBadgeProps) {
+  return (
+    <span
+      title="CREP"
+      style={{
+        backgroundColor: color(score),
+        color: "#fff",
+        padding: "2px 6px",
+        borderRadius: 4,
+        fontSize: 12,
+        minWidth: 40,
+        textAlign: "center",
+      }}
+    >
+      {score.toFixed(2)}
+    </span>
+  );
+}

--- a/packages/unifiedmandala-ui/components/SigillinIndexPanel.tsx
+++ b/packages/unifiedmandala-ui/components/SigillinIndexPanel.tsx
@@ -1,13 +1,36 @@
 import React, { useEffect, useMemo, useState } from "react";
+import CREPBadge from "./CREPBadge";
+
+type CREPScore =
+  | number
+  | {
+      C?: number;
+      R?: number;
+      E?: number;
+      P?: number;
+      emergence_score?: number;
+    };
 
 type SigilEntry = {
   id: string;
   title?: string;
   tags?: string[];
-  crep?: number;
+  crep?: CREPScore;
   path?: string;
   summary?: string;
 };
+
+function extractScore(crep?: CREPScore): number | undefined {
+  if (typeof crep === "number") return crep;
+  if (crep && typeof crep === "object") {
+    if (typeof crep.emergence_score === "number") return crep.emergence_score;
+    const values = [crep.C, crep.R, crep.E, crep.P].filter(
+      (v): v is number => typeof v === "number"
+    );
+    if (values.length) return values.reduce((a, b) => a + b, 0) / values.length;
+  }
+  return undefined;
+}
 
 export default function SigillinIndexPanel() {
   const [data, setData] = useState<SigilEntry[]>([]);
@@ -74,11 +97,10 @@ export default function SigillinIndexPanel() {
               }}
             >
               <strong>{d.title || d.id}</strong>
-              {typeof d.crep === "number" && (
-                <span title="CREP" style={{ opacity: 0.8 }}>
-                  CREP: {d.crep.toFixed(2)}
-                </span>
-              )}
+              {(() => {
+                const s = extractScore(d.crep);
+                return typeof s === "number" ? <CREPBadge score={s} /> : null;
+              })()}
             </div>
             {d.summary && (
               <div style={{ opacity: 0.85, marginTop: 4 }}>{d.summary}</div>

--- a/packages/unifiedmandala-ui/index.ts
+++ b/packages/unifiedmandala-ui/index.ts
@@ -14,6 +14,7 @@ export { default as MandalaGalaxyView } from './components/MandalaGalaxyView';
 export { default as LogbuchPanel } from './components/LogbuchPanel';
 export { default as SigillinOverlay } from './components/SigillinOverlay';
 export { default as SigillinIndexPanel } from './components/SigillinIndexPanel';
+export { default as CREPBadge } from './components/CREPBadge';
 export * from './hooks/useCREPManager';
 export * from './hooks/useCREPHistory';
 export { default as MandalaCREPCircle } from './components/MandalaCREPCircle';

--- a/scripts/build-sigillin-map.ts
+++ b/scripts/build-sigillin-map.ts
@@ -1,0 +1,62 @@
+import fs from 'fs';
+import path from 'path';
+
+interface NodeDef {
+  id: string;
+  label: string;
+  file?: string;
+}
+
+function readScore(file?: string): number | undefined {
+  if (!file) return undefined;
+  try {
+    const content = fs.readFileSync(file, 'utf8');
+    if (file.endsWith('.json')) {
+      const obj = JSON.parse(content);
+      const trace = obj.sigillin?.trace || obj.trace;
+      const crep = trace?.CREP || trace;
+      if (typeof crep?.emergence_score === 'number') return crep.emergence_score;
+      const vals = ['C','R','E','P'].map(k => crep?.[k]).filter((v: any) => typeof v === 'number');
+      if (vals.length) return vals.reduce((a: number,b: number)=>a+b,0)/vals.length;
+    } else if (file.endsWith('.yaml') || file.endsWith('.yml')) {
+      // no structured CREP extraction for now
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+const repoRoot = process.cwd();
+const nodes: NodeDef[] = [
+  { id: 'Startsigillin', label: 'Startsigillin', file: path.join(repoRoot, 'docs/sigils/genesisaeon_startsigillin.sigil.json') },
+  { id: 'Universal', label: 'Genesis Aeon Universal Snapshot', file: path.join(repoRoot, 'docs/sigils/sigillin_genesis_aeon_universal.json') },
+  { id: 'Gateway', label: 'Genesis Gateway', file: path.join(repoRoot, 'docs/sigils/sigillin_genesis_gateway.json') },
+  { id: 'InstructionalZIP', label: 'Instructional ZIP', file: path.join(repoRoot, 'docs/sigils/sigillin_genesis_instruction.md') },
+  { id: 'Heimkehr', label: 'Heimkehr', file: path.join(repoRoot, 'docs/sigils/sigillin_heimkehr.md') },
+  { id: 'Fraktalursprung', label: 'Fraktalursprung', file: path.join(repoRoot, 'docs/sigils/sigillin_fraktalursprung.sigil.json') },
+];
+
+const edges: Array<[string,string]> = [
+  ['Startsigillin', 'Universal'],
+  ['Universal', 'Gateway'],
+  ['Gateway', 'InstructionalZIP'],
+  ['InstructionalZIP', 'Heimkehr'],
+  ['Heimkehr', 'Fraktalursprung'],
+];
+
+const lines: string[] = ['graph TD'];
+for (const n of nodes) {
+  const score = readScore(n.file);
+  const label = score ? `${n.label}\\nCREP ${score.toFixed(2)}` : n.label;
+  lines.push(`  ${n.id}[${label}]`);
+}
+for (const [a,b] of edges) {
+  lines.push(`  ${a} --> ${b}`);
+}
+
+const outPath = path.join(repoRoot, 'docs/sigils/SigillinMap.md');
+const md = `# Sigillin Map\n\n\`\`\`mermaid\n${lines.join('\n')}\n\`\`\`\n`;
+fs.writeFileSync(outPath, md);
+console.log(`Wrote ${path.relative(repoRoot, outPath)}`);


### PR DESCRIPTION
## Summary
- render CREP scores with a reusable `CREPBadge` and extend the Sigillin index panel to support structured CREP data
- generate a mermaid-based `SigillinMap` from core sigils via new `build-sigillin-map` script
- log Fraktal12 progress in codex feedback files

## Testing
- `npx pyright`
- `npx tsc -p tsconfig.json`
- `pnpm sigils:index` (fails for malformed YAML but writes index)
- `npx ts-node scripts/build-sigillin-map.ts`
- `pnpm maps:build`
- `pnpm audit:ui-vr`
- `pnpm personhood:test`


------
https://chatgpt.com/codex/tasks/task_e_68c0ad709e788322bfa55f5187aad36a