### PR TITLE
feat: guard default metrics and offline vitest

### DIFF
--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -34,3 +34,4 @@
 - FR-UM-2025-11-25-Fraktal25: CI green, resonance panel and adapter hardening implemented – kein weiterer Lauf notwendig.
 - FR-UM-2025-11-26-Fraktal20-CIResonanceSTAC: Alle Änderungen in einem Lauf umgesetzt – kein zweiter Lauf notwendig.
 - FR-UM-2025-01-17-Fraktal30: Globale Prometheus-Registry und getOrCreate-Helper implementiert – kein weiterer Lauf notwendig.
+- FR-UM-2025-02-16-Fraktal23: Metrics defaults guarded, Vitest offline Setup, LowMem Membrane No-Op – ERA5 offline-matrix offen.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -47,8 +47,18 @@ fraktal22:
     - "Coverage wieder aktivieren (selektiv) wenn Stabilität erreicht"
 
 fraktal23:
-  notes:
-    - "LowMem-Modus: VITE_LOW_MEM=on / LOW_MEM=1 → Membrane & Ringdown disabled"
-    - "UI blendet MembraneBadge aus; KPI-Bridge liefert trivialen Pfad"
+  status: "in_progress"
+  checkpoints:
+    - "Metrics defaults guarded: ensureDefaultMetrics() once"
+    - "Vitest OFFLINE: fetch-stub + /tmp seeding"
+    - "LowMem No-Op for membrane/ringdown"
+    - "CI env OFFLINE/LOW_MEM global; OISST smoke present"
+    - "Conscious-CI docs: Core/Extended/Experimental"
+  definition_of_green:
+    - "No 'already been registered' at startup/test"
+    - "pnpm test:ts passes offline (no network)"
+    - "out/adapters_index.json contains OISST"
+    - "tsc + pyright pass"
   next:
-    - "Membrane in separatem Job/opt-in Tests wieder aktivieren (no LowMem)"
+    - "ERA5 offline-matrix"
+    - "Nightly extended-tests (no LOW_MEM) with coverage"

--- a/docs/CONSCIOUS_CI.md
+++ b/docs/CONSCIOUS_CI.md
@@ -1,0 +1,8 @@
+# Conscious-CI Ebenen
+
+- **Core**: Typechecks (tsc/pyright), Policy-Prüfungen (OPA), Metrics-Bootstrap und Offline-Adapter-Smoke.
+- **Extended**: STAC-Validate, Resonanz-Berechnung, Prompt-Lint (Dry-Run).
+- **Experimental**: Agents-Dry-Run, Maps-Build, Governance-Extended.
+
+Low-Mem und Offline sind Standard im CI. Nightly Jobs können ohne Low-Mem mit
+mehreren Workern und Coverage laufen.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,6 @@
+# Metrics Singleton
+
+Alle Prometheus-Metriken registrieren sich auf **REG**, eine gemeinsame Registry.
+Default-Metriken werden genau einmal über `ensureDefaultMetrics()` initialisiert.
+Eigene Metriken sollten mit `getOrCreate*`-Helpern erzeugt werden und niemals eine
+neue `Registry` anlegen.

--- a/packages/core/middleware/metrics.ts
+++ b/packages/core/middleware/metrics.ts
@@ -1,4 +1,3 @@
-import { collectDefaultMetrics } from 'prom-client';
 import { Request, Response, NextFunction } from 'express';
 import {
   REG,
@@ -6,8 +5,6 @@ import {
   getOrCreateHistogram,
   metricsText,
 } from '../../../src/metrics/singleton';
-
-collectDefaultMetrics({ register: REG });
 
 const httpRequestCounter = getOrCreateCounter({
   name: 'http_requests_total',

--- a/scripts/metrics-start.ts
+++ b/scripts/metrics-start.ts
@@ -1,10 +1,13 @@
 import express from 'express';
 import { metricsEndpoint } from '../packages/core/middleware/metrics';
+import { ensureDefaultMetrics } from '../src/metrics/singleton';
 
 const app = express();
 app.get('/metrics', metricsEndpoint);
 
 const port = Number(process.env.METRICS_PORT) || 9108;
+ensureDefaultMetrics();
+
 app.listen(port, () => {
   console.log(`Metrics server listening on port ${port}`);
 });

--- a/services/metrics.ts
+++ b/services/metrics.ts
@@ -1,7 +1,4 @@
-import { collectDefaultMetrics } from 'prom-client';
-import { REG, getOrCreateCounter } from '../src/metrics/singleton';
-
-collectDefaultMetrics({ register: REG });
+import { getOrCreateCounter } from '../src/metrics/singleton';
 
 export const patternCreateCounter = getOrCreateCounter({
   name: 'patterns_created_total',

--- a/src/membrane/index.ts
+++ b/src/membrane/index.ts
@@ -1,0 +1,17 @@
+export const isLowMem = process.env.LOW_MEM === '1' || process.env.VITE_LOW_MEM === 'on';
+
+export type HorizonState = 'subcritical' | 'apparent' | 'event';
+export type Reading = { t: number; value: number; severity: 'ok' | 'warn' | 'alarm'; state: HorizonState; dA: number; A: number };
+
+class NoOpMembrane {
+  step(t: number, v: number): Reading {
+    return { t, value: v, severity: 'ok', state: 'subcritical', dA: 0, A: 0 };
+  }
+}
+
+export const Membrane = isLowMem
+  ? NoOpMembrane
+  : (await import('./real-membrane.js')).NullMembrane;
+
+export const membraneSigil = (state: HorizonState) =>
+  state === 'event' ? '🛡️' : state === 'apparent' ? '⚠️' : '🟢';

--- a/src/membrane/real-membrane.ts
+++ b/src/membrane/real-membrane.ts
@@ -1,0 +1,5 @@
+export class NullMembrane {
+  step(t: number, v: number) {
+    return { t, value: v, severity: 'ok', state: 'subcritical', dA: 0, A: 0 } as import('./index').Reading;
+  }
+}

--- a/src/metrics/singleton.cjs
+++ b/src/metrics/singleton.cjs
@@ -4,12 +4,18 @@ const client = require("prom-client");
 const G = global;
 if (!G.__UM_METRICS__) {
   const REG = new client.Registry();
-  // Optional: Default-Label für Service/Env
   REG.setDefaultLabels({ service: "unified-mandala" });
-  G.__UM_METRICS__ = { REG, C: {}, G: {}, H: {}, S: {} };
+  G.__UM_METRICS__ = { REG, defaultsDone: false, C: {}, G: {}, H: {}, S: {} };
 }
 const store = G.__UM_METRICS__;
 const REG = store.REG;
+
+function ensureDefaultMetrics() {
+  if (!store.defaultsDone) {
+    client.collectDefaultMetrics({ register: REG });
+    store.defaultsDone = true;
+  }
+}
 
 function getOrCreateCounter(cfg) {
   const name = cfg.name;
@@ -49,6 +55,7 @@ async function metricsText() {
 
 module.exports = {
   REG,
+  ensureDefaultMetrics,
   getOrCreateCounter,
   getOrCreateGauge,
   getOrCreateHistogram,

--- a/src/metrics/singleton.ts
+++ b/src/metrics/singleton.ts
@@ -9,6 +9,7 @@ type Cfg<T extends string = string> =
 
 type Store = {
   REG: client.Registry;
+  defaultsDone: boolean;
   C: Record<string, client.Counter<string>>;
   G: Record<string, client.Gauge<string>>;
   H: Record<string, client.Histogram<string>>;
@@ -18,12 +19,25 @@ type Store = {
 const G: any = globalThis as any;
 if (!G.__UM_METRICS__) {
   const REG = new client.Registry();
-  // Optional: Default-Label für Service/Env
   REG.setDefaultLabels({ service: "unified-mandala" });
-  G.__UM_METRICS__ = { REG, C: {}, G: {}, H: {}, S: {} } as Store;
+  G.__UM_METRICS__ = {
+    REG,
+    defaultsDone: false,
+    C: {},
+    G: {},
+    H: {},
+    S: {},
+  } as Store;
 }
-const store: Store = G.__UM_METRICS__;
+const store = G.__UM_METRICS__ as Store;
 export const REG = store.REG;
+
+export function ensureDefaultMetrics() {
+  if (!store.defaultsDone) {
+    client.collectDefaultMetrics({ register: REG });
+    store.defaultsDone = true;
+  }
+}
 
 // --- Helpers -------------------------------------------------------------
 

--- a/tests/setup/ci.ts
+++ b/tests/setup/ci.ts
@@ -1,0 +1,30 @@
+import { beforeAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+process.env.OFFLINE ??= '1';
+process.env.LOW_MEM ??= '1';
+process.env.VITE_LOW_MEM ??= 'on';
+
+if (typeof fetch === 'undefined') {
+  const { fetch: undiciFetch } = await import('undici');
+  // @ts-expect-error assign global fetch
+  globalThis.fetch = (input: any, init?: any) => {
+    const url = String(input ?? '');
+    if (process.env.OFFLINE === '1' && /^https?:\/\//i.test(url)) {
+      return Promise.reject(new Error('OFFLINE: network calls are disabled in CI'));
+    }
+    return undiciFetch(input as any, init as any) as any;
+  };
+}
+
+beforeAll(() => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'um-'));
+  const statsPath = path.join(tmpDir, 'newadvanced-stats.json');
+  fs.writeFileSync(statsPath, JSON.stringify({ ok: true, t: Date.now() }));
+  try {
+    fs.copyFileSync(statsPath, '/tmp/newadvanced-stats.json');
+  } catch {}
+  process.env.UM_TMP_DIR = tmpDir;
+});

--- a/tools/metrics/patch-metrics.mjs
+++ b/tools/metrics/patch-metrics.mjs
@@ -1,12 +1,12 @@
-import { collectDefaultMetrics, register } from 'prom-client';
 import http from 'http';
+import { ensureDefaultMetrics, REG } from '../../src/metrics/singleton.cjs';
 
-collectDefaultMetrics();
+ensureDefaultMetrics();
 
 const server = http.createServer(async (req, res) => {
   if (req.url === '/metrics') {
-    res.setHeader('Content-Type', register.contentType);
-    res.end(await register.metrics());
+    res.setHeader('Content-Type', REG.contentType);
+    res.end(await REG.metrics());
   } else {
     res.statusCode = 404;
     res.end('not found');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,25 +1,16 @@
 import { defineConfig } from "vitest/config";
-import os from "node:os";
-
-const CPU = Math.max(1, Math.floor(os.cpus().length / 2));
-const WORKERS = Number(process.env.VITEST_WORKERS || 1); // default 1 → speicherschonend
 
 export default defineConfig({
   test: {
-    environment: "jsdom",
-    setupFiles: ["./vitest.setup.ts"],
-    // Vermeidet OOM durch Single-Worker-Run; bei Bedarf via env hochdrehen:
+    environment: "node",
+    setupFiles: ["./vitest.setup.ts", "tests/setup/ci.ts"],
     pool: "threads",
-    maxWorkers: WORKERS || CPU,
-    minWorkers: 1,
+    poolOptions: { threads: { singleThread: true } },
     isolate: true,
     sequence: { concurrent: false },
     testTimeout: 30_000,
     hookTimeout: 30_000,
-    coverage: {
-      provider: "v8",
-      enabled: false, // Coverage optional – kann OOM triggern, bei Bedarf in CI einschalten
-    },
+    coverage: { provider: "v8", enabled: false },
     watch: false,
   },
   // Große Verzeichnisse ausschließen (Scan & Memory ↓)


### PR DESCRIPTION
## Summary
- guard Prometheus default metrics with global singleton `ensureDefaultMetrics`
- run Vitest offline via CI setup file and single-thread pool
- document Conscious-CI levels and metrics singleton; update codex feedback

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npx pyright`
- `pnpm test:ts` *(fails: ReferenceError: describe is not defined and other test failures)*
- `CI=true pnpm adapter:build:oisst`


------
https://chatgpt.com/codex/tasks/task_e_68c5e2fd61a48322944a941154b174b7