### PR TITLE
fraktal32: Conscious-CI grün machen — echte OFFLINE-Tests, einmalige Metrics-Defaults, Low-Mem-No-Op, OISST-Smoke

### DIFF
--- a/.github/workflows/fraktal-ci.yml
+++ b/.github/workflows/fraktal-ci.yml
@@ -1,12 +1,15 @@
 name: fraktal-ci
 
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
 env:
   LOW_MEM: "1"
   VITE_LOW_MEM: "on"
   OFFLINE: "1"
   NODE_OPTIONS: "--max-old-space-size=2048"
-
-on: [push, pull_request]
 
 jobs:
   type-and-tests:
@@ -14,11 +17,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with:
-          node-version: 20
+        with: { node-version: 20 }
+      - run: corepack enable
+      - run: pnpm --version
       - run: pnpm install --frozen-lockfile
       - run: npx tsc -p tsconfig.json --noEmit
       - run: pnpm test:ts:ci
+      - run: npx pyright
 
   adapters-offline:
     runs-on: ubuntu-latest
@@ -26,12 +31,22 @@ jobs:
       CI: "true"
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
       - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - run: python -m pip install --upgrade pip && pip install -r requirements.txt
-      - run: PYTHONPATH=src pnpm adapter:build:oisst
-      - name: Smoke adapters_index
+        with: { python-version: '3.11' }
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - name: Build OISST (offline)
+        run: PYTHONPATH=src pnpm adapter:build:oisst
+      - name: Smoke: adapters_index.json contains OISST
         run: |
           test -f out/adapters_index.json
-          jq -e '.adapters[] | select(.id | test("oisst"; "i"))' out/adapters_index.json >/dev/null
+          jq -e '.adapters[] | select((.id // .name) | tostring | test("oisst"; "i"))' out/adapters_index.json >/dev/null
+      - name: Upload out (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with: { name: out, path: out }
+

--- a/codexfeedback.json
+++ b/codexfeedback.json
@@ -99,6 +99,11 @@
       "fraktalrun": "Fraktal30 MetricsSingleton",
       "status": "implemented",
       "notes": "Globale Prometheus-Registry mit getOrCreate-Helpern und LowMem-CI-Variablen integriert."
+    },
+    {
+      "fraktalrun": "Fraktal33 ConsciousCI",
+      "status": "implemented",
+      "notes": "Vitest OFFLINE enforced, metrics singleton, LowMem membrane No-Op; kein weiterer Lauf notwendig."
     }
   ]
 }

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -35,3 +35,4 @@
 - FR-UM-2025-11-26-Fraktal20-CIResonanceSTAC: Alle Änderungen in einem Lauf umgesetzt – kein zweiter Lauf notwendig.
 - FR-UM-2025-01-17-Fraktal30: Globale Prometheus-Registry und getOrCreate-Helper implementiert – kein weiterer Lauf notwendig.
 - FR-UM-2025-02-16-Fraktal23: Metrics defaults guarded, Vitest offline Setup, LowMem Membrane No-Op – ERA5 offline-matrix offen.
+- FR-UM-2025-09-13-Fraktal33: Conscious-CI grün; OFFLINE-Vitest enforced, Metrics defaults singleton, Low-Mem No-Op – kein weiterer Lauf notwendig.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -3,7 +3,7 @@ fraktal:
   history:
     - id: 32
       status: "in-progress"
-      notes: "Conscious-CI stabil: metrics singleton, Vitest offline, LowMem membrane"
+      notes: "Conscious-CI stabil: metrics singleton, Vitest offline (globals+fetch), LowMem membrane"
     - id: 25
       status: "done"
       notes: "pyright strict grün; OISST var=sst normalisiert"
@@ -21,6 +21,7 @@ fraktal:
   needs_repeat: false
 
 fraktal21:
+  status: "ready-for-review"
   checkpoints:
     - "OISST pipeline restored: fetch → postprocess → STAC → CREP → adapters_index.json"
     - "CI smoke asserts OISST presence in out/adapters_index.json"
@@ -28,7 +29,6 @@ fraktal21:
     - "check:ci → tsc + vitest(low-mem) + pyright"
     - "CI splits: adapters-offline + type-and-tests"
     - "Metrics: global Registry + getOrCreate-Helper verhindern Doppel-Registrierung"
-  status: "ready-for-review"
   notes:
     - "Bei Bedarf VITEST_WORKERS>1 lokal setzen; in CI bei 1 lassen."
     - "Fehler '...already been registered' behoben; HMR/ESM/Vitest sicher"
@@ -76,3 +76,4 @@ fraktal32:
   next:
     - "ERA5 offline-matrix"
     - "Nightly extended-tests (no LOW_MEM) with coverage"
+

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "ci:sigils": "pnpm sigils:index:strict && pnpm test:sigil tests/fixtures/sigillin/good.yaml && pnpm resonance:calc",
     "ci:adapters-offline": "CI=true pnpm adapter:build:oisst && CI=true pnpm adapter:build:era5 || true",
     "test:ts": "vitest run --config vitest.config.ts",
-    "test:ts:ci": "NODE_OPTIONS='--max-old-space-size=2048' vitest run --config vitest.config.ts",
+    "test:ts:ci": "NODE_OPTIONS=--max-old-space-size=2048 vitest run --config vitest.config.ts",
     "test:py": "pytest -q",
     "test:sigil": "ts-node scripts/validate-sigil-cli.ts",
     "test:ui": "vitest run --passWithNoTests",

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -1,9 +1,12 @@
 import express from "express";
 import path from "node:path";
+import { ensureDefaultMetrics } from "../src/metrics/singleton";
 
 const app = express();
 const PORT = Number(process.env.PORT || 3000);
 const UI_DIST = process.env.UI_DIST || path.resolve("apps/mandala-ui/dist");
+
+ensureDefaultMetrics();
 
 app.use(express.static(UI_DIST, { index: "index.html", fallthrough: true }));
 

--- a/src/metrics/singleton.ts
+++ b/src/metrics/singleton.ts
@@ -1,36 +1,13 @@
-// HMR/ESM- und Test-sichere Prometheus-Metriken (prom-client)
 import * as client from "prom-client";
-
-type Cfg<T extends string = string> =
-  | client.CounterConfiguration<T>
-  | client.GaugeConfiguration<T>
-  | client.HistogramConfiguration<T>
-  | client.SummaryConfiguration<T>;
-
-type Store = {
-  REG: client.Registry;
-  defaultsDone: boolean;
-  C: Record<string, client.Counter<string>>;
-  G: Record<string, client.Gauge<string>>;
-  H: Record<string, client.Histogram<string>>;
-  S: Record<string, client.Summary<string>>;
-};
 
 const G: any = globalThis as any;
 if (!G.__UM_METRICS__) {
   const REG = new client.Registry();
   REG.setDefaultLabels({ service: "unified-mandala" });
-  G.__UM_METRICS__ = {
-    REG,
-    defaultsDone: false,
-    C: {},
-    G: {},
-    H: {},
-    S: {},
-  } as Store;
+  G.__UM_METRICS__ = { REG, defaultsDone: false, C: {}, G: {}, H: {}, S: {} };
 }
-const store = G.__UM_METRICS__ as Store;
-export const REG = store.REG;
+const store = G.__UM_METRICS__;
+export const REG: client.Registry = store.REG;
 
 export function ensureDefaultMetrics() {
   if (!store.defaultsDone) {
@@ -39,50 +16,43 @@ export function ensureDefaultMetrics() {
   }
 }
 
-// --- Helpers -------------------------------------------------------------
+type Cfg = { name: string; help?: string; labelNames?: string[] };
 
-export function getOrCreateCounter<T extends string = string>(
-  cfg: client.CounterConfiguration<T>
-) {
-  const name = cfg.name;
-  if (store.C[name]) return store.C[name] as client.Counter<T>;
-  // Explizit in unsere REG registrieren (kein Default-Register!)
-  const c = new client.Counter<T>({ ...cfg, registers: [REG] });
-  store.C[name] = c as unknown as client.Counter<string>;
-  return c;
-}
+export const getOrCreateCounter = (c: Cfg) =>
+  (store.C[c.name] ||= new client.Counter({
+    registers: [REG],
+    name: c.name,
+    help: c.help ?? c.name,
+    labelNames: c.labelNames ?? [],
+  }));
 
-export function getOrCreateGauge<T extends string = string>(
-  cfg: client.GaugeConfiguration<T>
-) {
-  const name = cfg.name;
-  if (store.G[name]) return store.G[name] as client.Gauge<T>;
-  const g = new client.Gauge<T>({ ...cfg, registers: [REG] });
-  store.G[name] = g as unknown as client.Gauge<string>;
-  return g;
-}
+export const getOrCreateGauge = (c: Cfg) =>
+  (store.G[c.name] ||= new client.Gauge({
+    registers: [REG],
+    name: c.name,
+    help: c.help ?? c.name,
+    labelNames: c.labelNames ?? [],
+  }));
 
-export function getOrCreateHistogram<T extends string = string>(
-  cfg: client.HistogramConfiguration<T>
-) {
-  const name = cfg.name;
-  if (store.H[name]) return store.H[name] as client.Histogram<T>;
-  const h = new client.Histogram<T>({ ...cfg, registers: [REG] });
-  store.H[name] = h as unknown as client.Histogram<string>;
-  return h;
-}
+export const getOrCreateHistogram = (c: Cfg & { buckets?: number[] }) =>
+  (store.H[c.name] ||= new client.Histogram({
+    registers: [REG],
+    name: c.name,
+    help: c.help ?? c.name,
+    labelNames: c.labelNames ?? [],
+    buckets: c.buckets,
+  }));
 
-export function getOrCreateSummary<T extends string = string>(
-  cfg: client.SummaryConfiguration<T>
-) {
-  const name = cfg.name;
-  if (store.S[name]) return store.S[name] as client.Summary<T>;
-  const s = new client.Summary<T>({ ...cfg, registers: [REG] });
-  store.S[name] = s as unknown as client.Summary<string>;
-  return s;
-}
+export const getOrCreateSummary = (c: Cfg & { percentiles?: number[] }) =>
+  (store.S[c.name] ||= new client.Summary({
+    registers: [REG],
+    name: c.name,
+    help: c.help ?? c.name,
+    labelNames: c.labelNames ?? [],
+    percentiles: c.percentiles,
+  }));
 
-// Für /metrics-Endpoints:
 export async function metricsText(): Promise<string> {
   return REG.metrics();
 }
+

--- a/tests/setup/ci.ts
+++ b/tests/setup/ci.ts
@@ -1,36 +1,26 @@
-// tests/setup/ci.ts
 import { beforeAll, afterEach, vi, expect } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { createRequire } from "node:module";
 
-// 1) CI/LowMem/Offline Defaults
+// Env-Defaults für CI/LowMem/Offline
 process.env.OFFLINE ??= "1";
 process.env.LOW_MEM ??= "1";
 process.env.VITE_LOW_MEM ??= "on";
 
-// 2) Vitest-Globals (falls Tests jest-Style nutzen)
-(Object.assign as any)(globalThis, {
-  vi,
-  expect,
-});
-
-(globalThis as any).require ||= createRequire(import.meta.url);
-
-// Minimaler "jest"-Shim für Alt-Tests
+// Vitest-/Jest-Globals bereitstellen
+(Object.assign as any)(globalThis, { vi, expect });
 (globalThis as any).jest ||= {
   fn: vi.fn,
   spyOn: vi.spyOn,
   mock: vi.mock,
   clearAllMocks: vi.clearAllMocks,
   resetAllMocks: vi.resetAllMocks,
-  resetModules: vi.resetModules,
   useFakeTimers: vi.useFakeTimers,
   useRealTimers: vi.useRealTimers,
 };
 
-// 3) OFFLINE: existierendes fetch patchen (Node 18/20)
+// OFFLINE erzwingen: existierendes fetch patchen (Node 18/20)
 const originalFetch = globalThis.fetch?.bind(globalThis);
 const { fetch: undiciFetch } = await import("undici");
 (globalThis as any).fetch = (async (input: any, init?: any) => {
@@ -42,7 +32,7 @@ const { fetch: undiciFetch } = await import("undici");
   return impl(input, init) as any;
 }) as any;
 
-// 4) TextEncoder/Decoder (robust, falls in \u00e4lteren Umgebungen fehlen)
+// Encoder/Decoder fallback (robust)
 try {
   // @ts-ignore
   if (!globalThis.TextEncoder || !globalThis.TextDecoder) {
@@ -56,15 +46,13 @@ try {
   /* noop */
 }
 
-// 5) /tmp-Artefakte f\u00fcr Tests seeden
+// /tmp-Artefakte seeden
 beforeAll(() => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "um-"));
-  const statsPath = path.join(tmpDir, "newadvanced-stats.json");
-  fs.writeFileSync(statsPath, JSON.stringify({ ok: true, t: Date.now() }), "utf8");
-  try {
-    fs.copyFileSync(statsPath, "/tmp/newadvanced-stats.json");
-  } catch {}
-  process.env.UM_TMP_DIR = tmpDir;
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "um-"));
+  const p = path.join(tmp, "newadvanced-stats.json");
+  fs.writeFileSync(p, JSON.stringify({ ok: true, t: Date.now() }), "utf8");
+  try { fs.copyFileSync(p, "/tmp/newadvanced-stats.json"); } catch {}
+  process.env.UM_TMP_DIR = tmp;
   try {
     const outDir = path.resolve("out");
     fs.mkdirSync(outDir, { recursive: true });
@@ -73,12 +61,11 @@ beforeAll(() => {
       fs.writeFileSync(
         adaptersPath,
         JSON.stringify({ adapters: [{ id: "oisst", kind: "oisst" }] }),
-        "utf8"
+        "utf8",
       );
     }
   } catch {}
 });
 
-afterEach(() => {
-  vi.clearAllMocks();
-});
+afterEach(() => vi.clearAllMocks());
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,15 +7,8 @@ export default defineConfig({
     globals: true,
     pool: "threads",
     poolOptions: { threads: { singleThread: true } },
-    isolate: true,
-    sequence: { concurrent: false },
-    testTimeout: 30_000,
-    hookTimeout: 30_000,
-    coverage: { provider: "v8", enabled: false },
-    watch: false,
+    coverage: { enabled: false },
     include: ["tests/**/*.{test,spec}.ts"],
   },
-  // Große Verzeichnisse ausschließen (Scan & Memory ↓)
-  server: { watch: { ignored: ["**/data/**", "**/out/**", "**/dist/**"] } },
-  optimizeDeps: { exclude: ["stream-json"] }, // vermeidet falsches Vorbundling
 });
+


### PR DESCRIPTION
## Summary
- enforce offline Vitest bootstrap with fetch patch, jest globals and deterministic seeding
- provide metrics singleton that guards default metrics initialization and helpers
- ensure workflows install node/python and smoke-test adapters
- track fractal progress in codexfeedback files

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `pnpm test:ts:ci`
- `npx pyright`


------
https://chatgpt.com/codex/tasks/task_e_68c5f8d9c4d48322a0a57f4752e15d16