### PR TITLE
feat: wire reality gate and stabilize dev tooling

### DIFF
--- a/.github/workflows/ci.experimental.yml
+++ b/.github/workflows/ci.experimental.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '22.x', cache: 'pnpm' }
+      - run: corepack enable && corepack prepare pnpm@10.16.1 --activate
+      - run: pnpm install --frozen-lockfile
       - run: pnpm agents:dry-run --verbose > agents-dry-run.log || true
       - uses: actions/upload-artifact@v4
         with:
@@ -18,4 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '22.x', cache: 'pnpm' }
+      - run: corepack enable && corepack prepare pnpm@10.16.1 --activate
+      - run: pnpm install --frozen-lockfile
       - run: pnpm guardrails:validate || true

--- a/apps/ui/src/components/RealityBadge.tsx
+++ b/apps/ui/src/components/RealityBadge.tsx
@@ -1,0 +1,5 @@
+export default function RealityBadge({ score, decision }: { score: number; decision: "external"|"ambiguous"|"imaginative" }) {
+  const label = decision === "external" ? "🧭 external" : decision === "ambiguous" ? "🫧 ambiguous" : "🎭 imaginative";
+  const bg = decision === "external" ? "#1b5e20" : decision === "ambiguous" ? "#ef6c00" : "#6a1b9a";
+  return <span style={{background:bg,color:"#fff",padding:"2px 6px",borderRadius:6,fontSize:12,opacity:0.9}} title={`score ${score.toFixed(2)}`}>{label}</span>;
+}

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      "~config": path.resolve(__dirname, "..", "..", "src", "config"),
+      "~config": path.resolve(__dirname, "../../..", "config"),
     },
   },
   server: { host: true, port: 5173 }

--- a/codexfeedback.json
+++ b/codexfeedback.json
@@ -104,6 +104,11 @@
       "fraktalrun": "Fraktal33 ConsciousCI",
       "status": "implemented",
       "notes": "Vitest OFFLINE enforced, metrics singleton, LowMem membrane No-Op; kein weiterer Lauf notwendig."
+    },
+    {
+      "fraktalrun": "Fraktal35 RealityGate",
+      "status": "implemented",
+      "notes": "Reality-Gate primitive, tsx dev server, Vite alias fix und Experimental CI Node-Setup."
     }
   ]
 }

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -37,3 +37,4 @@
 - FR-UM-2025-02-16-Fraktal23: Metrics defaults guarded, Vitest offline Setup, LowMem Membrane No-Op – ERA5 offline-matrix offen.
 - FR-UM-2025-09-13-Fraktal33: Conscious-CI grün; OFFLINE-Vitest enforced, Metrics defaults singleton, Low-Mem No-Op – kein weiterer Lauf notwendig.
 - FR-UM-2025-09-14-Fraktal34: CI split (core/extended/experimental), Node22 dev-server ESM und UI alias fix – kein weiterer Lauf notwendig.
+- FR-UM-2025-09-15-Fraktal35: Reality-Gate primitive, tsx dev server, Vite alias path fix und Experimental CI Node-Setup – kein weiterer Lauf notwendig.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -1,8 +1,11 @@
 fraktal:
-  current: 34
+  current: 35
   history:
-    - id: 34
+    - id: 35
       status: "in-progress"
+      notes: "Reality-Gate primitive, tsx dev server, Vite alias path, experimental CI Node setup"
+    - id: 34
+      status: "done"
       notes: "CI split (core/extended/experimental), UI alias fix, Node22 dev server"
     - id: 32
       status: "in-progress"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:jest": "jest",
     "test:agents": "vitest run",
     "test:adapters": "vitest run src/adapters/tests/decorators.test.ts",
-    "dev": "node --loader ts-node/esm --experimental-specifier-resolution=node scripts/dev-server.ts",
+    "dev": "tsx scripts/dev-server.ts",
     "start": "pnpm -s build:ui && pnpm -s dev",
     "start:light": "pnpm -s build:ui && node scripts/light-static-server.mjs",
     "start:all": "cross-env NODE_ENV=development concurrently \"ts-node scripts/rag-api.ts\" \"ts-node scripts/flags-api.ts\" \"ts-node scripts/experiments-api.ts\" \"ts-node scripts/share-api.ts\" \"ts-node scripts/realtime-hub.ts\"",

--- a/packages/reality/gate.ts
+++ b/packages/reality/gate.ts
@@ -1,0 +1,32 @@
+export type RealityDecision = "external" | "ambiguous" | "imaginative";
+
+export interface RealityInputs {
+  evidenceStrength: number;   // 0..1  (SNR, replication, signature checks)
+  priorConfidence: number;    // 0..1  (model/agent certainty)
+  provenance: number;         // 0..1  (chain-of-custody, source trust)
+}
+
+export interface RealityResult {
+  score: number;              // 0..1
+  decision: RealityDecision;
+}
+
+export const defaultThresholds = {
+  external: 0.70,
+  ambiguous: 0.45,
+};
+
+export function realityScore(x: RealityInputs, t = defaultThresholds): RealityResult {
+  // Evidence-led blend; prior supports but cannot dominate
+  const s = 0.6 * clamp01(x.evidenceStrength)
+          + 0.3 * clamp01(x.provenance)
+          + 0.1 * clamp01(x.priorConfidence);
+
+  const decision: RealityDecision =
+    s >= t.external ? "external" :
+    s >= t.ambiguous ? "ambiguous" : "imaginative";
+
+  return { score: s, decision };
+}
+
+function clamp01(v: number) { return Math.max(0, Math.min(1, v)); }

--- a/src/metrics/reality.ts
+++ b/src/metrics/reality.ts
@@ -1,0 +1,9 @@
+import { getOrCreateGauge, getOrCreateCounter } from "./singleton";
+
+export const realityScoreGauge = getOrCreateGauge({ name: "reality_score", help: "Latest reality score", labelNames: ["source"] });
+export const realityDecisionTotal = getOrCreateCounter({ name: "reality_decision_total", help: "Reality decisions", labelNames: ["decision","source"] });
+
+export function recordReality(source: string, score: number, decision: "external"|"ambiguous"|"imaginative") {
+  realityScoreGauge.labels(source).set(score);
+  realityDecisionTotal.labels(decision, source).inc();
+}


### PR DESCRIPTION
## Summary
- add Reality-Gate primitive with metrics and UI badge
- fix Windows-friendly config alias and use `tsx` dev runner
- set up Node and pnpm install in experimental CI
- update codex feedback with Fraktal35 status

## Testing
- `pnpm install`
- `npx tsc -p tsconfig.json`
- `npx pyright`


------
https://chatgpt.com/codex/tasks/task_e_68c6b31a40808322adea822ea8c9934f