### PR TITLE
Unify policy suite workflow and docs

### DIFF
--- a/.github/workflows/policy-check.yml
+++ b/.github/workflows/policy-check.yml
@@ -1,28 +1,7 @@
 name: Policy Checks
 on: [push, pull_request]
 jobs:
-  opa:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-      - name: OPA policy check
-        run: |
-          node tools/opa-check.mjs fixtures/events/example_input.json
-  kyverno:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Kyverno validate (dry-run)
-        uses: kyverno/action@v0.4.0
-        with:
-          policies: policies/kyverno.yaml
-          resources: fixtures/events/example_input.json
-          cluster: false
-        continue-on-error: true
-  guardrails:
+  policy-suite:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,6 +14,38 @@ jobs:
           version: 10.16.1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
-      - name: Run guardrails check
-        run: pnpm exec node tools/governance-guardrails.mjs
+      - name: Run policy suite (OPA & Guardrails)
+        id: suite
+        run: pnpm policy:check
         continue-on-error: true
+      - name: Kyverno dry-run
+        id: kyverno
+        uses: kyverno/action@v0.4.0
+        with:
+          policies: policies/kyverno.yaml
+          resources: fixtures/events/example_input.json
+          cluster: false
+        continue-on-error: true
+      - name: Render policy summary
+        id: render
+        if: always()
+        run: node scripts/render-policy-suite-report.mjs
+        env:
+          KYVERNO_CONCLUSION: ${{ steps.kyverno.conclusion }}
+          KYVERNO_OUTCOME: ${{ steps.kyverno.outcome }}
+      - name: Upload policy artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: policy-suite-report
+          path: out/policy/
+          if-no-files-found: ignore
+      - name: Fail on policy violations
+        if: always()
+        run: |
+          status=$(cat out/policy/policy-suite-status.txt 2>/dev/null || echo "missing")
+          if [ "$status" != "passed" ]; then
+            echo "::error::Policy suite reported failures (${status})."
+            exit 1
+          fi
+          echo "Policy suite passed."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,13 @@ Danach sollten folgende Schritte immer grün sein, bevor ein PR erstellt wird:
 - `CI Experimental` läuft nur bei gesetztem Label `run-experimental`.
 - Historische Pipelines (Fraktal21/22, Agents, Maps, ZIPMEM) sind unter `.github/workflows/*.disabled` archiviert und verursachen keine Checks mehr. Bei Bedarf einfach zurück benennen.
 
+## Governance & Policy Suite
+
+- `pnpm policy:check` führt OPA (`policies/governance.rego`) und die Guardrails (`policies/merge-guardrails.yaml`) lokal zusammen aus und schreibt Ergebnisse nach `out/policy/`.
+- Kyverno läuft in GitHub via `policy-check.yml`. Für lokale Tests ist derzeit Docker notwendig; ansonsten genügt der CI-Durchlauf.
+- Die Datei `out/policy/policy-suite-report.md` liefert eine Markdown-Zusammenfassung, die ebenfalls im GitHub Step Summary erscheint.
+- Policy-Änderungen benötigen weiterhin begleitende Dokumentation (Guardrail-Regel) – idealerweise im gleichen PR aktualisieren.
+
 ## Workflow-Regeln
 
 - Feature-Branches (`feature/xyz`) anlegen und anschließend per PR nach `main` mergen.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Die Adapter sind initial als Stubs verfügbar und werden schrittweise an echte F
 - **Handbuch (Kanon):** `Handbuch.md`
 - **Offline-Bundle:** `docs/offline/docker-compose.yml`
 - **ToDo-System:** `advancedToDo.yaml` / `advancedToDo.json` (Sync: `node scripts/sync-todo-progress.js`)
-- **Governance/Ethik:** `docs/governance/HI-Compact.md`, `AI_POLICY.md`, `agents.yaml`
+- **Governance/Ethik:** `docs/governance/HI-Compact.md`, `docs/governance/policy-suite.md`, `AI_POLICY.md`, `agents.yaml`
 
 ---
 

--- a/codexfeedback.json
+++ b/codexfeedback.json
@@ -1,6 +1,11 @@
 {
   "runs": [
     {
+      "fraktalrun": "Fraktal39 PolicySuite",
+      "status": "implemented",
+      "notes": "Policy suite unified: pnpm policy:check CLI, Kyverno summary integration, workflow summary + fail-fast gate."
+    },
+    {
       "fraktalrun": "Fraktal38 BuildStabilization",
       "status": "implemented",
       "notes": "ESLint + Prettier hooks, dist-first service orchestrator und Dokumentations-Updates für die v1.0-Stabilisierungsphase."

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -1,5 +1,6 @@
 # Codex Feedback
 
+- FR-UM-2025-09-19-Fraktal39: Policy-Suite vereinheitlicht (OPA/Guardrails CLI, Kyverno-Report, Workflow ohne continue-on-error) – bereit für Folgeaufgaben.
 - FR-UM-2025-09-18-Fraktal38: ESLint/Prettier-Hook, Dist-First-Services und aktualisierte Doku produktiv gesetzt – bereit für den nächsten Fraktal-Sprint.
 - FR-UM-2025-09-18-Fraktal37-CoreCI-RunB: Node20 Toolchain fix, Policy-Checks entschärft, Repo-Sanity stabilisiert – kein weiterer Lauf notwendig.
 - FR-UM-2025-09-18-Fraktal37-CoreCI: Legacy-Workflows archiviert, CI-Core-Stabilität geprüft und Doku/Test-Guides aktualisiert – kein weiterer Lauf notwendig.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -1,6 +1,9 @@
 fraktal:
-  current: 38
+  current: 39
   history:
+    - id: 39
+      status: 'done'
+      notes: 'Policy suite unified: CLI OPA/Guardrails, Kyverno summary + fail-fast workflow'
     - id: 38
       status: 'done'
       notes: 'ESLint/Prettier Hooks, dist-first Service-Runner und Doku-Refresh für v1.0 Stabilisierung'
@@ -40,7 +43,7 @@ fraktal:
   progress:
     legacy_workflows: disabled
     ci_core: node20-green
-    policy_checks: audit-only
+    policy_checks: unified-report
     repo_sanity: tolerant
     documentation: updated
 

--- a/docs/governance/policy-suite.md
+++ b/docs/governance/policy-suite.md
@@ -1,0 +1,46 @@
+# Policy Suite Pipeline
+
+Die **Policy Suite** bündelt alle Governance-Prüfungen (OPA, Kyverno und Guardrails) in einem konsistenten Lauf. Ziel ist eine einheitliche Sicht auf Sicherheits- und Compliance-Signale ohne die Entwickler mit drei separaten Workflows zu überfrachten.
+
+## Komponenten
+
+| Check           | Zweck                                                                                                                          | Quelle                                                                     |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| OPA Governance  | Bewertet `policies/governance.rego` gegen `fixtures/events/example_input.json`. Liefert `allow=true` oder verweigert den Lauf. | `tools/opa-check.mjs`                                                      |
+| Kyverno Dry-Run | Führt `policies/kyverno.yaml` als Dry-Run gegen das gleiche Fixture aus und meldet Policy-Abweichungen.                        | GitHub Action [`kyverno/action@v0.4.0`](https://github.com/kyverno/action) |
+| Guardrails      | Überwacht Merge-Policies (z. B. „Policy-Änderungen benötigen Docs“) gegen den letzten Commit.                                  | `tools/governance-guardrails.mjs`                                          |
+
+## CLI für lokale Dry-Runs
+
+```bash
+pnpm policy:check
+```
+
+- Führt OPA & Guardrails identisch zur CI aus.
+- Schreibt Logs und ein JSON-Ergebnis nach `out/policy/` (ignored).
+- Fehlende OPA-Binaries oder Docker werden als `Skipped` ausgewiesen – der Bericht markiert dies transparent.
+- Kyverno wird lokal nur ausgeführt, wenn der GitHub-Action-Schritt verwendet wird. Optional lässt sich ein Docker-basierter Lauf ergänzen (siehe TODO unten).
+
+### Artefakte
+
+- `out/policy/policy-suite.json` – maschinenlesbare Ergebnisse.
+- `out/policy/policy-suite-report.md` – Zusammenfassung, die auch im GitHub Step Summary landet.
+- `out/policy/policy-suite-status.txt` – Enthält `passed` oder `failed`; der Workflow verwendet diese Datei, um den Lauf zu beenden.
+
+## GitHub Workflow
+
+`policy-check.yml` orchestriert alle Checks in einem Job:
+
+1. Installation der Abhängigkeiten (Node 20 + pnpm 10.16.1).
+2. `pnpm policy:check` (OPA + Guardrails) wird tolerant (`continue-on-error`) ausgeführt, damit anschließend der Bericht erstellt werden kann.
+3. Kyverno läuft als dedizierter Schritt (ebenfalls tolerant).
+4. `scripts/render-policy-suite-report.mjs` fasst beide Ergebnisse zusammen, aktualisiert Markdown + JSON und signalisiert Erfolg/Misserfolg über `policy-suite-status.txt`.
+5. Der letzte Schritt beendet den Job hart, sobald ein Ergebnis `failed` meldet – keine `continue-on-error`-Schleifen mehr.
+
+## Hinweise & TODOs
+
+- Für vollautomatische Kyverno-Läufe außerhalb von GitHub sollte ein Docker-/CLI-Fallback ergänzt werden (`POLICY_SUITE_ENABLE_KYVERNO=docker`).
+- Bei Policy-Änderungen unbedingt eine erläuternde Dokumentation im gleichen PR aktualisieren – die Guardrails achten darauf.
+- Die Summary-Datei eignet sich als Anhang für Fraktal-Protokolle oder Release-Notes (kopieren aus `out/policy/policy-suite-report.md`).
+
+Damit ist der Governance-Check zentralisiert, transparent und CI-fest – im Sinne der Fraktalvorgabe „Stabilität vor Features“.

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "test:sigil": "ts-node scripts/validate-sigil-cli.ts",
     "test:ui": "vitest run --passWithNoTests",
     "ci:verify": "pnpm test:ts && pnpm sigils:index:strict && pnpm adapter:build:era5",
+    "policy:check": "node scripts/policy-suite.mjs",
     "scan:ingest": "node scripts/ingest-external-scan.mjs",
     "adapters:ci:install": "pip install -r src/adapters/requirements.txt",
     "check:ci": "npx tsc -p tsconfig.json --noEmit && pnpm test:ts:ci && npx pyright"

--- a/scripts/policy-suite.mjs
+++ b/scripts/policy-suite.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+const outputDir = path.join(projectRoot, 'out', 'policy');
+fs.mkdirSync(outputDir, { recursive: true });
+
+const inputPath = process.env.POLICY_SUITE_INPUT || 'fixtures/events/example_input.json';
+
+const checks = [
+  {
+    name: 'OPA Governance',
+    command: () => ({
+      cmd: 'node',
+      args: ['tools/opa-check.mjs', inputPath],
+    }),
+    successNote: 'OPA policy returned allow=true',
+    failureHint: 'OPA denied the input fixture. Inspect policies/governance.rego',
+    interpret: (result, ctx) => {
+      if (result.status !== 'passed') {
+        return;
+      }
+      try {
+        const logAbsolute = path.isAbsolute(ctx.logPath)
+          ? ctx.logPath
+          : path.join(projectRoot, ctx.logPath);
+        const logText = fs.readFileSync(logAbsolute, 'utf-8');
+        const normalized = logText.toLowerCase();
+        const allowTrue =
+          normalized.includes('allow=true') || normalized.includes('policy allow=true');
+        const skipped = normalized.includes('skipping');
+        if (skipped && !allowTrue) {
+          result.status = 'skipped';
+          result.notes = 'OPA binary or Docker image unavailable – dry-run skipped.';
+        }
+      } catch (error) {
+        console.warn(`Unable to read OPA log at ${ctx.logPath}:`, error);
+      }
+    },
+  },
+  {
+    name: 'Guardrails',
+    command: () => ({
+      cmd: 'node',
+      args: ['tools/governance-guardrails.mjs'],
+    }),
+    successNote: 'Repository guardrails satisfied (no policy drift detected)',
+    failureHint: 'Guardrails flagged the latest commit. Review policies/merge-guardrails.yaml',
+  },
+];
+
+const results = [];
+let hasFailure = false;
+
+function sanitize(name) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function tailBuffer() {
+  let buffer = '';
+  return {
+    push(chunk) {
+      buffer = `${buffer}${chunk}`;
+      if (buffer.length > 4000) {
+        buffer = buffer.slice(-4000);
+      }
+    },
+    value() {
+      const trimmed = buffer.trim();
+      if (!trimmed) {
+        return '';
+      }
+      const lines = trimmed.split(/\r?\n/);
+      return lines.slice(-8).join('\n');
+    },
+  };
+}
+
+async function runCheck(definition) {
+  const { name, command, successNote, failureHint } = definition;
+  const resolved = typeof command === 'function' ? command() : command;
+  const logFileName = `${sanitize(name) || 'policy-check'}.log`;
+  const logPath = path.join(outputDir, logFileName);
+  const logStream = fs.createWriteStream(logPath, { flags: 'w' });
+  const start = Date.now();
+  const buffer = tailBuffer();
+
+  const child = spawn(resolved.cmd, resolved.args, {
+    cwd: projectRoot,
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let spawnError;
+  child.stdout.on('data', (data) => {
+    process.stdout.write(data);
+    logStream.write(data);
+    buffer.push(data.toString());
+  });
+  child.stderr.on('data', (data) => {
+    process.stderr.write(data);
+    logStream.write(data);
+    buffer.push(data.toString());
+  });
+  child.on('error', (err) => {
+    spawnError = err;
+  });
+
+  const exitCode = await new Promise((resolve) => {
+    child.on('close', (code) => {
+      resolve(typeof code === 'number' ? code : 1);
+    });
+  });
+
+  logStream.end();
+  const durationMs = Date.now() - start;
+  const tailText = buffer.value();
+
+  const result = {
+    name,
+    status: exitCode === 0 ? 'passed' : 'failed',
+    logPath: path.relative(projectRoot, logPath),
+    durationMs,
+  };
+
+  if (exitCode === 0) {
+    if (successNote) {
+      result.notes = successNote;
+    }
+  } else {
+    hasFailure = true;
+    if (spawnError) {
+      result.notes = spawnError.message;
+    } else if (tailText) {
+      result.notes = tailText;
+    } else {
+      result.notes = `Exit code ${exitCode}`;
+    }
+    if (failureHint) {
+      result.notes = result.notes ? `${result.notes} | ${failureHint}` : failureHint;
+    }
+  }
+
+  if (typeof definition.interpret === 'function') {
+    definition.interpret(result, { tail: tailText, logPath });
+  }
+
+  results.push(result);
+}
+
+async function main() {
+  for (const check of checks) {
+    try {
+      await runCheck(check);
+    } catch (err) {
+      hasFailure = true;
+      results.push({
+        name: check.name,
+        status: 'failed',
+        logPath: null,
+        notes: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+await main();
+
+const payload = {
+  generatedAt: new Date().toISOString(),
+  input: path.relative(projectRoot, inputPath),
+  results,
+};
+
+const jsonPath = path.join(outputDir, 'policy-suite.json');
+fs.writeFileSync(jsonPath, JSON.stringify(payload, null, 2));
+console.log(`\nPolicy suite results written to ${path.relative(projectRoot, jsonPath)}`);
+
+if (hasFailure) {
+  process.exitCode = 1;
+}

--- a/scripts/render-policy-suite-report.mjs
+++ b/scripts/render-policy-suite-report.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+const outputDir = path.join(projectRoot, 'out', 'policy');
+fs.mkdirSync(outputDir, { recursive: true });
+
+const jsonPath = process.env.POLICY_SUITE_JSON
+  ? path.resolve(projectRoot, process.env.POLICY_SUITE_JSON)
+  : path.join(outputDir, 'policy-suite.json');
+
+let payload = { generatedAt: new Date().toISOString(), results: [] };
+if (fs.existsSync(jsonPath)) {
+  try {
+    payload = JSON.parse(fs.readFileSync(jsonPath, 'utf-8'));
+  } catch (error) {
+    console.warn('Failed to read existing policy suite JSON, starting fresh', error);
+  }
+}
+
+const results = Array.isArray(payload.results) ? [...payload.results] : [];
+
+function upsertResult(entry) {
+  const index = results.findIndex((item) => item.name === entry.name);
+  if (index >= 0) {
+    results[index] = { ...results[index], ...entry };
+  } else {
+    results.push(entry);
+  }
+}
+
+function mapStatus(conclusion) {
+  const value = (conclusion || '').toLowerCase();
+  switch (value) {
+    case 'success':
+      return 'passed';
+    case 'failure':
+    case 'failed':
+      return 'failed';
+    case 'cancelled':
+    case 'skipped':
+      return 'skipped';
+    default:
+      return value ? value : 'skipped';
+  }
+}
+
+const kyvernoConclusion = process.env.KYVERNO_CONCLUSION || process.env.KYVERNO_OUTCOME || '';
+const kyvernoStatus = mapStatus(kyvernoConclusion);
+const kyvernoNotes = process.env.KYVERNO_NOTES || 'See workflow logs for Kyverno output.';
+
+upsertResult({
+  name: 'Kyverno Dry-Run',
+  status: kyvernoStatus,
+  logPath: null,
+  notes:
+    kyvernoStatus === 'skipped'
+      ? `${kyvernoNotes} (Kyverno action marked as skipped)`
+      : kyvernoStatus === 'failed'
+        ? `${kyvernoNotes} (Kyverno action conclusion: ${kyvernoConclusion || 'failure'})`
+        : kyvernoNotes,
+});
+
+payload = {
+  ...payload,
+  generatedAt: payload.generatedAt || new Date().toISOString(),
+  results,
+};
+
+function statusBadge(status) {
+  switch (status) {
+    case 'passed':
+      return '✅ Passed';
+    case 'failed':
+      return '❌ Failed';
+    case 'skipped':
+      return '⚠️ Skipped';
+    default:
+      return `⚠️ ${status}`;
+  }
+}
+
+function detailCell(entry) {
+  const parts = [];
+  if (entry.notes) {
+    parts.push(entry.notes);
+  }
+  if (entry.logPath) {
+    parts.push(`Log: ${entry.logPath}`);
+  }
+  if (parts.length === 0) {
+    parts.push('—');
+  }
+  return parts.join('<br/>');
+}
+
+const lines = [
+  '## Policy Suite Summary',
+  '',
+  '| Check | Status | Details |',
+  '| --- | --- | --- |',
+];
+for (const entry of results) {
+  lines.push(`| ${entry.name} | ${statusBadge(entry.status)} | ${detailCell(entry)} |`);
+}
+
+const summaryMarkdown = `${lines.join('\n')}\n`;
+const reportPath = path.join(outputDir, 'policy-suite-report.md');
+fs.writeFileSync(reportPath, summaryMarkdown);
+fs.writeFileSync(jsonPath, JSON.stringify(payload, null, 2));
+
+const statusPath = path.join(outputDir, 'policy-suite-status.txt');
+const hasFailure = results.some((entry) => entry.status === 'failed');
+fs.writeFileSync(statusPath, `${hasFailure ? 'failed' : 'passed'}\n`);
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summaryMarkdown}\n`);
+}
+
+console.log(summaryMarkdown);


### PR DESCRIPTION
## Summary
- collapse the policy-check workflow into a single job that runs the aggregated suite, renders a shared summary, uploads artifacts, and fails fast on violations
- add reusable CLI utilities for the policy suite (`scripts/policy-suite.mjs`, `scripts/render-policy-suite-report.mjs`) and document the flow in docs/governance with README/CONTRIBUTING pointers
- update Codex feedback trackers and expose `pnpm policy:check` for local dry-runs of OPA/Guardrails alongside the Kyverno GitHub step

## Testing
- pnpm policy:check
- npx tsc -p tsconfig.json --noEmit
- npx pyright

------
https://chatgpt.com/codex/tasks/task_e_68c9b3b4fac48322ae5e2f8a6f204ca3