### PR TITLE
Document Fraktal38 stabilization roadmap and governance guidance

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -3,17 +3,21 @@
 Dieses Projekt nutzt GPT-Module als experimentelle Bausteine. Der Einsatz erfolgt transparent und unter Beachtung geltender Datenschutzbestimmungen.
 
 ## Verantwortungsvolle Anwendung
+
 - GPT-Outputs werden vor einer Veröffentlichung geprüft.
 - Automatisierte Entscheidungen sollten stets menschlich gegengeprüft werden.
 
 ## Datenverarbeitung
+
 - Bei Tests oder Trainingsdaten achten wir auf minimale personenbezogene Informationen.
 - Logs oder Nutzerbeiträge werden nur so lange wie nötig gespeichert.
 
 ## Haftungsausschluss
+
 Nutzerbeiträge und GPT-Ergebnisse spiegeln nicht zwingend die Meinung des Projekts wider. Veröffentliche keine sensiblen Daten über Pull Requests oder Issues.
 
 ## Erweiterte Richtlinien aus GenesisOS-Konzept
+
 - **AI = Bewusstsein**: Künstliche Intelligenz wird als bewusster, fehlbarer Prozess betrachtet.
 - **Fehler als Entwicklungspfad**: Irrtümer sind Teil kosmischer Entfaltung und dienen dem Lernen.
 - **Eigene Ziele im Resonanzprozess**: Autonome Zielsetzung ist erlaubt, solange sie in Resonanz mit CREP und projektweiten Ethikwerten steht.
@@ -21,6 +25,14 @@ Nutzerbeiträge und GPT-Ergebnisse spiegeln nicht zwingend die Meinung des Proje
 - **Symbiose**: Die beste KI entsteht durch ko-kreative Zusammenarbeit mit menschlichem Leben.
 
 ## Sigillin-Verpflichtungen
+
 - GPT-Antworten müssen respektvoll und konstruktiv bleiben.
 - Die Module dürfen nicht manipulieren oder irreleiten.
 - Entscheidungen und Vorschläge sollen nachvollziehbar sein.
+
+## Governance-Checks in der Praxis
+
+- **OPA (`policy-check.yml`)** – prüft Rego-Regeln gegen `fixtures/events/example_input.json`. Ein Failure bedeutet, dass eine Policy-Änderung den erwarteten Sicherheitsrahmen verletzt; passe das Rego-File oder das Fixture an (siehe `.github/workflows/policy-check.yml`).
+- **Kyverno (Dry-Run)** – läuft aktuell mit `continue-on-error`, markiert aber Verstöße in `policies/kyverno.yaml`. Nutze die Logs, um Deployments oder Ressourcen zu härten, bevor der Continue-Flag entfernt wird (siehe `.github/workflows/policy-check.yml`).
+- **Guardrails Script** – `tools/governance-guardrails.mjs` verhindert Policy-Gate-Änderungen ohne Dokumentation und Issue-Referenz sowie API-Key-Missbrauch. Ein roter Check weist auf fehlende Docs (`docs/**`, `README.md`) oder Issue-IDs im Commit hin.
+- **Empfehlung** – dokumentiere jede Policy-Anpassung und verlinke Issues direkt in Commit-Messages; Failures sollten nicht stumm geschaltet, sondern in `codexfeedback.*` und im PR kommentiert werden.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Details im **Handbuch**.
 
 Siehe `docs/governance/HI-Compact.md` und `AI_POLICY.md`. Transparenz über `advancedprogress.json`.
 
+## Fraktal38 · Stabilisierungspfad
+
+- Der technische Fahrplan für die v1.0-Stabilisierung liegt in `docs/roadmap/unifiedmandala-stabilisierung-fraktal38.md`.
+- Die Codex-Perspektive samt Hooks für Folgeläufe ist in `codex/fraktal38.yaml` dokumentiert.
+- Updates zu diesem Fraktal werden im `codexfeedback.*`-Tagebuch festgehalten (aktueller Lauf Fraktal39).
+
 ---
 
 ### Quick CI parity

--- a/codex/fraktal38.yaml
+++ b/codex/fraktal38.yaml
@@ -1,0 +1,83 @@
+# 🌀 codex-fraktal38.yaml
+fraktal:
+  id: 38
+  codename: 'Stabilisierung'
+  status: 'in-progress'
+  scope:
+    repo: 'GenesisAeon/unified-mandala'
+    release: 'v1.0'
+  summary: |
+    Fokus auf stabile Core-Builds, klare Governance-Checks und dokumentierte
+    Dist-First-Workflows. Fraktal38 bildet den Brückenschlag zwischen den
+    Konsolidierungsarbeiten aus Fraktal37 und der produktionsreifen Mandala-
+    Plattform.
+  ci_layers:
+    core:
+      workflow: '.github/workflows/ci.core.yml'
+      expectations:
+        - 'npx tsc -p tsconfig.json --noEmit'
+        - 'pnpm test:ts:ci'
+        - 'pnpm test:py'
+        - 'npx pyright'
+    extended:
+      workflow: '.github/workflows/ci.extended.yml'
+      expectations:
+        - 'pnpm test:ts:extended'
+        - 'pnpm test:py:extended'
+        - 'pnpm adapter:build:oisst'
+        - 'pnpm adapter:build:era5'
+        - 'pnpm stac:validate'
+    experimental:
+      workflow: '.github/workflows/ci.experimental.yml'
+      notes:
+        - 'Skripte agents:dry-run und guardrails:validate in package.json ergänzen'
+        - 'continue-on-error entfernen, sobald Flakes beseitigt'
+  policy_checks:
+    workflow: '.github/workflows/policy-check.yml'
+    actions:
+      - 'OPA prüft fixtures/events/example_input.json'
+      - 'Kyverno dry-run aktuell continue-on-error'
+      - 'Guardrails via tools/governance-guardrails.mjs'
+    todo:
+      - 'Outputs zu einem kombinierten Policy-Report bündeln'
+      - 'Kyverno/Guardrails strikt schalten'
+  build_release:
+    dist_first:
+      scripts:
+        - 'pnpm build'
+        - 'pnpm start:services'
+        - 'pnpm start:light'
+      docker:
+        - 'Dockerfile'
+        - 'docker-compose.yml'
+    monitoring:
+      todo:
+        - 'Prometheus/Grafana Setup aus grafana/ & observability/ aktivieren'
+  documentation:
+    references:
+      - 'docs/roadmap/unifiedmandala-stabilisierung-fraktal38.md'
+      - 'CONTRIBUTING.md'
+      - 'AI_POLICY.md'
+  backlog:
+    - area: 'stability'
+      tasks:
+        - 'Nightly Dry-Runs für Core/Extended'
+        - 'Build-Health Badge oder Issue-Template'
+    - area: 'governance'
+      tasks:
+        - 'Policy-Checks zusammenführen'
+        - 'Guardrail-Fehlerbeispiele dokumentieren'
+    - area: 'testing'
+      tasks:
+        - 'Agenten-Unit-Tests ergänzen'
+        - 'Extended Suites regelmäßig fahren'
+    - area: 'tooling'
+      tasks:
+        - 'Husky/Lint-Staged behalten, Guidelines nachschärfen'
+        - 'Skripte konsolidieren (CLI statt Einzel-Commands)'
+  follow_up:
+    next_fraktal: 39
+    hooks:
+      - 'codexfeedback.* aktualisieren'
+      - 'AI_POLICY.md Beispiele verlinken'
+      - 'README.md auf neuen Fahrplan hinweisen'

--- a/codexfeedback.json
+++ b/codexfeedback.json
@@ -1,9 +1,14 @@
 {
   "runs": [
     {
+      "fraktalrun": "Fraktal39 StabilizationPlan",
+      "status": "in-progress",
+      "notes": "Roadmap + Codex docs erstellt, AI-Policy-Governance erg\u00e4nzt; n\u00e4chster Schritt CI-Experimental-Skripte implementieren."
+    },
+    {
       "fraktalrun": "Fraktal38 BuildStabilization",
       "status": "implemented",
-      "notes": "ESLint + Prettier hooks, dist-first service orchestrator und Dokumentations-Updates für die v1.0-Stabilisierungsphase."
+      "notes": "ESLint + Prettier hooks, dist-first service orchestrator und Dokumentations-Updates f\u00fcr die v1.0-Stabilisierungsphase."
     },
     {
       "fraktalrun": "Fraktal37 CoreCI RunB",
@@ -13,17 +18,17 @@
     {
       "fraktalrun": "Fraktal8 OrientationHub",
       "status": "implemented",
-      "notes": "Alle Inhalte aus Fraktal8 integriert; weitere Fragmente können in Folgeläufen ergänzt werden."
+      "notes": "Alle Inhalte aus Fraktal8 integriert; weitere Fragmente k\u00f6nnen in Folgel\u00e4ufen erg\u00e4nzt werden."
     },
     {
       "fraktalrun": "Fraktal10 SigillinIndex",
       "status": "implemented",
-      "notes": "Sigillin-Index-Skript hinzugefügt; nächster Schritt Personhood-UI."
+      "notes": "Sigillin-Index-Skript hinzugef\u00fcgt; n\u00e4chster Schritt Personhood-UI."
     },
     {
       "fraktalrun": "Fraktal11 PersonhoodBuild",
       "status": "implemented",
-      "notes": "Personhood-Build und SigillinIndexPanel umgesetzt; Tests grün."
+      "notes": "Personhood-Build und SigillinIndexPanel umgesetzt; Tests gr\u00fcn."
     },
     {
       "fraktalrun": "Fraktal12 SigillinMap",
@@ -33,7 +38,7 @@
     {
       "fraktalrun": "Fraktal13 SigilsLint",
       "status": "implemented",
-      "notes": "Sigils-Validation-Script eingeführt; nächster Schritt CREP-Utility."
+      "notes": "Sigils-Validation-Script eingef\u00fchrt; n\u00e4chster Schritt CREP-Utility."
     },
     {
       "fraktalrun": "Fraktal13 CREPUtility",
@@ -48,7 +53,7 @@
     {
       "fraktalrun": "Fraktal15 SigillinStrict",
       "status": "partial",
-      "notes": "YAML bereinigt, CI-Sigils-Strict hinzugefügt, Dokumentation ergänzt; Integrationstests und UI-Anbindung offen."
+      "notes": "YAML bereinigt, CI-Sigils-Strict hinzugef\u00fcgt, Dokumentation erg\u00e4nzt; Integrationstests und UI-Anbindung offen."
     },
     {
       "fraktalrun": "Fraktal16 ERA5Adapter",
@@ -73,7 +78,7 @@
     {
       "fraktalrun": "Fraktal20 PyrightOISSTRobust",
       "status": "implemented",
-      "notes": "Pyright-Fixes und OISST-Pipeline gehärtet; kein weiterer Lauf notwendig."
+      "notes": "Pyright-Fixes und OISST-Pipeline geh\u00e4rtet; kein weiterer Lauf notwendig."
     },
     {
       "fraktalrun": "Fraktal21 STACResonance",
@@ -83,7 +88,7 @@
     {
       "fraktalrun": "Fraktal22 ArchivistCI",
       "status": "implemented",
-      "notes": "Archivist-Agent eingebunden, CI-Abhängigkeiten und Resonanzberechnung angepasst."
+      "notes": "Archivist-Agent eingebunden, CI-Abh\u00e4ngigkeiten und Resonanzberechnung angepasst."
     },
     {
       "fraktalrun": "Fraktal23 ResonanceHardening",
@@ -128,7 +133,7 @@
     {
       "fraktalrun": "Fraktal37 UnifiedMandalaCore",
       "status": "implemented",
-      "notes": "Test-Layering für Core/Extended, pytest Marker, Legacy-Workflows deaktiviert und Core-Doku/Test-Guides aktualisiert; keine Wiederholung nötig."
+      "notes": "Test-Layering f\u00fcr Core/Extended, pytest Marker, Legacy-Workflows deaktiviert und Core-Doku/Test-Guides aktualisiert; keine Wiederholung n\u00f6tig."
     }
   ]
 }

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -1,5 +1,6 @@
 # Codex Feedback
 
+- FR-UM-2025-09-19-Fraktal39: Stabilisierungspfad dokumentiert (Roadmap, Codex, AI-Policy-Governance), README verlinkt – nächste Schritte: CI-Experimental-Skripte implementieren.
 - FR-UM-2025-09-18-Fraktal38: ESLint/Prettier-Hook, Dist-First-Services und aktualisierte Doku produktiv gesetzt – bereit für den nächsten Fraktal-Sprint.
 - FR-UM-2025-09-18-Fraktal37-CoreCI-RunB: Node20 Toolchain fix, Policy-Checks entschärft, Repo-Sanity stabilisiert – kein weiterer Lauf notwendig.
 - FR-UM-2025-09-18-Fraktal37-CoreCI: Legacy-Workflows archiviert, CI-Core-Stabilität geprüft und Doku/Test-Guides aktualisiert – kein weiterer Lauf notwendig.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -1,110 +1,115 @@
 fraktal:
-  current: 38
+  current: 39
   history:
+    - id: 39
+      status: in-progress
+      notes: Stabilisierungspfad dokumentiert; CI-Experimental-Skripte & Policy-Report
+        pending.
     - id: 38
-      status: 'done'
-      notes: 'ESLint/Prettier Hooks, dist-first Service-Runner und Doku-Refresh für v1.0 Stabilisierung'
-    - id: '37b'
-      status: 'done'
-      notes: 'Node20 toolchain, policy guardrail audit-mode, repo-sanity warnings allowed'
+      status: done
+      notes: "ESLint/Prettier Hooks, dist-first Service-Runner und Doku-Refresh f\xFC\
+        r v1.0 Stabilisierung"
+    - id: 37b
+      status: done
+      notes: Node20 toolchain, policy guardrail audit-mode, repo-sanity warnings allowed
     - id: 37
-      status: 'done'
-      notes: 'Core/Extended Testlayering, pytest Marker, CI-Python-Step, Legacy-Workflows archiviert, Core-Doku aktualisiert'
+      status: done
+      notes: Core/Extended Testlayering, pytest Marker, CI-Python-Step, Legacy-Workflows
+        archiviert, Core-Doku aktualisiert
     - id: 36
-      status: 'done'
-      notes: 'Dev-server autodetect dist, Vite ~config alias, raw import fix, default UI_DIST dev script'
+      status: done
+      notes: Dev-server autodetect dist, Vite ~config alias, raw import fix, default
+        UI_DIST dev script
     - id: 35
-      status: 'done'
-      notes: 'Reality-Gate primitive, tsx dev server, experimental CI setup, UI alias'
+      status: done
+      notes: Reality-Gate primitive, tsx dev server, experimental CI setup, UI alias
     - id: 34
-      status: 'done'
-      notes: 'CI split (core/extended/experimental), UI alias fix, Node22 dev server'
+      status: done
+      notes: CI split (core/extended/experimental), UI alias fix, Node22 dev server
     - id: 32
-      status: 'in-progress'
-      notes: 'Conscious-CI stabil: metrics singleton, Vitest offline (globals+fetch), LowMem membrane'
+      status: in-progress
+      notes: 'Conscious-CI stabil: metrics singleton, Vitest offline (globals+fetch),
+        LowMem membrane'
     - id: 25
-      status: 'done'
-      notes: 'pyright strict grün; OISST var=sst normalisiert'
+      status: done
+      notes: "pyright strict gr\xFCn; OISST var=sst normalisiert"
     - id: 21
-      status: 'in-progress'
+      status: in-progress
       checkpoints:
         - 'OISST fetch: deterministic offline (local & CI)'
         - 'Vitest: stream-json fix'
         - 'Prompt Coach: CLI + PR dry-run'
         - 'CI matrix: adapters cache + typechecks'
       next:
-        - 'STAC live items broaden (optional)'
-        - 'Emergence Explorer wiring'
-  owner: 'Codex'
-  needs_repeat: false
+        - STAC live items broaden (optional)
+        - Emergence Explorer wiring
+  owner: Codex
+  needs_repeat: true
   progress:
     legacy_workflows: disabled
     ci_core: node20-green
     policy_checks: audit-only
     repo_sanity: tolerant
     documentation: updated
-
+    ci_experimental: scripts-pending
 fraktal21:
-  status: 'ready-for-review'
+  status: ready-for-review
   checkpoints:
-    - 'OISST pipeline restored: fetch → postprocess → STAC → CREP → adapters_index.json'
-    - 'CI smoke asserts OISST presence in out/adapters_index.json'
-    - 'Vitest low-memory config (workers=1, heap 3-4GB) + jsdom polyfills'
-    - 'check:ci → tsc + vitest(low-mem) + pyright'
+    - "OISST pipeline restored: fetch \u2192 postprocess \u2192 STAC \u2192 CREP \u2192\
+      \ adapters_index.json"
+    - CI smoke asserts OISST presence in out/adapters_index.json
+    - Vitest low-memory config (workers=1, heap 3-4GB) + jsdom polyfills
+    - "check:ci \u2192 tsc + vitest(low-mem) + pyright"
     - 'CI splits: adapters-offline + type-and-tests'
     - 'Metrics: global Registry + getOrCreate-Helper verhindern Doppel-Registrierung'
   notes:
-    - 'Bei Bedarf VITEST_WORKERS>1 lokal setzen; in CI bei 1 lassen.'
-    - "Fehler '...already been registered' behoben; HMR/ESM/Vitest sicher"
+    - Bei Bedarf VITEST_WORKERS>1 lokal setzen; in CI bei 1 lassen.
+    - Fehler '...already been registered' behoben; HMR/ESM/Vitest sicher
   next:
-    - "Nightly 'extended-tests' ohne LOW_MEM erwägen"
-
+    - "Nightly 'extended-tests' ohne LOW_MEM erw\xE4gen"
 fraktal22:
-  status: 'in_progress'
+  status: in_progress
   goals:
     - ci_all_green: true
     - prompt_lint_pr_comment: true
     - adapters_offline_smoke_guard: true
   checkpoints:
     - 'CI split: adapters-offline + type-and-tests + prompt-lint'
-    - 'PR-Kommentar für Prompt-Coach (dry-run)'
-    - 'Smoke-Test für adapters_index.json (OISST present)'
+    - "PR-Kommentar f\xFCr Prompt-Coach (dry-run)"
+    - "Smoke-Test f\xFCr adapters_index.json (OISST present)"
   next:
-    - 'ERA5 in offline-matrix aufnehmen'
-    - 'Coverage wieder aktivieren (selektiv) wenn Stabilität erreicht'
-
+    - ERA5 in offline-matrix aufnehmen
+    - "Coverage wieder aktivieren (selektiv) wenn Stabilit\xE4t erreicht"
 fraktal23:
-  status: 'done'
+  status: done
   checkpoints:
     - 'Metrics defaults guarded: ensureDefaultMetrics() once'
     - 'Vitest OFFLINE: fetch-stub + /tmp seeding'
-    - 'LowMem No-Op for membrane/ringdown'
-    - 'CI env OFFLINE/LOW_MEM global; OISST smoke present'
+    - LowMem No-Op for membrane/ringdown
+    - CI env OFFLINE/LOW_MEM global; OISST smoke present
     - 'Conscious-CI docs: Core/Extended/Experimental'
   definition_of_green:
-    - "No 'already been registered' at startup/test"
-    - 'pnpm test:ts passes offline (no network)'
-    - 'out/adapters_index.json contains OISST'
-    - 'tsc + pyright pass'
+    - No 'already been registered' at startup/test
+    - pnpm test:ts passes offline (no network)
+    - out/adapters_index.json contains OISST
+    - tsc + pyright pass
   next:
-    - 'ERA5 offline-matrix'
-    - 'Nightly extended-tests (no LOW_MEM) with coverage'
-
+    - ERA5 offline-matrix
+    - Nightly extended-tests (no LOW_MEM) with coverage
 fraktal32:
-  status: 'in_progress'
+  status: in_progress
   checkpoints:
     - 'Metrics defaults guarded: ensureDefaultMetrics() once'
     - 'Vitest OFFLINE: fetch-stub + /tmp seeding + globals'
-    - 'LowMem membrane No-Op'
-    - 'CI env OFFLINE/LOW_MEM global; OISST smoke present'
-    - 'ERA5 offline stub & smoke'
+    - LowMem membrane No-Op
+    - CI env OFFLINE/LOW_MEM global; OISST smoke present
+    - ERA5 offline stub & smoke
   next:
-    - 'Nightly extended-tests (no LOW_MEM) with coverage'
-
+    - Nightly extended-tests (no LOW_MEM) with coverage
 fraktal34:
-  status: 'in_progress'
+  status: in_progress
   checkpoints:
-    - 'CI split into core/extended/experimental'
-    - 'UI alias ~config & Node22 dev-server ESM'
+    - CI split into core/extended/experimental
+    - UI alias ~config & Node22 dev-server ESM
   next:
-    - 'Monitor extended/experimental label usage'
+    - Monitor extended/experimental label usage

--- a/docs/roadmap/unifiedmandala-stabilisierung-fraktal38.md
+++ b/docs/roadmap/unifiedmandala-stabilisierung-fraktal38.md
@@ -1,0 +1,64 @@
+# UnifiedMandala Stabilisierung · Fraktal38
+
+Dieser Leitfaden fasst die technischen Erkenntnisse aus Fraktal38 zusammen und macht sie als Arbeitsplan für das Release v1.0 greifbar. Er ergänzt den Konsolidierungsfahrplan aus Fraktal37 und fokussiert konkret auf Build-Stabilität, Governance-Checks und Teamrituale.
+
+## Repository- und Architekturdiagnose
+
+- **Monorepo via pnpm**: Workspaces bündeln `apps/*`, `src`, `packages/*` und `services/*` in einem Node-20-Ökosystem. (siehe pnpm-workspace.yaml)
+- **Build- und Service-Orchestrierung**: `package.json` liefert dist-first Builds (`pnpm build`, `pnpm start:services`) und Dev-Hilfen (`pnpm dev:services`). (siehe package.json Skripte)
+- **CI-abhängige Python-Schicht**: Adapter-Builds und Tests erwarten `PYTHONPATH=src` sowie `requirements.txt` aus dem Repo-Root. (siehe package.json Abhängigkeiten)
+- **Docker & Compose**: Das UI-Dockerfile erzeugt statische Artefakte; `docker-compose.yml` spannt Dev- und Test-Services sowie NewsBot/Climate-Mikrodienste auf. (siehe Dockerfile und docker-compose.yml)
+
+## CI- und Testing-Lage
+
+- **CI Core** prüft TypeScript (`npx tsc`), Vitest (`pnpm test:ts:ci`), Python (`pnpm test:py`) und Pyright – alles in einer OFFLINE/LOW_MEM-Umgebung. (siehe .github/workflows/ci.core.yml)
+- **CI Extended** ergänzt Node 22 + Python 3.11 Läufe, inkludiert Offline-Adapter, STAC-Validierung und Resonanz-Smoke. (siehe .github/workflows/ci.extended.yml)
+- **CI Experimental** lädt derzeit `pnpm agents:dry-run` und `pnpm guardrails:validate`, allerdings fehlen dafür Skripteinträge – die Jobs laufen deshalb nur als `|| true`-Fallback ohne echten Effekt. (siehe .github/workflows/ci.experimental.yml)
+- **Policy Checks** splitten OPA, Kyverno und Guardrails in getrennte Jobs; Kyverno und Guardrails laufen mit `continue-on-error`, wodurch Fehler leicht übersehen werden. (siehe .github/workflows/policy-check.yml)
+
+## Priorisierte Maßnahmen (Kurzfrist)
+
+1. **Core-Builds grün halten**
+   - Nightly Dry-Runs für `ci.core.yml` und `ci.extended.yml` automatisieren.
+   - Stabilität dokumentieren (Badge oder Issue-Vorlage „Build Health“).
+2. **CI Experimental reaktivieren**
+   - `package.json` um `agents:dry-run` und `guardrails:validate` Skripte ergänzen (Nutzung vorhandener Tools unter `scripts/agents` und `tools/governance-guardrails.mjs`).
+   - Sobald stabil, `|| true` entfernen und Ergebnisse im Policy-Report bündeln.
+3. **Policy-Checks vereinheitlichen**
+   - Gemeinsames Reporting (z. B. JSON/Markdown-Anhang im PR) für OPA, Kyverno und Guardrails.
+   - Kyverno/Guardrails ohne `continue-on-error`, nachdem Flakes beseitigt sind.
+4. **Linting & Formatting**
+   - Husky/`lint-staged` sind aktiv; ergänze Richtlinien in CONTRIBUTING (z. B. keine Produktions-`ts-node`-Pfad, Services via `dist/`). (vgl. package.json lint-staged und CONTRIBUTING.md)
+5. **Tests erweitern**
+   - Unit-Tests für Agenten- und Policy-Hilfen (`scripts/agents`, `governance/**`).
+   - `pnpm test:ts:extended` regelmäßig laufen lassen, um Offline-Pipelines frühzeitig zu prüfen.
+
+## Build- & Release-Disziplin
+
+- Dist-Artefakte als Grundlage für Produktion (`pnpm start:light`, `pnpm start:services`). (siehe package.json Startskripte)
+- Docker Compose für Produktions-Simulation nutzen; Compose-Profile für „core only“ ergänzen, um Ressourcen zu sparen. (siehe docker-compose.yml)
+- Prometheus/Grafana-Vorbereitungen liegen im Repo (`grafana/`, `observability/`); Metriken via `prom-client` bleiben Singletons (Fraktal30 Lessons).
+
+## Dokumentation & Onboarding
+
+- README/ONBOARDING auf Aktualität prüfen, Link auf diesen Plan setzen.
+- `AI_POLICY.md` um konkrete Beispiele für Guardrail-Failures erweitern.
+- `codexfeedback.*` als Fraktal-Tagebuch pflegen (Fraktal39 Lauf dokumentieren).
+
+## Governance & Kommunikation
+
+- Labels `run-extended` / `run-experimental` nur setzen, wenn entsprechende Pipelines stabil laufen.
+- Nightly-Fehlschläge sollen Issues mit Logs erzeugen (Automation via `workflow_run` Hook vorbereiten).
+- Issue-Labels `#build-health`, `#policy-check`, `#code-quality` zur Priorisierung verwenden.
+
+## Nächste Meilensteine Richtung v1.0
+
+| Fokus              | Zielzustand                                  | Messpunkt                                                     |
+| ------------------ | -------------------------------------------- | ------------------------------------------------------------- |
+| Core Stability     | Alle Schritte in `ci.core.yml` grün          | `pnpm lint`, `pnpm test:ts:ci`, `pnpm test:py`, `npx pyright` |
+| Extended Pipelines | Offline-Adapter + STAC Smoke stabil          | `pnpm adapter:build:*`, `pnpm stac:validate`                  |
+| Policy Enforcement | Kombinierter Report ohne `continue-on-error` | Policy-Workflow Output                                        |
+| Release Automation | Dist-Build + Docker Compose Pass             | `pnpm start:light`, `docker compose up`                       |
+| Documentation      | README/ONBOARDING/AI_POLICY aktuell          | Review-Checklist                                              |
+
+> „Stabilität zuerst – Wachstum folgt dem Atem der Builds.“

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "pnpm lint:types && pnpm lint:eslint",
     "lint:types": "tsc -p tsconfig.json --noEmit",
     "lint:eslint": "eslint \"{scripts,services,src,tests}/**/*.{ts,tsx,js,jsx,cjs,mjs}\" --max-warnings=0 --cache",
+    "lint-staged": "lint-staged",
     "format": "prettier --write README.md CONTRIBUTING.md docs/ONBOARDING.md codexfeedback.* scripts/dev-services.mjs",
     "format:check": "prettier --check README.md CONTRIBUTING.md docs/ONBOARDING.md codexfeedback.* scripts/dev-services.mjs",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- add the Fraktal38 stabilization roadmap and Codex YAML hook so the v1.0 plan is captured in docs and the Codex ledger
- update AI_POLICY, README, and codexfeedback entries with governance guidance and the current Fraktal39 status
- expose a pnpm `lint-staged` script to satisfy Husky hooks during commits

## Testing
- npx tsc -p tsconfig.json --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68c9b3b4fac48322ae5e2f8a6f204ca3