### PR TITLE
Add Fraktal38 stabilization audit documentation

### DIFF
--- a/codexfeedback.json
+++ b/codexfeedback.json
@@ -1,6 +1,11 @@
 {
   "runs": [
     {
+      "fraktalrun": "Fraktal39 StabilizationAudit",
+      "status": "in-progress",
+      "notes": "Audit-Dossier für v1.0-Stabilisierung angelegt; Umsetzungsschritte (CI-Härtung, dist-first, Policy-Doku) für Folgeläufe eingeplant."
+    },
+    {
       "fraktalrun": "Fraktal38 BuildStabilization",
       "status": "implemented",
       "notes": "ESLint + Prettier hooks, dist-first service orchestrator und Dokumentations-Updates für die v1.0-Stabilisierungsphase."

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -1,5 +1,6 @@
 # Codex Feedback
 
+- FR-UM-2025-09-18-Fraktal39: Stabilisierungsaudit dokumentiert; Umsetzung (CI-Härtung, Dist-Builds, Policy-Doku) für Folgefraktal vorbereitet – Lauf aktiv.
 - FR-UM-2025-09-18-Fraktal38: ESLint/Prettier-Hook, Dist-First-Services und aktualisierte Doku produktiv gesetzt – bereit für den nächsten Fraktal-Sprint.
 - FR-UM-2025-09-18-Fraktal37-CoreCI-RunB: Node20 Toolchain fix, Policy-Checks entschärft, Repo-Sanity stabilisiert – kein weiterer Lauf notwendig.
 - FR-UM-2025-09-18-Fraktal37-CoreCI: Legacy-Workflows archiviert, CI-Core-Stabilität geprüft und Doku/Test-Guides aktualisiert – kein weiterer Lauf notwendig.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -1,6 +1,9 @@
 fraktal:
-  current: 38
+  current: 39
   history:
+    - id: 39
+      status: 'in-progress'
+      notes: 'Fraktal38 Stabilisierungsaudit dokumentiert; Umsetzungspaket (CI-Härtung, Dist-Builds, Policy-Docs) für Fraktal39 geplant.'
     - id: 38
       status: 'done'
       notes: 'ESLint/Prettier Hooks, dist-first Service-Runner und Doku-Refresh für v1.0 Stabilisierung'

--- a/docs/fraktal/Fraktal38-analysis.md
+++ b/docs/fraktal/Fraktal38-analysis.md
@@ -1,0 +1,107 @@
+# Fraktal38 – Unified Mandala Stabilisierungsaudit
+
+## Kontext und Zielsetzung
+
+Fraktal38 fokussiert auf die Vorbereitung des v1.0-Releasefensters von **unified-mandala**. Die Analyse bündelt Beobachtungen aus Repository-Struktur, Build-/Test-Infrastruktur sowie Governance-Layern, leitet kritische Risiken ab und formuliert Prioritäten für die nächsten Iterationen. Sie baut auf den Ergebnissen von Fraktal37 auf und dient als technische Entscheidungsgrundlage für den weiteren Fraktallauf.
+
+## Repository-Architektur & Codeflächen
+
+- **Monorepo mit PNPM-Workspaces**: `package.json` spannt `packages/*` und `apps/*` ein; zentrale Services liegen zusätzlich unter `scripts/`, `services/` und `src/`.【F:package.json†L1-L120】
+- **Multi-Language-Stack**: TypeScript/Vitest (`vitest.config.ts`) für Agenten/Services, Python/Pytest (`pytest.ini`) für Datenadapter sowie Go-Module (`go-agent`, `go-bridge`).【F:vitest.config.ts†L1-L36】【F:pytest.ini†L1-L7】
+- **UI-Build getrennt**: Der Produktions-Dockerfile kompiliert ausschließlich `packages/unifiedmandala-ui` und serviert das Resultat via NGINX; Backend-/Agentenlaufzeiten sind separat zu behandeln.【F:Dockerfile†L1-L11】
+
+### Ableitungen
+
+1. **Klare Layer-Trennung fortführen**: Core-Services in `src/` und `services/` brauchen Dist-Build-Artefakte analog zur UI, damit Production-Deployments ohne `ts-node` auskommen.
+2. **Scripts konsolidieren**: Mehrfach vorhandene CLI-Aufrufe (`scripts/**/*.ts|mjs`) sollten in eine einheitliche CLI-Basis überführt werden, um den Wartungsaufwand zu reduzieren.
+3. **Legacy-Bereiche markieren**: Experimente in `experiments/`, `demos/` und `simulations/` als optional kennzeichnen oder archivieren, sofern sie nicht mehr aktiv gepflegt werden.
+
+## CI- & Test-Layering
+
+### Core-Pipeline
+
+- `ci.core.yml` läuft bei Push und PR, setzt Node 20 sowie Python 3.11, führt `tsc`, `pnpm test:ts:ci`, `pytest` und `pyright` unter OFFLINE/LOW_MEM-Umgebungen aus.【F:.github/workflows/ci.core.yml†L1-L37】
+- Vitest-Konfiguration erzwingt Single-Thread-Execution, deaktiviert Coverage und blendet Extended/Experimental-Globs ohne entsprechende Flags aus.【F:vitest.config.ts†L14-L35】
+
+### Extended-Suite
+
+- `ci.extended.yml` wird über Label `run-extended` oder Nightly-Cron gestartet. Enthält TS- und Python-Extended-Tests, Adapter-Offlinesmokes sowie STAC-Validierung; `resonance:smoke` ist aktuell per `|| true` weichgestellt.【F:.github/workflows/ci.extended.yml†L1-L43】
+
+### Experimental-Layer
+
+- `ci.experimental.yml` hängt an Label `run-experimental`. Sowohl Agents-Dry-Run als auch Guardrails-Validierung laufen mit `|| true`, Ergebnisse werden als Artefakte hochgeladen.【F:.github/workflows/ci.experimental.yml†L1-L20】
+
+### Governance-Checks
+
+- Workflow `governance-check.yml` validiert Schemas und Governance-Skripte, lässt Fehler jedoch via `continue-on-error` passieren.【F:.github/workflows/governance-check.yml†L1-L20】
+- `policy-check.yml` führt OPA, Kyverno und Guardrails aus; Kyverno und Guardrails sind ebenfalls tolerant konfiguriert.【F:.github/workflows/policy-check.yml†L1-L27】
+
+### Handlungsempfehlungen
+
+1. **Stabilität vor Feature-Wachstum**: Core-Pipeline muss dauerhaft grün bleiben, bevor weitere Funktionsausbauten erfolgen.
+2. **`continue-on-error` abbauen**: Sobald Extended/Experimental Läufe reproduzierbar grün sind, Toleranzen entfernen (`resonance:smoke`, Guardrails, Kyverno, Governance-Checks).
+3. **Dry-Runs automatisieren**: Agents-Dry-Run und Guardrails sollen spätestens Nightly voll durchlaufen; Fehler erzeugen Issues mit Log-Artefakten.
+4. **Testschulden adressieren**: Kritische Agenten- und Policy-Pfade (z. B. `scripts/agents/runner.ts`, `tools/governance-guardrails.mjs`) benötigen gezielte Unit-Tests, um Regressionen frühzeitig zu erkennen.
+
+## Build- und Release-Disziplin
+
+- **Dist-First-Strategie**: Produktionsscripts nutzen teilweise noch `ts-node` (`scripts/agents/*.ts`, `scripts/export-depth-bundle.ts`). Für den Release-Train ist ein build step (`pnpm build`) mit anschließender Ausführung aus `dist/` erforderlich.【F:package.json†L52-L123】
+- **Start-Skripte**: `start:light` nutzt `scripts/light-static-server.mjs` und erwartet ein vorab gebautes UI-Bundle – Grundlage für Smoke- und Offline-Tests.【F:package.json†L28-L39】【F:scripts/light-static-server.mjs†L1-L26】
+- **Docker/Compose**: Neben dem UI-Dockerfile existieren Compose-Definitionen (`docker-compose.yml`, `.local`) für Mehrservice-Setups; müssen mit dist-Artifakten harmonieren.
+
+### Maßnahmenplan
+
+1. **Build-Pipelines vereinheitlichen**: `pnpm build` muss sämtliche produktionsrelevanten Services kompilieren; ergänzende Tasks in `scripts/dev-services.mjs` sollten dist-Verweise verwenden.
+2. **Docker-Image-Hardening**: Server-Container (z. B. orchestrator) sollen keine Quellen enthalten, sondern nur `dist/` + minimalen Runner; Build-Prüfungen gehören in CI (`pnpm build` + `pnpm start:light`).
+3. **Prometheus-Integration**: Prometheus-Exports (`prom-client`) sind vorhanden; Compose/Docker sollten die Ports standardisieren und ein Basisset an Alerts definieren.
+
+## Governance & Policy-Ebene
+
+- **Mehrere Policy-Layer**: OPA (`tools/opa-check.mjs`), Kyverno (`policies/kyverno.yaml`) und Guardrails (`tools/governance-guardrails.mjs`) existieren, liefern aber getrennte Reports und brechen Builds nicht.【F:.github/workflows/policy-check.yml†L1-L27】
+- **PactDepth & Sigillin**: Guardrails greifen auf `pact-depth-rules.ts` und Sigil-Indices zurück; Konsolidierung der Reports reduziert die kognitive Last für Contributor.
+
+### Empfehlungen
+
+1. **Einheitlichen Policy-Report erzeugen**: OPA-, Kyverno- und Guardrails-Ergebnisse in einem Markdown/JSON-Report sammeln und als einzigen Artefakt-Link veröffentlichen.
+2. **Fehlerbilder dokumentieren**: CONTRIBUTING/AI_POLICY sollen konkrete Beispiele enthalten, was ein Guardrails-Failure bedeutet und wie er lokal reproduziert wird.
+3. **Frühwarnsystem**: Nightly-Fails sollen automatisiert Issues erzeugen (Label `#policy-check` / `#build-health`).
+
+## Dokumentation & Onboarding
+
+- README, CONTRIBUTING und AI_POLICY existieren, decken aber noch nicht die neue CI-Trennung (Core/Extended/Experimental) oder Dist-First-Regeln ab.
+- Es fehlen detaillierte Beispiele für Governance-Workflows (z. B. Guardrails-Reproduktion, Kyverno-Dry-Run).
+
+### Tasks
+
+1. **README/ONBOARDING aktualisieren**: Neue Pipeline-Struktur, Label-Trigger und Offline-Anforderungen dokumentieren.
+2. **AI_POLICY um Praxisbeispiele ergänzen**: Guardrails-Failures, Sigillin-Governance, CREP-Checks.
+3. **Build-Health-Kommunikation**: Badge oder Dashboard aufsetzen, das `ci.core`, `ci.extended` und `ci.experimental` Status zeigt.
+4. **Nightly-Auto-Issues**: Workflow ergänzen, der bei Fehlschlägen Logs extrahiert und ein Issue mit Kontext erstellt.
+
+## Teamprozesse & Tracking
+
+- Fraktal-IDs sind etabliert (`fraktal-zyklus.md`, `codexfeedback.*`).
+- Labels wie `run-extended` / `run-experimental` existieren; zusätzliche Labels (`#build-health`, `#policy-check`) helfen bei Priorisierung.
+- Backlog-Struktur (Kanban/Jira) sollte die Roadmap „Stabilität → Wachstum“ widerspiegeln.
+
+## Roadmap Snapshot (Fraktal38 → v1.0)
+
+| Phase                   | Fokus             | Kernaufgaben                                                                                                         |
+| ----------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **Sofort**              | Core-Stabilität   | Core-Workflows grün halten, continue-on-error entfernen sobald möglich, Guardrails/Kyverno/Resonance dry-runs härten |
+| **Kurzfristig**         | Codequalität      | ESLint/Prettier-Hooks enforced lassen, Dead Code entfernen, Scripts zu CLI bündeln                                   |
+| **Kurzfristig**         | Tests             | Kritische Agent- & Policy-Unit-Tests, Extended/Experimental automatisieren                                           |
+| **Kurz-/Mittelfristig** | Release           | Dist-Builds für alle Services, Docker/Compose mit Build-Prüfungen, Prometheus im Deployment                          |
+| **Mittelfristig**       | Doku & Governance | README/ONBOARDING/AI_POLICY aktualisieren, Policy-Reports konsolidieren, Nightly-Issue-Automation                    |
+| **Langfristig**         | Strategie         | Roadmap v1.x (Performance, UI-Integration Sigils) & v2.0 (Sigil-UI, emergente Features) ausarbeiten                  |
+
+## Offene Risiken & Nächste Schritte
+
+1. **Flaky Extended/Experimental-Läufe** (Kyverno & Resonance Smoke) – Reproduzierbarkeit sicherstellen, Logs sammeln, tolerierte Fehler abschalten.
+2. **Dist-First-Lücke bei Services** – Build-Artefakt-Pipeline definieren, `ts-node` im Produktionspfad eliminieren.
+3. **Policy-Überlagerungen** – Standardisierte Reports + Dokumentation verhindern Doppelarbeit.
+4. **Monitoring** – Prometheus/Grafana bereits vorhanden (`observability/`, `grafana/`), aber CI-Integration fehlt.
+
+## Übergabe an Fraktal39
+
+- Diese Analyse bildet die technische Basis für Fraktal39. Nächster Schritt ist die Umsetzung der priorisierten Maßnahmen (CI-Härtung, Dist-Builds, Dokumentationsupdates) und die fortlaufende Aktualisierung von `codexfeedback.*`.

--- a/docs/fraktal/Fraktal38-analysis.yaml
+++ b/docs/fraktal/Fraktal38-analysis.yaml
@@ -1,0 +1,96 @@
+schema: fractal-analysis.v1
+fraktal_id: 38
+status: delivered
+focus: v1.0-stabilization
+inputs:
+  repo: unified-mandala
+  reference_pr: 1668
+  artifacts:
+    - .github/workflows/ci.core.yml
+    - .github/workflows/ci.extended.yml
+    - .github/workflows/ci.experimental.yml
+    - .github/workflows/governance-check.yml
+    - .github/workflows/policy-check.yml
+    - package.json
+    - vitest.config.ts
+    - pytest.ini
+    - Dockerfile
+summary:
+  highlights:
+    - 'Core-, Extended- und Experimental-Layer existieren getrennt; Stabilität des Core-Workflows ist Voraussetzung für v1.0.'
+    - 'Extended- und Experimental-Läufe verwenden weiterhin continue-on-error-Pfade (resonance smoke, guardrails, kyverno).'
+    - 'Produktionsscripts nutzen teils ts-node – dist-first-Buildkette muss vervollständigt werden.'
+    - 'Dokumentation deckt neue Build-/Policy-Anforderungen noch nicht ausreichend ab.'
+  risks:
+    - id: flaky_extended
+      description: 'resonance:smoke, guardrails und kyverno liefern keine harten Fehler → echte Regressionsgefahr'
+      mitigation:
+        - 'Runbook für Extended-Läufe erstellen (Label run-extended, nightly cron)'
+        - 'continue-on-error deaktivieren, sobald Läufe 3x stabil waren'
+    - id: dist_gap
+      description: 'Services/Agents laufen via ts-node – Produktionsdeployments ohne Vorab-Build möglich'
+      mitigation:
+        - 'pnpm build erweitert um Agenten/Services'
+        - 'Docker/Compose auf dist-Artefakte umstellen'
+    - id: policy_fragmentation
+      description: 'OPA, Kyverno, Guardrails generieren getrennte Reports und blockieren Pipelines nicht'
+      mitigation:
+        - 'Policy-Report-Aggregator schreiben (Markdown/JSON)'
+        - 'CONTRIBUTING/AI_POLICY um Troubleshooting ergänzen'
+areas:
+  architecture:
+    observations:
+      - 'Monorepo via PNPM-Workspaces (`package.json` → apps/*, packages/*) mit zusätzlichen Top-Level-Services (`src/`, `services/`, `scripts/`).'
+      - 'UI-Build trennt sich über Dockerfile (Node 20 → pnpm install → NGINX deploy).'
+      - 'Polyglot: TypeScript (Vitest), Python (Pytest) und Go-Kerne.'
+    actions:
+      - 'Dist-Builds für Kernservices planen, CLI-Skripte bündeln.'
+      - 'Experimente/Demos markieren oder archivieren, um Fokus auf Minimal Viable Core zu halten.'
+  ci:
+    core:
+      workflow: .github/workflows/ci.core.yml
+      notes:
+        - 'Runs on push & PR; Node 20 + Python 3.11; tsc, vitest (ci), pytest, pyright.'
+        - 'OFFLINE/LOW_MEM Envs sichern Reproduzierbarkeit.'
+    extended:
+      workflow: .github/workflows/ci.extended.yml
+      notes:
+        - 'Trigger: nightly cron + run-extended label.'
+        - 'Adapter-Offlinesmoke (OISST, ERA5) + resonance smoke tolerant.'
+        - 'Python Extended Tests laufen ohne experimental marker.'
+    experimental:
+      workflow: .github/workflows/ci.experimental.yml
+      notes:
+        - 'Trigger: run-experimental label.'
+        - 'Agents dry-run & guardrails validate liefern Artefakte, brechen aber nicht.'
+    recommendations:
+      - 'continue-on-error entfernen, sobald Läufe stabil sind.'
+      - 'Nightly-Fails in Issues spiegeln (Label build-health/policy-check).'
+      - 'Unit-Tests für Agents/Policy-Funktionen ergänzen, um Testschulden abzubauen.'
+  build_release:
+    dist_first:
+      - 'pnpm build: tsc → agents build, dennoch verbleibende ts-node Skripte (scripts/agents/*.ts, scripts/export-depth-bundle.ts).'
+      - 'start:light nutzt light-static-server und benötigt vorab gebaute UI-Dist.'
+    actions:
+      - 'Build-Pipeline erweitern, damit Services dist-Artefakte erzeugen.'
+      - 'Docker/Compose Jobs in CI testen (pnpm build + pnpm start:light).'
+      - 'Prometheus/Grafana-Setups in Compose verankern.'
+  documentation:
+    gaps:
+      - 'README/ONBOARDING beschreiben Core/Extended/Experimental Trennung noch nicht.'
+      - 'AI_POLICY liefert keine Guardrails/Kyverno Troubleshooting-Guides.'
+    tasks:
+      - 'Doku um Build-Health-Layer, Label-Triggers und Offline-Anforderungen erweitern.'
+      - 'Policy-Guide mit Beispielen (OPA, Kyverno, Guardrails) erstellen.'
+  process:
+    checklist:
+      - 'Fraktal-IDs & codexfeedback aktualisieren (Fraktal39 vorbereitet).'
+      - 'Kanban/Jira-Board für Stabilitätsinitiativen pflegen.'
+      - 'Labels #build-health, #policy-check, #code-quality etablieren.'
+handover:
+  next_fraktal: 39
+  priority_backlog:
+    - 'Core-Builds dauerhaft grün halten.'
+    - 'Extended/Experimental Härten & continue-on-error entfernen.'
+    - 'Dist-First Releasepipeline fertigstellen.'
+    - 'Dokumentation & Policy-Playbooks aktualisieren.'


### PR DESCRIPTION
## Summary
- add a Markdown dossier for Fraktal38 covering architecture, CI layering, release discipline, governance and roadmap priorities
- provide a Codex-compatible YAML export of the Fraktal38 analysis for downstream agents
- update codexfeedback trackers to register Fraktal39 as in-progress and link it to the new stabilization audit

## Testing
- npx pyright
- npx tsc -p tsconfig.json --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68c9b3b4fac48322ae5e2f8a6f204ca3