### PR TITLE
docs: add Fraktal40 stabilization playbook

### DIFF
--- a/codexfeedback.json
+++ b/codexfeedback.json
@@ -1,6 +1,11 @@
 {
   "runs": [
     {
+      "fraktalrun": "Fraktal40 V1Stabilization",
+      "status": "analysis-ready",
+      "notes": "Playbook + YAML blueprint for v1.0 stabilization (docs/roadmap/v1.0-stabilization-playbook.*). Implementation tasks pending."
+    },
+    {
       "fraktalrun": "Fraktal39 PolicySuite",
       "status": "implemented",
       "notes": "Policy suite unified: pnpm policy:check CLI, Kyverno summary integration, workflow summary + fail-fast gate."

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -1,5 +1,6 @@
 # Codex Feedback
 
+- FR-UM-2025-09-20-Fraktal40: v1.0-Stabilization-Playbook (docs/roadmap/v1.0-stabilization-playbook.md & .yaml) erstellt – Umsetzungsschritte offen, Folgefraktale erforderlich.
 - FR-UM-2025-09-19-Fraktal39: Policy-Suite vereinheitlicht (OPA/Guardrails CLI, Kyverno-Report, Workflow ohne continue-on-error) – bereit für Folgeaufgaben.
 - FR-UM-2025-09-18-Fraktal38: ESLint/Prettier-Hook, Dist-First-Services und aktualisierte Doku produktiv gesetzt – bereit für den nächsten Fraktal-Sprint.
 - FR-UM-2025-09-18-Fraktal37-CoreCI-RunB: Node20 Toolchain fix, Policy-Checks entschärft, Repo-Sanity stabilisiert – kein weiterer Lauf notwendig.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -1,6 +1,9 @@
 fraktal:
-  current: 39
+  current: 40
   history:
+    - id: 40
+      status: 'analysis-ready'
+      notes: 'v1.0 Stabilization Playbook (docs/roadmap/v1.0-stabilization-playbook.*) vorbereitet; Umsetzung folgt in Folgefraktalen'
     - id: 39
       status: 'done'
       notes: 'Policy suite unified: CLI OPA/Guardrails, Kyverno summary + fail-fast workflow'
@@ -46,6 +49,16 @@ fraktal:
     policy_checks: unified-report
     repo_sanity: tolerant
     documentation: updated
+    v1_stabilization_playbook: prepared
+
+fraktal40:
+  status: 'analysis-ready'
+  checkpoints:
+    - 'Playbook veröffentlicht: docs/roadmap/v1.0-stabilization-playbook.md'
+    - 'Blueprint erstellt: docs/roadmap/v1.0-stabilization-playbook.yaml'
+  next:
+    - 'Owner pro Stream (stability/code-quality/build-release/governance/observability) festlegen'
+    - 'Issues mit Playbook-Checkpoints anlegen und Status über codexfeedback synchronisieren'
 
 fraktal21:
   status: 'ready-for-review'

--- a/docs/roadmap/v1.0-stabilization-playbook.md
+++ b/docs/roadmap/v1.0-stabilization-playbook.md
@@ -1,0 +1,92 @@
+# Unified Mandala v1.0 Stabilization Playbook · Fraktal40
+
+Dieses Playbook übersetzt die Ergebnisse des Fraktal40-Entwicklungsgesprächs in konkrete technische Arbeitspakete. Es ergänzt den Konsolidierungsfahrplan aus Fraktal37 und liefert für das Kernteam eine umsetzbare Reihenfolge für die v1.0-Stabilisierung von **unified-mandala**.
+
+## Ausgangslage & Repository-Baseline
+
+- Unified-Mandala ist ein PNPM-Monorepo mit `apps/`, `packages/` und weitreichenden Skripten im Projektstamm (`package.json`). Die Core-Build-Pipeline nutzt `pnpm test:ts:ci`, `pnpm test:py` und `npx pyright` innerhalb von `.github/workflows/ci.core.yml` (Node 20, Offline-/Low-Mem-Flags).【F:package.json†L12-L111】【F:.github/workflows/ci.core.yml†L1-L33】
+- Das Experimental-Workflow (`ci.experimental.yml`) führt aktuell Guardrails- und Agenten-Dry-Runs nur als `|| true`-Checks aus, wodurch Fehlermeldungen nicht blockierend wirken.【F:.github/workflows/ci.experimental.yml†L6-L25】
+- Die Policy-Suite bündelt derzeit OPA und Guardrails, erzeugt die Ergebnisse jedoch nur als JSON und ohne Kyverno-Einbindung.【F:scripts/policy-suite.mjs†L13-L103】
+- Docker-Artefakte nutzen gemischte Node-Baselines (`Dockerfile` → Node 20 Alpine, `Dockerfile.dev` → Node 18 Bullseye) und `docker-compose.yml` startet zahlreiche Services im Dev-Modus mit `pnpm dev` oder `ts-node`-Kommandos.【F:Dockerfile†L1-L11】【F:Dockerfile.dev†L1-L19】【F:docker-compose.yml†L1-L56】【F:package.json†L26-L122】
+- Prometheus/Grafana-Artefakte existieren (`observability/`), werden aber noch nicht in einen automatisierten Release-Check eingebunden.【F:observability/prometheus.yml†L1-L7】
+
+## 1. Stabilität der Kern-Builds
+
+1. **Core-Gates härten**
+   - Sicherstellen, dass `ci.core.yml` bei Fehlern in `pnpm test:ts:ci`, `pnpm test:py` oder `npx pyright` sofort abbricht; Nightly-Workflow mit identischer Matrix vorbereiten.
+   - Node-/PNPM-Versionen ausgeben (`Debug toolchain versions`) und als Build-Health-Artefakt veröffentlichen.
+2. **Extended-/Experimental-Schicht**
+   - In `ci.experimental.yml` die `|| true`-Konstrukte durch echte Fehlerpfade ersetzen und Guardrails/Agents-Dry-Run nur noch mit optionalen `continue-on-error`-Strategien versehen, sobald die Checks stabil sind.
+   - Dry-Run-Logs als Artefakt beibehalten, zusätzlich Statuskommentare in PRs posten.
+3. **Agent-/Service-Workflows**
+   - `ci/agent.yml` auf Node 20 heben und `pnpm policy:check` als Sammler für Policy-Checks einsetzen, damit Lambda/Go/Python/Node-Pfade synchron laufen.【F:ci/agent.yml†L1-L23】【F:package.json†L93-L141】
+
+## 2. Codequalität & Technische Schulden
+
+1. **Lint/Format-Disziplin**
+   - Husky-Hooks (`.husky/pre-commit`) verwenden bereits `lint-staged`; ergänzen um explizite ESLint/Vitest-Dry-Run-Befehle für kritische Dateien.
+   - Richtlinien (z. B. „kein `ts-node` im Produktionspfad“) in `CONTRIBUTING.md` und `README.md` dokumentieren.
+2. **Dead Code & Skript-Konsolidierung**
+   - Scripts aus `package.json` auditieren: Legacy-Kommandos (z. B. `ghost-shell:*`, `export_depth_bundle`) nur noch über kompilierten Output (`node dist/...`) ausführen.
+   - Gemeinsames CLI (`scripts/dev-services.mjs`, `scripts/dev-server.ts`) dokumentieren und verwaiste Services in `docker-compose.yml` archivieren, falls nicht mehr aktiv betrieben.
+
+## 3. Build- und Release-Härtung
+
+1. **Dist-First Strategie**
+   - `pnpm build` erzeugt derzeit TS/JS-Artefakte via `tsconfig.build.json`; nach erfolgreichem Build sollen Produktionskommandos ausschließlich `node dist/...` nutzen, keine `ts-node`/`tsx` Calls.【F:package.json†L12-L111】
+   - `Dockerfile.dev` von Node 18 auf Node 20 aktualisieren, damit lokale Compose-Umgebungen und CI identische Toolchains verwenden.【F:Dockerfile.dev†L1-L19】
+2. **Runtime Smoke Tests**
+   - `pnpm start:light` (Light Static Server) nach jedem Build ausführen und via Script (`scripts/light-static-server.mjs`) Response-Header (Brotli/Gzip) testen.【F:scripts/light-static-server.mjs†L1-L24】
+   - `docker-compose.yml` für Produktions-Simulation nutzen (`pnpm build`, `docker compose up --profile prod`), Services mit Health-Endpoints ausstatten.
+3. **Docker/Compose Integration**
+   - `Dockerfile` weiterhin für statische UI-Builds nutzen, aber Multi-Stage-Build um CLI/Agent-Artefakte erweitern.
+   - Compose-Profile einführen (`core`, `newsbot`, `climate`) und Default-Profil schlank halten.
+
+## 4. Teststrategie & Abdeckung
+
+1. **Unit-Tests für Kernfunktionen**
+   - Agenten (`agents/`, `services/ghost-shell/`) und CREP-/Policy-Komponenten (`src/adapters/**`, `policies/`) mit Vitest/Pytest-Minimaltests absichern.
+2. **Extended Suites**
+   - `pnpm test:ts:extended` und `pnpm test:py:extended` weiterhin offline fahren; Flakes markieren (`pytest -m slow`) und nightly triggern.
+3. **Coverage & Reporting**
+   - Coverage-Bericht nur aktivieren, wenn Core stabil; optional `vitest --coverage` in Extended-Läufen.
+
+## 5. Governance & Policy Checks
+
+1. **Policy-Suite bündeln**
+   - `scripts/policy-suite.mjs` um Kyverno CLI (`pnpm kyverno:validate`) erweitern und einheitliches JSON/Markdown-Reporting in `out/policy/` erzeugen.【F:scripts/policy-suite.mjs†L13-L132】
+   - Ergebnisse als GitHub Check zusammenführen (OPA, Guardrails, Kyverno) und in `policy:check` Script einbinden.【F:package.json†L109-L141】
+2. **Dokumentation**
+   - `AI_POLICY.md` und `AI_POLICY.yaml` mit Beispielen (Allow/Deny) aktualisieren.
+   - Erläutern, wie Guardrail-Fehler zu interpretieren sind (`policies/merge-guardrails.yaml`).
+
+## 6. Dokumentation & Onboarding
+
+1. **README / CONTRIBUTING / ONBOARDING**
+   - Release-Pipeline (Core vs. Extended vs. Experimental) beschreiben und Dist-First-Vorgaben aufnehmen.
+   - Quickstart um `scripts/setup-dev-env.sh` ergänzen.
+2. **AI Governance Doku**
+   - `AI_POLICY.md` mit praktischen Beispielen, `docs/CommunityOnboarding.md` mit Build-Health-Badges versehen.
+3. **Build Health Kommunikation**
+   - Badge/Issue-Template, das CI-Status (Core/Extended) visualisiert; Nightly-Fehlschläge erzeugen Issues mit Anhängen.
+
+## 7. Observability & Monitoring
+
+- `observability/prometheus.yml` und `observability/grafana/` in Deploy-Pipeline einbinden; Compose-Profile um Prometheus/Grafana ergänzen.【F:observability/prometheus.yml†L1-L7】
+- Workspace-Package `packages/health` (`@um/health`) zur Bereitstellung eines einheitlichen `/metrics`-Endpoints verwenden (Node-Services, Python/Go via Sidecar).
+- Prometheus-Scrapes in Release-Dokumentation beschreiben, Alerts für 5xx/Latency definieren.
+
+## 8. Tracking & Kommunikation
+
+- `codexfeedback.(md|json|yaml)` als Fraktal-Tagebuch weiterführen und pro Umsetzungslauf aktualisieren.
+- Issues mit Labels `#build-health`, `#policy-check`, `#code-quality` anlegen und mit diesem Playbook verlinken.
+- Für Nightly-Automatisierung `runlog-archive.yml` und `repo-sanity.yml` monitoren (Fehler → automatisches Issue).
+
+## Empfohlene Umsetzungsetappen
+
+1. **Sprint 0 – Analyse verankern**: Playbook im Team reviewen, Verantwortlichkeiten zuweisen, Issue-Board vorbereiten.
+2. **Sprint 1 – Core stabilisieren**: CI-Core-Workflow und Policy-Suite härten, Node-Versionen angleichen, Dist-First-Builds durchsetzen.
+3. **Sprint 2 – Extended & Docs**: Extended-/Experimental-CI, Governance-Doku, README/CONTRIBUTING-Updates, Compose-Profiles.
+4. **Sprint 3 – Release Drill**: Vollständiger `pnpm build` → `pnpm start:light` → Docker Compose → Prometheus Smoke → Nightly Report.
+
+> **Hook:** Fortschritt bitte nach jedem Sprint in `codexfeedback.*` und `advancedprogress.json` spiegeln. Sobald alle Etappen als "done" markiert sind, kann der Fraktal40-Lauf geschlossen werden.

--- a/docs/roadmap/v1.0-stabilization-playbook.yaml
+++ b/docs/roadmap/v1.0-stabilization-playbook.yaml
@@ -1,0 +1,138 @@
+fraktal: 40
+release: v1.0
+owner: codex
+updated: 2025-09-20
+summary: |
+  Strukturierter Maßnahmenplan zur Umsetzung der Fraktal40-Besprechung.
+  Fokus auf stabile Kern-Builds, dist-first Services, verschärfte Governance
+  und dokumentierte Release-Drills.
+streams:
+  - key: stability
+    objective: Core- und Extended-Builds dauerhaft grün halten.
+    related_files:
+      - .github/workflows/ci.core.yml
+      - .github/workflows/ci.experimental.yml
+      - ci/agent.yml
+    checkpoints:
+      - id: core-ci-hardening
+        description: 'Fail-fast Verhalten und Nightly-Matrix in CI Core etablieren'
+        status: pending
+        success:
+          - pnpm test:ts:ci
+          - pnpm test:py
+          - npx pyright
+      - id: experimental-signal
+        description: 'Guardrails & Agent Dry-Runs ohne `|| true`; Ergebnisse als Checks publizieren'
+        status: pending
+        artifacts:
+          - agents-dry-run.log
+          - out/policy/policy-suite.json
+      - id: policy-suite-unify
+        description: 'pnpm policy:check bündelt OPA, Guardrails und Kyverno'
+        status: pending
+        output:
+          - out/policy/policy-suite.json
+          - out/policy/policy-suite.md
+  - key: code-quality
+    objective: Linting, Formatting und Skriptlandschaft konsolidieren.
+    related_files:
+      - package.json
+      - .husky/pre-commit
+      - scripts/dev-services.mjs
+      - docker-compose.yml
+    checkpoints:
+      - id: lint-doc-refresh
+        description: 'README/CONTRIBUTING mit Dist-First und Hook-Hinweisen erweitern'
+        status: planned
+      - id: ts-node-retire
+        description: 'Produktionspfade auf `node dist/...` umstellen'
+        status: planned
+  - key: build-release
+    objective: Dist-First-Builds, Docker-Drills und Smoke-Tests automatisieren.
+    related_files:
+      - Dockerfile
+      - Dockerfile.dev
+      - scripts/light-static-server.mjs
+      - docker-compose.yml
+    checkpoints:
+      - id: dist-first
+        description: '`pnpm build` liefert alle Artefakte für Prod-Start ohne ts-node'
+        status: pending
+      - id: compose-profiles
+        description: 'docker-compose Profile für core/newsbot/climate definieren'
+        status: planned
+      - id: runtime-smoke
+        description: '`pnpm start:light` + HTTP-Smoketest automatisieren'
+        status: planned
+  - key: governance
+    objective: Transparente Policy-Gates & Dokumentation.
+    related_files:
+      - scripts/policy-suite.mjs
+      - AI_POLICY.md
+      - policies/merge-guardrails.yaml
+    checkpoints:
+      - id: kyverno-integration
+        description: 'Kyverno CLI in policy-suite aufnehmen'
+        status: pending
+      - id: policy-docs
+        description: 'AI_POLICY.md/Ai_POLICY.yaml mit Allow/Deny Beispielen ergänzen'
+        status: planned
+  - key: observability
+    objective: Prometheus/Grafana in den Release-Fluss integrieren.
+    related_files:
+      - observability/prometheus.yml
+      - observability/grafana
+      - packages/health
+    checkpoints:
+      - id: metrics-endpoints
+        description: 'Alle Services exportieren `/metrics` via @um/health'
+        status: planned
+      - id: prom-compose
+        description: 'Compose-Profile für Prometheus/Grafana aktivieren'
+        status: planned
+milestones:
+  - name: Sprint 0 – Playbook Review
+    target: 2025-09-24
+    deliverables:
+      - Playbook im Team abgestimmt
+      - Aufgaben in Issue-Board gespiegelt
+  - name: Sprint 1 – Core Stabilization
+    target: 2025-10-01
+    deliverables:
+      - core-ci-hardening
+      - policy-suite-unify
+      - kyverno-integration
+  - name: Sprint 2 – Extended & Docs
+    target: 2025-10-08
+    deliverables:
+      - experimental-signal
+      - lint-doc-refresh
+      - runtime-smoke
+  - name: Sprint 3 – Release Drill
+    target: 2025-10-15
+    deliverables:
+      - dist-first
+      - compose-profiles
+      - prom-compose
+tracking:
+  codexfeedback_hook: 'fraktal40'
+  progress_log:
+    - file: codexfeedback.md
+      action: 'neue Laufnotizen hinzufügen'
+    - file: codexfeedback.json
+      action: 'statusflag aktualisieren'
+    - file: codexfeedback.yaml
+      action: 'current=40 setzen, checkpoints pflegen'
+  follow_up:
+    - file: advancedprogress.json
+      action: 'Sprint-Ergebnisse spiegeln'
+risks:
+  - id: ci-flakes
+    description: 'Persistente Vitest/Pytest-Flakes können Fail-Fast-Ansatz ausbremsen'
+    mitigation: 'Tests taggen, Retries nur in Nightlies zulassen, Flake-Issues pflegen'
+  - id: docker-toolchain-drift
+    description: 'Unterschiedliche Node-Versionen (Dockerfile vs Dockerfile.dev)'
+    mitigation: 'Baseline auf Node 20 angleichen, Renovate/Dependabot für Images erwägen'
+  - id: policy-tooling-gaps
+    description: 'Kyverno/OPA Binaries nicht auf Runner verfügbar'
+    mitigation: 'Fallback auf Containerized CLI, Preflight-Check in policy-suite'

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint:eslint": "eslint \"{scripts,services,src,tests}/**/*.{ts,tsx,js,jsx,cjs,mjs}\" --max-warnings=0 --cache",
     "format": "prettier --write README.md CONTRIBUTING.md docs/ONBOARDING.md codexfeedback.* scripts/dev-services.mjs",
     "format:check": "prettier --check README.md CONTRIBUTING.md docs/ONBOARDING.md codexfeedback.* scripts/dev-services.mjs",
+    "lint-staged": "lint-staged",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:unit": "vitest run --coverage",


### PR DESCRIPTION
## Summary
- add a Fraktal40 v1.0 stabilization playbook in Markdown and YAML with actionable CI, release and governance checkpoints
- record the new run in codexfeedback metadata files and flag the follow-up hook for execution planning
- expose a `lint-staged` script so the existing Husky hook can execute without manual intervention

## Testing
- npx pyright
- npx tsc -p tsconfig.json

------
https://chatgpt.com/codex/tasks/task_e_68c9c71aa17483229d714785dd58a6c6