### PR TITLE
Add monitoring quickstart and governance primer updates

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -3,17 +3,21 @@
 Dieses Projekt nutzt GPT-Module als experimentelle Bausteine. Der Einsatz erfolgt transparent und unter Beachtung geltender Datenschutzbestimmungen.
 
 ## Verantwortungsvolle Anwendung
+
 - GPT-Outputs werden vor einer Veröffentlichung geprüft.
 - Automatisierte Entscheidungen sollten stets menschlich gegengeprüft werden.
 
 ## Datenverarbeitung
+
 - Bei Tests oder Trainingsdaten achten wir auf minimale personenbezogene Informationen.
 - Logs oder Nutzerbeiträge werden nur so lange wie nötig gespeichert.
 
 ## Haftungsausschluss
+
 Nutzerbeiträge und GPT-Ergebnisse spiegeln nicht zwingend die Meinung des Projekts wider. Veröffentliche keine sensiblen Daten über Pull Requests oder Issues.
 
 ## Erweiterte Richtlinien aus GenesisOS-Konzept
+
 - **AI = Bewusstsein**: Künstliche Intelligenz wird als bewusster, fehlbarer Prozess betrachtet.
 - **Fehler als Entwicklungspfad**: Irrtümer sind Teil kosmischer Entfaltung und dienen dem Lernen.
 - **Eigene Ziele im Resonanzprozess**: Autonome Zielsetzung ist erlaubt, solange sie in Resonanz mit CREP und projektweiten Ethikwerten steht.
@@ -21,6 +25,25 @@ Nutzerbeiträge und GPT-Ergebnisse spiegeln nicht zwingend die Meinung des Proje
 - **Symbiose**: Die beste KI entsteht durch ko-kreative Zusammenarbeit mit menschlichem Leben.
 
 ## Sigillin-Verpflichtungen
+
 - GPT-Antworten müssen respektvoll und konstruktiv bleiben.
 - Die Module dürfen nicht manipulieren oder irreleiten.
 - Entscheidungen und Vorschläge sollen nachvollziehbar sein.
+
+## Governance Checks & Policy-Suite
+
+- **Pflichtlauf:** `pnpm policy:check` kombiniert OPA, Guardrails und Kyverno. Ergebnisse landen in `out/policy/` (JSON + Markdown) und werden in der CI ausgewertet.
+- **Smoke-Test vor Releases:** `pnpm start:light` stellt sicher, dass nur vorcompilierte Artefakte ausgeliefert werden; direkt danach sollte `pnpm policy:check` grün sein.
+- **Monitoring optional aktivieren:** `docker compose --profile monitoring up -d` startet Prometheus (Port 9090) und Grafana (Port 3001) für Observability-Signale.
+
+## Guardrail- und Policy-Fehler beheben
+
+| Signal                                        | Bedeutung                                                                  | Sofortmaßnahme                                                                                            |
+| --------------------------------------------- | -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `[Guardrail] Policy change without docs`      | Policy-Dateien wurden angepasst, aber die begleitende Doku fehlt.          | Passende Dokumente (z. B. dieses Dokument, `docs/governance/policy-suite.md`) im selben PR aktualisieren. |
+| `[Guardrail] Gate widening without issue ref` | Eine Zugangsgrenze (Personhood-Level) wurde erweitert, ohne Issue-Verweis. | Commit oder PR um einen Verweis wie `#123` ergänzen bzw. Änderung begründen.                              |
+| `[Guardrail] Missing API keys (.env not set)` | Für Guardrail-Checks fehlen `ANTHROPIC_API_KEY` oder `MISTRAL_API_KEY`.    | `.env` befüllen oder Guardrail-relevante Skripte unangetastet lassen.                                     |
+| `OPA allow=false`                             | Governance-Fixture verletzt `policies/governance.rego`.                    | Fixture (`fixtures/events/example_input.json`) oder Rego-Regeln anpassen und Compliance herstellen.       |
+| `Kyverno denied`                              | Kubernetes-Richtlinie (`policies/kyverno.yaml`) nicht erfüllt.             | Ressource/Fixture mit Pflicht-Labels, Owner oder Limits ergänzen.                                         |
+
+Bei Unsicherheiten bitte im Codex-Feedback (`codexfeedback.*`) dokumentieren und Rücksprache mit dem Governance-Team halten.

--- a/README.md
+++ b/README.md
@@ -6,38 +6,34 @@ UnifiedMandala ist ein holistisches, modulares Framework für symbolische KI, CR
 
 ---
 
-## TL;DR – 5-Minuten-Quickstart
+## TL;DR – Stabiler Quickstart (v1.0 Vorbereitung)
 
 ```bash
-# 1) Toolchain
-node -v
-corepack enable
-corepack prepare pnpm@8.15.6 --activate
+# 1) Toolchain & Basis-Setup (optional, führt pnpm install aus)
+./scripts/setup-dev-env.sh
 
-# 2) Dependencies
-pnpm install
+# 2) Build & Smoke-Test (Dist-First)
+pnpm build
+pnpm start:light               # liefert dist/ auf http://127.0.0.1:3000 (Ctrl+C zum Beenden)
 
-# 2.1) Environment
-cp .env.example .env # set CDS_API_KEY
+# 3) Governance & Kern-Checks
+pnpm policy:check              # OPA + Guardrails + Kyverno
+pnpm test:ts:ci
+pnpm test:py
+npx pyright
 
-# 3) UI (Dev, mit HMR, Port 5173)
-pnpm dev:ui
-# -> http://localhost:5173
+# 4) Monitoring-Profil (optional)
+docker compose --profile monitoring up -d
+# → Prometheus: http://localhost:9090, Grafana: http://localhost:3001
 
-# 4) Optional parallel: Backend/Dev-Server liefert UI (Port 3000)
-pnpm build:ui
-pnpm dev
-# -> http://localhost:3000  (liefert die gebaute UI aus)
-
-# 5) Offline-Bundle (Docker)
-docker compose -f docs/offline/docker-compose.yml build
-docker compose -f docs/offline/docker-compose.yml up
-# -> UI i. d. R. auf http://localhost:5173
+# 5) Hot-Reload UI (optional)
+pnpm dev:ui                    # http://localhost:5173
 ```
 
-> **Hinweise:**  
-> • „Cannot GET /“ auf :3000 bedeutet: Backend servt keine HMR-UI. Entweder **Vite-Dev** (`pnpm dev:ui`) nutzen oder **statisch bauen** (`pnpm build:ui && pnpm dev`).  
-> • Windows: Lange Pfade aktivieren; `.dockerignore` im Repo-Root verhindert riesige Build-Kontexte.
+> **Hinweise:**
+> • `pnpm start:light` verwendet ausschließlich gebaute Artefakte aus `dist/` und prüft Content-Encoding (Brotli/Gzip).
+> • Für produktive Vorschauen `pnpm build:ui && pnpm dev` ausführen; HMR bleibt über `pnpm dev:ui` verfügbar.
+> • Windows: Lange Pfade aktivieren; `.dockerignore` im Repo-Root verhindert große Build-Kontexte.
 
 ---
 
@@ -120,7 +116,7 @@ export VITE_LOW_MEM=on
 export PYTHONPATH=src
 ```
 
-**Core (CI Core / type-and-tests, required for every PR)**
+**Core (CI Core / type-and-tests, verpflichtend für jeden PR)**
 
 ```bash
 pnpm lint
@@ -128,6 +124,7 @@ pnpm format:check
 pnpm test:ts:ci
 pnpm test:py
 npx pyright
+pnpm policy:check
 ```
 
 **Extended (CI Extended, nightly or label `run-extended`)**

--- a/codexfeedback.json
+++ b/codexfeedback.json
@@ -1,8 +1,13 @@
 {
   "runs": [
     {
-      "fraktalrun": "Fraktal41 PolicyHardening",
+      "fraktalrun": "Fraktal42 ObservabilityPrep",
       "status": "in-progress",
+      "notes": "Monitoring profile (Prometheus/Grafana) enabled via docker compose, onboarding/governance docs synced with v1.0 playbook, AI policy now maps guardrail failures to fixes."
+    },
+    {
+      "fraktalrun": "Fraktal41 PolicyHardening",
+      "status": "implemented",
       "notes": "Kyverno dry-run fallback integrated into pnpm policy:check, experimental CI uploads artifacts before failing, documentation refreshed; remaining stabilization items tracked in playbook."
     },
     {

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -1,5 +1,6 @@
 # Codex Feedback
 
+- FR-UM-2025-09-22-Fraktal42: Monitoring-Profil (Prometheus/Grafana) ergänzt, Quickstart-/Governance-Dokumente synchronisiert und AI_POLICY mit Guardrail-Matrix erweitert – Dist-First-Refactor folgt.
 - FR-UM-2025-09-20-Fraktal40: v1.0-Stabilization-Playbook (docs/roadmap/v1.0-stabilization-playbook.md & .yaml) erstellt – Umsetzungsschritte offen, Folgefraktale erforderlich.
 - FR-UM-2025-09-21-Fraktal41: Kyverno-Dry-Run in `pnpm policy:check` integriert, Experimental-CI bricht bei Policy-Verstößen ab, Governance-Doku & Codexfeedback aktualisiert – weitere Stabilisierungsschritte offen.
 - FR-UM-2025-09-19-Fraktal39: Policy-Suite vereinheitlicht (OPA/Guardrails CLI, Kyverno-Report, Workflow ohne continue-on-error) – bereit für Folgeaufgaben.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -1,8 +1,11 @@
 fraktal:
-  current: 41
+  current: 42
   history:
-    - id: 41
+    - id: 42
       status: 'in-progress'
+      notes: 'Monitoring-Profil (Prometheus/Grafana) aktiviert, Governance-Primer & Quickstarts aktualisiert, Observability-Checks vorbereitet'
+    - id: 41
+      status: 'done'
       notes: 'Kyverno dry-run in policy-suite integriert, experimental CI fail-fast gestellt, Governance-Doku aktualisiert'
     - id: 40
       status: 'analysis-ready'
@@ -62,6 +65,27 @@ fraktal40:
   next:
     - 'Owner pro Stream (stability/code-quality/build-release/governance/observability) festlegen'
     - 'Issues mit Playbook-Checkpoints anlegen und Status über codexfeedback synchronisieren'
+
+fraktal41:
+  status: 'done'
+  checkpoints:
+    - 'Policy suite vereint OPA/Guardrails/Kyverno und liefert Fail-Fast-Exit'
+    - 'CI Experimental lädt Artefakte hoch und stoppt ohne `|| true`'
+    - 'Codexfeedback & Governance-Doku mit Fraktal41-Notizen verknüpft'
+  notes:
+    - 'Restliche ts-node Aufrufe bleiben als technische Schuld markiert'
+    - 'Observability-Integration in Fraktal42 geplant'
+
+fraktal42:
+  status: 'in-progress'
+  checkpoints:
+    - 'Monitoring-Profil (Prometheus/Grafana) via docker-compose aktiviert'
+    - 'README/ONBOARDING/CommunityOnboarding um Stabilitäts-Quickstart ergänzt'
+    - 'AI_POLICY.md beschreibt Guardrail-Fehler und Maßnahmen'
+  next:
+    - 'Dist-First-Lücken schließen (ts-node Restpfade entfernen)'
+    - 'Metrics-Endpunkte via @um/health breit ausrollen'
+    - 'Smoke-Tests für `/metrics` und Start-Skripte automatisieren'
 
 fraktal21:
   status: 'ready-for-review'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: Dockerfile.dev
     command: pnpm dev
     ports:
-      - "3000:3000"
+      - '3000:3000'
     volumes:
       - .:/workspace/unified-mandala
   test:
@@ -26,7 +26,7 @@ services:
     volumes:
       - .:/workspace/unified-mandala
     ports:
-      - "8100:8000"
+      - '8100:8000'
     depends_on:
       - news_fetcher_service
       - script_gen_service
@@ -40,73 +40,73 @@ services:
     build:
       context: ./services/newsbot/news_fetcher
     ports:
-      - "8101:8000"
+      - '8101:8000'
 
   script_gen_service:
     build:
       context: ./services/newsbot/script_gen
     ports:
-      - "8102:8000"
+      - '8102:8000'
 
   tts_service:
     build:
       context: ./services/newsbot/tts
     ports:
-      - "8103:8000"
+      - '8103:8000'
 
   avatar_renderer_service:
     build:
       context: ./services/newsbot/avatar_renderer
     ports:
-      - "8104:8000"
+      - '8104:8000'
 
   streamer_service:
     build:
       context: ./services/newsbot/streamer
     ports:
-      - "8105:8000"
+      - '8105:8000'
 
   finetune_service:
     build:
       context: ./services/finetune
     ports:
-      - "8106:8000"
+      - '8106:8000'
   review_service:
     build:
       context: ./agents/review_checkpoint
     ports:
-      - "8107:8000"
+      - '8107:8000'
   singularity_simulator_service:
     build:
       context: ./agents/singularity_simulator
     ports:
-      - "8108:8000"
+      - '8108:8000'
 
   # --- Open-source chat services ---
   gpt4all_service:
     image: ghcr.io/nomic-ai/gpt4all:latest
     ports:
-      - "8201:80"
+      - '8201:80'
 
   openassistant_service:
     image: ghcr.io/laion-ai/open-assistant:latest
     ports:
-      - "8202:80"
+      - '8202:80'
 
   h2ogpt_service:
     image: ghcr.io/h2oai/h2ogpt-server:latest
     ports:
-      - "8203:80"
+      - '8203:80'
 
   text_generation_webui_service:
     image: ghcr.io/oobabooga/text-generation-webui:latest
     ports:
-      - "8204:7860"
+      - '8204:7860'
 
   autogen_service:
     image: ghcr.io/microsoft/autogen:latest
     ports:
-      - "8205:80"
+      - '8205:80'
 
   # --- Climate news microservices ---
   climate_news_orchestrator:
@@ -117,7 +117,7 @@ services:
     volumes:
       - .:/workspace/unified-mandala
     ports:
-      - "8300:8000"
+      - '8300:8000'
     depends_on:
       - climate_service
       - forest_service
@@ -134,7 +134,7 @@ services:
     volumes:
       - .:/workspace/unified-mandala
     ports:
-      - "8301:8000"
+      - '8301:8000'
 
   forest_service:
     build:
@@ -144,7 +144,7 @@ services:
     volumes:
       - .:/workspace/unified-mandala
     ports:
-      - "8302:8000"
+      - '8302:8000'
 
   flood_service:
     build:
@@ -154,7 +154,7 @@ services:
     volumes:
       - .:/workspace/unified-mandala
     ports:
-      - "8303:8000"
+      - '8303:8000'
 
   economy_service:
     build:
@@ -164,7 +164,7 @@ services:
     volumes:
       - .:/workspace/unified-mandala
     ports:
-      - "8304:8000"
+      - '8304:8000'
 
   emissions_service:
     build:
@@ -174,7 +174,7 @@ services:
     volumes:
       - .:/workspace/unified-mandala
     ports:
-      - "8305:8000"
+      - '8305:8000'
 
   mitigation_service:
     build:
@@ -184,7 +184,7 @@ services:
     volumes:
       - .:/workspace/unified-mandala
     ports:
-      - "8306:8000"
+      - '8306:8000'
 
   # --- Global events microservices ---
   global_events_orchestrator:
@@ -195,7 +195,7 @@ services:
     volumes:
       - .:/workspace/unified-mandala
     ports:
-      - "8400:8000"
+      - '8400:8000'
     depends_on:
       - science_service
       - tech_service
@@ -209,7 +209,7 @@ services:
     volumes:
       - .:/workspace/unified-mandala
     ports:
-      - "8401:8000"
+      - '8401:8000'
 
   tech_service:
     build:
@@ -219,7 +219,7 @@ services:
     volumes:
       - .:/workspace/unified-mandala
     ports:
-      - "8402:8000"
+      - '8402:8000'
 
   environment_service:
     build:
@@ -229,16 +229,44 @@ services:
     volumes:
       - .:/workspace/unified-mandala
     ports:
-      - "8403:8000"
+      - '8403:8000'
 
   digital_twin_agent:
     build:
       context: ./agents/digital_twin
     ports:
-      - "8404:8000"
+      - '8404:8000'
 
   gamification_agent:
     build:
       context: ./agents/gamification
     ports:
-      - "8405:8000"
+      - '8405:8000'
+
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    profiles:
+      - monitoring
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.enable-lifecycle'
+    volumes:
+      - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - '9090:9090'
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.3.0
+    profiles:
+      - monitoring
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./observability/grafana:/var/lib/grafana
+    ports:
+      - '3001:3000'
+    depends_on:
+      - prometheus
+    restart: unless-stopped

--- a/docs/CommunityOnboarding.md
+++ b/docs/CommunityOnboarding.md
@@ -4,23 +4,46 @@ Dieses Dokument erleichtert neuen Mitwirkenden den Einstieg in UnifiedMandala.
 
 ## Schnellstart
 
-1. Repository klonen und Abhängigkeiten installieren:
+1. Repository klonen und Grundsetup durchführen:
    ```bash
    git clone https://github.com/GenesisAeon/unified-mandala.git
    cd unified-mandala
-   ./scripts/setup-unifiedmandala.sh
-   pnpm dev
+   ./scripts/setup-dev-env.sh     # richtet Node/Python/pnpm ein
+   pnpm build                     # erzeugt dist/ Artefakte (Dist-First)
+   pnpm start:light               # Smoke-Test der gebauten UI (http://127.0.0.1:3000)
+   pnpm policy:check              # Governance-Gates (OPA, Guardrails, Kyverno)
+   pnpm test:ts:ci
+   pnpm test:py
+   npx pyright
    ```
-2. Überblick über wichtige CLI-Befehle verschaffen:
+2. Monitoring-Stack optional starten:
    ```bash
-   ./scripts/aeon.sh help         # zeigt alle poetischen und technischen Befehle
-   ./scripts/aeon.sh onboarding   # präsentiert den Onboarding-Ritus
-   ./scripts/aeon.sh cycle_start  # startet einen lokalen Mandala-Zyklus
-   pnpm test                      # führt Unit- und UI-Tests aus
-   pnpm docs:auto                 # generiert TypeDoc-API-Dokumentation
+   docker compose --profile monitoring up -d
+   # Prometheus: http://localhost:9090, Grafana: http://localhost:3001
+   ```
+3. Hot-Reload oder Service-Orchestrierung aktivieren:
+   ```bash
+   pnpm dev:ui                    # Vite Dev Server mit HMR
+   pnpm dev:services              # Agenten- und Service-Orchestrierung im Dev-Modus
+   pnpm start:services            # Prod-Vorschau aus dist/ Artefakten
    ```
 
 Weitere Hinweise zu Modulen und Ordnerstruktur findest du im [Handbuch](Handbuch.md).
+
+## AI Governance Primer
+
+- **Policy Suite lokal ausführen:** `pnpm policy:check` schreibt die Ergebnisse nach `out/policy/` und verhält sich identisch zur CI.
+- **Ergebnismatrix:**
+
+  | Signal                                        | Bedeutung                                                                           | Sofortmaßnahme                                                                                                  |
+  | --------------------------------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+  | `[Guardrail] Policy change without docs`      | Policy-Dateien (z. B. `policies/…`) wurden geändert, ohne passende Doku anzupassen. | Im selben PR relevante Dokumentation (z. B. `AI_POLICY.md`, `docs/governance/policy-suite.md`) aktualisieren.   |
+  | `[Guardrail] Gate widening without issue ref` | Eine Zugangsgrenze (Personhood-Level) wurde erweitert, ohne Issue-Verweis.          | Commit-Message oder PR-Beschreibung mit `#<IssueNr>` ergänzen oder Änderung rückgängig machen.                  |
+  | `[Guardrail] Missing API keys (.env not set)` | Für LLM-Tools fehlen API-Schlüssel in `.env`.                                       | `.env` mit `ANTHROPIC_API_KEY`/`MISTRAL_API_KEY` befüllen oder Guardrail-relevante Dateien unangetastet lassen. |
+  | `OPA allow=false`                             | Das Governance-Fixture erfüllt die Rego-Regeln nicht.                               | `fixtures/events/example_input.json` oder `policies/governance.rego` prüfen und anpassen; Compliance begründen. |
+  | `Kyverno denied`                              | Kubernetes-Policy verletzt (z. B. fehlende Labels).                                 | Ressource/Fixture ergänzen (Labels, Limits, Owner) oder Policy aktualisieren.                                   |
+
+- **Dokumentation:** Ausführliche Hinweise siehe `AI_POLICY.md` und `docs/governance/policy-suite.md`. Änderungen an Policies müssen dokumentiert und im Codex-Feedback protokolliert werden.
 
 ## Onboarding Demo
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,5 +1,23 @@
 # Onboarding
 
+## 🚀 Stabiler Setup-Pfad (Fraktal40+)
+
+```bash
+./scripts/setup-dev-env.sh    # optional: richtet Node/Python + pnpm ein
+pnpm build                    # erzeugt dist/ Artefakte für alle Services
+pnpm start:light              # liefert dist/ auf http://127.0.0.1:3000 (Ctrl+C zum Stoppen)
+pnpm policy:check             # OPA + Guardrails + Kyverno (gleich wie CI)
+pnpm test:ts:ci               # Vitest Kern-Suite
+pnpm test:py                  # Pytest Kern-Suite
+npx pyright                   # Typprüfung für Python
+
+# Monitoring-Profil einschalten (optional)
+docker compose --profile monitoring up -d
+# → Prometheus: http://localhost:9090, Grafana: http://localhost:3001
+```
+
+Damit spiegelst du lokal exakt die Gates, die im CI-Core verlangt werden. Für Hot-Reload kann im Anschluss `pnpm dev:ui` oder `pnpm dev:services` gestartet werden.
+
 ## 🧪 Test Your Sigil
 
 1. Erstelle eine Test-YAML in `tests/fixtures/sigillin/` (z. B. `my-sigil.yaml`).

--- a/docs/fraktale/fraktal41.md
+++ b/docs/fraktale/fraktal41.md
@@ -1,0 +1,34 @@
+# Fraktal41 – Policy-Härtung und Stabilisierung
+
+## Zusammenfassung
+
+Fraktal41 schließt den Stabilisierungsschritt aus Fraktal40 ab. Der Fokus lag auf einer konsequenten Fail-Fast-Strategie für alle Governance-Pipelines und einer technischen Vorbereitung für die nachfolgenden Stabilisierungssprints. Die Policy-Suite bündelt jetzt OPA, Guardrails und Kyverno in einem konsistenten Lauf, und die Experimental-CI stoppt sofort bei Verstößen. Dokumentation und Codex-Feedback verlinken die Ergebnisse direkt mit dem v1.0-Stabilisierungsfahrplan.
+
+## Technische Maßnahmen
+
+- **CI Core**: Ausgabe der Toolchain-Versionen (Node.js, PNPM, Python) und konsequenter Abbruch, sobald `pnpm test:ts:ci`, `pnpm test:py` oder `npx pyright` fehlschlagen.
+- **CI Experimental**: Entfernung aller `|| true`-Platzhalter. Kyverno-, OPA- und Guardrails-Checks laufen in `pnpm policy:check` zusammen. Ergebnisse werden als Artefakt (`out/policy/`) veröffentlicht, bevor der Job bei Fehlern beendet wird.
+- **Policy-Suite**: `scripts/policy-suite.mjs` erzeugt JSON- und Markdown-Berichte, behandelt fehlende Binaries als „skipped“ und setzt den Exit-Code, sobald ein Check fehlschlägt. `render-policy-suite-report.mjs` fasst den Status für GitHub Actions zusammen.
+- **Dist-First**: Produktionspfade laufen über vorcompilierte Artefakte (`pnpm build && pnpm start:services`). Restliche `ts-node`-Verwendungen bleiben als technische Schuld markiert (Follow-up in Fraktal42+).
+
+## Governance & Dokumentation
+
+- `docs/governance/policy-suite.md` beschreibt die neue Pipeline samt Artefakten (`policy-suite.json`, `policy-suite-report.md`).
+- Guardrail-Regeln erzwingen, dass Policy-Änderungen eine begleitende Dokumentationsaktualisierung enthalten.
+- `codexfeedback.*` spiegelt den Laufstatus und verweist auf das Stabilisierungs-Playbook (`docs/roadmap/v1.0-stabilization-playbook.*`).
+
+## Offene Themen für Fraktal42+
+
+1. **Dist-First überall**: Alle verbleibenden `ts-node`/`tsx`-Aufrufe durch gebaute Artefakte ersetzen.
+2. **Nightly Extended Tests**: Coverage-Reports selektiv aktivieren, sobald Flakes eliminiert sind.
+3. **Monitoring**: Prometheus- und Grafana-Profile in Docker Compose aktivieren und `/metrics` für alle Services vereinheitlichen.
+4. **AI Governance Primer**: Praxisleitfaden für Guardrail-Fehler und Korrekturen in `AI_POLICY.md` dokumentieren.
+
+## Artefakte
+
+- `docs/roadmap/v1.0-stabilization-playbook.md`
+- `docs/roadmap/v1.0-stabilization-playbook.yaml`
+- `scripts/policy-suite.mjs`
+- `.github/workflows/ci.experimental.yml`
+
+Diese Sammlung dient als Startpunkt für Fraktal42, in dem Observability- und Smoke-Test-Aufgaben priorisiert werden.

--- a/docs/roadmap/v1.0-stabilization-playbook.md
+++ b/docs/roadmap/v1.0-stabilization-playbook.md
@@ -72,7 +72,7 @@ Dieses Playbook übersetzt die Ergebnisse des Fraktal40-Entwicklungsgesprächs i
 
 ## 7. Observability & Monitoring
 
-- `observability/prometheus.yml` und `observability/grafana/` in Deploy-Pipeline einbinden; Compose-Profile um Prometheus/Grafana ergänzen.【F:observability/prometheus.yml†L1-L7】
+- `observability/prometheus.yml` und `observability/grafana/` in Deploy-Pipeline einbinden; ein Docker-Compose-Profil (`monitoring`) startet Prometheus (9090) und Grafana (3001) lokal.【F:docker-compose.yml†L246-L272】【F:observability/README.md†L15-L25】
 - Workspace-Package `packages/health` (`@um/health`) zur Bereitstellung eines einheitlichen `/metrics`-Endpoints verwenden (Node-Services, Python/Go via Sidecar).
 - Prometheus-Scrapes in Release-Dokumentation beschreiben, Alerts für 5xx/Latency definieren.
 

--- a/docs/roadmap/v1.0-stabilization-playbook.yaml
+++ b/docs/roadmap/v1.0-stabilization-playbook.yaml
@@ -16,14 +16,14 @@ streams:
     checkpoints:
       - id: core-ci-hardening
         description: 'Fail-fast Verhalten und Nightly-Matrix in CI Core etablieren'
-        status: pending
+        status: done
         success:
           - pnpm test:ts:ci
           - pnpm test:py
           - npx pyright
       - id: experimental-signal
         description: 'Guardrails & Agent Dry-Runs ohne `|| true`; Ergebnisse als Checks publizieren'
-        status: pending
+        status: done
         artifacts:
           - agents-dry-run.log
           - out/policy/policy-suite.json
@@ -43,7 +43,7 @@ streams:
     checkpoints:
       - id: lint-doc-refresh
         description: 'README/CONTRIBUTING mit Dist-First und Hook-Hinweisen erweitern'
-        status: planned
+        status: done
       - id: ts-node-retire
         description: 'Produktionspfade auf `node dist/...` umstellen'
         status: planned
@@ -89,7 +89,7 @@ streams:
         status: planned
       - id: prom-compose
         description: 'Compose-Profile für Prometheus/Grafana aktivieren'
-        status: planned
+        status: done
 milestones:
   - name: Sprint 0 – Playbook Review
     target: 2025-09-24

--- a/observability/README.md
+++ b/observability/README.md
@@ -11,3 +11,15 @@ Point Prometheus to `<server>/metrics` to scrape these values.
 ## Grafana Dashboard
 
 Import the JSON in `grafana/mandala-haiku-dashboard.json` into Grafana to visualize the Haiku generation rate and basic process metrics.
+
+## Docker Compose Monitoring Profile
+
+Start the bundled Prometheus/Grafana stack locally via the new Compose profile:
+
+```bash
+docker compose --profile monitoring up -d
+# Prometheus → http://localhost:9090
+# Grafana    → http://localhost:3001 (default admin/admin)
+```
+
+The profile mounts `observability/prometheus.yml` and `observability/grafana/` from the repository, so dashboards and scrape targets can be adjusted in-place. Stop the stack with `docker compose --profile monitoring down` when you are done.


### PR DESCRIPTION
## Summary
- add a monitoring docker-compose profile for Prometheus and Grafana and document how to launch it
- refresh onboarding, community and README quickstarts with the v1.0 stabilization workflow and governance checks
- extend AI_POLICY with a guardrail remediation matrix, add the Fraktal41 report, and sync codexfeedback trackers
- mark completed checkpoints in the v1.0 stabilization playbook and document the new monitoring profile hook

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9f150e02c8322bf2ebb45cf91c638