### PR TITLE
chore: sync nightly ci mirror and dist-first docs

### DIFF
--- a/.github/workflows/ci.nightly.yml
+++ b/.github/workflows/ci.nightly.yml
@@ -1,11 +1,18 @@
-name: CI Core
+name: CI Nightly
+
 on:
-  pull_request:
-  push:
-    branches: [main]
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
 jobs:
-  type-and-tests:
+  nightly-type-and-tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['20.x']
+        python: ['3.11']
     env:
       OFFLINE: '1'
       LOW_MEM: '1'
@@ -17,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: ${{ matrix.node }}
           cache: 'pnpm'
       - uses: pnpm/action-setup@v4
         with:
@@ -26,13 +33,12 @@ jobs:
         run: |
           echo "Node $(node -v)"
           echo "PNPM v$(pnpm -v)"
-          python --version
       - run: pnpm install --frozen-lockfile
       - run: pnpm format:check
       - run: pnpm lint
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python }}
           cache: 'pip'
           cache-dependency-path: requirements.txt
       - run: python -m pip install --upgrade pip
@@ -47,7 +53,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: toolchain-versions
+          name: toolchain-versions-${{ matrix.node }}-${{ matrix.python }}
           path: toolchain-versions.txt
       - run: npx tsc -p tsconfig.json --noEmit
       - run: pnpm test:ts:ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,3 +67,8 @@ Danach sollten folgende Schritte immer grün sein, bevor ein PR erstellt wird:
 - Entwicklungsmodus: `pnpm dev:services` (nutzt `tsx`).
 - Produktionsmodus: `pnpm start:services` (nutzt `node dist/...`).
 - Falls beim Start Artefakte fehlen, zuerst `pnpm build` ausführen.
+- Der Helper `scripts/run-dist.mjs` steckt hinter allen produktiven Skripten (`pnpm agents:health`, `pnpm sigils:lint`, …). Er prüft, ob das passende `dist/*.js` existiert, baut ansonsten automatisch und reicht zusätzliche Flags weiter.
+- Für Spezialfälle:
+  - `UM_RUN_DIST_SKIP_BUILD=1` → Skip Auto-Build (z. B. im CI nach vorherigem `pnpm build`).
+  - `UM_RUN_DIST_BUILD_CMD="pnpm -r --filter mandala-ui build"` → alternatives Build-Kommando.
+  - Direktaufruf: `node scripts/run-dist.mjs scripts/qa-test-runner.ts --suite smoke`.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,13 @@ pnpm test:unit                # Coverage-Report der Kernmodule
 
 > ℹ️ `CI Experimental` läuft nur mit Label `run-experimental`. `ENABLE_EXPERIMENTAL_TESTS=1` schaltet zusätzliche, instabile Suites frei (z.B. `pnpm test:ts:experimental`).
 
+### Dist-First Ausführung (`scripts/run-dist.mjs`)
+
+- Produktionsskripte in `package.json` nutzen durchgängig `node scripts/run-dist.mjs <pfad-zur-ts-datei>`.
+- Der Helper übersetzt TypeScript-Pfade deterministisch auf `dist/*.js`, stößt bei Bedarf automatisch `pnpm build` an und aktiviert `--enable-source-maps` für sauberes Debugging.
+- Mit `UM_RUN_DIST_SKIP_BUILD=1` lässt sich der Auto-Build deaktivieren (z. B. in bereits gebauten CI-Läufen). Eigene Build-Kommandos können via `UM_RUN_DIST_BUILD_CMD="pnpm -r --filter my-app build"` hinterlegt werden.
+- Direktaufruf möglich: `node scripts/run-dist.mjs services/ghost-shell/server.ts --flag`. Vorher `pnpm build`, wenn das Artefakt noch nicht existiert.
+
 ---
 
 ## Contributing

--- a/advancedprogress.json
+++ b/advancedprogress.json
@@ -33,6 +33,10 @@
   ],
   "progress": [
     {
+      "commit": "Fraktal43: nightly mirror + dist-first docs",
+      "status": "in-progress"
+    },
+    {
       "commit": "Fraktal41: Kyverno policy suite fallback",
       "status": "in-progress"
     },
@@ -6364,6 +6368,6 @@
     }
   ],
   "changedFiles": [],
-  "lastUpdated": "2025-09-04T13:48:52.382Z",
+  "lastUpdated": "2025-09-23T09:00:00Z",
   "commitHash": "743851c2bde0ad40d543d912aeebbbde384e43fd"
 }

--- a/codexfeedback.json
+++ b/codexfeedback.json
@@ -3,7 +3,7 @@
     {
       "fraktalrun": "Fraktal43 DistFirstRunner",
       "status": "in-progress",
-      "notes": "Dist-first runner (scripts/run-dist.mjs) ersetzt ts-node Kommandos, AI-Policy-Beispiele veröffentlicht; README/CONTRIBUTING Follow-up geplant."
+      "notes": "Dist-first runner ersetzt ts-node; README/CONTRIBUTING dokumentieren run-dist, Nightly-Core-Mirror vorbereitet."
     },
     {
       "fraktalrun": "Fraktal41 PolicyHardening",
@@ -12,8 +12,8 @@
     },
     {
       "fraktalrun": "Fraktal40 V1Stabilization",
-      "status": "analysis-ready",
-      "notes": "Playbook + YAML blueprint for v1.0 stabilization (docs/roadmap/v1.0-stabilization-playbook.*). Implementation tasks pending."
+      "status": "in-progress",
+      "notes": "Playbook + YAML blueprint für v1.0 Stabilisierung; Owner/Backup je Stream gesetzt, ci.nightly Mirror aktiv, Status-Tracking über codexfeedback.*."
     },
     {
       "fraktalrun": "Fraktal39 PolicySuite",

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -1,7 +1,16 @@
 # Codex Feedback
 
+- FR-UM-2025-09-23-Fraktal43-Nightly: CI-Nightly (`ci.nightly.yml`) spiegelt den Core-Lauf inkl. Toolchain-Artefakt, README/CONTRIBUTING beschreiben den Dist-First-Runner `scripts/run-dist.mjs`, Playbook-Owner-Map + codexfeedback-Tracker aktualisiert – Extended/Nightly Optimierungen laufen weiter über Fraktal41.
 - FR-UM-2025-09-22-Fraktal43: Dist-first Runner (`scripts/run-dist.mjs`) ersetzt ts-node-Kommandos, AI-Policy-Beispiele dokumentiert, codexfeedback-Hooks aktualisiert – V1-Stabilisierungsschritte laufen weiter.
-- FR-UM-2025-09-20-Fraktal40: v1.0-Stabilization-Playbook (docs/roadmap/v1.0-stabilization-playbook.md & .yaml) erstellt – Umsetzungsschritte offen, Folgefraktale erforderlich.
+
+## V1.0 Playbook Tracker (Fraktal40)
+
+- **stability** (Codex CoreOps ↔ SyncRunner): `core-ci-hardening` in-progress – Nightly-Mirror `ci.nightly.yml` + Toolchain-Artefakt aktiv.
+- **code-quality** (DevX Guild ↔ PatternReactivator): `lint-doc-refresh` done – README/CONTRIBUTING führen `scripts/run-dist.mjs`, CLI-Doku-Follow-up offen.
+- **build-release** (ReleaseOps Circle ↔ VisionContextIntegrator): `dist-first` & Compose-Profile pending – nächste Sprintplanung.
+- **governance** (AI Governance Council ↔ PactDepthGatekeeper): Kyverno/Policy-Doku done – laufendes Monitoring der Entscheidungen.
+- **observability** (TelemetryOps ↔ Health Maintainers): `prom-compose` done – `/metrics`-Rollout via @um/health noch ausstehend.
+- FR-UM-2025-09-20-Fraktal40: v1.0-Stabilization-Playbook (docs/roadmap/v1.0-stabilization-playbook.md & .yaml) erstellt – Owner-Matrix & Status-Tracker ergänzt, Umsetzungsschritte offen, Folgefraktale erforderlich.
 - FR-UM-2025-09-21-Fraktal41: CI-Core mit Lint/Format erweitert, Extended-Nightly auf Node20 mit Coverage-Job aktiviert, Monitoring-Profil (Prometheus/Grafana) ergänzt – Dist-first Agent-Skripte & AI-Policy-Beispiele via Fraktal43 erledigt, Extended/Nightly Optimierungen folgen.
 - FR-UM-2025-09-19-Fraktal39: Policy-Suite vereinheitlicht (OPA/Guardrails CLI, Kyverno-Report, Workflow ohne continue-on-error) – bereit für Folgeaufgaben.
 - FR-UM-2025-09-18-Fraktal38: ESLint/Prettier-Hook, Dist-First-Services und aktualisierte Doku produktiv gesetzt – bereit für den nächsten Fraktal-Sprint.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -3,13 +3,13 @@ fraktal:
   history:
     - id: 43
       status: 'in-progress'
-      notes: 'Dist-first Runner (scripts/run-dist.mjs) + AI-Policy-Beispiele implementiert; V1-Playbook Sync laufend'
+      notes: 'Dist-first Runner (scripts/run-dist.mjs) + AI-Policy-Beispiele implementiert; CI-Nightly Mirror & Owner-Mapping aktiv'
     - id: 41
       status: 'in-progress'
       notes: 'CI-Core erweitert (Lint/Format/Coverage-Hooks), Extended-Workflow auf Node20 mit Coverage-Job, Monitoring-Profil in docker-compose hinterlegt'
     - id: 40
-      status: 'analysis-ready'
-      notes: 'v1.0 Stabilization Playbook (docs/roadmap/v1.0-stabilization-playbook.*) vorbereitet; Umsetzung folgt in Folgefraktalen'
+      status: 'in-progress'
+      notes: 'v1.0 Stabilization Playbook (docs/roadmap/v1.0-stabilization-playbook.*) plus Owner-/Backup-Matrix; Umsetzung läuft, Tracker synchronisiert'
     - id: 39
       status: 'done'
       notes: 'Policy suite unified: CLI OPA/Guardrails, Kyverno summary + fail-fast workflow'
@@ -62,8 +62,8 @@ fraktal43:
   checkpoints:
     - 'scripts/run-dist.mjs ersetzt ts-node für Produktionskommandos'
     - 'AI_POLICY.md/.yaml enthalten Allow/Review/Block Beispiele'
+    - 'ci.nightly.yml spiegelt type-and-tests (Node20/Python3.11) inkl. Toolchain-Artefakt'
   next:
-    - 'Dist-first Rollout dokumentieren (README/CONTRIBUTING)'
     - 'Fraktal41 Nightly/Extended Follow-ups koordinieren'
 
 fraktal41:
@@ -75,18 +75,39 @@ fraktal41:
       implemented: yes
     - name: 'Nightly/Extended Tests etabliert'
       implemented: partial
+      notes: 'Nightly Mirror via ci.nightly.yml aktiv, Extended-Auswertung & Alerts offen'
     - name: 'Monitoring-Profil (Prometheus/Grafana)'
       implemented: yes
     - name: 'ts-node im Produktionspfad entfernt'
       implemented: yes
 
 fraktal40:
-  status: 'analysis-ready'
+  status: 'in-progress'
   checkpoints:
     - 'Playbook veröffentlicht: docs/roadmap/v1.0-stabilization-playbook.md'
     - 'Blueprint erstellt: docs/roadmap/v1.0-stabilization-playbook.yaml'
+  tracker:
+    stability:
+      owner: 'Codex CoreOps / SyncRunner'
+      status: 'in-progress'
+      notes: 'ci.nightly.yml aktiv, Toolchain-Artefakt verfügbar; Ergebnis-Auswertung geplant'
+    code-quality:
+      owner: 'DevX Guild / PatternReactivator'
+      status: 'done'
+      notes: 'README & CONTRIBUTING dokumentieren run-dist inkl. Overrides'
+    build-release:
+      owner: 'ReleaseOps Circle / VisionContextIntegrator'
+      status: 'planned'
+      notes: 'dist-first Checkpoint & Compose-Profile offen'
+    governance:
+      owner: 'AI Governance Council / PactDepthGatekeeper'
+      status: 'done'
+      notes: 'Kyverno & Policy-Doku abgeschlossen, Monitoring weiterführen'
+    observability:
+      owner: 'TelemetryOps / Health Maintainers'
+      status: 'planned'
+      notes: '`prom-compose` aktiv, `/metrics`-Rollout ausstehend'
   next:
-    - 'Owner pro Stream (stability/code-quality/build-release/governance/observability) festlegen'
     - 'Issues mit Playbook-Checkpoints anlegen und Status über codexfeedback synchronisieren'
 
 fraktal21:

--- a/docs/roadmap/v1.0-stabilization-playbook.md
+++ b/docs/roadmap/v1.0-stabilization-playbook.md
@@ -10,12 +10,23 @@ Dieses Playbook übersetzt die Ergebnisse des Fraktal40-Entwicklungsgesprächs i
 - Docker-Artefakte nutzen gemischte Node-Baselines (`Dockerfile` → Node 20 Alpine, `Dockerfile.dev` → Node 18 Bullseye) und `docker-compose.yml` startet zahlreiche Services im Dev-Modus mit `pnpm dev` oder `ts-node`-Kommandos.【F:Dockerfile†L1-L11】【F:Dockerfile.dev†L1-L19】【F:docker-compose.yml†L1-L56】【F:package.json†L26-L122】
 - Prometheus/Grafana-Artefakte existieren (`observability/`), werden aber noch nicht in einen automatisierten Release-Check eingebunden.【F:observability/prometheus.yml†L1-L7】
 
+## Verantwortlichkeiten · Fraktal43 Sync
+
+| Stream        | Owner (Lead)                        | Backup / Tandem                  | Notizen                                                                |
+| ------------- | ----------------------------------- | -------------------------------- | ---------------------------------------------------------------------- |
+| stability     | Codex CoreOps / CodexAuditAgent     | Nightly Stewardship (SyncRunner) | Nightly CI spiegelt Core-Gates, Artefakte dienen als Health-Protokoll. |
+| code-quality  | DevX Guild                          | PatternReactivator               | README & CONTRIBUTING dokumentieren Dist-First-Regeln und `run-dist`.  |
+| build-release | ReleaseOps Circle                   | VisionContextIntegrator          | Compose-/Docker-Profilierung bleibt geplant, Dist-First bleibt offen.  |
+| governance    | AI Governance Council               | PactDepthGatekeeper              | Policy-Suite konsolidiert, Docs laufen über Governance-Review.         |
+| observability | TelemetryOps / GenesisAeonNavigator | Health Package Maintainers       | Monitoring-Profil aktiv, `/metrics`-Rollout steht aus.                 |
+
 ## 1. Stabilität der Kern-Builds
 
 1. **Core-Gates härten**
    - Sicherstellen, dass `ci.core.yml` bei Fehlern in `pnpm test:ts:ci`, `pnpm test:py` oder `npx pyright` sofort abbricht; Nightly-Workflow mit identischer Matrix vorbereiten.
    - Node-/PNPM-Versionen ausgeben (`Debug toolchain versions`) und als Build-Health-Artefakt veröffentlichen.
-   - _Status 2025-09-21:_ Format/Lint sind Teil des Core-Jobs, Toolchain-Logging aktiv; Nightly-Matrix in Arbeit.
+   - Nightly-Mirror `ci.nightly.yml` repliziert den Core-Lauf (Node 20/Python 3.11) und lädt Toolchain-Artefakte pro Matrix-Kombination hoch.
+   - _Status 2025-09-23:_ Format/Lint sind Teil des Core-Jobs, Toolchain-Logging + Artefakt aktiv; Nightly-Matrix spiegelt Core, Auswertung der Ergebnisse folgt.
 2. **Extended-/Experimental-Schicht**
    - In `ci.experimental.yml` die `|| true`-Konstrukte durch echte Fehlerpfade ersetzen und Guardrails/Agents-Dry-Run nur noch mit optionalen `continue-on-error`-Strategien versehen, sobald die Checks stabil sind.
    - Dry-Run-Logs als Artefakt beibehalten, zusätzlich Statuskommentare in PRs posten.
@@ -28,10 +39,11 @@ Dieses Playbook übersetzt die Ergebnisse des Fraktal40-Entwicklungsgesprächs i
 1. **Lint/Format-Disziplin**
    - Husky-Hooks (`.husky/pre-commit`) verwenden bereits `lint-staged`; ergänzen um explizite ESLint/Vitest-Dry-Run-Befehle für kritische Dateien.
    - Richtlinien (z. B. „kein `ts-node` im Produktionspfad“) in `CONTRIBUTING.md` und `README.md` dokumentieren.
+   - README & CONTRIBUTING dokumentieren den Dist-First-Runner `scripts/run-dist.mjs`, inklusive `UM_RUN_DIST_*` Overrides und Direktaufrufen.
 2. **Dead Code & Skript-Konsolidierung**
    - Scripts aus `package.json` auditieren: Legacy-Kommandos (z. B. `ghost-shell:*`, `export_depth_bundle`) nur noch über kompilierten Output (`node dist/...`) ausführen.
    - Gemeinsames CLI (`scripts/dev-services.mjs`, `scripts/dev-server.ts`) dokumentieren und verwaiste Services in `docker-compose.yml` archivieren, falls nicht mehr aktiv betrieben.
-   - _Status 2025-09-22:_ `scripts/run-dist.mjs` ersetzt `ts-node` in produktiven Kommandos und erzwingt dist-first Läufe.
+   - _Status 2025-09-23:_ `scripts/run-dist.mjs` ersetzt `ts-node`, Dist-First-Richtlinien sind in README/CONTRIBUTING verankert; weitere CLI-Dokumentation folgt.
 
 ## 3. Build- und Release-Härtung
 

--- a/docs/roadmap/v1.0-stabilization-playbook.yaml
+++ b/docs/roadmap/v1.0-stabilization-playbook.yaml
@@ -1,13 +1,16 @@
 fraktal: 40
 release: v1.0
 owner: codex
-updated: 2025-09-22
+updated: 2025-09-23
 summary: |
   Strukturierter Maßnahmenplan zur Umsetzung der Fraktal40-Besprechung.
   Fokus auf stabile Kern-Builds, dist-first Services, verschärfte Governance
   und dokumentierte Release-Drills.
 streams:
   - key: stability
+    owner:
+      lead: Codex CoreOps / CodexAuditAgent
+      backup: SyncRunner Nightly Stewardship
     objective: Core- und Extended-Builds dauerhaft grün halten.
     related_files:
       - .github/workflows/ci.core.yml
@@ -17,6 +20,7 @@ streams:
       - id: core-ci-hardening
         description: 'Fail-fast Verhalten und Nightly-Matrix in CI Core etablieren'
         status: in-progress
+        notes: 'ci.nightly.yml spiegelt type-and-tests; Toolchain-Artefakt wird hochgeladen'
         success:
           - pnpm test:ts:ci
           - pnpm test:py
@@ -34,6 +38,9 @@ streams:
           - out/policy/policy-suite.json
           - out/policy/policy-suite.md
   - key: code-quality
+    owner:
+      lead: DevX Guild
+      backup: PatternReactivator Collective
     objective: Linting, Formatting und Skriptlandschaft konsolidieren.
     related_files:
       - package.json
@@ -43,12 +50,16 @@ streams:
     checkpoints:
       - id: lint-doc-refresh
         description: 'README/CONTRIBUTING mit Dist-First und Hook-Hinweisen erweitern'
-        status: planned
+        status: done
+        notes: 'README & CONTRIBUTING beschreiben scripts/run-dist.mjs inkl. `UM_RUN_DIST_*` Overrides'
       - id: ts-node-retire
         description: 'Produktionspfade auf `node dist/...` umstellen'
         status: done
         notes: 'scripts/run-dist.mjs ersetzt ts-node in Paket-Skripten'
   - key: build-release
+    owner:
+      lead: ReleaseOps Circle
+      backup: VisionContextIntegrator
     objective: Dist-First-Builds, Docker-Drills und Smoke-Tests automatisieren.
     related_files:
       - Dockerfile
@@ -66,6 +77,9 @@ streams:
         description: '`pnpm start:light` + HTTP-Smoketest automatisieren'
         status: planned
   - key: governance
+    owner:
+      lead: AI Governance Council
+      backup: PactDepthGatekeeper
     objective: Transparente Policy-Gates & Dokumentation.
     related_files:
       - scripts/policy-suite.mjs
@@ -80,6 +94,9 @@ streams:
         status: done
         notes: 'Entscheidungsbeispiele dokumentiert (Allow/Review/Block)'
   - key: observability
+    owner:
+      lead: TelemetryOps / GenesisAeonNavigator
+      backup: Health Package Maintainers
     objective: Prometheus/Grafana in den Release-Fluss integrieren.
     related_files:
       - observability/prometheus.yml


### PR DESCRIPTION
## Summary
- add a nightly mirror of the core CI job with toolchain artifacts while capturing the same manifest in ci.core.yml
- document scripts/run-dist.mjs usage and overrides in README/CONTRIBUTING to reinforce the dist-first rollout
- align the v1.0 stabilization playbook, codexfeedback trackers, and advancedprogress with stream owners and current progress

## Testing
- not run (docs/workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68c9ffca18608322bdefd7a566df2627