### PR TITLE
Align build-release tooling with light static smoke

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,8 +1,8 @@
-FROM node:18-bullseye
+FROM node:20-bullseye
 
 # Install Go
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends golang-go && \
+    apt-get install -y --no-install-recommends golang-go python3 python3-pip python3-venv && \
     rm -rf /var/lib/apt/lists/*
 
 # Install pnpm globally

--- a/codexfeedback.json
+++ b/codexfeedback.json
@@ -3,7 +3,7 @@
     {
       "fraktalrun": "Fraktal43 DistFirstRunner",
       "status": "in-progress",
-      "notes": "Dist-first runner ersetzt ts-node; README/CONTRIBUTING dokumentieren run-dist, Nightly-Core-Mirror vorbereitet."
+      "notes": "Dist-first runner ersetzt ts-node; Dockerfile.dev Node20+Python3, light-static smoke (`pnpm smoke:light-static`), Compose profiles documented; README/CONTRIBUTING follow-ups pending."
     },
     {
       "fraktalrun": "Fraktal41 PolicyHardening",
@@ -13,7 +13,7 @@
     {
       "fraktalrun": "Fraktal40 V1Stabilization",
       "status": "in-progress",
-      "notes": "Playbook + YAML blueprint für v1.0 Stabilisierung; Owner/Backup je Stream gesetzt, ci.nightly Mirror aktiv, Status-Tracking über codexfeedback.*."
+      "notes": "Playbook/YAML updated: dist-first & runtime-smoke in-progress (Node20 dev baseline, light-static smoke script), compose profiles done; ci.nightly Mirror aktiv, Status-Tracking via codexfeedback.*."
     },
     {
       "fraktalrun": "Fraktal39 PolicySuite",

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -1,5 +1,6 @@
 # Codex Feedback
 
+- FR-UM-2025-09-24-Fraktal43-BuildRelease: Dockerfile.dev jetzt Node20+Python3 (Compose parity), docker-compose Profile (core/newsbot/climate/llm/global/agents/monitoring) + Grafana 3300, Light-Static-Server mit Health/Vary/Cache-Control, neues `pnpm smoke:light-static` für Brotli/Gzip; Playbook/YAML-Tracker aktualisiert (dist-first/runtime-smoke in-progress, compose-profiles done).
 - FR-UM-2025-09-23-Fraktal43-Nightly: CI-Nightly (`ci.nightly.yml`) spiegelt den Core-Lauf inkl. Toolchain-Artefakt, README/CONTRIBUTING beschreiben den Dist-First-Runner `scripts/run-dist.mjs`, Playbook-Owner-Map + codexfeedback-Tracker aktualisiert – Extended/Nightly Optimierungen laufen weiter über Fraktal41.
 - FR-UM-2025-09-22-Fraktal43: Dist-first Runner (`scripts/run-dist.mjs`) ersetzt ts-node-Kommandos, AI-Policy-Beispiele dokumentiert, codexfeedback-Hooks aktualisiert – V1-Stabilisierungsschritte laufen weiter.
 
@@ -7,7 +8,7 @@
 
 - **stability** (Codex CoreOps ↔ SyncRunner): `core-ci-hardening` in-progress – Nightly-Mirror `ci.nightly.yml` + Toolchain-Artefakt aktiv.
 - **code-quality** (DevX Guild ↔ PatternReactivator): `lint-doc-refresh` done – README/CONTRIBUTING führen `scripts/run-dist.mjs`, CLI-Doku-Follow-up offen.
-- **build-release** (ReleaseOps Circle ↔ VisionContextIntegrator): `dist-first` & Compose-Profile pending – nächste Sprintplanung.
+- **build-release** (ReleaseOps Circle ↔ VisionContextIntegrator): `dist-first` & `runtime-smoke` in-progress, Compose-Profile done – Dockerfile.dev Node20/Python3 + Profile-Matrix aktiv.
 - **governance** (AI Governance Council ↔ PactDepthGatekeeper): Kyverno/Policy-Doku done – laufendes Monitoring der Entscheidungen.
 - **observability** (TelemetryOps ↔ Health Maintainers): `prom-compose` done – `/metrics`-Rollout via @um/health noch ausstehend.
 - FR-UM-2025-09-20-Fraktal40: v1.0-Stabilization-Playbook (docs/roadmap/v1.0-stabilization-playbook.md & .yaml) erstellt – Owner-Matrix & Status-Tracker ergänzt, Umsetzungsschritte offen, Folgefraktale erforderlich.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -2,52 +2,61 @@ fraktal:
   current: 43
   history:
     - id: 43
-      status: 'in-progress'
-      notes: 'Dist-first Runner (scripts/run-dist.mjs) + AI-Policy-Beispiele implementiert; CI-Nightly Mirror & Owner-Mapping aktiv'
+      status: in-progress
+      notes: Dist-first Runner (scripts/run-dist.mjs) + AI-Policy-Beispiele implementiert;
+        CI-Nightly Mirror & Owner-Mapping aktiv; Dockerfile.dev Node20+Python3 und light-static-smoke
+        aufgenommen.
     - id: 41
-      status: 'in-progress'
-      notes: 'CI-Core erweitert (Lint/Format/Coverage-Hooks), Extended-Workflow auf Node20 mit Coverage-Job, Monitoring-Profil in docker-compose hinterlegt'
+      status: in-progress
+      notes: CI-Core erweitert (Lint/Format/Coverage-Hooks), Extended-Workflow auf Node20
+        mit Coverage-Job, Monitoring-Profil in docker-compose hinterlegt
     - id: 40
-      status: 'in-progress'
-      notes: 'v1.0 Stabilization Playbook (docs/roadmap/v1.0-stabilization-playbook.*) plus Owner-/Backup-Matrix; Umsetzung läuft, Tracker synchronisiert'
+      status: in-progress
+      notes: v1.0 Stabilization Playbook (docs/roadmap/v1.0-stabilization-playbook.*)
+        plus Owner-/Backup-Matrix; Umsetzung läuft, Tracker synchronisiert
     - id: 39
-      status: 'done'
-      notes: 'Policy suite unified: CLI OPA/Guardrails, Kyverno summary + fail-fast workflow'
+      status: done
+      notes: 'Policy suite unified: CLI OPA/Guardrails, Kyverno summary + fail-fast
+        workflow'
     - id: 38
-      status: 'done'
-      notes: 'ESLint/Prettier Hooks, dist-first Service-Runner und Doku-Refresh für v1.0 Stabilisierung'
-    - id: '37b'
-      status: 'done'
-      notes: 'Node20 toolchain, policy guardrail audit-mode, repo-sanity warnings allowed'
+      status: done
+      notes: ESLint/Prettier Hooks, dist-first Service-Runner und Doku-Refresh für v1.0
+        Stabilisierung
+    - id: 37b
+      status: done
+      notes: Node20 toolchain, policy guardrail audit-mode, repo-sanity warnings allowed
     - id: 37
-      status: 'done'
-      notes: 'Core/Extended Testlayering, pytest Marker, CI-Python-Step, Legacy-Workflows archiviert, Core-Doku aktualisiert'
+      status: done
+      notes: Core/Extended Testlayering, pytest Marker, CI-Python-Step, Legacy-Workflows
+        archiviert, Core-Doku aktualisiert
     - id: 36
-      status: 'done'
-      notes: 'Dev-server autodetect dist, Vite ~config alias, raw import fix, default UI_DIST dev script'
+      status: done
+      notes: Dev-server autodetect dist, Vite ~config alias, raw import fix, default
+        UI_DIST dev script
     - id: 35
-      status: 'done'
-      notes: 'Reality-Gate primitive, tsx dev server, experimental CI setup, UI alias'
+      status: done
+      notes: Reality-Gate primitive, tsx dev server, experimental CI setup, UI alias
     - id: 34
-      status: 'done'
-      notes: 'CI split (core/extended/experimental), UI alias fix, Node22 dev server'
+      status: done
+      notes: CI split (core/extended/experimental), UI alias fix, Node22 dev server
     - id: 32
-      status: 'in-progress'
-      notes: 'Conscious-CI stabil: metrics singleton, Vitest offline (globals+fetch), LowMem membrane'
+      status: in-progress
+      notes: 'Conscious-CI stabil: metrics singleton, Vitest offline (globals+fetch),
+        LowMem membrane'
     - id: 25
-      status: 'done'
-      notes: 'pyright strict grün; OISST var=sst normalisiert'
+      status: done
+      notes: pyright strict grün; OISST var=sst normalisiert
     - id: 21
-      status: 'in-progress'
+      status: in-progress
       checkpoints:
         - 'OISST fetch: deterministic offline (local & CI)'
         - 'Vitest: stream-json fix'
         - 'Prompt Coach: CLI + PR dry-run'
         - 'CI matrix: adapters cache + typechecks'
       next:
-        - 'STAC live items broaden (optional)'
-        - 'Emergence Explorer wiring'
-  owner: 'Codex'
+        - STAC live items broaden (optional)
+        - Emergence Explorer wiring
+  owner: Codex
   needs_repeat: false
   progress:
     legacy_workflows: disabled
@@ -56,121 +65,117 @@ fraktal:
     repo_sanity: tolerant
     documentation: updated
     v1_stabilization_playbook: executing
-
 fraktal43:
-  status: 'in-progress'
+  status: in-progress
   checkpoints:
-    - 'scripts/run-dist.mjs ersetzt ts-node für Produktionskommandos'
-    - 'AI_POLICY.md/.yaml enthalten Allow/Review/Block Beispiele'
-    - 'ci.nightly.yml spiegelt type-and-tests (Node20/Python3.11) inkl. Toolchain-Artefakt'
+    - scripts/run-dist.mjs ersetzt ts-node für Produktionskommandos
+    - AI_POLICY.md/.yaml enthalten Allow/Review/Block Beispiele
+    - ci.nightly.yml spiegelt type-and-tests (Node20/Python3.11) inkl. Toolchain-Artefakt
+    - Dockerfile.dev Node20+Python3 für Compose-Parität, light-static-smoke verfügbar
   next:
-    - 'Fraktal41 Nightly/Extended Follow-ups koordinieren'
-
+    - Fraktal41 Nightly/Extended Follow-ups koordinieren
+    - Light-static smoke in CI/monitoring verankern
 fraktal41:
-  status: 'in-progress'
+  status: in-progress
   subgoals:
-    - name: 'CI-Härtung (Fail-Fast-Pipelines)'
-      implemented: yes
-    - name: 'Kyverno-Policytest integriert'
-      implemented: yes
-    - name: 'Nightly/Extended Tests etabliert'
+    - name: CI-Härtung (Fail-Fast-Pipelines)
+      implemented: true
+    - name: Kyverno-Policytest integriert
+      implemented: true
+    - name: Nightly/Extended Tests etabliert
       implemented: partial
-      notes: 'Nightly Mirror via ci.nightly.yml aktiv, Extended-Auswertung & Alerts offen'
-    - name: 'Monitoring-Profil (Prometheus/Grafana)'
-      implemented: yes
-    - name: 'ts-node im Produktionspfad entfernt'
-      implemented: yes
-
+      notes: Nightly Mirror via ci.nightly.yml aktiv, Extended-Auswertung & Alerts offen
+    - name: Monitoring-Profil (Prometheus/Grafana)
+      implemented: true
+    - name: ts-node im Produktionspfad entfernt
+      implemented: true
 fraktal40:
-  status: 'in-progress'
+  status: in-progress
   checkpoints:
     - 'Playbook veröffentlicht: docs/roadmap/v1.0-stabilization-playbook.md'
     - 'Blueprint erstellt: docs/roadmap/v1.0-stabilization-playbook.yaml'
   tracker:
     stability:
-      owner: 'Codex CoreOps / SyncRunner'
-      status: 'in-progress'
-      notes: 'ci.nightly.yml aktiv, Toolchain-Artefakt verfügbar; Ergebnis-Auswertung geplant'
+      owner: Codex CoreOps / SyncRunner
+      status: in-progress
+      notes: ci.nightly.yml aktiv, Toolchain-Artefakt verfügbar; Ergebnis-Auswertung
+        geplant
     code-quality:
-      owner: 'DevX Guild / PatternReactivator'
-      status: 'done'
-      notes: 'README & CONTRIBUTING dokumentieren run-dist inkl. Overrides'
+      owner: DevX Guild / PatternReactivator
+      status: done
+      notes: README & CONTRIBUTING dokumentieren run-dist inkl. Overrides
     build-release:
-      owner: 'ReleaseOps Circle / VisionContextIntegrator'
-      status: 'planned'
-      notes: 'dist-first Checkpoint & Compose-Profile offen'
+      owner: ReleaseOps Circle / VisionContextIntegrator
+      status: in-progress
+      notes: Dockerfile.dev Node20+Python3; compose profiles aktiv, runtime-smoke
+        Script wartet auf CI-Gate.
     governance:
-      owner: 'AI Governance Council / PactDepthGatekeeper'
-      status: 'done'
-      notes: 'Kyverno & Policy-Doku abgeschlossen, Monitoring weiterführen'
+      owner: AI Governance Council / PactDepthGatekeeper
+      status: done
+      notes: Kyverno & Policy-Doku abgeschlossen, Monitoring weiterführen
     observability:
-      owner: 'TelemetryOps / Health Maintainers'
-      status: 'planned'
+      owner: TelemetryOps / Health Maintainers
+      status: planned
       notes: '`prom-compose` aktiv, `/metrics`-Rollout ausstehend'
   next:
-    - 'Issues mit Playbook-Checkpoints anlegen und Status über codexfeedback synchronisieren'
-
+    - Issues mit Playbook-Checkpoints anlegen und Status über codexfeedback synchronisieren
 fraktal21:
-  status: 'ready-for-review'
+  status: ready-for-review
   checkpoints:
     - 'OISST pipeline restored: fetch → postprocess → STAC → CREP → adapters_index.json'
-    - 'CI smoke asserts OISST presence in out/adapters_index.json'
-    - 'Vitest low-memory config (workers=1, heap 3-4GB) + jsdom polyfills'
-    - 'check:ci → tsc + vitest(low-mem) + pyright'
+    - CI smoke asserts OISST presence in out/adapters_index.json
+    - Vitest low-memory config (workers=1, heap 3-4GB) + jsdom polyfills
+    - check:ci → tsc + vitest(low-mem) + pyright
     - 'CI splits: adapters-offline + type-and-tests'
     - 'Metrics: global Registry + getOrCreate-Helper verhindern Doppel-Registrierung'
   notes:
-    - 'Bei Bedarf VITEST_WORKERS>1 lokal setzen; in CI bei 1 lassen.'
-    - "Fehler '...already been registered' behoben; HMR/ESM/Vitest sicher"
+    - Bei Bedarf VITEST_WORKERS>1 lokal setzen; in CI bei 1 lassen.
+    - Fehler '...already been registered' behoben; HMR/ESM/Vitest sicher
   next:
-    - "Nightly 'extended-tests' ohne LOW_MEM erwägen"
-
+    - Nightly 'extended-tests' ohne LOW_MEM erwägen
 fraktal22:
-  status: 'in_progress'
+  status: in_progress
   goals:
     - ci_all_green: true
     - prompt_lint_pr_comment: true
     - adapters_offline_smoke_guard: true
   checkpoints:
     - 'CI split: adapters-offline + type-and-tests + prompt-lint'
-    - 'PR-Kommentar für Prompt-Coach (dry-run)'
-    - 'Smoke-Test für adapters_index.json (OISST present)'
+    - PR-Kommentar für Prompt-Coach (dry-run)
+    - Smoke-Test für adapters_index.json (OISST present)
   next:
-    - 'ERA5 in offline-matrix aufnehmen'
-    - 'Coverage wieder aktivieren (selektiv) wenn Stabilität erreicht'
-
+    - ERA5 in offline-matrix aufnehmen
+    - Coverage wieder aktivieren (selektiv) wenn Stabilität erreicht
 fraktal23:
-  status: 'done'
+  status: done
   checkpoints:
     - 'Metrics defaults guarded: ensureDefaultMetrics() once'
     - 'Vitest OFFLINE: fetch-stub + /tmp seeding'
-    - 'LowMem No-Op for membrane/ringdown'
-    - 'CI env OFFLINE/LOW_MEM global; OISST smoke present'
+    - LowMem No-Op for membrane/ringdown
+    - CI env OFFLINE/LOW_MEM global; OISST smoke present
     - 'Conscious-CI docs: Core/Extended/Experimental'
   definition_of_green:
-    - "No 'already been registered' at startup/test"
-    - 'pnpm test:ts passes offline (no network)'
-    - 'out/adapters_index.json contains OISST'
-    - 'tsc + pyright pass'
+    - No 'already been registered' at startup/test
+    - pnpm test:ts passes offline (no network)
+    - out/adapters_index.json contains OISST
+    - tsc + pyright pass
   next:
-    - 'ERA5 offline-matrix'
-    - 'Nightly extended-tests (no LOW_MEM) with coverage'
-
+    - ERA5 offline-matrix
+    - Nightly extended-tests (no LOW_MEM) with coverage
 fraktal32:
-  status: 'in_progress'
+  status: in_progress
   checkpoints:
     - 'Metrics defaults guarded: ensureDefaultMetrics() once'
     - 'Vitest OFFLINE: fetch-stub + /tmp seeding + globals'
-    - 'LowMem membrane No-Op'
-    - 'CI env OFFLINE/LOW_MEM global; OISST smoke present'
-    - 'ERA5 offline stub & smoke'
+    - LowMem membrane No-Op
+    - CI env OFFLINE/LOW_MEM global; OISST smoke present
+    - ERA5 offline stub & smoke
   next:
-    - 'Nightly extended-tests (no LOW_MEM) with coverage'
-
+    - Nightly extended-tests (no LOW_MEM) with coverage
 fraktal34:
-  status: 'in_progress'
+  status: in_progress
   checkpoints:
-    - 'CI split into core/extended/experimental'
-    - 'UI alias ~config & Node22 dev-server ESM'
+    - CI split into core/extended/experimental
+    - UI alias ~config & Node22 dev-server ESM
   next:
-    - 'Monitor extended/experimental label usage'
+    - Monitor extended/experimental label usage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,32 +1,32 @@
 version: '3.8'
+
+x-node-dev: &node_dev
+  build:
+    context: .
+    dockerfile: Dockerfile.dev
+  volumes:
+    - .:/workspace/unified-mandala
+
 services:
   ui:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
+    <<: *node_dev
     command: pnpm dev
     ports:
       - '3000:3000'
-    volumes:
-      - .:/workspace/unified-mandala
+    profiles:
+      - core
+      - default
+
   test:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
-    volumes:
-      - .:/workspace/unified-mandala
+    <<: *node_dev
     command: ./scripts/run-all-tests.sh
+    profiles:
+      - ci
 
   # --- NewsBot microservices ---
   newsbot_orchestrator:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
+    <<: *node_dev
     command: python orchestrator/newsbot_orchestrator.py
-    volumes:
-      - .:/workspace/unified-mandala
-    ports:
-      - '8100:8000'
     depends_on:
       - news_fetcher_service
       - script_gen_service
@@ -35,89 +35,115 @@ services:
       - streamer_service
       - finetune_service
       - review_service
+    ports:
+      - '8100:8000'
+    profiles:
+      - newsbot
 
   news_fetcher_service:
     build:
       context: ./services/newsbot/news_fetcher
     ports:
       - '8101:8000'
+    profiles:
+      - newsbot
 
   script_gen_service:
     build:
       context: ./services/newsbot/script_gen
     ports:
       - '8102:8000'
+    profiles:
+      - newsbot
 
   tts_service:
     build:
       context: ./services/newsbot/tts
     ports:
       - '8103:8000'
+    profiles:
+      - newsbot
 
   avatar_renderer_service:
     build:
       context: ./services/newsbot/avatar_renderer
     ports:
       - '8104:8000'
+    profiles:
+      - newsbot
 
   streamer_service:
     build:
       context: ./services/newsbot/streamer
     ports:
       - '8105:8000'
+    profiles:
+      - newsbot
 
   finetune_service:
     build:
       context: ./services/finetune
     ports:
       - '8106:8000'
+    profiles:
+      - newsbot
+
   review_service:
     build:
       context: ./agents/review_checkpoint
     ports:
       - '8107:8000'
+    profiles:
+      - newsbot
+
   singularity_simulator_service:
     build:
       context: ./agents/singularity_simulator
     ports:
       - '8108:8000'
+    profiles:
+      - newsbot
 
   # --- Open-source chat services ---
   gpt4all_service:
     image: ghcr.io/nomic-ai/gpt4all:latest
     ports:
       - '8201:80'
+    profiles:
+      - llm
 
   openassistant_service:
     image: ghcr.io/laion-ai/open-assistant:latest
     ports:
       - '8202:80'
+    profiles:
+      - llm
 
   h2ogpt_service:
     image: ghcr.io/h2oai/h2ogpt-server:latest
     ports:
       - '8203:80'
+    profiles:
+      - llm
 
   text_generation_webui_service:
     image: ghcr.io/oobabooga/text-generation-webui:latest
     ports:
       - '8204:7860'
+    profiles:
+      - llm
 
   autogen_service:
     image: ghcr.io/microsoft/autogen:latest
     ports:
       - '8205:80'
+    profiles:
+      - llm
 
   # --- Climate news microservices ---
   climate_news_orchestrator:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
+    <<: *node_dev
     command: python agents/news_climate/orchestrator.py
-    volumes:
-      - .:/workspace/unified-mandala
-    ports:
-      - '8300:8000'
     depends_on:
       - climate_service
       - forest_service
@@ -125,123 +151,111 @@ services:
       - economy_service
       - emissions_service
       - mitigation_service
+    ports:
+      - '8300:8000'
+    profiles:
+      - climate
 
   climate_service:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
+    <<: *node_dev
     command: python agents/news_climate/climate_service.py
-    volumes:
-      - .:/workspace/unified-mandala
     ports:
       - '8301:8000'
+    profiles:
+      - climate
 
   forest_service:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
+    <<: *node_dev
     command: python agents/news_climate/forest_service.py
-    volumes:
-      - .:/workspace/unified-mandala
     ports:
       - '8302:8000'
+    profiles:
+      - climate
 
   flood_service:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
+    <<: *node_dev
     command: python agents/news_climate/flood_service.py
-    volumes:
-      - .:/workspace/unified-mandala
     ports:
       - '8303:8000'
+    profiles:
+      - climate
 
   economy_service:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
+    <<: *node_dev
     command: python agents/news_climate/economy_service.py
-    volumes:
-      - .:/workspace/unified-mandala
     ports:
       - '8304:8000'
+    profiles:
+      - climate
 
   emissions_service:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
+    <<: *node_dev
     command: python agents/news_climate/emissions_service.py
-    volumes:
-      - .:/workspace/unified-mandala
     ports:
       - '8305:8000'
+    profiles:
+      - climate
 
   mitigation_service:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
+    <<: *node_dev
     command: python agents/news_climate/mitigation_service.py
-    volumes:
-      - .:/workspace/unified-mandala
     ports:
       - '8306:8000'
+    profiles:
+      - climate
 
   # --- Global events microservices ---
   global_events_orchestrator:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
+    <<: *node_dev
     command: python agents/global_events/orchestrator.py
-    volumes:
-      - .:/workspace/unified-mandala
-    ports:
-      - '8400:8000'
     depends_on:
       - science_service
       - tech_service
       - environment_service
+    ports:
+      - '8400:8000'
+    profiles:
+      - global
 
   science_service:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
+    <<: *node_dev
     command: python agents/global_events/science_service.py
-    volumes:
-      - .:/workspace/unified-mandala
     ports:
       - '8401:8000'
+    profiles:
+      - global
 
   tech_service:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
+    <<: *node_dev
     command: python agents/global_events/tech_service.py
-    volumes:
-      - .:/workspace/unified-mandala
     ports:
       - '8402:8000'
+    profiles:
+      - global
 
   environment_service:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
+    <<: *node_dev
     command: python agents/global_events/environment_service.py
-    volumes:
-      - .:/workspace/unified-mandala
     ports:
       - '8403:8000'
+    profiles:
+      - global
 
   digital_twin_agent:
     build:
       context: ./agents/digital_twin
     ports:
       - '8404:8000'
+    profiles:
+      - agents
 
   gamification_agent:
     build:
       context: ./agents/gamification
     ports:
       - '8405:8000'
+    profiles:
+      - agents
 
   prometheus:
     image: prom/prometheus:latest
@@ -264,4 +278,4 @@ services:
     depends_on:
       - prometheus
     ports:
-      - '3000:3000'
+      - '3300:3000'

--- a/docs/roadmap/v1.0-stabilization-playbook.md
+++ b/docs/roadmap/v1.0-stabilization-playbook.md
@@ -50,12 +50,18 @@ Dieses Playbook übersetzt die Ergebnisse des Fraktal40-Entwicklungsgesprächs i
 1. **Dist-First Strategie**
    - `pnpm build` erzeugt derzeit TS/JS-Artefakte via `tsconfig.build.json`; nach erfolgreichem Build sollen Produktionskommandos ausschließlich `node dist/...` nutzen, keine `ts-node`/`tsx` Calls.【F:package.json†L12-L111】
    - `Dockerfile.dev` von Node 18 auf Node 20 aktualisieren, damit lokale Compose-Umgebungen und CI identische Toolchains verwenden.【F:Dockerfile.dev†L1-L19】
+   - `Dockerfile.dev` installiert zusätzlich Python 3 (inkl. Pip/Venv), damit News-/Climate-Orchestratoren mit identischer Toolchain wie in CI laufen.【F:Dockerfile.dev†L1-L23】
+   - _Status 2025-09-24:_ Node20-Basiscontainer mit Go & Python aktiv; Dist-First-Kommandos bleiben über `scripts/run-dist.mjs` gewahrt.
 2. **Runtime Smoke Tests**
-   - `pnpm start:light` (Light Static Server) nach jedem Build ausführen und via Script (`scripts/light-static-server.mjs`) Response-Header (Brotli/Gzip) testen.【F:scripts/light-static-server.mjs†L1-L24】
+   - `pnpm start:light` (Light Static Server) nach jedem Build ausführen und via Script (`scripts/light-static-server.mjs`) Response-Header (Brotli/Gzip) testen.【F:scripts/light-static-server.mjs†L1-L211】
+   - Neues Smoke-Script `scripts/smoke/light-static-smoke.mjs` validiert Status-Code, Content-Encoding, Cache-Control und HTML-Fallback nach `pnpm build:ui`.【F:scripts/smoke/light-static-smoke.mjs†L1-L148】
+   - _Status 2025-09-24:_ `pnpm smoke:light-static` nutzt den Light-Server (inkl. Health-Endpoint) für Brotli/Gzip-Checks; `smoke:ttfb` bleibt für Performance-Benchmarks bestehen.
    - `docker-compose.yml` für Produktions-Simulation nutzen (`pnpm build`, `docker compose up --profile prod`), Services mit Health-Endpoints ausstatten.
 3. **Docker/Compose Integration**
    - `Dockerfile` weiterhin für statische UI-Builds nutzen, aber Multi-Stage-Build um CLI/Agent-Artefakte erweitern.
    - Compose-Profile einführen (`core`, `newsbot`, `climate`) und Default-Profil schlank halten.
+   - `docker-compose.yml` nutzt Profile für `core`, `newsbot`, `climate`, `llm`, `global`, `agents` und `monitoring`; Grafana läuft konfliktfrei auf Port 3300.【F:docker-compose.yml†L1-L194】
+   - _Status 2025-09-24:_ Standard-Aufruf (`docker compose up`) startet nur `ui`; weitere Services werden per Profil explizit zugeschaltet.
 
 ## 4. Teststrategie & Abdeckung
 

--- a/docs/roadmap/v1.0-stabilization-playbook.yaml
+++ b/docs/roadmap/v1.0-stabilization-playbook.yaml
@@ -1,7 +1,7 @@
 fraktal: 40
 release: v1.0
 owner: codex
-updated: 2025-09-23
+updated: '2025-09-24'
 summary: |
   Strukturierter Maßnahmenplan zur Umsetzung der Fraktal40-Besprechung.
   Fokus auf stabile Kern-Builds, dist-first Services, verschärfte Governance
@@ -18,21 +18,22 @@ streams:
       - ci/agent.yml
     checkpoints:
       - id: core-ci-hardening
-        description: 'Fail-fast Verhalten und Nightly-Matrix in CI Core etablieren'
+        description: Fail-fast Verhalten und Nightly-Matrix in CI Core etablieren
         status: in-progress
-        notes: 'ci.nightly.yml spiegelt type-and-tests; Toolchain-Artefakt wird hochgeladen'
+        notes: ci.nightly.yml spiegelt type-and-tests; Toolchain-Artefakt wird hochgeladen
         success:
           - pnpm test:ts:ci
           - pnpm test:py
           - npx pyright
       - id: experimental-signal
-        description: 'Guardrails & Agent Dry-Runs ohne `|| true`; Ergebnisse als Checks publizieren'
+        description: Guardrails & Agent Dry-Runs ohne `|| true`; Ergebnisse als Checks
+          publizieren
         status: in-progress
         artifacts:
           - agents-dry-run.log
           - out/policy/policy-suite.json
       - id: policy-suite-unify
-        description: 'pnpm policy:check bündelt OPA, Guardrails und Kyverno'
+        description: pnpm policy:check bündelt OPA, Guardrails und Kyverno
         status: done
         output:
           - out/policy/policy-suite.json
@@ -49,13 +50,14 @@ streams:
       - docker-compose.yml
     checkpoints:
       - id: lint-doc-refresh
-        description: 'README/CONTRIBUTING mit Dist-First und Hook-Hinweisen erweitern'
+        description: README/CONTRIBUTING mit Dist-First und Hook-Hinweisen erweitern
         status: done
-        notes: 'README & CONTRIBUTING beschreiben scripts/run-dist.mjs inkl. `UM_RUN_DIST_*` Overrides'
+        notes: README & CONTRIBUTING beschreiben scripts/run-dist.mjs inkl. `UM_RUN_DIST_*`
+          Overrides
       - id: ts-node-retire
-        description: 'Produktionspfade auf `node dist/...` umstellen'
+        description: Produktionspfade auf `node dist/...` umstellen
         status: done
-        notes: 'scripts/run-dist.mjs ersetzt ts-node in Paket-Skripten'
+        notes: scripts/run-dist.mjs ersetzt ts-node in Paket-Skripten
   - key: build-release
     owner:
       lead: ReleaseOps Circle
@@ -69,13 +71,19 @@ streams:
     checkpoints:
       - id: dist-first
         description: '`pnpm build` liefert alle Artefakte für Prod-Start ohne ts-node'
-        status: pending
+        status: in-progress
+        notes: Dockerfile.dev auf Node20/Python3 gehoben; dist-first CLI-Dokumentation
+          folgt.
       - id: compose-profiles
-        description: 'docker-compose Profile für core/newsbot/climate definieren'
-        status: planned
+        description: docker-compose Profile für core/newsbot/climate definieren
+        status: done
+        notes: docker-compose Profile für core/newsbot/climate/llm/global/agents/monitoring
+          aktiv.
       - id: runtime-smoke
         description: '`pnpm start:light` + HTTP-Smoketest automatisieren'
-        status: planned
+        status: in-progress
+        notes: Light-static smoke script verfügbar (`pnpm smoke:light-static`); CI-Einbindung
+          offen.
   - key: governance
     owner:
       lead: AI Governance Council
@@ -87,12 +95,12 @@ streams:
       - policies/merge-guardrails.yaml
     checkpoints:
       - id: kyverno-integration
-        description: 'Kyverno CLI in policy-suite aufnehmen'
+        description: Kyverno CLI in policy-suite aufnehmen
         status: done
       - id: policy-docs
-        description: 'AI_POLICY.md/Ai_POLICY.yaml mit Allow/Deny Beispielen ergänzen'
+        description: AI_POLICY.md/Ai_POLICY.yaml mit Allow/Deny Beispielen ergänzen
         status: done
-        notes: 'Entscheidungsbeispiele dokumentiert (Allow/Review/Block)'
+        notes: Entscheidungsbeispiele dokumentiert (Allow/Review/Block)
   - key: observability
     owner:
       lead: TelemetryOps / GenesisAeonNavigator
@@ -104,10 +112,10 @@ streams:
       - packages/health
     checkpoints:
       - id: metrics-endpoints
-        description: 'Alle Services exportieren `/metrics` via @um/health'
+        description: Alle Services exportieren `/metrics` via @um/health
         status: planned
       - id: prom-compose
-        description: 'Compose-Profile für Prometheus/Grafana aktivieren'
+        description: Compose-Profile für Prometheus/Grafana aktivieren
         status: done
 milestones:
   - name: Sprint 0 – Playbook Review
@@ -134,24 +142,24 @@ milestones:
       - compose-profiles
       - prom-compose
 tracking:
-  codexfeedback_hook: 'fraktal40'
+  codexfeedback_hook: fraktal40
   progress_log:
     - file: codexfeedback.md
-      action: 'neue Laufnotizen hinzufügen'
+      action: neue Laufnotizen hinzufügen
     - file: codexfeedback.json
-      action: 'statusflag aktualisieren'
+      action: statusflag aktualisieren
     - file: codexfeedback.yaml
-      action: 'current=40 setzen, checkpoints pflegen'
+      action: current=40 setzen, checkpoints pflegen
   follow_up:
     - file: advancedprogress.json
-      action: 'Sprint-Ergebnisse spiegeln'
+      action: Sprint-Ergebnisse spiegeln
 risks:
   - id: ci-flakes
-    description: 'Persistente Vitest/Pytest-Flakes können Fail-Fast-Ansatz ausbremsen'
-    mitigation: 'Tests taggen, Retries nur in Nightlies zulassen, Flake-Issues pflegen'
+    description: Persistente Vitest/Pytest-Flakes können Fail-Fast-Ansatz ausbremsen
+    mitigation: Tests taggen, Retries nur in Nightlies zulassen, Flake-Issues pflegen
   - id: docker-toolchain-drift
-    description: 'Unterschiedliche Node-Versionen (Dockerfile vs Dockerfile.dev)'
-    mitigation: 'Baseline auf Node 20 angleichen, Renovate/Dependabot für Images erwägen'
+    description: Unterschiedliche Node-Versionen (Dockerfile vs Dockerfile.dev)
+    mitigation: Baseline auf Node 20 angleichen, Renovate/Dependabot für Images erwägen
   - id: policy-tooling-gaps
-    description: 'Kyverno/OPA Binaries nicht auf Runner verfügbar'
-    mitigation: 'Fallback auf Containerized CLI, Preflight-Check in policy-suite'
+    description: Kyverno/OPA Binaries nicht auf Runner verfügbar
+    mitigation: Fallback auf Containerized CLI, Preflight-Check in policy-suite

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "smoke:ui": "node scripts/smoke/ui-dev-smoke.mjs",
     "smoke:dev": "node scripts/smoke/dev-server-smoke.mjs",
     "smoke:mrv": "node scripts/smoke/mrv-smoke.mjs",
+    "smoke:light-static": "node scripts/smoke/light-static-smoke.mjs",
     "smoke:ttfb": "pnpm -s build:ui && node scripts/smoke/ttfb-smoke.mjs",
     "agents:health": "node scripts/run-dist.mjs scripts/agents/runner.ts --health-all",
     "agents:run": "node scripts/run-dist.mjs scripts/agents/runner.ts",

--- a/scripts/light-static-server.mjs
+++ b/scripts/light-static-server.mjs
@@ -1,28 +1,211 @@
 import express from 'express';
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pipeline } from 'node:stream';
+import { fileURLToPath } from 'node:url';
+import { createBrotliCompress, createGzip, constants as zlibConstants } from 'node:zlib';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const distDir = path.resolve(__dirname, '../apps/ui/dist');
 
 const app = express();
+app.disable('x-powered-by');
+
+const ensureVaryAcceptEncoding = (res) => {
+  const existing = res.getHeader('Vary');
+  if (!existing) {
+    res.setHeader('Vary', 'Accept-Encoding');
+    return;
+  }
+  const normalized = Array.isArray(existing) ? existing.join(', ') : String(existing);
+  if (!normalized.toLowerCase().includes('accept-encoding')) {
+    res.setHeader('Vary', `${normalized}, Accept-Encoding`);
+  }
+};
+
+const setCacheHeaders = (res, relativePath) => {
+  const normalized = relativePath.startsWith('/') ? relativePath.slice(1) : relativePath;
+  const isIndex = normalized === 'index.html';
+  res.setHeader(
+    'Cache-Control',
+    isIndex ? 'public, max-age=0, must-revalidate' : 'public, max-age=31536000, immutable',
+  );
+};
+
+app.get('/healthz', (_req, res) => {
+  res.json({ status: 'ok' });
+});
 
 app.use((req, res, next) => {
-  const enc = req.headers['accept-encoding'] || '';
-  if (enc.includes('br') && fs.existsSync(path.join(distDir, req.url + '.br'))) {
-    res.set('Content-Encoding', 'br');
-    req.url += '.br';
-  } else if (enc.includes('gzip') && fs.existsSync(path.join(distDir, req.url + '.gz'))) {
-    res.set('Content-Encoding', 'gzip');
-    req.url += '.gz';
+  const acceptEncoding = req.headers['accept-encoding'] ?? '';
+  if (!acceptEncoding) {
+    return next();
   }
+
+  ensureVaryAcceptEncoding(res);
+
+  const relativePath = req.path === '/' ? '/index.html' : req.path;
+  const basePath = path.join(distDir, relativePath);
+
+  const sendIfExists = (candidatePath, encoding) => {
+    if (!fs.existsSync(candidatePath)) {
+      return false;
+    }
+    res.type(path.basename(relativePath));
+    setCacheHeaders(res, relativePath);
+    if (encoding) {
+      res.setHeader('Content-Encoding', encoding);
+    }
+    res.sendFile(candidatePath, (err) => {
+      if (err) {
+        next(err);
+      }
+    });
+    return true;
+  };
+
+  const streamCompressed = (encoding) => {
+    if (!fs.existsSync(basePath)) {
+      return false;
+    }
+    const compressor =
+      encoding === 'br'
+        ? createBrotliCompress({
+            params: {
+              [zlibConstants.BROTLI_PARAM_QUALITY]: 5,
+            },
+          })
+        : createGzip({ level: zlibConstants.Z_BEST_SPEED });
+    res.type(path.basename(relativePath));
+    setCacheHeaders(res, relativePath);
+    res.setHeader('Content-Encoding', encoding);
+    pipeline(fs.createReadStream(basePath), compressor, res, (err) => {
+      if (err) {
+        next(err);
+      }
+    });
+    return true;
+  };
+
+  if (acceptEncoding.includes('br')) {
+    if (sendIfExists(`${basePath}.br`, 'br') || streamCompressed('br')) {
+      return;
+    }
+  }
+
+  if (acceptEncoding.includes('gzip')) {
+    if (sendIfExists(`${basePath}.gz`, 'gzip') || streamCompressed('gzip')) {
+      return;
+    }
+  }
+
   next();
 });
 
-app.use(express.static(distDir));
+app.use(
+  express.static(distDir, {
+    extensions: ['html'],
+    setHeaders(res, servedPath) {
+      ensureVaryAcceptEncoding(res);
+      const normalizedPath = servedPath.replace(/\.(br|gz)$/u, '');
+      res.type(normalizedPath);
+      const relative = path.relative(distDir, normalizedPath);
+      setCacheHeaders(res, `/${relative}`);
+      if (servedPath.endsWith('.br')) {
+        res.setHeader('Content-Encoding', 'br');
+      } else if (servedPath.endsWith('.gz')) {
+        res.setHeader('Content-Encoding', 'gzip');
+      }
+    },
+  }),
+);
 
-const port = process.env.PORT || 3000;
-app.listen(port, () => {
-  console.log(`Light static server listening on http://127.0.0.1:${port}`);
+app.get('*', (req, res, next) => {
+  if (req.method !== 'GET') {
+    return next();
+  }
+  const acceptsHtml = (req.headers.accept ?? '').includes('text/html');
+  if (!acceptsHtml) {
+    return next();
+  }
+
+  const served = path.join(distDir, 'index.html');
+  if (!fs.existsSync(served)) {
+    return next();
+  }
+
+  const acceptEncoding = req.headers['accept-encoding'] ?? '';
+  ensureVaryAcceptEncoding(res);
+  setCacheHeaders(res, '/index.html');
+
+  const trySend = (extension, encoding) => {
+    const candidate = `${served}${extension}`;
+    if (!fs.existsSync(candidate)) {
+      return false;
+    }
+    res.type('text/html');
+    res.setHeader('Content-Encoding', encoding);
+    res.sendFile(candidate, (err) => {
+      if (err) {
+        next(err);
+      }
+    });
+    return true;
+  };
+
+  const streamIndex = (encoding) => {
+    if (!fs.existsSync(served)) {
+      return false;
+    }
+    const compressor =
+      encoding === 'br'
+        ? createBrotliCompress({
+            params: {
+              [zlibConstants.BROTLI_PARAM_QUALITY]: 5,
+            },
+          })
+        : createGzip({ level: zlibConstants.Z_BEST_SPEED });
+    res.type('text/html');
+    res.setHeader('Content-Encoding', encoding);
+    setCacheHeaders(res, '/index.html');
+    pipeline(fs.createReadStream(served), compressor, res, (err) => {
+      if (err) {
+        next(err);
+      }
+    });
+    return true;
+  };
+
+  if (acceptEncoding.includes('br') && (trySend('.br', 'br') || streamIndex('br'))) {
+    return;
+  }
+
+  if (acceptEncoding.includes('gzip') && (trySend('.gz', 'gzip') || streamIndex('gzip'))) {
+    return;
+  }
+
+  res.type('text/html');
+  res.sendFile(served, (err) => {
+    if (err) {
+      next(err);
+    }
+  });
 });
+
+const parsedPort = Number.parseInt(process.env.PORT ?? '', 10);
+const port = Number.isNaN(parsedPort) ? 3000 : parsedPort;
+
+const server = app.listen(port, () => {
+  const address = server.address();
+  const actualPort = typeof address === 'object' && address !== null ? address.port : port;
+  console.log(`[light-static-server] listening on http://127.0.0.1:${actualPort}`);
+});
+
+const shutdown = () => {
+  server.close(() => {
+    process.exit(0);
+  });
+};
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/scripts/smoke/light-static-smoke.mjs
+++ b/scripts/smoke/light-static-smoke.mjs
@@ -1,0 +1,148 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import { once } from 'node:events';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distIndex = path.resolve(__dirname, '../../apps/ui/dist/index.html');
+
+if (!fs.existsSync(distIndex)) {
+  console.error('[light-static-smoke] missing dist assets – run `pnpm build:ui` first');
+  process.exit(1);
+}
+
+const requestedPort = process.env.START_LIGHT_PORT ?? '0';
+
+const server = spawn('node', ['scripts/light-static-server.mjs'], {
+  env: { ...process.env, PORT: requestedPort },
+  stdio: ['ignore', 'pipe', 'inherit'],
+});
+
+let actualPort;
+let serverClosed = false;
+
+server.stdout.setEncoding('utf8');
+server.stdout.on('data', (chunk) => {
+  process.stdout.write(chunk);
+  const match = chunk.match(/http:\/\/127\.0\.0\.1:(\d+)/u);
+  if (match) {
+    actualPort = Number.parseInt(match[1], 10);
+  }
+});
+
+server.on('close', () => {
+  serverClosed = true;
+});
+
+const waitForServer = async () => {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (typeof actualPort === 'number' && !Number.isNaN(actualPort)) {
+      return;
+    }
+    if (server.exitCode !== null) {
+      throw new Error(`light-static-server exited early with code ${server.exitCode}`);
+    }
+    await sleep(100);
+  }
+  throw new Error('light-static-server did not report a listening port');
+};
+
+const getHeaderValue = (headers, name) => {
+  const value = headers[name.toLowerCase()];
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+};
+
+const fetchRoot = (headers) =>
+  new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port: actualPort,
+        path: '/',
+        headers,
+      },
+      (res) => {
+        const chunks = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks),
+          });
+        });
+      },
+    );
+
+    req.on('error', reject);
+    req.end();
+  });
+
+const stopServer = async () => {
+  if (serverClosed || server.killed) {
+    return;
+  }
+  server.kill('SIGTERM');
+  try {
+    await once(server, 'close');
+  } catch {
+    // ignore close errors when shutting down intentionally
+  }
+};
+
+let exitCode = 0;
+
+try {
+  await waitForServer();
+  await sleep(150);
+
+  const compressed = await fetchRoot({ 'accept-encoding': 'br, gzip' });
+  if (compressed.statusCode !== 200) {
+    throw new Error(`expected 200 response, received ${compressed.statusCode}`);
+  }
+  const encoding = getHeaderValue(compressed.headers, 'content-encoding');
+  if (!encoding || !['br', 'gzip'].includes(encoding)) {
+    throw new Error(`expected br/gzip encoding, received ${encoding ?? 'none'}`);
+  }
+  const vary = getHeaderValue(compressed.headers, 'vary') ?? '';
+  if (!vary.toLowerCase().includes('accept-encoding')) {
+    throw new Error('response is missing Vary: Accept-Encoding');
+  }
+  const cacheControl = getHeaderValue(compressed.headers, 'cache-control') ?? '';
+  if (!cacheControl.includes('must-revalidate')) {
+    throw new Error('cache-control for index.html must include must-revalidate');
+  }
+  if (compressed.body.length === 0) {
+    throw new Error('compressed response body is empty');
+  }
+
+  const identity = await fetchRoot({ 'accept-encoding': 'identity' });
+  if (identity.statusCode !== 200) {
+    throw new Error(`identity request failed with status ${identity.statusCode}`);
+  }
+  const identityEncoding = getHeaderValue(identity.headers, 'content-encoding');
+  if (identityEncoding && identityEncoding !== 'identity') {
+    throw new Error(`unexpected content-encoding for identity request: ${identityEncoding}`);
+  }
+  const identityBody = identity.body.toString('utf8');
+  if (!identityBody.toLowerCase().includes('<!doctype html')) {
+    throw new Error('identity response does not look like HTML');
+  }
+
+  console.log('[light-static-smoke] HTTP checks passed');
+} catch (error) {
+  exitCode = 1;
+  console.error('[light-static-smoke] smoke check failed:', error);
+} finally {
+  await stopServer();
+  if (exitCode === 0 && server.exitCode && server.exitCode !== 0) {
+    exitCode = server.exitCode;
+  }
+  process.exitCode = exitCode;
+}


### PR DESCRIPTION
## Summary
- align the development Dockerfile with the Node 20/Python toolchain and reorganize docker-compose into anchor-backed profiles with a default-only UI
- enhance the light static server with health checks and dynamic Brotli/gzip handling plus a dedicated `pnpm smoke:light-static` workflow
- update the stabilization playbook and codexfeedback trackers to reflect the new build-release progress and smoke coverage

## Testing
- pnpm -s build:ui
- pnpm -s smoke:light-static
- pnpm -s lint:eslint

------
https://chatgpt.com/codex/tasks/task_e_68ca89bc4e6883228b86e907797fda83