### PR TITLE
Fix CI test job by restoring TypeScript ESLint preset

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,6 +8,7 @@ module.exports = {
   plugins: ['import', '@typescript-eslint'],
   extends: [
     'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
     'plugin:import/recommended',
     'plugin:import/typescript',
     'prettier'
@@ -30,6 +31,8 @@ module.exports = {
     'import/no-named-as-default-member': 'off',
     'import/no-duplicates': 'off',
     'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': 'off',
+    '@typescript-eslint/no-var-requires': 'off',
     'no-undef': 'off',
     'no-empty': 'off',
     'no-constant-condition': 'off',

--- a/codexfeedback-fraktal45.yaml
+++ b/codexfeedback-fraktal45.yaml
@@ -1,0 +1,29 @@
+fraktal: 45
+status: done
+owner: Codex
+summary:
+  - CI-Core Vitest-Lauf (`pnpm test:ts:ci`) repariert: ESLint-Konfiguration wieder mit `plugin:@typescript-eslint/recommended` versehen.
+  - Konfliktregeln deaktiviert, damit bestehende Skript-/Test-Suites ohne Umbauten laufen.
+  - Alle Kernschritte des CI-Core-Jobs lokal validiert (Format, Lint, Tests, Pyright).
+ci_jobs:
+  - name: ci.core → format:check
+    validation: pnpm format:check
+    result: green
+  - name: ci.core → lint
+    validation: pnpm lint
+    result: green
+  - name: ci.core → type-and-tests
+    validation: pnpm test:ts:ci
+    result: green
+  - name: ci.core → test:py
+    validation: pnpm test:py
+    result: green
+  - name: ci.core → pyright
+    validation: npx pyright
+    result: green
+notes:
+  - Ursprünglicher Fehler: Tests erwarteten `plugin:@typescript-eslint/recommended`, wodurch pnpm test:ts:ci scheiterte.
+  - Ergänzende Deaktivierung von `@typescript-eslint/no-unused-vars` und `@typescript-eslint/no-var-requires` verhindert Legacy-Brüche.
+next_steps:
+  repeat_required: false
+  focus: Beobachte nachgelagerte Workflows (policy-check, nightly) auf Nebeneffekte der ESLint-Anpassung.

--- a/codexfeedback.json
+++ b/codexfeedback.json
@@ -1,6 +1,11 @@
 {
   "runs": [
     {
+      "fraktalrun": "Fraktal45 CIJobRepair",
+      "status": "implemented",
+      "notes": "pnpm test:ts:ci scheiterte an fehlender plugin:@typescript-eslint/recommended-Erweiterung; ESLint-Konfiguration angepasst und Konfliktregeln deaktiviert. pnpm format:check, pnpm lint, pnpm test:ts:ci, pnpm test:py und npx pyright lokal grün."
+    },
+    {
       "fraktalrun": "Fraktal44 StabilizationFinale",
       "status": "implemented",
       "notes": "Fraktal40/41/43 Backlog geschlossen; Sigillin-Validator + CI-Workflow hinzugefügt; Dev-Skripte reorganisiert (`pnpm dev`, `pnpm dev:services`, `pnpm dev:stack`); Release-Drill inkl. Monitoring-Smoke verifiziert."

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -1,5 +1,9 @@
 # Codex Feedback
 
+- FR-UM-2025-09-17-Fraktal45-CIJobs: pnpm test:ts:ci schlug aufgrund fehlender `plugin:@typescript-eslint/recommended`
+  Erweiterung fehl; ESLint-Konfiguration aktualisiert und blockierende Regeln (`@typescript-eslint/no-unused-vars`,
+  `@typescript-eslint/no-var-requires`) für bestehende Skripte deaktiviert. `pnpm format:check`, `pnpm lint`,
+  `pnpm test:ts:ci`, `pnpm test:py` und `npx pyright` lokal grün, CI-Core-Aufgaben damit validiert.
 - FR-UM-2025-10-01-Fraktal44-StabilizationFinale: Fraktal40/41/43 Backlog geschlossen, neue Sigillin-Validierung (`scripts/sigillin/validate-sigillins.ts`, `pnpm validate:sigillins`, CI-Workflow) aktiv, Dev-Skripte in `package.json`/README/CONTRIBUTING neu sortiert (`pnpm dev`, `pnpm dev:services`, `pnpm dev:stack`), Release-Drill inkl. Monitoring-Smokes dokumentiert.
 - FR-UM-2025-09-24-Fraktal43-BuildRelease: Dockerfile.dev jetzt Node20+Python3 (Compose parity), docker-compose Profile (core/newsbot/climate/llm/global/agents/monitoring) + Grafana 3300, Light-Static-Server mit Health/Vary/Cache-Control, neues `pnpm smoke:light-static` für Brotli/Gzip; Playbook/YAML-Tracker aktualisiert (dist-first/runtime-smoke in-progress, compose-profiles done).
 - FR-UM-2025-09-23-Fraktal43-Nightly: CI-Nightly (`ci.nightly.yml`) spiegelt den Core-Lauf inkl. Toolchain-Artefakt, README/CONTRIBUTING beschreiben den Dist-First-Runner `scripts/run-dist.mjs`, Playbook-Owner-Map + codexfeedback-Tracker aktualisiert – Extended/Nightly Optimierungen laufen weiter über Fraktal41.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -1,6 +1,13 @@
 fraktal:
-  current: 44
+  current: 45
   history:
+    - id: 45
+      status: done
+      notes: >-
+        CI-Core-Lauf scheiterte an fehlender plugin:@typescript-eslint/recommended-Erweiterung.
+        ESLint-Konfiguration ergänzt und störende Regeln (`@typescript-eslint/no-unused-vars`,
+        `@typescript-eslint/no-var-requires`) deaktiviert; pnpm format:check, pnpm lint,
+        pnpm test:ts:ci, pnpm test:py und npx pyright erfolgreich lokal ausgeführt.
     - id: 44
       status: done
       notes:
@@ -68,6 +75,25 @@ fraktal:
     repo_sanity: resilient
     documentation: finalized
     v1_stabilization_playbook: complete
+fraktal45:
+  status: done
+  summary:
+    - pnpm test:ts:ci Reparatur: ESLint-Konfiguration ergänzt und Konfliktregeln deaktiviert.
+    - CI-Core-Aufgaben lokal validiert (`pnpm format:check`, `pnpm lint`, `pnpm test:ts:ci`, `pnpm test:py`, `npx pyright`).
+  validation:
+    - job: ci.core → type-and-tests
+      result: green
+      notes: >-
+        Vitest-Run (`pnpm test:ts:ci`) erfolgreich nach ESLint-Fix.
+    - job: ci.core → lint
+      result: green
+      notes: >-
+        ESLint läuft ohne neue Fehler trotz aktivierter Recommended-Regeln.
+    - job: ci.core → python-tests
+      result: green
+      notes: >-
+        `pnpm test:py` deckt pytest-Aufgaben des Jobs ab.
+
 fraktal44:
   status: done
   summary:


### PR DESCRIPTION
## Summary
- restore the TypeScript ESLint recommended preset and disable conflicting rules so the CI core Vitest step succeeds again
- record the Fraktal45 CI job repair in the codexfeedback trackers, including a dedicated codexfeedback-fraktal45.yaml summary

## Testing
- pnpm format:check
- pnpm lint
- pnpm test:ts:ci
- pnpm test:py
- npx pyright

------
https://chatgpt.com/codex/tasks/task_e_68cac34f5684832298a8f3f37f4d8009