### PR TITLE
Normalize sigillin validator paths for Windows

### DIFF
--- a/codexfeedback-fraktal50.yaml
+++ b/codexfeedback-fraktal50.yaml
@@ -1,0 +1,24 @@
+fraktal: 50
+status: running
+owner: ChefDevAI
+summary:
+  - 'Sigillin validator normalisiert relative Pfade (Windows ↔ POSIX) und liefert echte Ergebnisse statt Non-Bridge-Skips.'
+  - 'Bridge-Matcher decken JSON/YAML/Markdown mit (^|/) Präfix ab; Skip-Logs nennen jetzt klare Gründe.'
+  - 'Codexfeedback-Tracker auf Fraktal50 gehoben, Hook für Windows-Validerungs-Feedback gesetzt.'
+deliverables:
+  - scripts/validate-sigillins.mjs
+  - codexfeedback.yaml
+  - codexfeedback.json
+  - codexfeedback.md
+  - codexfeedback-fraktal50.yaml
+follow_up:
+  windows_validator_regression_watch:
+    description: 'Windows-Entwickler sollen corepack pnpm validate:sigillins erneut laufen lassen und Ergebnisse teilen.'
+    status: ongoing
+  docker_desktop_followup:
+    description: 'Docker Desktop/WSL Ready-Check im nächsten Fragment adressieren, sobald Validator bestätigt ist.'
+    status: planned
+hook:
+  progress: 'Pfadnormalisierung & Skip-Transparenz fertig; Windows-Feedback steht aus.'
+  next_step: 'Validator-Ausgabe aus Windows-Lauf einsammeln, danach Docker-Setup prüfen.'
+repeat_required: false

--- a/codexfeedback.json
+++ b/codexfeedback.json
@@ -1,6 +1,11 @@
 {
   "runs": [
     {
+      "fraktalrun": "Fraktal50 Validator Windows Parity",
+      "status": "in-progress",
+      "notes": "Sigillin validator normalizes relative paths for Windows, extends bridge matchers and clarifies skip logs; Windows validation feedback & Docker follow-up pending."
+    },
+    {
       "fraktalrun": "Fraktal49 Validator+CI Guardrails",
       "status": "in-progress",
       "notes": "Validator scope fokussiert sigils/bridges, Repo-Sanity wartet auf apps/ui/dist/index.html und AgentWorkflowEngine setzt ethical_guardrails standardmäßig (inkl. Vitest-Abdeckung)."

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -1,5 +1,6 @@
 # Codex Feedback
 
+- FR-UM-2025-10-09-Fraktal50-Validator-Windows: Sigillin-Validator normalisiert relative Pfade für Windows, erweitert Bridge-Matcher um (^|/) Präfixe und protokolliert Skip-Gründe; Windows-Bestätigung & Docker-WSL-Check folgen als nächste Schritte.
 - FR-UM-2025-10-08-Fraktal49-Validator+CI: Sigillin-Validator prüft ausschließlich sigils/bridges (Registry/Archive skipped, Agent-Overlay-Hook vorbereitet), Repo-Sanity wartet auf apps/ui/dist/index.html nach pnpm build:ui und AgentWorkflowEngine defaultet ethical_guardrails (inkl. neuem Vitest-Test).
 - FR-UM-2025-10-07-Fraktal48-Dashboard+CLI: Sigillin-Authoring CLI (`scripts/sigillin-authoring.mjs`) und Trikāya-Dashboard-Generator (`scripts/generate-trikaya-dashboard.mjs`) liefern analysis/trikaya-dashboard.(json|md|yaml); Stub-Replacement-Roadmap in `docs/roadmap/stub-replacement-roadmap.(md|yaml)` verankert, MandalaMap-Follow-up auf „in-progress“ gesetzt.
 - FR-UM-2025-09-19-Fraktal48-CI+MandalaMap: Sigillin-Validator verschärft (Schema + Semantik), MandalaMap-Workflow ergänzt (continue-on-error + Artefakt), Smoke-Build wartet auf apps/ui/dist/index.html; MandalaMap.\* mit Bridge-Registry aktualisiert und Follow-ups angepasst.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -1,6 +1,9 @@
 fraktal:
-  current: 49
+  current: 50
   history:
+    - id: 50
+      status: running
+      notes: 'Fraktal50 Windows-Pfadnormalisierung für sigillin validator aktiv, Skip-Logs mit Gründen; Windows-Feedback & Docker-Follow-up offen.'
     - id: 49
       status: running
       notes: 'Validator scope konzentriert sich auf sigils/bridges, Repo-Sanity wartet auf den UI-Build und AgentWorkflowEngine setzt ethical_guardrails standardmäßig.'

--- a/scripts/validate-sigillins.mjs
+++ b/scripts/validate-sigillins.mjs
@@ -45,8 +45,12 @@ const DEFAULT_PATTERNS = [
   'docs/sigillin/bridges/**/*.md',
 ];
 
-const BRIDGE_SIGIL_REGEX = /sigils\/bridges\/.+\.(json|ya?ml)$/i;
-const BRIDGE_MD_REGEX = /docs\/sigillin\/bridges\/.+\.md$/i;
+const BRIDGE_SIGIL_REGEX = /(^|\/)sigils\/bridges\/.+\.(json|ya?ml)$/i;
+const BRIDGE_MD_REGEX = /(^|\/)docs\/sigillin\/bridges\/.+\.md$/i;
+
+function toPosix(p) {
+  return (p || '').replaceAll('\\', '/');
+}
 
 function isBridgeSigilPath(relativePath) {
   return BRIDGE_SIGIL_REGEX.test(relativePath);
@@ -134,10 +138,10 @@ async function loadSchema() {
 
 async function validateStructured(obj, ajvValidate, relativePath) {
   const errors = [];
-  const relPath = relativePath || '';
+  const relPath = toPosix(relativePath || '');
 
   if (!isBridgeSigilPath(relPath)) {
-    return { errors, skipped: true, reason: 'non-bridge' };
+    return { errors, skipped: true, reason: 'not bridge path' };
   }
 
   const ok = ajvValidate(obj);
@@ -149,7 +153,7 @@ async function validateStructured(obj, ajvValidate, relativePath) {
   }
   const sigillin = obj?.sigillin ?? obj ?? {};
   if (isRegistryOrArchiveSigil(sigillin, relPath)) {
-    return { errors, skipped: true, reason: 'registry' };
+    return { errors, skipped: true, reason: 'registry/archive' };
   }
 
   applySemanticOverlay(sigillin);
@@ -266,26 +270,27 @@ async function main() {
   for (const f of files) {
     const ext = path.extname(f).toLowerCase();
     const rel = path.relative(ROOT, f);
+    const relNorm = toPosix(rel);
     try {
       let errs = [];
       let skipped = false;
       let skipReason = '';
       if (ext === '.json') {
         const obj = await readJson(f);
-        const result = await validateStructured(obj, ajvValidate, rel);
+        const result = await validateStructured(obj, ajvValidate, relNorm);
         errs = result.errors;
         skipped = result.skipped;
         skipReason = result.reason || '';
       } else if (ext === '.yml' || ext === '.yaml') {
         const obj = await readYaml(f);
-        const result = await validateStructured(obj, ajvValidate, rel);
+        const result = await validateStructured(obj, ajvValidate, relNorm);
         errs = result.errors;
         skipped = result.skipped;
         skipReason = result.reason || '';
       } else if (ext === '.md') {
-        if (!isBridgeMarkdownPath(rel)) {
+        if (!isBridgeMarkdownPath(relNorm)) {
           skipped = true;
-          skipReason = 'non-bridge';
+          skipReason = 'not bridge path';
         } else {
           errs = await validateMarkdown(f);
         }
@@ -293,20 +298,20 @@ async function main() {
         continue;
       }
       if (skipped) {
-        const suffix = skipReason ? ` (${skipReason})` : '';
-        console.log(`⏭️  ${rel}${suffix}`);
+        const suffix = skipReason ? ` (skip: ${skipReason})` : '';
+        console.log(`⏭️  ${relNorm}${suffix}`);
         continue;
       }
       if (errs.length) {
         hasErrors = true;
-        console.log(`❌ ${rel}`);
+        console.log(`❌ ${relNorm}`);
         for (const e of errs) console.log(`   - ${e}`);
       } else {
-        console.log(`✅ ${rel}`);
+        console.log(`✅ ${relNorm}`);
       }
     } catch (e) {
       hasErrors = true;
-      console.log(`❌ ${rel}\n   - Fehler: ${(e && e.message) || e}`);
+      console.log(`❌ ${relNorm}\n   - Fehler: ${(e && e.message) || e}`);
     }
   }
   process.exit(hasErrors ? 1 : 0);


### PR DESCRIPTION
## Summary
- normalize sigillin validator paths to POSIX form so bridge detection works on Windows
- clarify skip reasons while updating bridge regexes to accept nested prefixes for JSON/YAML/Markdown
- document Fraktal50 progress in codexfeedback trackers and add a new hook file

## Testing
- pnpm validate:sigillins

------
https://chatgpt.com/codex/tasks/task_e_68cdb46dcf8883229e6760a67dfa9f4c