### PR TITLE
Add install state export to Windows setup script

### DIFF
--- a/MandalaMap.json
+++ b/MandalaMap.json
@@ -713,7 +713,8 @@
       "notes": [
         "Dist-first convention via scripts/run-dist.mjs; referenced throughout docs.",
         "Sigillin-Fix-CLI (scripts/fix-sigillin.ts) unterstützt Bridges bei Trikāya/CREP/Nächste-Schritt-Korrekturen.",
-        "Windows-Parität über scripts/setup-dev-env.ps1 + scripts/run-powershell.mjs dokumentiert (PowerShell-Fallback)."
+        "Windows-Parität über scripts/setup-dev-env.ps1 + scripts/run-powershell.mjs dokumentiert (PowerShell-Fallback).",
+        "PowerShell-Setup exportiert Installationsstatus nach out/setup/install-state.json für Codexfeedback-Reports."
       ],
       "links": [
         {

--- a/MandalaMap.md
+++ b/MandalaMap.md
@@ -147,7 +147,7 @@ Repository: unified-mandala
 
 - `scripts/` — **active** Automation scripts
   - Extensive Node/TS automation: dev servers, exports, QA, smoke tests, repo map, etc.
-  - Notes: Dist-first convention via scripts/run-dist.mjs; Sigillin-Fix-CLI (`scripts/fix-sigillin.ts`) ergänzt Bridge-Tooling; Windows-Parität via `scripts/setup-dev-env.ps1` + `scripts/run-powershell.mjs` dokumentiert.
+  - Notes: Dist-first convention via scripts/run-dist.mjs; Sigillin-Fix-CLI (`scripts/fix-sigillin.ts`) ergänzt Bridge-Tooling; Windows-Parität via `scripts/setup-dev-env.ps1` + `scripts/run-powershell.mjs` dokumentiert; PowerShell-Setup exportiert Installationsstatus nach `out/setup/install-state.json`.
   - Links: [run-dist](scripts/run-dist.mjs), [dev-services](scripts/dev-services.mjs), [sigil-fix](scripts/fix-sigillin.ts), [setup-dev-env.ps1](scripts/setup-dev-env.ps1), [run-powershell](scripts/run-powershell.mjs)
 
 - `tasks/` — **active** Task manifests

--- a/MandalaMap.yaml
+++ b/MandalaMap.yaml
@@ -596,6 +596,7 @@ entries:
       - Dist-first convention via scripts/run-dist.mjs; referenced throughout docs.
       - Sigillin-Fix-CLI (`scripts/fix-sigillin.ts`) unterstützt Bridges bei Trikāya/CREP/Nächste-Schritt-Korrekturen.
       - Windows-Parität über `scripts/setup-dev-env.ps1` + `scripts/run-powershell.mjs` dokumentiert (PowerShell-Fallback).
+      - PowerShell-Setup exportiert Installationsstatus nach `out/setup/install-state.json` für Codexfeedback-Reports.
     links:
       - label: run-dist
         path: scripts/run-dist.mjs

--- a/codexfeedback-fraktal56.yaml
+++ b/codexfeedback-fraktal56.yaml
@@ -6,6 +6,7 @@ summary:
   - 'PowerShell-Bootstrap `scripts/setup-dev-env.ps1` installiert Git/Node/Python, aktiviert Corepack und führt pnpm install auf Windows aus.'
   - 'Node-Wrapper `scripts/run-powershell.mjs` sucht pwsh oder Windows PowerShell, sodass `pnpm build:windows-tools` ohne pwsh-Laufzeit funktioniert.'
   - 'Dokumentation (README/ONBOARDING/CommunityOnboarding), Command-Catalog & MandalaMap verweisen jetzt auf Windows-Parität; Playbook-Notizen ergänzt.'
+  - 'Setup-Skript schreibt nach Abschluss eine JSON-Zusammenfassung unter `out/setup/install-state.json` (Shell-Version, Tool-Status, Skip-Flags) für Codexfeedback-Auswertungen.'
 deliverables:
   - scripts/setup-dev-env.ps1
   - scripts/run-powershell.mjs
@@ -29,6 +30,6 @@ follow_up:
     description: 'Docker Compose Windows-Dokumentation ergänzen (z. B. `--build`, WSL vs. Hyper-V) sobald Image-Build bestätigt ist.'
     status: planned
 hook:
-  progress: 'Windows-Bootstrap + PowerShell-Fallback stehen; Setup-Skript liefert Installationsübersicht und pnpm build:windows-tools nutzt den Node-Wrapper.'
+  progress: 'Windows-Bootstrap + PowerShell-Fallback stehen; Setup-Skript exportiert Installationsübersicht (`out/setup/install-state.json`) und pnpm build:windows-tools nutzt den Node-Wrapper.'
   next_step: 'Verifizierung auf Windows-Hosts (PowerShell 5.1/7) durchführen und Compose-Profil-Notizen ergänzen.'
 repeat_required: false

--- a/codexfeedback.json
+++ b/codexfeedback.json
@@ -1,6 +1,11 @@
 {
   "runs": [
     {
+      "fraktalrun": "Fraktal56 InstallState Export",
+      "status": "implemented",
+      "notes": "PowerShell setup writes out/setup/install-state.json with shell/tool versions and skip flags; roadmap & MandalaMap reference the export for codexfeedback analysis."
+    },
+    {
       "fraktalrun": "Fraktal56 WindowsBootstrap",
       "status": "in-progress",
       "notes": "PowerShell setup script (`scripts/setup-dev-env.ps1`) now tracks InstallState (Git/Node/Python/Corepack/pnpm/Docker/NATS) with PowerShell 5.1 fallback; Node wrapper (`scripts/run-powershell.mjs`) covers pwsh/powershell and docs/command catalog/playbook remain updated."

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -1,5 +1,6 @@
 # Codex Feedback
 
+- FR-UM-2025-10-15-Fraktal56-InstallStateExport: `scripts/setup-dev-env.ps1` schreibt nach Abschluss eine JSON-Zusammenfassung (`out/setup/install-state.json`) inklusive Shell-/Tool-Versionsinfo und Skip-Flags; MandalaMap & Playbook dokumentieren den Export für Codexfeedback-Auswertungen.
 - FR-UM-2025-10-14-Fraktal56-WindowsBootstrap: PowerShell-Setup (`scripts/setup-dev-env.ps1`) trackt InstallState (Git/Node/Python/Corepack/pnpm/Docker/NATS) und funktioniert unter PowerShell 5.1 via `powershell -NoProfile -ExecutionPolicy Bypass`; `scripts/run-powershell.mjs` bleibt Wrapper für pwsh/powershell und README/Onboarding/Command-Catalog/MandalaMap spiegeln Windows-Parität.
 - FR-UM-2025-10-13-Fraktal55-DevTalkWindowsHardening: `pnpm find-bad-yaml` nutzt yaml-lint für Strict-Läufe, `pnpm audit:ui-vr` generiert fehlende repo-map-Artefakte automatisch und `scripts/generate-agents-diagram.js` läuft als ESM ohne require.
 - FR-UM-2025-10-12-Fraktal54-SigillinFix: Neues CLI `pnpm sigil:fix` analysiert Bridges (Trikāya/CREP/Nächste Schritte) und kann fehlende Elemente automatisch ergänzen; README verweist auf den Fix-Guide (`docs/sigillin/FIX_GUIDE.md`), MandalaMap & codexfeedback aktualisiert.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -3,7 +3,7 @@ fraktal:
   history:
     - id: 56
       status: running
-      notes: 'Fraktal56 WindowsBootstrap: PowerShell-Setup (`scripts/setup-dev-env.ps1`) trackt InstallState (Git/Node/Python/Corepack/pnpm/Docker/NATS) und unterstützt PowerShell 5.1; Node-Wrapper (`scripts/run-powershell.mjs`) sichert pwsh/powershell-Fallback; Docs/MandalaMap/Command-Catalog aktualisiert.'
+      notes: 'Fraktal56 WindowsBootstrap: PowerShell-Setup (`scripts/setup-dev-env.ps1`) trackt InstallState (Git/Node/Python/Corepack/pnpm/Docker/NATS), exportiert eine JSON-Zusammenfassung (`out/setup/install-state.json`) und unterstützt PowerShell 5.1; Node-Wrapper (`scripts/run-powershell.mjs`) sichert pwsh/powershell-Fallback; Docs/MandalaMap/Command-Catalog aktualisiert.'
       deliverables:
         - scripts/setup-dev-env.ps1
         - scripts/run-powershell.mjs
@@ -21,7 +21,7 @@ fraktal:
         - docs/roadmap/v1.0-stabilization-playbook.yaml
         - codexfeedback-fraktal56.yaml
       hook:
-        progress: 'Windows-Bootstrap dokumentiert; Setup-Skript gibt Installationsstatus aus und `pnpm build:windows-tools` nutzt den Node-Wrapper statt direktem pwsh-Aufruf.'
+        progress: 'Windows-Bootstrap dokumentiert; Setup-Skript exportiert Installationszustand nach `out/setup/install-state.json` und `pnpm build:windows-tools` nutzt den Node-Wrapper statt direktem pwsh-Aufruf.'
         next_step: 'Feedback von Windows-Hosts (PowerShell 5.1/7) einsammeln und Docker Compose Flow (\`--build\`/WSL) ergänzen.'
     - id: 55
       status: done

--- a/docs/roadmap/v1.0-stabilization-playbook.md
+++ b/docs/roadmap/v1.0-stabilization-playbook.md
@@ -95,6 +95,7 @@ Dieses Playbook übersetzt die Ergebnisse des Fraktal40-Entwicklungsgesprächs i
 1. **README / CONTRIBUTING / ONBOARDING**
    - Release-Pipeline (Core vs. Extended vs. Experimental) beschreiben und Dist-First-Vorgaben aufnehmen.
    - Quickstart um `scripts/setup-dev-env.sh` **und** `scripts/setup-dev-env.ps1` ergänzen; Windows-Build (`scripts/run-powershell.mjs`) dokumentieren.
+   - Windows-Setup (`scripts/setup-dev-env.ps1`) exportiert den Installationsstatus nach `out/setup/install-state.json`, damit Codexfeedback-Läufe den Zustand referenzieren können.
 2. **AI Governance Doku**
    - `AI_POLICY.md` mit praktischen Beispielen, `docs/CommunityOnboarding.md` mit Build-Health-Badges versehen.
 3. **Build Health Kommunikation**

--- a/docs/roadmap/v1.0-stabilization-playbook.yaml
+++ b/docs/roadmap/v1.0-stabilization-playbook.yaml
@@ -55,7 +55,8 @@ streams:
         status: done
         notes: README & CONTRIBUTING beschreiben scripts/run-dist.mjs inkl. `UM_RUN_DIST_*`
           Overrides; Windows-Onboarding referenziert `scripts/setup-dev-env.ps1` und
-          `scripts/run-powershell.mjs`.
+          `scripts/run-powershell.mjs`. PowerShell-Setup exportiert den Installationsstatus
+          nach `out/setup/install-state.json` für Codexfeedback-Läufe.
       - id: ts-node-retire
         description: Produktionspfade auf `node dist/...` umstellen
         status: done

--- a/scripts/setup-dev-env.ps1
+++ b/scripts/setup-dev-env.ps1
@@ -2,7 +2,8 @@
 param(
   [switch]$SkipPackageInstall,
   [switch]$SkipPythonSetup,
-  [switch]$SkipNodeSetup
+  [switch]$SkipNodeSetup,
+  [string]$StateOutput = 'out/setup/install-state.json'
 )
 
 Set-StrictMode -Version Latest
@@ -11,6 +12,12 @@ $ErrorActionPreference = 'Stop'
 if (-not (Get-Variable InstallState -Scope Script -ErrorAction SilentlyContinue)) {
   $script:InstallState = @{}
 }
+
+if (-not (Get-Variable InstallMetadata -Scope Script -ErrorAction SilentlyContinue)) {
+  $script:InstallMetadata = @{}
+}
+
+$script:StateOutput = if ($StateOutput) { $StateOutput } else { $null }
 
 function Write-Step {
   param([string]$Message)
@@ -33,6 +40,74 @@ function Update-InstallState {
   }
 
   $script:InstallState[$Key] = $Present
+}
+
+function Resolve-StatePath {
+  param([string]$Path)
+
+  if (-not $Path) {
+    return $null
+  }
+
+  $target = $Path
+  if (-not [System.IO.Path]::IsPathRooted($target)) {
+    $base = $PSScriptRoot
+    if ($base) {
+      $repoRoot = Resolve-Path -LiteralPath (Join-Path $base '..') -ErrorAction SilentlyContinue
+      if ($repoRoot) {
+        $target = Join-Path $repoRoot.Path $target
+      } else {
+        $target = Join-Path (Get-Location).Path $target
+      }
+    } else {
+      $target = Join-Path (Get-Location).Path $target
+    }
+  }
+
+  $directory = Split-Path -Path $target -Parent
+  if ($directory -and -not (Test-Path $directory)) {
+    New-Item -ItemType Directory -Path $directory -Force | Out-Null
+  }
+
+  return $target
+}
+
+function Export-InstallReport {
+  param([string]$OutputPath)
+
+  if (-not $OutputPath) {
+    return
+  }
+
+  $resolved = Resolve-StatePath -Path $OutputPath
+  if (-not $resolved) {
+    return
+  }
+
+  $report = [ordered]@{
+    timestamp      = (Get-Date).ToString('o')
+    shellVersion   = $PSVersionTable.PSVersion.ToString()
+    workingDir     = (Get-Location).Path
+    packageManager = $script:PackageManager
+    options        = [ordered]@{
+      skipPackageInstall = [bool]$SkipPackageInstall
+      skipPythonSetup    = [bool]$SkipPythonSetup
+      skipNodeSetup      = [bool]$SkipNodeSetup
+    }
+    installState   = $script:InstallState
+  }
+
+  if ($script:InstallMetadata.Keys.Count -gt 0) {
+    $report['metadata'] = $script:InstallMetadata
+  }
+
+  try {
+    $json = $report | ConvertTo-Json -Depth 6
+    Set-Content -LiteralPath $resolved -Value $json -Encoding UTF8
+    Write-Step "Installationsstatus exportiert nach $resolved"
+  } catch {
+    Write-Warning "Konnte Installationsstatus nicht nach $resolved schreiben: $($_.Exception.Message)"
+  }
 }
 
 function Get-PackageManager {
@@ -123,6 +198,7 @@ function Resolve-PythonCommand {
 Write-Step "Windows Entwicklungsumgebung initialisieren"
 
 $script:PackageManager = Get-PackageManager
+$script:InstallMetadata['packageManager'] = $script:PackageManager
 if ($SkipPackageInstall) {
   Write-Host "(Paketinstallation übersprungen)"
 } elseif (-not $script:PackageManager) {
@@ -139,6 +215,20 @@ if ($SkipPackageInstall) {
 
 if (-not $SkipPythonSetup) {
   $pythonCommand = Resolve-PythonCommand
+  $script:InstallMetadata['pythonCommand'] = $pythonCommand
+  if ($pythonCommand) {
+    try {
+      $pythonVersionOutput = & $pythonCommand --version 2>&1
+      if ($pythonVersionOutput) {
+        if ($pythonVersionOutput -is [System.Array]) {
+          $pythonVersionOutput = $pythonVersionOutput | Select-Object -First 1
+        }
+        $script:InstallMetadata['pythonVersion'] = $pythonVersionOutput.ToString().Trim()
+      }
+    } catch {
+      # ignore version errors
+    }
+  }
   if (-not $pythonCommand) {
     Write-Warning 'Python wurde nicht gefunden. Überspringe virtuellen Python-Umgebungsschritt.'
     Update-InstallState -Key 'python-venv' -Present $false
@@ -203,6 +293,48 @@ Update-InstallState -Key 'pnpm' -Present (Test-CommandExists 'pnpm')
 Update-InstallState -Key 'nats-server' -Present (Test-CommandExists 'nats-server')
 Update-InstallState -Key 'docker' -Present (Test-CommandExists 'docker')
 
+if (Test-CommandExists 'node') {
+  try {
+    $nodeVersionOutput = & node --version 2>&1
+    if ($nodeVersionOutput) {
+      if ($nodeVersionOutput -is [System.Array]) {
+        $nodeVersionOutput = $nodeVersionOutput | Select-Object -First 1
+      }
+      $script:InstallMetadata['nodeVersion'] = $nodeVersionOutput.ToString().Trim()
+    }
+  } catch {
+    # ignore node version errors
+  }
+}
+
+if (Test-CommandExists 'pnpm') {
+  try {
+    $pnpmVersionOutput = & pnpm --version 2>&1
+    if ($pnpmVersionOutput) {
+      if ($pnpmVersionOutput -is [System.Array]) {
+        $pnpmVersionOutput = $pnpmVersionOutput | Select-Object -First 1
+      }
+      $script:InstallMetadata['pnpmVersion'] = $pnpmVersionOutput.ToString().Trim()
+    }
+  } catch {
+    # ignore pnpm version errors
+  }
+}
+
+if (Test-CommandExists 'corepack') {
+  try {
+    $corepackVersionOutput = & corepack --version 2>&1
+    if ($corepackVersionOutput) {
+      if ($corepackVersionOutput -is [System.Array]) {
+        $corepackVersionOutput = $corepackVersionOutput | Select-Object -First 1
+      }
+      $script:InstallMetadata['corepackVersion'] = $corepackVersionOutput.ToString().Trim()
+    }
+  } catch {
+    # ignore corepack version errors
+  }
+}
+
 if (Test-CommandExists 'git') {
   Write-Step 'Git Konfiguration überprüfen'
   try {
@@ -239,4 +371,5 @@ function Write-InstallSummary {
 }
 
 Write-InstallSummary
+Export-InstallReport -OutputPath $script:StateOutput
 Write-Step 'Setup abgeschlossen. Öffne eine neue PowerShell für aktivierte PATH-Einstellungen bei Bedarf.'


### PR DESCRIPTION
## Summary
- extend `scripts/setup-dev-env.ps1` with an optional JSON export of install state metadata and tool versions for Windows runs
- document the new export path in the v1.0 stabilization playbook and MandalaMap references
- record the install-state snapshot capability inside the codexfeedback trackers for Fraktal56

## Testing
- not run (PowerShell script + documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68ce963f64848322bcc581b2816d2ced