### PR TITLE
Add emergence breath watcher and update UI smoke flow

### DIFF
--- a/MandalaMap.json
+++ b/MandalaMap.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "version": "1.0",
-    "generated": "2025-10-08T12:00:00Z",
+    "generated": "2025-10-19T12:00:00Z",
     "fraktal": 49,
     "repo": "unified-mandala",
     "source": "ChefDevAI MandalaMap bootstrap",
@@ -715,7 +715,8 @@
         "Sigillin-Fix-CLI (scripts/fix-sigillin.ts) unterstützt Bridges bei Trikāya/CREP/Nächste-Schritt-Korrekturen.",
         "Windows-Parität über scripts/setup-dev-env.ps1 + scripts/run-powershell.mjs dokumentiert (PowerShell-Fallback).",
         "PowerShell-Setup exportiert Installationsstatus nach out/setup/install-state.json für Codexfeedback-Reports.; Corepack-Admin-Check vermeidet EPERM, bietet Benutzeraktivierung ohne Admin-Rechte und ergänzt NATS-Installationshinweise für `pnpm start:all`.",
-        "ParserFix: (Test-CommandExists ...) jetzt geklammert und Installationsresultate werden zu Bool gecastet, damit PowerShell 7.5 den Dev-Setup ohne ParserError ausführt."
+        "ParserFix: (Test-CommandExists ...) jetzt geklammert und Installationsresultate werden zu Bool gecastet, damit PowerShell 7.5 den Dev-Setup ohne ParserError ausführt.",
+        "Emergence-Breath (scripts/emergence-breath.mjs) koppelt pnpm dev:breath an validate:sigillins + trikaya:dashboard und meldet Coverage-Metriken nach jedem Lauf."
       ],
       "links": [
         {
@@ -737,6 +738,10 @@
         {
           "label": "run-powershell",
           "path": "scripts/run-powershell.mjs"
+        },
+        {
+          "label": "emergence-breath",
+          "path": "scripts/emergence-breath.mjs"
         }
       ]
     },

--- a/MandalaMap.md
+++ b/MandalaMap.md
@@ -1,6 +1,6 @@
 # Mandala Map · Fraktal49
 
-Generated: 2025-10-08T12:00:00Z
+Generated: 2025-10-19T12:00:00Z
 Repository: unified-mandala
 
 ## Reference Docs
@@ -147,7 +147,7 @@ Repository: unified-mandala
 
 - `scripts/` — **active** Automation scripts
   - Extensive Node/TS automation: dev servers, exports, QA, smoke tests, repo map, etc.
-- Notes: Dist-first convention via scripts/run-dist.mjs; Sigillin-Fix-CLI (`scripts/fix-sigillin.ts`) ergänzt Bridge-Tooling; Windows-Parität via `scripts/setup-dev-env.ps1` + `scripts/run-powershell.mjs` dokumentiert; PowerShell-Setup exportiert Installationsstatus nach `out/setup/install-state.json`; ParserFix `(Test-CommandExists ...)` + Bool-Cast heben PowerShell 7.5 ParserError auf; Corepack-Admin-Check vermeidet EPERM und liefert Benutzeraktivierung samt NATS-Installationshinweis.
+- Notes: Dist-first convention via scripts/run-dist.mjs; Sigillin-Fix-CLI (`scripts/fix-sigillin.ts`) ergänzt Bridge-Tooling; Windows-Parität via `scripts/setup-dev-env.ps1` + `scripts/run-powershell.mjs` dokumentiert; PowerShell-Setup exportiert Installationsstatus nach `out/setup/install-state.json`; ParserFix `(Test-CommandExists ...)` + Bool-Cast heben PowerShell 7.5 ParserError auf; Corepack-Admin-Check vermeidet EPERM und liefert Benutzeraktivierung samt NATS-Installationshinweis; Emergence-Breath (`scripts/emergence-breath.mjs`) koppelt `pnpm dev:breath` an `validate:sigillins` + Trikāya-Dashboard und protokolliert Coverage-Metriken.
   - Links: [run-dist](scripts/run-dist.mjs), [dev-services](scripts/dev-services.mjs), [sigil-fix](scripts/fix-sigillin.ts), [setup-dev-env.ps1](scripts/setup-dev-env.ps1), [run-powershell](scripts/run-powershell.mjs)
 
 - `tasks/` — **active** Task manifests

--- a/MandalaMap.yaml
+++ b/MandalaMap.yaml
@@ -1,6 +1,6 @@
 meta:
   version: '1.0'
-  generated: '2025-10-08T12:00:00Z'
+  generated: '2025-10-19T12:00:00Z'
   fraktal: 49
   repo: unified-mandala
   source: ChefDevAI MandalaMap bootstrap
@@ -599,6 +599,7 @@ entries:
       - PowerShell-Setup exportiert Installationsstatus nach `out/setup/install-state.json` für Codexfeedback-Reports.
       - 'ParserFix: `(Test-CommandExists ...)` jetzt geklammert und Installationsresultate zu Bool gecastet, damit PowerShell 7.5 den Dev-Setup ohne ParserError ausführt.'
       - 'Corepack-Admin-Check vermeidet EPERM, setzt Benutzeraktivierung wenn keine Admin-Rechte vorliegen und ergänzt NATS-Installationshinweise für `pnpm start:all`.'
+      - Emergence-Breath (`scripts/emergence-breath.mjs`) koppelt `pnpm dev:breath` an `validate:sigillins` und das Trikāya-Dashboard; Ausgabe enthält Coverage-Metriken für Bridges.
     links:
       - label: run-dist
         path: scripts/run-dist.mjs
@@ -610,6 +611,8 @@ entries:
         path: scripts/setup-dev-env.ps1
       - label: run-powershell
         path: scripts/run-powershell.mjs
+      - label: emergence-breath
+        path: scripts/emergence-breath.mjs
   - path: services/
     category: core-runtime
     status: active

--- a/codexfeedback-fraktal56.yaml
+++ b/codexfeedback-fraktal56.yaml
@@ -1,5 +1,5 @@
 fraktal: 56
-status: running
+status: done
 owner: ChefDevAI
 summary:
   - 'Installationsstatus-Tracking ergänzt: `scripts/setup-dev-env.ps1` initialisiert eine InstallState-Map, fasst Git/Node/Python/Corepack/pnpm/Docker/NATS zusammen und unterstützt Windows PowerShell 5.1 via ExecutionPolicy Bypass.'
@@ -9,9 +9,13 @@ summary:
   - 'Setup-Skript schreibt nach Abschluss eine JSON-Zusammenfassung unter `out/setup/install-state.json` (Shell-Version, Tool-Status, Skip-Flags) für Codexfeedback-Auswertungen.'
   - 'Corepack-Admin-Erkennung vermeidet EPERM, protokolliert Aktivierungsmodus (`system`, `user`, `system-fallback`, `skipped`) und blendet NATS-Installationshinweise (winget/Docker) ein.'
   - 'PowerShell 7.5 ParserError behoben: `Ensure-Tool` nutzt jetzt `(Test-CommandExists ...)` in `-and`-Ausdrücken und castet Installationsresultate zu Bool, sodass der Dev-Setup-Lauf auf Windows wieder durchläuft.'
+  - 'Emergence-Breath (`scripts/emergence-breath.mjs`) koppelt `pnpm dev:breath` an `validate:sigillins` + `trikaya:dashboard`, überwacht sigils/, apps/ui/ und scripts/ und meldet Coverage-Metriken nach jedem Lauf.'
+  - '`scripts/smoke/ui-dev-smoke.mjs` respektiert `UI_DEV_URL` und vermeidet zusätzliche Vite-Instanzen, wodurch Windows-Portkonflikte (5173→5174) verschwinden.'
 deliverables:
   - scripts/setup-dev-env.ps1
   - scripts/run-powershell.mjs
+  - scripts/emergence-breath.mjs
+  - scripts/smoke/ui-dev-smoke.mjs
   - package.json
   - README.md
   - docs/ONBOARDING.md
@@ -19,19 +23,23 @@ deliverables:
   - docs/runbooks/command-catalog.md
   - docs/runbooks/command-catalog.yaml
   - docs/runbooks/command-catalog.json
+  - codexfeedback.md
+  - codexfeedback.json
+  - codexfeedback.yaml
   - MandalaMap.md
   - MandalaMap.yaml
   - MandalaMap.json
   - docs/roadmap/v1.0-stabilization-playbook.md
   - docs/roadmap/v1.0-stabilization-playbook.yaml
+  - codexfeedback-fraktal56.yaml
 follow_up:
   windows_script_validation:
     description: 'Windows-Terminallauf für scripts/setup-dev-env.ps1 (inkl. Installationsstatus-Output + winget/choco fallback) validieren und Feedback sammeln.'
-    status: in-progress
+    status: done
   docker_windows_profile:
     description: 'Docker Compose Windows-Dokumentation ergänzen (z. B. `--build`, WSL vs. Hyper-V) sobald Image-Build bestätigt ist.'
     status: planned
 hook:
-  progress: 'Windows-Bootstrap + PowerShell-Fallback stehen; ParserError (Test-CommandExists ohne Klammern) beseitigt, Setup-Skript exportiert Installationsübersicht (`out/setup/install-state.json`), dokumentiert Corepack-Aktivierungsmodus/NATS-Hinweis und pnpm build:windows-tools nutzt den Node-Wrapper.'
-  next_step: 'Verifizierung auf Windows-Hosts (PowerShell 5.1/7) durchführen und Compose-Profil-Notizen ergänzen; ParserFix in DevTalk-Track bestätigen.'
+  progress: 'Windows-Bootstrap + PowerShell-Fallback stehen; Windows-Lauf bestätigt InstallState-Export, `pnpm dev:breath` automatisiert Sigillin/Trikāya-Checks und UI-Smoke respektiert `UI_DEV_URL` ohne zusätzliche Vite-Instanz.'
+  next_step: 'Compose-/Docker-Windows-Profil dokumentieren (`docker_windows_profile`) und DevTalk-Track um Emergence-Breath-Status ergänzen.'
 repeat_required: false

--- a/codexfeedback.json
+++ b/codexfeedback.json
@@ -12,8 +12,8 @@
     },
     {
       "fraktalrun": "Fraktal56 WindowsBootstrap",
-      "status": "in-progress",
-      "notes": "PowerShell setup script (`scripts/setup-dev-env.ps1`) now tracks InstallState (Git/Node/Python/Corepack/pnpm/Docker/NATS), exports out/setup/install-state.json, fixes the PowerShell parser error by wrapping `(Test-CommandExists ...)` in `-and` checks, and keeps a pwsh/powershell wrapper plus docs/playbook references."
+      "status": "implemented",
+      "notes": "PowerShell setup validates InstallState export on Windows, pnpm dev:breath (`scripts/emergence-breath.mjs`) watches sigils/apps/ui/scripts to rerun validate:sigillins & trikaya dashboard with coverage logs, and the UI smoke respects UI_DEV_URL without spawning another Vite instance."
     },
     {
       "fraktalrun": "Fraktal55 DevTalk Windows Hardening",

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -1,5 +1,6 @@
 # Codex Feedback
 
+- FR-UM-2025-10-18-Fraktal56-DevBreath: Neues Watcher-Skript `pnpm dev:breath` (`scripts/emergence-breath.mjs`) verbindet `validate:sigillins` + `trikaya:dashboard` mit Datei-Watches (sigils/, apps/ui/, scripts/) und loggt Coverage; `scripts/smoke/ui-dev-smoke.mjs` respektiert `UI_DEV_URL` und vermeidet zusätzliche Vite-Ports; Command-Catalog, MandalaMap und Playbook dokumentieren den Ablauf.
 - FR-UM-2025-10-17-Fraktal56-CorepackAdmin: `scripts/setup-dev-env.ps1` erkennt Administrator-Rechte, überspringt `corepack enable` ohne Elevation, dokumentiert Aktivierungsmodus im InstallReport und weist auf fehlende `nats-server`-Installationen (winget/Docker) hin; README/Onboarding/Command-Catalog/MandalaMap aktualisiert.
 - FR-UM-2025-10-16-Fraktal56-PowerShellParserFix: `scripts/setup-dev-env.ps1` castet Installationsresultate zu Bool und setzt `(Test-CommandExists ...)` in `-and`-Bedingungen, sodass PowerShell 7.5 ParserError 181 verschwindet; DevTalk-Fragment bestätigt und Codexfeedback/MandalaMap/Playbook spiegeln den Fix.
 - FR-UM-2025-10-15-Fraktal56-InstallStateExport: `scripts/setup-dev-env.ps1` schreibt nach Abschluss eine JSON-Zusammenfassung (`out/setup/install-state.json`) inklusive Shell-/Tool-Versionsinfo und Skip-Flags; MandalaMap & Playbook dokumentieren den Export für Codexfeedback-Auswertungen.

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -2,11 +2,13 @@ fraktal:
   current: 56
   history:
     - id: 56
-      status: running
-      notes: 'Fraktal56 WindowsBootstrap: PowerShell-Setup (`scripts/setup-dev-env.ps1`) trackt InstallState (Git/Node/Python/Corepack/pnpm/Docker/NATS), exportiert eine JSON-Zusammenfassung (`out/setup/install-state.json`), fixt den PowerShell-ParserError via `(Test-CommandExists ...)` in `-and`-Checks und unterstützt PowerShell 5.1; Node-Wrapper (`scripts/run-powershell.mjs`) sichert pwsh/powershell-Fallback; Docs/MandalaMap/Command-Catalog aktualisiert; Corepack-Admin-Check überspringt `corepack enable` ohne Elevation, protokolliert Aktivierungsmodus und ergänzt NATS-Installationshinweise.'
+      status: done
+      notes: 'Fraktal56 WindowsBootstrap: PowerShell-Setup (`scripts/setup-dev-env.ps1`) trackt InstallState (Git/Node/Python/Corepack/pnpm/Docker/NATS), exportiert eine JSON-Zusammenfassung (`out/setup/install-state.json`), fixt den PowerShell-ParserError via `(Test-CommandExists ...)` in `-and`-Checks und unterstützt PowerShell 5.1; Node-Wrapper (`scripts/run-powershell.mjs`) sichert pwsh/powershell-Fallback; Docs/MandalaMap/Command-Catalog aktualisiert; Corepack-Admin-Check überspringt `corepack enable` ohne Elevation, protokolliert Aktivierungsmodus und ergänzt NATS-Installationshinweise; pnpm dev:breath (`scripts/emergence-breath.mjs`) automatisiert Sigillin/Trikāya-Checks und das UI-Smoke-Skript respektiert `UI_DEV_URL` ohne zusätzliche Vite-Instanz.'
       deliverables:
         - scripts/setup-dev-env.ps1
         - scripts/run-powershell.mjs
+        - scripts/emergence-breath.mjs
+        - scripts/smoke/ui-dev-smoke.mjs
         - package.json
         - README.md
         - docs/ONBOARDING.md
@@ -14,6 +16,9 @@ fraktal:
         - docs/runbooks/command-catalog.md
         - docs/runbooks/command-catalog.yaml
         - docs/runbooks/command-catalog.json
+        - codexfeedback.md
+        - codexfeedback.json
+        - codexfeedback.yaml
         - MandalaMap.md
         - MandalaMap.yaml
         - MandalaMap.json
@@ -21,8 +26,8 @@ fraktal:
         - docs/roadmap/v1.0-stabilization-playbook.yaml
         - codexfeedback-fraktal56.yaml
       hook:
-        progress: 'Windows-Bootstrap dokumentiert; ParserError (Test-CommandExists ohne Klammern) behoben, Setup-Skript exportiert Installationszustand nach `out/setup/install-state.json`, dokumentiert Corepack-Aktivierungsmodus und blendet NATS-Installationshinweise ein; `pnpm build:windows-tools` nutzt den Node-Wrapper statt direktem pwsh-Aufruf.'
-        next_step: 'Feedback von Windows-Hosts (PowerShell 5.1/7) einsammeln, ParserFix im DevTalk-Track spiegeln und Docker Compose Flow (`--build`/WSL) ergänzen.'
+        progress: 'Windows-Bootstrap dokumentiert; ParserFix + InstallState-Export bestätigt, `pnpm dev:breath` verbindet Sigillin-Validator & Trikāya-Dashboard mit Watcher-Cycle und das UI-Smoke-Skript respektiert `UI_DEV_URL` ohne zusätzliche Vite-Instanz.'
+        next_step: 'Compose-/Docker-Windows-Flows dokumentieren (`docker_windows_profile`) und DevTalk-Track um Emergence-Breath-Status ergänzen.'
     - id: 55
       status: done
       notes: 'Fraktal55 DevTalk Windows Hardening: yaml-lint powered `pnpm find-bad-yaml`, repo-map auto-generation for `audit:ui-vr`, und ESM-Update für `scripts/generate-agents-diagram.js`.'

--- a/docs/roadmap/v1.0-stabilization-playbook.md
+++ b/docs/roadmap/v1.0-stabilization-playbook.md
@@ -88,6 +88,7 @@ Dieses Playbook übersetzt die Ergebnisse des Fraktal40-Entwicklungsgesprächs i
    - _Status 2025-09-22:_ Entscheidungsbeispiele für Allow/Review/Block sind in Markdown und YAML dokumentiert.
 3. **Sigillin Governance**
    - `pnpm validate:sigillins` nutzt `scripts/validate-sigillins.mjs` + Schema (`mandala-sigillin.schema.json`); CI-Workflow `sigillin-validate` blockt fehlende CREP/Trikāya/NEXT Angaben.
+   - Neues Dev-Protokoll `pnpm dev:breath` koppelt `validate:sigillins` und `trikaya:dashboard` an Dateiänderungen (sigils/, apps/ui/, scripts/) und meldet Coverage-Metriken direkt nach jedem Lauf.
    - _Status 2025-10-01 (Fraktal44):_ Validator & Workflow aktiv, Links-Prüfung + Content-Hooks dokumentiert.
 
 ## 6. Dokumentation & Onboarding

--- a/docs/roadmap/v1.0-stabilization-playbook.yaml
+++ b/docs/roadmap/v1.0-stabilization-playbook.yaml
@@ -1,7 +1,7 @@
 fraktal: 40
 release: v1.0
 owner: codex
-updated: '2025-10-01'
+updated: '2025-10-19'
 summary: 'Strukturierter Maßnahmenplan zur Umsetzung der Fraktal40-Besprechung.
 
   Fokus auf stabile Kern-Builds, dist-first Services, verschärfte Governance
@@ -114,8 +114,7 @@ streams:
       - id: sigillin-validator
         description: Sigillin-Validator + CI-Workflow etablieren
         status: done
-        notes: pnpm validate:sigillins + .github/workflows/sigillin-validate.yml aktiv
-          (Fraktal44)
+        notes: pnpm validate:sigillins + .github/workflows/sigillin-validate.yml aktiv (Fraktal44); pnpm dev:breath koppelt validate:sigillins & trikaya:dashboard an Dateiänderungen und meldet Coverage.
         artifacts:
           - scripts/validate-sigillins.mjs
           - scripts/schemas/mandala-sigillin.schema.json

--- a/docs/runbooks/command-catalog.json
+++ b/docs/runbooks/command-catalog.json
@@ -581,6 +581,15 @@
           "source": ["package.json#scripts.dev:stack"]
         },
         {
+          "id": "runtime.dev-breath",
+          "name": "Emergence breath watcher",
+          "command": "pnpm dev:breath",
+          "type": "pnpm",
+          "runs": "node scripts/emergence-breath.mjs",
+          "description": "Watches sigils, apps/ui, and scripts to rerun `validate:sigillins`, rebuild the Trikāya dashboard, and print coverage metrics.",
+          "source": ["package.json#scripts.dev:breath"]
+        },
+        {
           "id": "runtime.start",
           "name": "Start UI & dev",
           "command": "pnpm start",
@@ -674,7 +683,7 @@
           "command": "pnpm smoke:ui",
           "type": "pnpm",
           "runs": "node scripts/smoke/ui-dev-smoke.mjs",
-          "description": "Performs smoke testing against the UI dev server.",
+          "description": "Performs smoke testing against the UI dev server and respects `UI_DEV_URL` without spawning a new Vite instance.",
           "source": ["package.json#scripts.smoke:ui"]
         },
         {

--- a/docs/runbooks/command-catalog.md
+++ b/docs/runbooks/command-catalog.md
@@ -95,34 +95,36 @@ Diese Sammlung bündelt pnpm-Skripte, Shell-Kommandos sowie wiederverwendbare To
 
 > Commands for launching dev servers, stacks, and runtime utilities.
 
-| Command                          | Type   | Runs                                                                             | Beschreibung                                                              |
-| -------------------------------- | ------ | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `pnpm dev`                       | `pnpm` | `cross-env UI_DIST=http://localhost:5173 pnpm -F mandala-ui dev`                 | Starts the mandala-ui dev server with UI_DIST override.                   |
-| `pnpm dev:ui`                    | `pnpm` | `pnpm -F mandala-ui dev`                                                         | Runs the UI workspace dev server without overrides.                       |
-| `pnpm dev:services`              | `pnpm` | `tsx scripts/dev-server.ts`                                                      | Launches backend/dev services via the TypeScript dev server orchestrator. |
-| `pnpm dev:stack`                 | `pnpm` | `node scripts/dev-services.mjs --mode=dev`                                       | Starts the dev stack orchestrator with default dev profiles.              |
-| `pnpm start`                     | `pnpm` | `pnpm -s build:ui && pnpm -s dev`                                                | Builds the UI then launches the dev server.                               |
-| `pnpm start:light`               | `pnpm` | `pnpm -s build:ui && node scripts/light-static-server.mjs`                       | Serves the built UI via the light static Node server.                     |
-| `pnpm start:services`            | `pnpm` | `pnpm -s build && NODE_ENV=production node scripts/dev-services.mjs --mode=prod` | Builds the workspace and starts services in production mode.              |
-| `pnpm start:all`                 | `pnpm` | `pnpm dev:stack`                                                                 | Convenience alias to boot the full dev stack.                             |
-| `pnpm dev:voiceos`               | `pnpm` | `node scripts/run-dist.mjs scripts/voice-os-control-api.ts`                      | Launches the Voice OS control API for voice interaction workflows.        |
-| `pnpm ghost-shell:cluster`       | `pnpm` | `node scripts/run-dist.mjs services/ghost-shell/cluster.ts`                      | Starts the Ghost Shell clustering process.                                |
-| `pnpm ghost-shell:server`        | `pnpm` | `node scripts/run-dist.mjs services/ghost-shell/server.ts`                       | Runs the Ghost Shell server entrypoint.                                   |
-| `pnpm generate:ghostshell-nginx` | `pnpm` | `node scripts/run-dist.mjs scripts/generate-ghostshell-nginx.ts`                 | Generates Nginx configuration for Ghost Shell deployments.                |
-| `pnpm audit:ui-vr`               | `pnpm` | `node scripts/run-dist.mjs scripts/ui-vr-audit.ts`                               | Audits UI and VR integration paths via Node runner.                       |
+| Command                                                                                                            | Type   | Runs                                                                             | Beschreibung                                                              |
+| ------------------------------------------------------------------------------------------------------------------ | ------ | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `pnpm dev`                                                                                                         | `pnpm` | `cross-env UI_DIST=http://localhost:5173 pnpm -F mandala-ui dev`                 | Starts the mandala-ui dev server with UI_DIST override.                   |
+| `pnpm dev:ui`                                                                                                      | `pnpm` | `pnpm -F mandala-ui dev`                                                         | Runs the UI workspace dev server without overrides.                       |
+| `pnpm dev:services`                                                                                                | `pnpm` | `tsx scripts/dev-server.ts`                                                      | Launches backend/dev services via the TypeScript dev server orchestrator. |
+| `pnpm dev:stack`                                                                                                   | `pnpm` | `node scripts/dev-services.mjs --mode=dev`                                       | Starts the dev stack orchestrator with default dev profiles.              |
+| `pnpm dev:breath`                                                                                                  | `pnpm` | `node scripts/emergence-breath.mjs`                                              |
+| Watches sigils/UI/scripts, reruns `validate:sigillins`, rebuilds the Trikāya dashboard, and prints coverage stats. |
+| `pnpm start`                                                                                                       | `pnpm` | `pnpm -s build:ui && pnpm -s dev`                                                | Builds the UI then launches the dev server.                               |
+| `pnpm start:light`                                                                                                 | `pnpm` | `pnpm -s build:ui && node scripts/light-static-server.mjs`                       | Serves the built UI via the light static Node server.                     |
+| `pnpm start:services`                                                                                              | `pnpm` | `pnpm -s build && NODE_ENV=production node scripts/dev-services.mjs --mode=prod` | Builds the workspace and starts services in production mode.              |
+| `pnpm start:all`                                                                                                   | `pnpm` | `pnpm dev:stack`                                                                 | Convenience alias to boot the full dev stack.                             |
+| `pnpm dev:voiceos`                                                                                                 | `pnpm` | `node scripts/run-dist.mjs scripts/voice-os-control-api.ts`                      | Launches the Voice OS control API for voice interaction workflows.        |
+| `pnpm ghost-shell:cluster`                                                                                         | `pnpm` | `node scripts/run-dist.mjs services/ghost-shell/cluster.ts`                      | Starts the Ghost Shell clustering process.                                |
+| `pnpm ghost-shell:server`                                                                                          | `pnpm` | `node scripts/run-dist.mjs services/ghost-shell/server.ts`                       | Runs the Ghost Shell server entrypoint.                                   |
+| `pnpm generate:ghostshell-nginx`                                                                                   | `pnpm` | `node scripts/run-dist.mjs scripts/generate-ghostshell-nginx.ts`                 | Generates Nginx configuration for Ghost Shell deployments.                |
+| `pnpm audit:ui-vr`                                                                                                 | `pnpm` | `node scripts/run-dist.mjs scripts/ui-vr-audit.ts`                               | Audits UI and VR integration paths via Node runner.                       |
 
 ## Smoke & Monitoring
 
 > Operational smoke tests and monitoring helpers.
 
-| Command                   | Type   | Runs                                                    | Beschreibung                                               |
-| ------------------------- | ------ | ------------------------------------------------------- | ---------------------------------------------------------- |
-| `pnpm smoke:ui`           | `pnpm` | `node scripts/smoke/ui-dev-smoke.mjs`                   | Performs smoke testing against the UI dev server.          |
-| `pnpm smoke:dev`          | `pnpm` | `node scripts/smoke/dev-server-smoke.mjs`               | Checks dev server readiness endpoints.                     |
-| `pnpm smoke:mrv`          | `pnpm` | `node scripts/smoke/mrv-smoke.mjs`                      | Executes MRV smoke validation routine.                     |
-| `pnpm smoke:light-static` | `pnpm` | `node scripts/smoke/light-static-smoke.mjs`             | Validates the light static server responses (Brotli/Gzip). |
-| `pnpm smoke:ttfb`         | `pnpm` | `pnpm -s build:ui && node scripts/smoke/ttfb-smoke.mjs` | Measures time-to-first-byte after building the UI.         |
-| `pnpm smoke:agents`       | `pnpm` | `node scripts/smoke/agents-smoke.mjs`                   | Runs smoke tests across agent services.                    |
+| Command                   | Type   | Runs                                                    | Beschreibung                                                                                                     |
+| ------------------------- | ------ | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `pnpm smoke:ui`           | `pnpm` | `node scripts/smoke/ui-dev-smoke.mjs`                   | Performs smoke testing against the UI dev server (respects `UI_DEV_URL` without spawning another Vite instance). |
+| `pnpm smoke:dev`          | `pnpm` | `node scripts/smoke/dev-server-smoke.mjs`               | Checks dev server readiness endpoints.                                                                           |
+| `pnpm smoke:mrv`          | `pnpm` | `node scripts/smoke/mrv-smoke.mjs`                      | Executes MRV smoke validation routine.                                                                           |
+| `pnpm smoke:light-static` | `pnpm` | `node scripts/smoke/light-static-smoke.mjs`             | Validates the light static server responses (Brotli/Gzip).                                                       |
+| `pnpm smoke:ttfb`         | `pnpm` | `pnpm -s build:ui && node scripts/smoke/ttfb-smoke.mjs` | Measures time-to-first-byte after building the UI.                                                               |
+| `pnpm smoke:agents`       | `pnpm` | `node scripts/smoke/agents-smoke.mjs`                   | Runs smoke tests across agent services.                                                                          |
 
 ## Agents & Emergence
 

--- a/docs/runbooks/command-catalog.yaml
+++ b/docs/runbooks/command-catalog.yaml
@@ -505,6 +505,14 @@ categories:
         description: 'Starts the dev stack orchestrator with default dev profiles.'
         source:
           - package.json#scripts.dev:stack
+      - id: runtime.dev-breath
+        name: 'Emergence breath watcher'
+        command: 'pnpm dev:breath'
+        type: pnpm
+        runs: 'node scripts/emergence-breath.mjs'
+        description: 'Watches sigils, apps/ui, and scripts to rerun `validate:sigillins`, rebuild the Trikāya dashboard, and print coverage metrics.'
+        source:
+          - package.json#scripts.dev:breath
       - id: runtime.start
         name: 'Start UI & dev'
         command: 'pnpm start'
@@ -586,7 +594,7 @@ categories:
         command: 'pnpm smoke:ui'
         type: pnpm
         runs: 'node scripts/smoke/ui-dev-smoke.mjs'
-        description: 'Performs smoke testing against the UI dev server.'
+        description: 'Performs smoke testing against the UI dev server and respects `UI_DEV_URL` without spawning a new Vite instance.'
         source:
           - package.json#scripts.smoke:ui
       - id: smoke.dev

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "start:all": "pnpm dev:stack",
     "dev:services": "tsx scripts/dev-server.ts",
     "dev:stack": "node scripts/dev-services.mjs --mode=dev",
+    "dev:breath": "node scripts/emergence-breath.mjs",
     "start:services": "pnpm -s build && NODE_ENV=production node scripts/dev-services.mjs --mode=prod",
     "docs:build": "typedoc",
     "docs:auto": "node scripts/generate-api-docs.js",

--- a/scripts/emergence-breath.mjs
+++ b/scripts/emergence-breath.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+import chokidar from 'chokidar';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const WATCH_PATHS = ['sigils', 'apps/ui', 'scripts'];
+const DASHBOARD_PATH = path.resolve('analysis/trikaya-dashboard.json');
+const CREP_MIN = Number.parseFloat(process.env.BREATH_CREP_MIN ?? '0.85');
+
+const log = (...args) => console.log('\n🌬️  emergence-breath:', ...args);
+const warn = (...args) => console.warn('\n⚠️  emergence-breath:', ...args);
+const error = (...args) => console.error('\n⛔  emergence-breath:', ...args);
+
+function runPnpm(command, args = []) {
+  return new Promise((resolve, reject) => {
+    const bin = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+    const child = spawn(bin, [command, ...args], {
+      stdio: 'inherit',
+      env: process.env,
+      shell: process.platform === 'win32',
+    });
+    child.on('error', (err) => {
+      reject(err);
+    });
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+let busy = false;
+let pending = false;
+
+async function analyseDashboard() {
+  try {
+    const raw = fs.readFileSync(DASHBOARD_PATH, 'utf8');
+    const dashboard = JSON.parse(raw);
+    const providers = Array.isArray(dashboard?.providers) ? dashboard.providers : [];
+    if (providers.length === 0) {
+      warn('Trikāya dashboard contains no providers yet.');
+      return;
+    }
+
+    const fullTrikaya = (record) => {
+      const layer = record?.trikaya ?? {};
+      return ['dharmakāya', 'sambhogakāya', 'nirmāṇakāya'].every((key) => Boolean(layer?.[key]));
+    };
+
+    const metrics = providers.reduce(
+      (acc, provider) => {
+        if (typeof provider?.averageCREP === 'number' && fullTrikaya(provider)) {
+          acc.covered += 1;
+          if (provider.averageCREP >= CREP_MIN) {
+            acc.crepAligned += 1;
+          }
+        }
+        if (provider?.nextActionRule) {
+          acc.nextAction += 1;
+        }
+        return acc;
+      },
+      { covered: 0, crepAligned: 0, nextAction: 0 },
+    );
+
+    const total = providers.length;
+    log(
+      `✨ Providers with full Trikāya coverage: ${metrics.covered}/${total} · ` +
+        `CREP≥${CREP_MIN.toFixed(2)}: ${metrics.crepAligned}/${total} · ` +
+        `Next action ready: ${metrics.nextAction}/${total}`,
+    );
+  } catch (err) {
+    warn(`Unable to read dashboard at ${DASHBOARD_PATH}: ${err.message}`);
+  }
+}
+
+async function cycle() {
+  if (busy) {
+    pending = true;
+    return;
+  }
+  busy = true;
+  try {
+    log('validate → trikāya dashboard');
+    await runPnpm('validate:sigillins');
+    await runPnpm('trikaya:dashboard');
+    await analyseDashboard();
+  } catch (err) {
+    error(err.message);
+  } finally {
+    busy = false;
+    if (pending) {
+      pending = false;
+      setImmediate(cycle);
+    }
+  }
+}
+
+const watcher = chokidar.watch(WATCH_PATHS, {
+  ignoreInitial: true,
+  awaitWriteFinish: {
+    stabilityThreshold: 200,
+    pollInterval: 100,
+  },
+});
+
+watcher.on('all', (event, filePath) => {
+  log(`change detected (${event}): ${filePath}`);
+  cycle();
+});
+
+watcher.on('error', (err) => {
+  error(`Watcher error: ${err.message}`);
+});
+
+log(`watching ${WATCH_PATHS.join(', ')} (Ctrl+C to stop)`);
+cycle();
+
+const shutdown = (signal) => {
+  warn(`received ${signal}, shutting down watcher`);
+  watcher
+    .close()
+    .catch((err) => error(`Failed to close watcher: ${err.message}`))
+    .finally(() => {
+      process.exit(signal === 'SIGINT' ? 130 : 143);
+    });
+};
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/scripts/smoke/ui-dev-smoke.mjs
+++ b/scripts/smoke/ui-dev-smoke.mjs
@@ -55,18 +55,75 @@ function logError(message) {
   console.error(`${LOG_PREFIX} ${message}`);
 }
 
-const child = spawn('pnpm', ['-s', 'dev:ui'], {
-  stdio: ['inherit', 'pipe', 'pipe'],
-  env: process.env,
-  shell: process.platform === 'win32',
-});
-
 let resolvedUrl = null;
 let fallbackCandidate = null;
 let fallbackTimer = null;
 let pollTimer = null;
 let timeoutTimer = null;
 let finished = false;
+let child = null;
+
+function startDevServer() {
+  if (child) return;
+  const pnpmBin = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+  child = spawn(pnpmBin, ['-s', 'dev:ui'], {
+    stdio: ['inherit', 'pipe', 'pipe'],
+    env: process.env,
+    shell: process.platform === 'win32',
+  });
+
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => {
+    process.stdout.write(chunk);
+    if (overrideUrl || resolvedUrl || finished) {
+      return;
+    }
+    const matches = stripAnsi(chunk).match(/https?:\/\/[^\s]+/g);
+    if (!matches) return;
+    let networkCandidate = null;
+    for (const raw of matches) {
+      const candidate = parseUrl(raw);
+      if (!candidate) continue;
+      const hostname = candidate.hostname.toLowerCase();
+      if (hostname === 'localhost' || hostname === '127.0.0.1') {
+        beginPolling(candidate, 'vite-output');
+        return;
+      }
+      if (!networkCandidate) {
+        networkCandidate = candidate;
+      }
+    }
+    if (networkCandidate && !fallbackCandidate) {
+      fallbackCandidate = networkCandidate;
+      fallbackTimer = setTimeout(() => {
+        if (!resolvedUrl && fallbackCandidate && !finished) {
+          beginPolling(fallbackCandidate, 'vite-network');
+        }
+      }, 300);
+    }
+  });
+
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk) => {
+    process.stderr.write(chunk);
+  });
+
+  child.on('error', (err) => {
+    if (!finished) {
+      finish(1, `Failed to launch dev server: ${err.message}`);
+    }
+  });
+
+  child.on('exit', (code, signal) => {
+    if (finished) return;
+    if (signal) {
+      finish(1, `Dev server terminated due to ${signal}`);
+      return;
+    }
+    const exitCode = code ?? 1;
+    finish(exitCode, `Dev server exited with code ${exitCode}`);
+  });
+}
 
 function clearTimers() {
   if (pollTimer) {
@@ -101,7 +158,7 @@ function finish(code, message) {
     }
   }
   try {
-    if (!child.killed) {
+    if (child && !child.killed) {
       child.kill('SIGTERM');
     }
   } catch {
@@ -140,62 +197,20 @@ function checkServer() {
   });
 }
 
-const override = (process.env.UI_DEV_URL ?? '').trim();
-if (override) {
-  const parsed = parseUrl(override);
-  if (!parsed) {
-    finish(1, `Invalid UI_DEV_URL override: ${override}`);
+const overrideRaw = (process.env.UI_DEV_URL ?? '').trim();
+const overrideUrl = overrideRaw ? parseUrl(overrideRaw) : null;
+if (overrideRaw) {
+  if (!overrideUrl) {
+    finish(1, `Invalid UI_DEV_URL override: ${overrideRaw}`);
   } else {
-    log(`Using UI_DEV_URL override: ${parsed.href}`);
-    beginPolling(parsed, 'UI_DEV_URL');
+    log(`Using UI_DEV_URL override: ${overrideUrl.href}`);
+    beginPolling(overrideUrl, 'UI_DEV_URL');
   }
 }
 
-child.stdout.setEncoding('utf8');
-child.stdout.on('data', (chunk) => {
-  process.stdout.write(chunk);
-  if (override || resolvedUrl || finished) {
-    return;
-  }
-  const matches = stripAnsi(chunk).match(/https?:\/\/[^\s]+/g);
-  if (!matches) return;
-  let networkCandidate = null;
-  for (const raw of matches) {
-    const candidate = parseUrl(raw);
-    if (!candidate) continue;
-    const hostname = candidate.hostname.toLowerCase();
-    if (hostname === 'localhost' || hostname === '127.0.0.1') {
-      beginPolling(candidate, 'vite-output');
-      return;
-    }
-    if (!networkCandidate) {
-      networkCandidate = candidate;
-    }
-  }
-  if (networkCandidate && !fallbackCandidate) {
-    fallbackCandidate = networkCandidate;
-    fallbackTimer = setTimeout(() => {
-      if (!resolvedUrl && fallbackCandidate && !finished) {
-        beginPolling(fallbackCandidate, 'vite-network');
-      }
-    }, 300);
-  }
-});
-
-child.stderr.setEncoding('utf8');
-child.stderr.on('data', (chunk) => {
-  process.stderr.write(chunk);
-});
-
-child.on('exit', (code, signal) => {
-  if (finished) return;
-  if (signal) {
-    finish(1, `Dev server terminated due to ${signal}`);
-    return;
-  }
-  const exitCode = code ?? 1;
-  finish(exitCode, `Dev server exited with code ${exitCode}`);
-});
+if (!overrideUrl) {
+  startDevServer();
+}
 
 process.on('SIGINT', () => {
   finish(130, 'Received SIGINT');


### PR DESCRIPTION
## Summary
- add scripts/emergence-breath.mjs and expose it via the new pnpm dev:breath command
- make the UI smoke script honour UI_DEV_URL overrides instead of spawning a second dev server
- refresh the command catalog, MandalaMap, stabilization playbook, and codexfeedback artifacts to document the new workflow

## Testing
- pnpm lint *(fails: existing unused variable violations in legacy scripts)*
- npx eslint scripts/emergence-breath.mjs scripts/smoke/ui-dev-smoke.mjs

------
https://chatgpt.com/codex/tasks/task_e_68ceae3f12d48322acbd03b26cab8cdd