### PR TITLE
chore(policy): wire sigillin reports into policy suite

### DIFF
--- a/.github/workflows/ci.core.yml
+++ b/.github/workflows/ci.core.yml
@@ -57,5 +57,16 @@ jobs:
       - run: pnpm nats:doctor
       - run: pnpm test:ts:ci
       - run: pnpm test:jetstream
+      - name: Run Vitest coverage
+        run: |
+          rm -rf coverage
+          pnpm test:unit
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-vitest
+          path: coverage/
+          if-no-files-found: ignore
       - run: pnpm test:py
       - run: npx pyright

--- a/.github/workflows/policy-check.yml
+++ b/.github/workflows/policy-check.yml
@@ -40,6 +40,13 @@ jobs:
           name: policy-suite-report
           path: out/policy/
           if-no-files-found: ignore
+      - name: Upload sigillin governance reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: policy-sigillins
+          path: out/policy/sigillins/
+          if-no-files-found: ignore
       - name: Fail on policy violations
         if: always()
         run: |

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,5 @@
 . "$(dirname "$0")/_/husky.sh"
 
 pnpm store:commit-memory >/dev/null 2>&1 || true
+pnpm validate:sigillins:changed
 pnpm lint-staged

--- a/MandalaMap.json
+++ b/MandalaMap.json
@@ -100,7 +100,9 @@
         "Core/extended workflows documented in docs/roadmap/v1.0-stabilization-playbook.md.",
         "Sigillin validator is required on main; mandala-map workflow uploads artifacts without blocking CI.",
         "Repo Sanity builds the UI dist and waits on apps/ui/dist/index.html before running map/audit checks to avoid race conditions.",
-        "CI-Core startet einen Docker-basierten NATS-Server und ruft `pnpm nats:doctor` sowie `pnpm test:jetstream` im type-and-tests-Gate auf (Fraktal57)."
+        "CI-Core startet einen Docker-basierten NATS-Server und ruft `pnpm nats:doctor` sowie `pnpm test:jetstream` im type-and-tests-Gate auf (Fraktal57).",
+        "CI-Core erzeugt Coverage via `pnpm test:unit` und publiziert das Artefakt `coverage-vitest`.",
+        "`policy-check.yml` lädt Sigillin-Governance-Berichte als separates GitHub-Artefakt `policy-sigillins`."
       ],
       "links": [
         {
@@ -586,7 +588,9 @@
       "status": "generated",
       "title": "Generated outputs",
       "description": "Build artifacts such as sigillin_index.json and validation error exports.",
-      "notes": ["Cleared/rebuilt by validation scripts (pnpm validate:sigillins, etc.)."],
+      "notes": [
+        "Cleared/rebuilt by validation scripts (pnpm validate:sigillins, etc.); pnpm policy:check legt Sigillin-Reports unter out/policy/sigillins/ ab."
+      ],
       "links": []
     },
     {
@@ -719,7 +723,9 @@
         "ParserFix: (Test-CommandExists ...) jetzt geklammert und Installationsresultate werden zu Bool gecastet, damit PowerShell 7.5 den Dev-Setup ohne ParserError ausführt.",
         "Emergence-Breath (scripts/emergence-breath.mjs) koppelt pnpm dev:breath an validate:sigillins + trikaya:dashboard und meldet Coverage-Metriken nach jedem Lauf.",
         "Dev-Stack prüft Ports automatisch, räumt Standard-Ports via `pnpm dlx kill-port` auf (Opt-out: `UM_DEV_SERVICES_AUTOFREE_PORTS=0`) und verweist bei Bedarf auf `pnpm dev:ports:free`.",
-        "`scripts/nats-doctor.mjs` liefert JetStream-Hinweise (fehlendes `-js`, Timeout, Berechtigungen) und `scripts/nats-docker.mjs` startet bzw. überwacht JetStream-Container für lokale Tests."
+        "`scripts/nats-doctor.mjs` liefert JetStream-Hinweise (fehlendes `-js`, Timeout, Berechtigungen) und `scripts/nats-docker.mjs` startet bzw. überwacht JetStream-Container für lokale Tests.",
+        "Git-Hook-Validator (scripts/sigillins-validate-changed.mjs) prüft nur geänderte Bridges vor dem Commit.",
+        "Governance-Reports (scripts/sigillins-generate-reports.mjs) erzeugen JUnit-XML und Markdown für Policy-Auswertungen; pnpm policy:check schreibt die Artefakte automatisch nach out/policy/sigillins/."
       ],
       "links": [
         {
@@ -745,6 +751,14 @@
         {
           "label": "emergence-breath",
           "path": "scripts/emergence-breath.mjs"
+        },
+        {
+          "label": "sigillins-validate-changed",
+          "path": "scripts/sigillins-validate-changed.mjs"
+        },
+        {
+          "label": "sigillins-generate-reports",
+          "path": "scripts/sigillins-generate-reports.mjs"
         }
       ]
     },

--- a/MandalaMap.md
+++ b/MandalaMap.md
@@ -68,7 +68,7 @@ Repository: unified-mandala
 
 - `.github/` — **active** GitHub workflows & templates
   - Workflow definitions (core, nightly, experimental) and community health files.
-  - Notes: Audit instructions encoded as jobs; isolate non-actionable tasks to stop false CI failures.; Core/extended workflows documented in docs/roadmap/v1.0-stabilization-playbook.md.; Sigillin validator is required on main; mandala-map workflow uploads artifacts without blocking CI.; Repo Sanity builds the UI dist and waits on apps/ui/dist/index.html before running map/audit checks to avoid race conditions.; CI-Core startet einen Docker-basierten NATS-Server und ruft `pnpm nats:doctor` + `pnpm test:jetstream` im type-and-tests-Gate auf (Fraktal57).
+  - Notes: Audit instructions encoded as jobs; isolate non-actionable tasks to stop false CI failures.; Core/extended workflows documented in docs/roadmap/v1.0-stabilization-playbook.md.; Sigillin validator is required on main; mandala-map workflow uploads artifacts without blocking CI.; Repo Sanity builds the UI dist and waits on apps/ui/dist/index.html before running map/audit checks to avoid race conditions.; CI-Core startet einen Docker-basierten NATS-Server und ruft `pnpm nats:doctor` + `pnpm test:jetstream` im type-and-tests-Gate auf (Fraktal57). CI-Core erzeugt zusätzlich Coverage via `pnpm test:unit` (Artefakt `coverage-vitest`), und `policy-check.yml` veröffentlicht die Sigillin-Governance als separates Artefakt `policy-sigillins`.
   - Links: [CI Core](.github/workflows/ci.core.yml), [Nightly Mirror](.github/workflows/ci.nightly.yml), [Sigillin validate](.github/workflows/sigillin-validate.yml), [Mandala map job](.github/workflows/mandala-map.yml)
 
 - `.husky/` — **active** Git hooks
@@ -147,7 +147,7 @@ Repository: unified-mandala
 
 - `scripts/` — **active** Automation scripts
   - Extensive Node/TS automation: dev servers, exports, QA, smoke tests, repo map, etc.
-- Notes: Dist-first convention via scripts/run-dist.mjs; Sigillin-Fix-CLI (`scripts/fix-sigillin.ts`) ergänzt Bridge-Tooling; Windows-Parität via `scripts/setup-dev-env.ps1` + `scripts/run-powershell.mjs` dokumentiert; PowerShell-Setup exportiert Installationsstatus nach `out/setup/install-state.json`; ParserFix `(Test-CommandExists ...)` + Bool-Cast heben PowerShell 7.5 ParserError auf; Corepack-Admin-Check vermeidet EPERM und liefert Benutzeraktivierung samt NATS-Installationshinweis; Emergence-Breath (`scripts/emergence-breath.mjs`) koppelt `pnpm dev:breath` an `validate:sigillins` + Trikāya-Dashboard und protokolliert Coverage-Metriken; Dev-Stack prüft Ports automatisch, räumt Standard-Ports via `pnpm dlx kill-port` auf (Opt-out: `UM_DEV_SERVICES_AUTOFREE_PORTS=0`) und verweist bei Bedarf auf `pnpm dev:ports:free`; `scripts/nats-doctor.mjs` liefert JetStream-Hinweise (fehlendes `-js`, Timeout, Berechtigungen) und `scripts/nats-docker.mjs` startet bzw. überwacht JetStream-Container für lokale Tests.
+- Notes: Dist-first convention via scripts/run-dist.mjs; Sigillin-Fix-CLI (`scripts/fix-sigillin.ts`) ergänzt Bridge-Tooling; Windows-Parität via `scripts/setup-dev-env.ps1` + `scripts/run-powershell.mjs` dokumentiert; PowerShell-Setup exportiert Installationsstatus nach `out/setup/install-state.json`; ParserFix `(Test-CommandExists ...)` + Bool-Cast heben PowerShell 7.5 ParserError auf; Corepack-Admin-Check vermeidet EPERM und liefert Benutzeraktivierung samt NATS-Installationshinweis; Emergence-Breath (`scripts/emergence-breath.mjs`) koppelt `pnpm dev:breath` an `validate:sigillins` + Trikāya-Dashboard und protokolliert Coverage-Metriken; Dev-Stack prüft Ports automatisch, räumt Standard-Ports via `pnpm dlx kill-port` auf (Opt-out: `UM_DEV_SERVICES_AUTOFREE_PORTS=0`) und verweist bei Bedarf auf `pnpm dev:ports:free`; `scripts/nats-doctor.mjs` liefert JetStream-Hinweise (fehlendes `-js`, Timeout, Berechtigungen) und `scripts/nats-docker.mjs` startet bzw. überwacht JetStream-Container für lokale Tests; staged Bridge-Checks laufen via `scripts/sigillins-validate-changed.mjs`, Governance-Reports (`JUnit`/Markdown) entstehen durch `scripts/sigillins-generate-reports.mjs` und werden über `pnpm policy:check` nach `out/policy/sigillins/` geschrieben.
   - Links: [run-dist](scripts/run-dist.mjs), [dev-services](scripts/dev-services.mjs), [sigil-fix](scripts/fix-sigillin.ts), [setup-dev-env.ps1](scripts/setup-dev-env.ps1), [run-powershell](scripts/run-powershell.mjs)
 
 - `tasks/` — **active** Task manifests
@@ -222,7 +222,7 @@ Repository: unified-mandala
 
 - `out/` — **generated** Generated outputs
   - Build artifacts such as sigillin_index.json and validation error exports.
-  - Notes: Cleared/rebuilt by validation scripts (pnpm validate:sigillins, etc.).
+- Notes: Cleared/rebuilt by validation scripts (pnpm validate:sigillins, etc.); `pnpm policy:check` legt Sigillin-Reports unter `out/policy/sigillins/` ab.
 
 - `pipelines/` — **active** Pipeline manifests
   - Pipelines (e.g., universe_pulse.yaml) orchestrating data/analysis flows.

--- a/MandalaMap.yaml
+++ b/MandalaMap.yaml
@@ -108,6 +108,8 @@ entries:
       - CI-Core startet einen Docker-basierten NATS-Server und ruft `pnpm
         nats:doctor` sowie `pnpm test:jetstream` im type-and-tests-Gate auf
         (Fraktal57).
+      - 'CI-Core erzeugt Coverage via `pnpm test:unit` und publiziert das Artefakt `coverage-vitest`.'
+      - '`policy-check.yml` lädt Sigillin-Governance-Berichte als separates GitHub-Artefakt `policy-sigillins`.'
     links:
       - label: CI Core
         path: .github/workflows/ci.core.yml
@@ -507,7 +509,9 @@ entries:
     title: Generated outputs
     description: Build artifacts such as sigillin_index.json and validation error exports.
     notes:
-      - Cleared/rebuilt by validation scripts (pnpm validate:sigillins, etc.).
+      - Cleared/rebuilt by validation scripts (pnpm validate:sigillins, etc.);
+        `pnpm policy:check` legt Sigillin-Reports unter `out/policy/sigillins/`
+        ab.
     links: []
   - path: packages/
     category: core-runtime
@@ -643,6 +647,11 @@ entries:
       - '`scripts/nats-doctor.mjs` liefert JetStream-Hinweise (fehlendes `-js`,
         Timeout, Berechtigungen) und `scripts/nats-docker.mjs` startet bzw.
         überwacht JetStream-Container für lokale Tests.'
+      - Git-Hook-Validator (`scripts/sigillins-validate-changed.mjs`) prüft nur
+        geänderte Bridges vor dem Commit.
+      - Governance-Reports (`scripts/sigillins-generate-reports.mjs`) erzeugen
+        JUnit-XML und Markdown für Policy-Auswertungen; `pnpm policy:check`
+        schreibt die Artefakte automatisch nach `out/policy/sigillins/`.
     links:
       - label: run-dist
         path: scripts/run-dist.mjs

--- a/codexfeedback-fraktal59.yaml
+++ b/codexfeedback-fraktal59.yaml
@@ -1,0 +1,38 @@
+fraktal: 59
+status: done
+owner: ChefDevAI
+summary:
+  - 'Shared sigillin validator logic lives in scripts/lib/sigillin-validator.mjs; validate-sigillins.mjs
+    now wraps the module and exposes structured results for other tooling.'
+  - 'New CLI scripts validate staged bridges (scripts/sigillins-validate-changed.mjs)
+    and generate JUnit + Markdown governance reports (scripts/sigillins-generate-reports.mjs);
+    package.json & Husky hook invoke them via pnpm validate:sigillins:changed and pnpm
+    sigillins:report.'
+  - 'Command catalog + MandalaMap entries updated to document the staged validator, reporting
+    workflow, and link to the new scripts (including MandalaMap.* links).'
+deliverables:
+  - scripts/lib/sigillin-validator.mjs
+  - scripts/validate-sigillins.mjs
+  - scripts/sigillins-validate-changed.mjs
+  - scripts/sigillins-generate-reports.mjs
+  - package.json
+  - .husky/pre-commit
+  - docs/runbooks/command-catalog.md
+  - docs/runbooks/command-catalog.yaml
+  - docs/runbooks/command-catalog.json
+  - MandalaMap.md
+  - MandalaMap.yaml
+  - MandalaMap.json
+follow_up:
+  governance_report_ci:
+    description: Wire pnpm sigillins:report into CI governance pipeline and archive
+      reports as build artifacts. (Artefakte landen jetzt unter out/policy/sigillins/).
+    status: done
+hook:
+  progress: |
+    Staged sigillin changes are auto-validated before commit and governance
+    reviewers get ready-to-consume JUnit/Markdown summaries.
+  next_step: |
+    Optional: CI-Artefakt-Upload für die Sigillin-Reports evaluieren oder in
+    PR-Kommentaren verlinken.
+repeat_required: false

--- a/codexfeedback-fraktal60.yaml
+++ b/codexfeedback-fraktal60.yaml
@@ -1,0 +1,29 @@
+fraktal: 60
+status: done
+owner: ChefDevAI
+summary:
+  - 'Policy suite integriert Sigillin-Governance: `scripts/policy-suite.mjs` ruft `pnpm sigillins:report` auf und legt JUnit/Markdown unter `out/policy/sigillins/` ab.'
+  - 'Docs (docs/governance/policy-suite.md, Command-Catalog, MandalaMap, Stabilization-Playbook) beschreiben den neuen Speicherort sowie `POLICY_SUITE_SKIP_SIGILLINS`.'
+  - 'Codexfeedback-Tracker auf Fraktal60 gehoben, Follow-up "governance_report_ci" abgeschlossen.'
+deliverables:
+  - scripts/policy-suite.mjs
+  - docs/governance/policy-suite.md
+  - docs/runbooks/command-catalog.md
+  - docs/runbooks/command-catalog.yaml
+  - docs/runbooks/command-catalog.json
+  - docs/roadmap/v1.0-stabilization-playbook.md
+  - docs/roadmap/v1.0-stabilization-playbook.yaml
+  - MandalaMap.md
+  - MandalaMap.yaml
+  - MandalaMap.json
+  - codexfeedback.md
+  - codexfeedback.json
+  - codexfeedback.yaml
+commands:
+  - pnpm policy:check
+  - pnpm sigillins:report --out-dir out/policy/sigillins
+notes:
+  skip_flags:
+    - name: POLICY_SUITE_SKIP_SIGILLINS
+      description: Kann Sigillin-Report-Läufe bewusst überspringen (lokale Schnelltests)
+repeat_required: false

--- a/codexfeedback-fraktal61.yaml
+++ b/codexfeedback-fraktal61.yaml
@@ -1,0 +1,28 @@
+fraktal: 61
+status: done
+owner: ChefDevAI
+summary:
+  - 'ci.core führt `pnpm test:unit` mit Coverage aus und veröffentlicht das Artefakt `coverage-vitest`.'
+  - 'policy-check.yml lädt Sigillin-Governance-Reports zusätzlich als GitHub-Artefakt `policy-sigillins`.'
+  - 'Command-Catalog, MandalaMap und Stabilization-Playbook dokumentieren die neuen CI-Artefakte.'
+deliverables:
+  - .github/workflows/ci.core.yml
+  - .github/workflows/policy-check.yml
+  - docs/governance/policy-suite.md
+  - docs/roadmap/v1.0-stabilization-playbook.md
+  - docs/roadmap/v1.0-stabilization-playbook.yaml
+  - docs/runbooks/command-catalog.md
+  - docs/runbooks/command-catalog.yaml
+  - docs/runbooks/command-catalog.json
+  - MandalaMap.md
+  - MandalaMap.yaml
+  - MandalaMap.json
+  - codexfeedback-fraktal61.yaml
+  - codexfeedback.md
+  - codexfeedback.json
+  - codexfeedback.yaml
+follow_up:
+  coverage_gate:
+    description: 'Coverage-Schwellenwerte prüfen und bei Stabilität als ci.core-Gate aktivieren.'
+    status: planned
+repeat_required: false

--- a/codexfeedback.json
+++ b/codexfeedback.json
@@ -1,6 +1,21 @@
 {
   "runs": [
     {
+      "fraktalrun": "Fraktal61 CIArtifacts",
+      "status": "implemented",
+      "notes": "ci.core runs `pnpm test:unit` with coverage and uploads the `coverage-vitest` artifact; policy-check.yml publishes sigillin governance as a dedicated `policy-sigillins` artifact; docs (command catalog, MandalaMap, stabilization playbook, policy suite) highlight the new outputs."
+    },
+    {
+      "fraktalrun": "Fraktal60 PolicySuiteSigillin",
+      "status": "implemented",
+      "notes": "policy-suite.mjs now invokes pnpm sigillins:report, storing JUnit/Markdown outputs in out/policy/sigillins/; docs (policy-suite, command catalog, MandalaMap, stabilization playbook) highlight the new reports and the POLICY_SUITE_SKIP_SIGILLINS flag."
+    },
+    {
+      "fraktalrun": "Fraktal59 SigillinGovernance",
+      "status": "implemented",
+      "notes": "Shared validator module (scripts/lib/sigillin-validator.mjs) powers validate-sigillins + new CLIs; staged bridge checks run via pnpm validate:sigillins:changed and pnpm sigillins:report emits JUnit/Markdown summaries. Command catalog and MandalaMap link to the new tooling."
+    },
+    {
       "fraktalrun": "Fraktal58 AdapterHardening",
       "status": "implemented",
       "notes": "xarray helper prefers netcdf4/h5netcdf, closes datasets cleanly and emits file:// URIs in STAC assets; ghostshell nginx config now generates ${PORT_BASE:-3000} style placeholders by default with an opt-out; Node utility scripts run as ES modules and @vitest/coverage-v8 aligns with vitest 1.6.x."

--- a/codexfeedback.md
+++ b/codexfeedback.md
@@ -1,5 +1,16 @@
 # Codex Feedback
 
+- FR-UM-2025-10-25-Fraktal61-CIArtifacts: ci.core führt `pnpm test:unit` mit Coverage aus und lädt das Artefakt `coverage-vitest`; policy-check.yml publiziert die Sigillin-Governance separat als `policy-sigillins`; Command-Catalog, MandalaMap und das Stabilization-Playbook verweisen auf die neuen CI-Artefakte.
+- FR-UM-2025-10-24-Fraktal60-PolicySuiteSigillin: `pnpm policy:check` ruft jetzt
+  `pnpm sigillins:report` auf, legt JUnit-/Markdown-Reports unter
+  `out/policy/sigillins/` ab und dokumentiert den Skip-Flag
+  `POLICY_SUITE_SKIP_SIGILLINS`; Policy-Suite-Doku, Command-Catalog,
+  MandalaMap.\* und das Stabilization-Playbook verweisen auf den neuen Pfad.
+- FR-UM-2025-10-23-Fraktal59-SigillinGovernance: Validatorlogik steckt jetzt in
+  `scripts/lib/sigillin-validator.mjs`, `pnpm validate:sigillins:changed` prüft
+  geänderte Bridges vor dem Commit und `pnpm sigillins:report` erzeugt JUnit- und
+  Markdown-Governance-Reports; Command-Catalog und MandalaMap verlinken die neuen
+  Workflows.
 - FR-UM-2025-10-22-Fraktal58-AdapterHardening: NetCDF-Pipelines nutzen
   `adapters.shared.xarray_utils.open_dataset` mit Engine-Fallback (netcdf4/h5netcdf),
   schließen Datensätze sauber und STAC-Assets liefern `file://`-URIs; das

--- a/codexfeedback.yaml
+++ b/codexfeedback.yaml
@@ -1,6 +1,86 @@
 fraktal:
-  current: 58
+  current: 61
   history:
+    - id: 61
+      status: done
+      notes: |
+        Fraktal61 CIArtifacts: ci.core führt nun `pnpm test:unit` mit Coverage aus und veröffentlicht das Artefakt `coverage-vitest`; policy-check.yml lädt die Sigillin-Governance separat als GitHub-Artefakt `policy-sigillins`. Dokumentation (Command-Catalog, MandalaMap, Stabilization-Playbook) beschreibt die neuen Artefakte.
+      deliverables:
+        - .github/workflows/ci.core.yml
+        - .github/workflows/policy-check.yml
+        - docs/governance/policy-suite.md
+        - docs/roadmap/v1.0-stabilization-playbook.md
+        - docs/roadmap/v1.0-stabilization-playbook.yaml
+        - docs/runbooks/command-catalog.md
+        - docs/runbooks/command-catalog.yaml
+        - docs/runbooks/command-catalog.json
+        - MandalaMap.md
+        - MandalaMap.yaml
+        - MandalaMap.json
+        - codexfeedback-fraktal61.yaml
+        - codexfeedback.md
+        - codexfeedback.json
+        - codexfeedback.yaml
+      hook:
+        progress: Coverage- und Sigillin-Artefakte werden jetzt automatisch in den CI-Workflows veröffentlicht.
+        next_step: Coverage-Schwellenwerte evaluieren und optional als Gate in ci.core verankern.
+    - id: 60
+      status: done
+      notes: |
+        Fraktal60 PolicySuiteSigillin: `scripts/policy-suite.mjs` ruft jetzt
+        `pnpm sigillins:report` auf, legt JUnit/Markdown unter
+        `out/policy/sigillins/` ab und vermerkt die Artefakte im JSON-Payload;
+        Docs (Policy-Suite, Command-Catalog, MandalaMap, Playbook) zeigen den
+        neuen Pfad und vermerken den Skip-Schalter
+        `POLICY_SUITE_SKIP_SIGILLINS`.
+      deliverables:
+        - scripts/policy-suite.mjs
+        - docs/governance/policy-suite.md
+        - docs/runbooks/command-catalog.md
+        - docs/runbooks/command-catalog.yaml
+        - docs/runbooks/command-catalog.json
+        - docs/roadmap/v1.0-stabilization-playbook.md
+        - docs/roadmap/v1.0-stabilization-playbook.yaml
+        - MandalaMap.md
+        - MandalaMap.yaml
+        - MandalaMap.json
+        - codexfeedback-fraktal60.yaml
+        - codexfeedback.md
+        - codexfeedback.json
+        - codexfeedback.yaml
+      hook:
+        progress: Policy suite Artefakte enthalten jetzt Sigillin-Reports unter
+          out/policy/sigillins/; Governance hat eine einheitliche Ablagestelle.
+        next_step: CI policy-check Workflow optional erweitern, um die
+          Sigillin-Reports als Upload-Artefakt zu veröffentlichen.
+    - id: 59
+      status: done
+      notes: |
+        Fraktal59 SigillinGovernance: validatorlogik wurde in
+        scripts/lib/sigillin-validator.mjs zentralisiert; validate-sigillins.mjs
+        nutzt den Helper und neue CLIs prüfen nur geänderte Bridges bzw.
+        generieren JUnit/Markdown-Reports für Governance-Flows. Husky ruft
+        `pnpm validate:sigillins:changed` vor lint-staged auf und `pnpm
+        sigillins:report` liefert Berichte, Command-Catalog + MandalaMap
+        dokumentieren den Flow samt Link auf die neuen Skripte.
+      deliverables:
+        - scripts/lib/sigillin-validator.mjs
+        - scripts/validate-sigillins.mjs
+        - scripts/sigillins-validate-changed.mjs
+        - scripts/sigillins-generate-reports.mjs
+        - package.json
+        - .husky/pre-commit
+        - docs/runbooks/command-catalog.md
+        - docs/runbooks/command-catalog.yaml
+        - docs/runbooks/command-catalog.json
+        - MandalaMap.md
+        - MandalaMap.yaml
+        - MandalaMap.json
+      hook:
+        progress: Git-Hooks prüfen Sigillin-Änderungen automatisch und Governance
+          erhält JUnit/Markdown-Reports ohne manuellen Schritt.
+        next_step: sigillins:report in CI policy:check einhängen und Reports als
+          Artefakt publizieren.
     - id: 58
       status: done
       notes: |

--- a/docs/governance/policy-suite.md
+++ b/docs/governance/policy-suite.md
@@ -4,11 +4,12 @@ Die **Policy Suite** bündelt alle Governance-Prüfungen (OPA, Kyverno und Guard
 
 ## Komponenten
 
-| Check           | Zweck                                                                                                                          | Quelle                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| OPA Governance  | Bewertet `policies/governance.rego` gegen `fixtures/events/example_input.json`. Liefert `allow=true` oder verweigert den Lauf. | `tools/opa-check.mjs`                                                      |
-| Kyverno Dry-Run | Führt `policies/kyverno.yaml` als Dry-Run gegen das gleiche Fixture aus und meldet Policy-Abweichungen.                        | GitHub Action [`kyverno/action@v0.4.0`](https://github.com/kyverno/action) |
-| Guardrails      | Überwacht Merge-Policies (z. B. „Policy-Änderungen benötigen Docs“) gegen den letzten Commit.                                  | `tools/governance-guardrails.mjs`                                          |
+| Check               | Zweck                                                                                                                          | Quelle                                                                     |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| OPA Governance      | Bewertet `policies/governance.rego` gegen `fixtures/events/example_input.json`. Liefert `allow=true` oder verweigert den Lauf. | `tools/opa-check.mjs`                                                      |
+| Kyverno Dry-Run     | Führt `policies/kyverno.yaml` als Dry-Run gegen das gleiche Fixture aus und meldet Policy-Abweichungen.                        | GitHub Action [`kyverno/action@v0.4.0`](https://github.com/kyverno/action) |
+| Guardrails          | Überwacht Merge-Policies (z. B. „Policy-Änderungen benötigen Docs“) gegen den letzten Commit.                                  | `tools/governance-guardrails.mjs`                                          |
+| Sigillin Governance | Validiert Bridge-Sigillins und erzeugt Governance-Reports (JUnit + Markdown) in `out/policy/sigillins/`.                       | `pnpm sigillins:report` (via `pnpm policy:check`)                          |
 
 ## CLI für lokale Dry-Runs
 
@@ -17,6 +18,7 @@ pnpm policy:check
 ```
 
 - Führt OPA, Guardrails **und** den neuen Kyverno-Dry-Run-Fallback (`tools/kyverno-dry-run.mjs`) identisch zur CI aus.
+- Generiert zusätzlich Sigillin-Governance-Reports über `pnpm sigillins:report` (JUnit + Markdown) in `out/policy/sigillins/`.
 - Schreibt Logs und ein JSON-Ergebnis nach `out/policy/` (ignored).
 - Fehlende OPA-Binaries oder Docker werden als `Skipped` ausgewiesen – der Bericht markiert dies transparent.
 - Der Kyverno-Fallback kann separat getestet werden:
@@ -32,6 +34,9 @@ pnpm policy:check
 - `out/policy/policy-suite.json` – maschinenlesbare Ergebnisse.
 - `out/policy/policy-suite-report.md` – Zusammenfassung, die auch im GitHub Step Summary landet.
 - `out/policy/policy-suite-status.txt` – Enthält `passed` oder `failed`; der Workflow verwendet diese Datei, um den Lauf zu beenden.
+- `out/policy/sigillins/sigillins-junit-report.xml` – JUnit-kompatibler Export der Sigillin-Prüfungen.
+- `out/policy/sigillins/sigillins-report.md` – Markdown-Übersicht (Provider, CREP-Mittelwert, Trikāya-Abdeckung, Fehlerdetails).
+- GitHub-Artefakt `policy-sigillins` – Kopie der Sigillin-Governance-Reports für den direkten Download aus der Workflow-Ansicht.
 
 ## GitHub Workflow
 
@@ -40,13 +45,15 @@ pnpm policy:check
 1. Installation der Abhängigkeiten (Node 20 + pnpm 10.16.1).
 2. `pnpm policy:check` (OPA + Guardrails) wird tolerant (`continue-on-error`) ausgeführt, damit anschließend der Bericht erstellt werden kann.
 3. Kyverno läuft als dedizierter Schritt (ebenfalls tolerant).
-4. `scripts/render-policy-suite-report.mjs` fasst beide Ergebnisse zusammen, aktualisiert Markdown + JSON und signalisiert Erfolg/Misserfolg über `policy-suite-status.txt`.
-5. Der letzte Schritt beendet den Job hart, sobald ein Ergebnis `failed` meldet – keine `continue-on-error`-Schleifen mehr.
+4. Der Policy-Runner ruft intern `pnpm sigillins:report --out-dir out/policy/sigillins` auf; der Workflow lädt die erzeugten Dateien zusätzlich als separates Artefakt (`policy-sigillins`) hoch.
+5. `scripts/render-policy-suite-report.mjs` fasst die Ergebnisse zusammen, aktualisiert Markdown + JSON und signalisiert Erfolg/Misserfolg über `policy-suite-status.txt`.
+6. Der letzte Schritt beendet den Job hart, sobald ein Ergebnis `failed` meldet – keine `continue-on-error`-Schleifen mehr.
 
 ## Hinweise & TODOs
 
 - Der lokale Fallback (`pnpm kyverno:validate`) kann bei Bedarf durch ein echtes CLI/Docker-Setup ersetzt werden (`POLICY_SUITE_SKIP_KYVERNO=1` deaktiviert den Node-Fallback für eigene Experimente).
 - Bei Policy-Änderungen unbedingt eine erläuternde Dokumentation im gleichen PR aktualisieren – die Guardrails achten darauf.
 - Die Summary-Datei eignet sich als Anhang für Fraktal-Protokolle oder Release-Notes (kopieren aus `out/policy/policy-suite-report.md`).
+- Sigillin-Reports lassen sich für schnelle Tests deaktivieren (`POLICY_SUITE_SKIP_SIGILLINS=1`), z. B. wenn lokal keine Bridge-Artefakte vorliegen.
 
 Damit ist der Governance-Check zentralisiert, transparent und CI-fest – im Sinne der Fraktalvorgabe „Stabilität vor Features“.

--- a/docs/roadmap/v1.0-stabilization-playbook.md
+++ b/docs/roadmap/v1.0-stabilization-playbook.md
@@ -79,13 +79,15 @@ Dieses Playbook übersetzt die Ergebnisse des Fraktal40-Entwicklungsgesprächs i
 2. **Extended Suites**
    - `pnpm test:ts:extended` und `pnpm test:py:extended` weiterhin offline fahren; Flakes markieren (`pytest -m slow`) und nightly triggern.
 3. **Coverage & Reporting**
-   - Coverage-Bericht nur aktivieren, wenn Core stabil; optional `vitest --coverage` in Extended-Läufen.
+   - `ci.core` führt `pnpm test:unit` mit Vitest-Coverage aus und veröffentlicht den `coverage/`-Ordner als Artefakt (`coverage-vitest`).
 
 ## 5. Governance & Policy Checks
 
 1. **Policy-Suite bündeln**
    - `scripts/policy-suite.mjs` um Kyverno CLI (`pnpm kyverno:validate`) erweitern und einheitliches JSON/Markdown-Reporting in `out/policy/` erzeugen.【F:scripts/policy-suite.mjs†L13-L141】【F:tools/kyverno-dry-run.mjs†L1-L200】
    - Ergebnisse als GitHub Check zusammenführen (OPA, Guardrails, Kyverno) und in `policy:check` Script einbinden.【F:package.json†L109-L146】【F:.github/workflows/ci.experimental.yml†L1-L56】
+   - _Status 2025-10-24:_ `pnpm policy:check` ruft `pnpm sigillins:report` auf und legt JUnit + Markdown unter `out/policy/sigillins/` ab; Reports landen gemeinsam mit OPA/Guardrails/Kyverno im Policy-Artefakt.
+   - _Status 2025-10-25:_ `policy-check.yml` lädt die Sigillin-Governance-Berichte zusätzlich als separates GitHub-Artefakt (`policy-sigillins`).
 2. **Dokumentation**
    - `AI_POLICY.md` und `AI_POLICY.yaml` mit Beispielen (Allow/Deny) aktualisieren.
    - Erläutern, wie Guardrail-Fehler zu interpretieren sind (`policies/merge-guardrails.yaml`).

--- a/docs/roadmap/v1.0-stabilization-playbook.yaml
+++ b/docs/roadmap/v1.0-stabilization-playbook.yaml
@@ -1,7 +1,7 @@
 fraktal: 40
 release: v1.0
 owner: codex
-updated: '2025-10-20'
+updated: '2025-10-25'
 summary: 'Strukturierter Maßnahmenplan zur Umsetzung der Fraktal40-Besprechung.
 
   Fokus auf stabile Kern-Builds, dist-first Services, verschärfte Governance
@@ -35,9 +35,13 @@ streams:
           und verweist bei Bedarf auf `pnpm dev:ports:free`. Runbook `docs/runbooks/nats-jetstream.md`
           dokumentiert Setup und Troubleshooting, README & Tests-Runbook spiegeln die neuen Hinweise.
 
+          Fraktal61: CI-Core führt zusätzlich `pnpm test:unit` mit Coverage aus und veröffentlicht
+          den Report als Artefakt (`coverage-vitest`).
+
           '
         success:
           - pnpm test:ts:ci
+          - pnpm test:unit
           - pnpm test:py
           - npx pyright
       - id: experimental-signal
@@ -51,9 +55,15 @@ streams:
       - id: policy-suite-unify
         description: pnpm policy:check bündelt OPA, Guardrails und Kyverno
         status: done
+        notes: |-
+          Fraktal60: policy:check ruft sigillins:report auf und erzeugt Artefakte in out/policy/sigillins/.
+          Fraktal61: policy-check.yml lädt die Sigillin-Governance-Berichte als separates GitHub-Artefakt (`policy-sigillins`).
         output:
           - out/policy/policy-suite.json
           - out/policy/policy-suite.md
+          - out/policy/sigillins/sigillins-junit-report.xml
+          - out/policy/sigillins/sigillins-report.md
+          - policy-sigillins (GitHub artifact)
   - key: code-quality
     owner:
       lead: DevX Guild

--- a/docs/runbooks/command-catalog.json
+++ b/docs/runbooks/command-catalog.json
@@ -257,7 +257,7 @@
           "command": "pnpm test:unit",
           "type": "pnpm",
           "runs": "vitest run --coverage",
-          "description": "Executes Vitest with coverage reporting enabled.",
+          "description": "Executes Vitest with coverage reporting enabled; CI Core publishes the `coverage-vitest` artifact from this run.",
           "source": ["package.json#scripts.test:unit"]
         },
         {
@@ -971,6 +971,24 @@
           "source": ["package.json#scripts.validate:sigillins"]
         },
         {
+          "id": "sigils.validate-sigillins-changed",
+          "name": "Validate staged sigillins",
+          "command": "pnpm validate:sigillins:changed",
+          "type": "pnpm",
+          "runs": "node scripts/sigillins-validate-changed.mjs",
+          "description": "Validates only staged Sigillin bridge files (Git hook friendly).",
+          "source": ["package.json#scripts.validate:sigillins:changed"]
+        },
+        {
+          "id": "sigils.sigillins-report",
+          "name": "Generate sigillin reports",
+          "command": "pnpm sigillins:report",
+          "type": "pnpm",
+          "runs": "node scripts/sigillins-generate-reports.mjs",
+          "description": "Produces JUnit XML and Markdown summaries for governance review (default output: out/policy/sigillins/).",
+          "source": ["package.json#scripts.sigillins:report"]
+        },
+        {
           "id": "sigils.map-mandala",
           "name": "Validate Mandala map",
           "command": "pnpm map:mandala",
@@ -1249,7 +1267,7 @@
           "command": "pnpm policy:check",
           "type": "pnpm",
           "runs": "node scripts/policy-suite.mjs",
-          "description": "Runs the unified policy suite (OPA, Guardrails, Kyverno).",
+          "description": "Runs the unified policy suite (OPA, Guardrails, Kyverno) and persists sigillin governance reports to out/policy/sigillins/.",
           "source": ["package.json#scripts.policy:check"]
         },
         {

--- a/docs/runbooks/command-catalog.md
+++ b/docs/runbooks/command-catalog.md
@@ -48,28 +48,28 @@ Diese Sammlung bündelt pnpm-Skripte, Shell-Kommandos sowie wiederverwendbare To
 
 > Unit, integration, and regression test commands.
 
-| Command                     | Type   | Runs                                                                                                 | Beschreibung                                                               |
-| --------------------------- | ------ | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| `pnpm test`                 | `pnpm` | `vitest run`                                                                                         | Runs the default Vitest suite.                                             |
-| `pnpm test:watch`           | `pnpm` | `vitest`                                                                                             | Starts Vitest in watch mode.                                               |
-| `pnpm test:unit`            | `pnpm` | `vitest run --coverage`                                                                              | Executes Vitest with coverage reporting enabled.                           |
-| `pnpm test:jest`            | `pnpm` | `echo "(Jest deaktiviert – nutze vitest)" && exit 0`                                                 | Legacy alias that prints a Vitest migration hint (Jest disabled).          |
-| `pnpm test:agents`          | `pnpm` | `vitest run`                                                                                         | Executes tests scoped to agent modules.                                    |
-| `pnpm test:adapters`        | `pnpm` | `vitest run src/adapters/tests/decorators.test.ts`                                                   | Runs targeted adapter decorator tests.                                     |
-| `pnpm test:ts`              | `pnpm` | `vitest run --config vitest.config.ts`                                                               | Executes the TypeScript Vitest configuration.                              |
-| `pnpm test:ts:ci`           | `pnpm` | `NODE_OPTIONS=--max-old-space-size=2048 vitest run --config vitest.config.ts`                        | Vitest run tuned for CI memory constraints.                                |
-| `pnpm test:jetstream`       | `pnpm` | `vitest run --config vitest.config.ts --reporter=default tests/event-bus/jetstream-bus.test.ts`      | Executes the JetStream bus contract test via Vitest (migrated from Jest).  |
-| `pnpm test:ts:extended`     | `pnpm` | `cross-env ENABLE_EXTENDED_TESTS=1 vitest run --config vitest.config.ts`                             | Runs the extended TypeScript Vitest matrix.                                |
-| `pnpm test:ts:experimental` | `pnpm` | `cross-env ENABLE_EXTENDED_TESTS=1 ENABLE_EXPERIMENTAL_TESTS=1 vitest run --config vitest.config.ts` | Executes experimental TypeScript tests gated by feature flags.             |
-| `pnpm test:py`              | `pnpm` | `pytest -m "not slow and not experimental" -q`                                                       | Runs the default Python adapter test selection.                            |
-| `pnpm test:py:extended`     | `pnpm` | `pytest -m "not experimental" -q`                                                                    | Runs extended Python adapter tests including slow markers.                 |
-| `pnpm test:py:all`          | `pnpm` | `pytest -q`                                                                                          | Executes the entire Python test suite.                                     |
-| `pnpm test:sigil`           | `pnpm` | `node scripts/run-dist.mjs scripts/validate-sigil-cli.ts`                                            | Validates the sigil CLI over sample fixtures.                              |
-| `pnpm test:ui`              | `pnpm` | `vitest run --passWithNoTests`                                                                       | Runs UI-targeted Vitest suite tolerant to empty spec sets.                 |
-| `pnpm ci:verify`            | `pnpm` | `pnpm test:ts && pnpm sigils:index:strict && pnpm adapter:build:era5`                                | Composite CI gate combining tests, sigil indexing, and ERA5 adapter build. |
-| `pnpm qa`                   | `pnpm` | `node scripts/run-dist.mjs scripts/qa-test-runner.ts`                                                | Runs the QA orchestrator over prioritized checks.                          |
-| `pnpm qa:gpt5`              | `pnpm` | `node scripts/run-dist.mjs scripts/qa-test-runner.ts scripts/qa-gpt5.json`                           | Executes QA runner using the GPT-5 scenario manifest.                      |
-| `pnpm cy:run`               | `pnpm` | `cypress run`                                                                                        | Starts Cypress end-to-end tests.                                           |
+| Command                     | Type   | Runs                                                                                                 | Beschreibung                                                                                                     |
+| --------------------------- | ------ | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `pnpm test`                 | `pnpm` | `vitest run`                                                                                         | Runs the default Vitest suite.                                                                                   |
+| `pnpm test:watch`           | `pnpm` | `vitest`                                                                                             | Starts Vitest in watch mode.                                                                                     |
+| `pnpm test:unit`            | `pnpm` | `vitest run --coverage`                                                                              | Executes Vitest with coverage reporting enabled; CI Core publishes the `coverage-vitest` artifact from this run. |
+| `pnpm test:jest`            | `pnpm` | `echo "(Jest deaktiviert – nutze vitest)" && exit 0`                                                 | Legacy alias that prints a Vitest migration hint (Jest disabled).                                                |
+| `pnpm test:agents`          | `pnpm` | `vitest run`                                                                                         | Executes tests scoped to agent modules.                                                                          |
+| `pnpm test:adapters`        | `pnpm` | `vitest run src/adapters/tests/decorators.test.ts`                                                   | Runs targeted adapter decorator tests.                                                                           |
+| `pnpm test:ts`              | `pnpm` | `vitest run --config vitest.config.ts`                                                               | Executes the TypeScript Vitest configuration.                                                                    |
+| `pnpm test:ts:ci`           | `pnpm` | `NODE_OPTIONS=--max-old-space-size=2048 vitest run --config vitest.config.ts`                        | Vitest run tuned for CI memory constraints.                                                                      |
+| `pnpm test:jetstream`       | `pnpm` | `vitest run --config vitest.config.ts --reporter=default tests/event-bus/jetstream-bus.test.ts`      | Executes the JetStream bus contract test via Vitest (migrated from Jest).                                        |
+| `pnpm test:ts:extended`     | `pnpm` | `cross-env ENABLE_EXTENDED_TESTS=1 vitest run --config vitest.config.ts`                             | Runs the extended TypeScript Vitest matrix.                                                                      |
+| `pnpm test:ts:experimental` | `pnpm` | `cross-env ENABLE_EXTENDED_TESTS=1 ENABLE_EXPERIMENTAL_TESTS=1 vitest run --config vitest.config.ts` | Executes experimental TypeScript tests gated by feature flags.                                                   |
+| `pnpm test:py`              | `pnpm` | `pytest -m "not slow and not experimental" -q`                                                       | Runs the default Python adapter test selection.                                                                  |
+| `pnpm test:py:extended`     | `pnpm` | `pytest -m "not experimental" -q`                                                                    | Runs extended Python adapter tests including slow markers.                                                       |
+| `pnpm test:py:all`          | `pnpm` | `pytest -q`                                                                                          | Executes the entire Python test suite.                                                                           |
+| `pnpm test:sigil`           | `pnpm` | `node scripts/run-dist.mjs scripts/validate-sigil-cli.ts`                                            | Validates the sigil CLI over sample fixtures.                                                                    |
+| `pnpm test:ui`              | `pnpm` | `vitest run --passWithNoTests`                                                                       | Runs UI-targeted Vitest suite tolerant to empty spec sets.                                                       |
+| `pnpm ci:verify`            | `pnpm` | `pnpm test:ts && pnpm sigils:index:strict && pnpm adapter:build:era5`                                | Composite CI gate combining tests, sigil indexing, and ERA5 adapter build.                                       |
+| `pnpm qa`                   | `pnpm` | `node scripts/run-dist.mjs scripts/qa-test-runner.ts`                                                | Runs the QA orchestrator over prioritized checks.                                                                |
+| `pnpm qa:gpt5`              | `pnpm` | `node scripts/run-dist.mjs scripts/qa-test-runner.ts scripts/qa-gpt5.json`                           | Executes QA runner using the GPT-5 scenario manifest.                                                            |
+| `pnpm cy:run`               | `pnpm` | `cypress run`                                                                                        | Starts Cypress end-to-end tests.                                                                                 |
 
 ## Build & Documentation
 
@@ -152,23 +152,25 @@ Diese Sammlung bündelt pnpm-Skripte, Shell-Kommandos sowie wiederverwendbare To
 
 > Sigil validation, map generation, and mandala topology helpers.
 
-| Command                    | Type   | Runs                                                                                | Beschreibung                                                                        |
-| -------------------------- | ------ | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `pnpm sigils:lint`         | `pnpm` | `node scripts/run-dist.mjs scripts/sigils-validate.ts`                              | Validates sigil definitions via dist runner.                                        |
-| `pnpm sigils:scan`         | `pnpm` | `node scripts/run-dist.mjs scripts/validate-sigils.ts`                              | Scans sigil manifests for consistency.                                              |
-| `pnpm sigils:index`        | `pnpm` | `node scripts/build-sigillin-index.mjs`                                             | Generates the sigil index artifacts.                                                |
-| `pnpm find-bad-yaml`       | `pnpm` | `node scripts/find-bad-yaml.mjs`                                                    | Lints sigil YAML files via yaml-lint and fast-glob before strict indexing.          |
-| `pnpm sigils:index:strict` | `pnpm` | `pnpm find-bad-yaml && pnpm sigils:scan && pnpm stac:validate && pnpm sigils:index` | Runs strict sigil validation pipeline prior to indexing.                            |
-| `pnpm sigils:errors`       | `pnpm` | `cat out/sigils_errors.json \|\| echo 'no errors file'`                             | Prints the last sigil error report if available.                                    |
-| `pnpm sigillins:scaffold`  | `pnpm` | `node scripts/scaffold-interai-bridges.mjs`                                         | Creates scaffold files for inter-AI sigillin bridges.                               |
-| `pnpm sigillins:authoring` | `pnpm` | `node scripts/sigillin-authoring.mjs`                                               | Interactive authoring CLI for sigillin records.                                     |
-| `pnpm sigillins:build`     | `pnpm` | `node scripts/build-sigillin-archive.mjs`                                           | Constructs sigillin archive bundles.                                                |
-| `pnpm validate:sigillins`  | `pnpm` | `node scripts/validate-sigillins.mjs`                                               | Runs the sigillin validator with schema and semantic checks.                        |
-| `pnpm map:mandala`         | `pnpm` | `node scripts/mandala-map-validate.mjs`                                             | Validates Mandala map artifacts prior to publication.                               |
-| `pnpm maps:build`          | `pnpm` | `node scripts/run-dist.mjs scripts/repo-map.ts`                                     | Regenerates repository map datasets.                                                |
-| `pnpm maps:validate`       | `pnpm` | `node scripts/maps/validate-maps.mjs`                                               | Validates map artifacts (`RepoMap.yaml` braucht `repo`, `ProgramFlow.yaml` `meta`). |
-| `pnpm maps:list`           | `pnpm` | `node -e "console.log(require('./analysis/repo-map.json').length+' files')"`        | Prints the repository map file count.                                               |
-| `pnpm graph:build`         | `pnpm` | `node scripts/build-sigillin-graph.mjs`                                             | Generates graph representations of sigillin relationships.                          |
+| Command                           | Type   | Runs                                                                                | Beschreibung                                                                                         |
+| --------------------------------- | ------ | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `pnpm sigils:lint`                | `pnpm` | `node scripts/run-dist.mjs scripts/sigils-validate.ts`                              | Validates sigil definitions via dist runner.                                                         |
+| `pnpm sigils:scan`                | `pnpm` | `node scripts/run-dist.mjs scripts/validate-sigils.ts`                              | Scans sigil manifests for consistency.                                                               |
+| `pnpm sigils:index`               | `pnpm` | `node scripts/build-sigillin-index.mjs`                                             | Generates the sigil index artifacts.                                                                 |
+| `pnpm find-bad-yaml`              | `pnpm` | `node scripts/find-bad-yaml.mjs`                                                    | Lints sigil YAML files via yaml-lint and fast-glob before strict indexing.                           |
+| `pnpm sigils:index:strict`        | `pnpm` | `pnpm find-bad-yaml && pnpm sigils:scan && pnpm stac:validate && pnpm sigils:index` | Runs strict sigil validation pipeline prior to indexing.                                             |
+| `pnpm sigils:errors`              | `pnpm` | `cat out/sigils_errors.json \|\| echo 'no errors file'`                             | Prints the last sigil error report if available.                                                     |
+| `pnpm sigillins:scaffold`         | `pnpm` | `node scripts/scaffold-interai-bridges.mjs`                                         | Creates scaffold files for inter-AI sigillin bridges.                                                |
+| `pnpm sigillins:authoring`        | `pnpm` | `node scripts/sigillin-authoring.mjs`                                               | Interactive authoring CLI for sigillin records.                                                      |
+| `pnpm sigillins:build`            | `pnpm` | `node scripts/build-sigillin-archive.mjs`                                           | Constructs sigillin archive bundles.                                                                 |
+| `pnpm validate:sigillins`         | `pnpm` | `node scripts/validate-sigillins.mjs`                                               | Runs the sigillin validator with schema and semantic checks.                                         |
+| `pnpm validate:sigillins:changed` | `pnpm` | `node scripts/sigillins-validate-changed.mjs`                                       | Validates only staged Sigillin bridge files (Git hook friendly).                                     |
+| `pnpm sigillins:report`           | `pnpm` | `node scripts/sigillins-generate-reports.mjs`                                       | Produces JUnit XML + Markdown summaries for governance reporting (default: `out/policy/sigillins/`). |
+| `pnpm map:mandala`                | `pnpm` | `node scripts/mandala-map-validate.mjs`                                             | Validates Mandala map artifacts prior to publication.                                                |
+| `pnpm maps:build`                 | `pnpm` | `node scripts/run-dist.mjs scripts/repo-map.ts`                                     | Regenerates repository map datasets.                                                                 |
+| `pnpm maps:validate`              | `pnpm` | `node scripts/maps/validate-maps.mjs`                                               | Validates map artifacts (`RepoMap.yaml` braucht `repo`, `ProgramFlow.yaml` `meta`).                  |
+| `pnpm maps:list`                  | `pnpm` | `node -e "console.log(require('./analysis/repo-map.json').length+' files')"`        | Prints the repository map file count.                                                                |
+| `pnpm graph:build`                | `pnpm` | `node scripts/build-sigillin-graph.mjs`                                             | Generates graph representations of sigillin relationships.                                           |
 
 ## Data, Adapters & Ingestion
 
@@ -211,12 +213,12 @@ Diese Sammlung bündelt pnpm-Skripte, Shell-Kommandos sowie wiederverwendbare To
 
 > Policy validation and CI governance gates.
 
-| Command                    | Type   | Runs                                                                                                   | Beschreibung                                                                              |
-| -------------------------- | ------ | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
-| `pnpm policy:check`        | `pnpm` | `node scripts/policy-suite.mjs`                                                                        | Runs the unified policy suite (OPA, Guardrails, Kyverno).                                 |
-| `pnpm kyverno:validate`    | `pnpm` | `node tools/kyverno-dry-run.mjs`                                                                       | Executes Kyverno validation across manifests.                                             |
-| `pnpm ci:sigils`           | `pnpm` | `pnpm sigils:index:strict && pnpm test:sigil tests/fixtures/sigillin/good.yaml && pnpm resonance:calc` | CI pipeline for sigils combining strict index, CLI tests, and resonance calc.             |
-| `pnpm ci:adapters-offline` | `pnpm` | `cross-env CI=true pnpm adapter:build:oisst && cross-env CI=true pnpm adapter:build:era5 \|\| true`    | Runs offline adapter builds in CI with non-blocking fallback (cross-platform env export). |
+| Command                    | Type   | Runs                                                                                                   | Beschreibung                                                                                                         |
+| -------------------------- | ------ | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `pnpm policy:check`        | `pnpm` | `node scripts/policy-suite.mjs`                                                                        | Runs the unified policy suite (OPA, Guardrails, Kyverno) and persists `sigillins:report` to `out/policy/sigillins/`. |
+| `pnpm kyverno:validate`    | `pnpm` | `node tools/kyverno-dry-run.mjs`                                                                       | Executes Kyverno validation across manifests.                                                                        |
+| `pnpm ci:sigils`           | `pnpm` | `pnpm sigils:index:strict && pnpm test:sigil tests/fixtures/sigillin/good.yaml && pnpm resonance:calc` | CI pipeline for sigils combining strict index, CLI tests, and resonance calc.                                        |
+| `pnpm ci:adapters-offline` | `pnpm` | `cross-env CI=true pnpm adapter:build:oisst && cross-env CI=true pnpm adapter:build:era5 \|\| true`    | Runs offline adapter builds in CI with non-blocking fallback (cross-platform env export).                            |
 
 ## Aeon & Symbolic Operations
 

--- a/docs/runbooks/command-catalog.yaml
+++ b/docs/runbooks/command-catalog.yaml
@@ -246,7 +246,7 @@ categories:
         command: pnpm test:unit
         type: pnpm
         runs: vitest run --coverage
-        description: Executes Vitest with coverage reporting enabled.
+        description: Executes Vitest with coverage reporting enabled; CI Core publishes the `coverage-vitest` artifact from this run.
         source:
           - package.json#scripts.test:unit
       - id: testing.test-jest
@@ -883,6 +883,22 @@ categories:
         description: Runs the sigillin validator with schema and semantic checks.
         source:
           - package.json#scripts.validate:sigillins
+      - id: sigils.validate-sigillins-changed
+        name: Validate staged sigillins
+        command: pnpm validate:sigillins:changed
+        type: pnpm
+        runs: node scripts/sigillins-validate-changed.mjs
+        description: Validates only staged Sigillin bridge files (Git hook friendly).
+        source:
+          - package.json#scripts.validate:sigillins:changed
+      - id: sigils.sigillins-report
+        name: Generate sigillin reports
+        command: pnpm sigillins:report
+        type: pnpm
+        runs: node scripts/sigillins-generate-reports.mjs
+        description: 'Produces JUnit XML and Markdown summaries for governance review (default output: out/policy/sigillins/).'
+        source:
+          - package.json#scripts.sigillins:report
       - id: sigils.map-mandala
         name: Validate Mandala map
         command: pnpm map:mandala
@@ -1124,7 +1140,7 @@ categories:
         command: pnpm policy:check
         type: pnpm
         runs: node scripts/policy-suite.mjs
-        description: Runs the unified policy suite (OPA, Guardrails, Kyverno).
+        description: 'Runs the unified policy suite (OPA, Guardrails, Kyverno) and persists sigillin governance reports to out/policy/sigillins/.'
         source:
           - package.json#scripts.policy:check
       - id: policy.kyverno-validate

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "sigils:scan": "node scripts/run-dist.mjs scripts/validate-sigils.ts",
     "sigils:errors": "cat out/sigils_errors.json || echo 'no errors file'",
     "validate:sigillins": "node scripts/validate-sigillins.mjs",
+    "validate:sigillins:changed": "node scripts/sigillins-validate-changed.mjs",
     "emergence:scan": "pnpm sigils:index && pnpm agents:scan",
     "adapter:build:era5": "node scripts/adapter-build-era5.mjs",
     "adapter:build:oisst": "node scripts/build-adapter-oisst.mjs",
@@ -132,6 +133,7 @@
     "check:ci": "npx tsc -p tsconfig.json --noEmit && pnpm nats:doctor && pnpm test:ts:ci && pnpm test:jetstream && npx pyright",
     "sigillins:scaffold": "node scripts/scaffold-interai-bridges.mjs",
     "sigillins:authoring": "node scripts/sigillin-authoring.mjs",
+    "sigillins:report": "node scripts/sigillins-generate-reports.mjs",
     "sigillins:build": "node scripts/build-sigillin-archive.mjs",
     "trikaya:dashboard": "node scripts/generate-trikaya-dashboard.mjs"
   },

--- a/scripts/lib/sigillin-validator.mjs
+++ b/scripts/lib/sigillin-validator.mjs
@@ -1,0 +1,395 @@
+#!/usr/bin/env node
+// Shared validation utilities for Sigillin bridge artifacts.
+// Provides reusable helpers for schema + semantic validation so that
+// CLI tools (validate-sigillins, report generators, Git hooks) can
+// rely on a single implementation.
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+import yaml from 'js-yaml';
+import fg from 'fast-glob';
+import Ajv from 'ajv';
+
+const CREP_KEYS = [
+  'Coherence',
+  'Resonance',
+  'Emergence',
+  'Poetics',
+  'CREP',
+  'Kohärenz',
+  'Resonanz',
+  'Emergenz',
+  'Poetik',
+];
+
+const TRIKAYA_KEYS = [
+  'Dharmakāya',
+  'Sambhogakāya',
+  'Nirmāṇakāya',
+  'Trikāya',
+  'Dharma',
+  'Sambhoga',
+  'Nirmāṇa',
+];
+
+const TRIKAYA_BASE_TERMS = ['dharmakāya', 'sambhogakāya', 'nirmāṇakāya'];
+
+const NEXT_KEYS = [
+  'nächste Handlung',
+  'nächste Schritte',
+  'nächster Schritt',
+  'next action',
+  'next steps',
+];
+
+const BRIDGE_SIGIL_REGEX = /(^|\/)sigils\/bridges\/.+\.(json|ya?ml)$/i;
+const BRIDGE_MD_REGEX = /(^|\/)docs\/sigillin\/bridges\/.+\.md$/i;
+
+export const DEFAULT_PATTERNS = [
+  'sigils/bridges/**/*.json',
+  'sigils/bridges/**/*.yaml',
+  'sigils/bridges/**/*.yml',
+  'docs/sigillin/bridges/**/*.md',
+];
+
+function toPosix(p) {
+  return (p || '').replaceAll('\\', '/');
+}
+
+function isBridgeSigilPath(relativePath) {
+  return BRIDGE_SIGIL_REGEX.test(relativePath);
+}
+
+function isBridgeMarkdownPath(relativePath) {
+  return BRIDGE_MD_REGEX.test(relativePath);
+}
+
+function isRegistryOrArchiveSigil(candidate, relativePath) {
+  const sigillinType = (candidate?.sigillin_type ?? '').toString().toLowerCase();
+  if (sigillinType.includes('registry') || sigillinType.includes('archive')) {
+    return true;
+  }
+  if (relativePath && /bridges\.index\.ya?ml$/i.test(relativePath)) {
+    return true;
+  }
+  return false;
+}
+
+function applySemanticOverlay(candidate) {
+  const sigType = (candidate?.sigillin_type ?? '').toString().toLowerCase();
+  if (!sigType.includes('agent')) {
+    return;
+  }
+
+  if (!candidate.trace || typeof candidate.trace !== 'object') {
+    candidate.trace = {};
+  }
+  const trace = candidate.trace;
+  const crep = trace.CREP && typeof trace.CREP === 'object' ? trace.CREP : {};
+  const metricEntries = Object.entries(crep).filter(([, value]) => Number.isFinite(value));
+  if (metricEntries.length < 2) {
+    if (!Number.isFinite(crep.coherence)) crep.coherence = 0.5;
+    if (!Number.isFinite(crep.resonance)) crep.resonance = 0.5;
+  }
+  trace.CREP = crep;
+
+  if (!Array.isArray(candidate.trikaya) || candidate.trikaya.length === 0) {
+    candidate.trikaya = ['Nirmāṇakāya'];
+  }
+
+  if (!candidate.guidelines || typeof candidate.guidelines !== 'object') {
+    candidate.guidelines = { next_action: 'Lege ein Mini-Sigillin mit CREP-Hypothese an.' };
+  } else if (!candidate.guidelines.next_action) {
+    candidate.guidelines.next_action = 'Lege ein Mini-Sigillin mit CREP-Hypothese an.';
+  }
+}
+
+function includesAny(haystack, needles) {
+  const normalized = haystack.toLowerCase();
+  return needles.some((k) => normalized.includes(k.toLowerCase()));
+}
+
+function collectStrings(value, bucket) {
+  if (typeof value === 'string') {
+    bucket.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectStrings(item, bucket);
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const item of Object.values(value)) collectStrings(item, bucket);
+  }
+}
+
+async function readJson(p) {
+  const s = await fs.readFile(p, 'utf8');
+  return JSON.parse(s);
+}
+
+async function readYaml(p) {
+  const s = await fs.readFile(p, 'utf8');
+  return yaml.load(s);
+}
+
+async function readText(p) {
+  return fs.readFile(p, 'utf8');
+}
+
+const schemaCache = new Map();
+
+async function loadSchema(schemaPath) {
+  const key = path.resolve(schemaPath);
+  if (schemaCache.has(key)) {
+    return schemaCache.get(key);
+  }
+  const schemaRaw = await fs.readFile(key, 'utf8');
+  const schema = JSON.parse(schemaRaw);
+  schemaCache.set(key, schema);
+  return schema;
+}
+
+async function prepareAjv(schemaPath) {
+  const schema = await loadSchema(schemaPath);
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  const validator = ajv.compile(schema);
+  return validator;
+}
+
+async function validateStructured(obj, ajvValidate, relativePath, cwd) {
+  const errors = [];
+  const relPath = toPosix(relativePath || '');
+
+  if (!isBridgeSigilPath(relPath)) {
+    return { errors, skipped: true, skipReason: 'not bridge path' };
+  }
+
+  const ok = ajvValidate(obj);
+  if (!ok) {
+    for (const e of ajvValidate.errors || []) {
+      const loc = e.instancePath || e.dataPath || '';
+      errors.push(`Schema: ${loc} ${e.message}`);
+    }
+  }
+
+  const sigillin = obj?.sigillin ?? obj ?? {};
+  if (isRegistryOrArchiveSigil(sigillin, relPath)) {
+    return { errors, skipped: true, skipReason: 'registry/archive' };
+  }
+
+  applySemanticOverlay(sigillin);
+
+  const contentStr = JSON.stringify(obj);
+  if (!includesAny(contentStr, CREP_KEYS)) errors.push('Content: CREP-Begriffe fehlen.');
+  if (!includesAny(contentStr, TRIKAYA_KEYS)) errors.push('Content: Trikāya-Begriffe fehlen.');
+  if (!includesAny(contentStr, NEXT_KEYS)) errors.push("Content: 'Nächste Schritte' fehlen.");
+
+  const trace = sigillin.trace;
+  if (!trace || typeof trace !== 'object') {
+    errors.push('Trace: CREP-Struktur fehlt.');
+  } else {
+    const crep = trace.CREP;
+    if (!crep || typeof crep !== 'object') {
+      errors.push('Trace: CREP-Metriken fehlen.');
+    } else {
+      const metrics = Object.entries(crep).filter(([, value]) => Number.isFinite(value));
+      if (metrics.length < 2) {
+        errors.push('Trace: Mindestens zwei CREP-Metriken erforderlich.');
+      }
+      for (const [key, value] of metrics) {
+        if (value < 0 || value > 1) {
+          errors.push(`Trace: CREP-Wert ${key} außerhalb des erwarteten Bereichs (0–1).`);
+          break;
+        }
+      }
+    }
+    if ('emergence_score' in trace) {
+      const score = trace.emergence_score;
+      if (typeof score !== 'number' || Number.isNaN(score) || score < 0) {
+        errors.push('Trace: emergence_score muss eine nicht-negative Zahl sein.');
+      }
+    }
+  }
+
+  const sections = sigillin?.content?.sections;
+  if (Array.isArray(sections) && sections.length) {
+    const textFragments = [];
+    for (const section of sections) collectStrings(section, textFragments);
+    const trikayaHits = new Set();
+    for (const fragment of textFragments) {
+      const lower = fragment.toLowerCase();
+      for (const base of TRIKAYA_BASE_TERMS) {
+        if (lower.includes(base)) {
+          trikayaHits.add(base);
+        }
+      }
+    }
+    if (trikayaHits.size < 1) {
+      errors.push('Content: Mindestens eine Trikāya-Ebene muss konkret benannt sein.');
+    }
+    const guidelinesSection = sections.find((section) => {
+      const id = (section?.id ?? '').toString().toLowerCase();
+      const title = (section?.title ?? '').toString().toLowerCase();
+      return id.includes('guideline') || title.includes('leitlinie') || title.includes('guideline');
+    });
+    if (!guidelinesSection) {
+      errors.push('Content: Leitlinien-Sektion fehlt.');
+    } else {
+      const rules = Array.isArray(guidelinesSection.rules) ? guidelinesSection.rules : [];
+      if (!rules.length) {
+        errors.push('Content: Leitlinien enthalten keine Regeln.');
+      }
+      const hasNextAction = rules.some((rule) => {
+        if (typeof rule !== 'string') return false;
+        const lower = rule.toLowerCase();
+        return NEXT_KEYS.some((key) => lower.includes(key.toLowerCase()));
+      });
+      if (!hasNextAction) {
+        errors.push('Content: Leitlinien benennen keine nächste Handlung.');
+      }
+    }
+  } else {
+    errors.push('Content: sections fehlen oder sind leer.');
+  }
+
+  const links = obj?.sigillin?.links || [];
+  const root = cwd ?? process.cwd();
+  for (const link of links) {
+    if (typeof link !== 'string') continue;
+    if (link.startsWith('aeon://')) continue;
+    try {
+      const maybePath = path.isAbsolute(link) ? link : path.join(root, link);
+      await fs.access(maybePath);
+    } catch {
+      errors.push(`Hint: Verlinkte Datei nicht gefunden (optional): ${link}`);
+    }
+  }
+
+  return { errors, skipped: false };
+}
+
+async function validateMarkdown(filepath, relativePath) {
+  const relPath = toPosix(relativePath || '');
+  if (!isBridgeMarkdownPath(relPath)) {
+    return { errors: [], skipped: true, skipReason: 'not bridge path' };
+  }
+  const content = await readText(filepath);
+  const errors = [];
+  if (!includesAny(content, CREP_KEYS)) errors.push('MD: CREP-Begriffe fehlen.');
+  if (!includesAny(content, TRIKAYA_KEYS)) errors.push('MD: Trikāya-Begriffe fehlen.');
+  if (!includesAny(content, NEXT_KEYS)) errors.push("MD: 'Nächste Schritte' fehlen.");
+  return { errors, skipped: false };
+}
+
+function mapKind(ext) {
+  if (ext === '.json') return 'json';
+  if (ext === '.yaml' || ext === '.yml') return 'yaml';
+  if (ext === '.md') return 'markdown';
+  return 'other';
+}
+
+export async function validatePatterns(patterns = DEFAULT_PATTERNS, options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const schemaPath =
+    options.schemaPath ?? path.join(cwd, 'scripts', 'schemas', 'mandala-sigillin.schema.json');
+  const resolvedPatterns = Array.isArray(patterns) && patterns.length ? patterns : DEFAULT_PATTERNS;
+
+  const files = await fg(resolvedPatterns, { cwd, absolute: true, dot: false });
+  if (!files.length) {
+    return {
+      results: [],
+      hasErrors: false,
+      usedPatterns: resolvedPatterns,
+      matchedFiles: [],
+    };
+  }
+
+  const ajvValidate = await prepareAjv(schemaPath);
+  const results = [];
+
+  for (const file of files) {
+    const ext = path.extname(file).toLowerCase();
+    const relativePath = toPosix(path.relative(cwd, file));
+    try {
+      if (ext === '.json') {
+        const obj = await readJson(file);
+        const validation = await validateStructured(obj, ajvValidate, relativePath, cwd);
+        results.push({
+          filePath: file,
+          relativePath,
+          errors: validation.errors,
+          skipped: validation.skipped,
+          skipReason: validation.skipReason,
+          kind: mapKind(ext),
+        });
+        continue;
+      }
+      if (ext === '.yaml' || ext === '.yml') {
+        const obj = await readYaml(file);
+        const validation = await validateStructured(obj, ajvValidate, relativePath, cwd);
+        results.push({
+          filePath: file,
+          relativePath,
+          errors: validation.errors,
+          skipped: validation.skipped,
+          skipReason: validation.skipReason,
+          kind: mapKind(ext),
+        });
+        continue;
+      }
+      if (ext === '.md') {
+        const validation = await validateMarkdown(file, relativePath);
+        results.push({
+          filePath: file,
+          relativePath,
+          errors: validation.errors,
+          skipped: validation.skipped,
+          skipReason: validation.skipReason,
+          kind: mapKind(ext),
+        });
+        continue;
+      }
+      // Unknown extension -> skip silently.
+    } catch (error) {
+      results.push({
+        filePath: file,
+        relativePath,
+        errors: [`Fehler: ${(error && error.message) || error}`],
+        skipped: false,
+        kind: mapKind(ext),
+      });
+    }
+  }
+
+  const hasErrors = results.some(
+    (result) => !result.skipped && result.errors && result.errors.length,
+  );
+
+  return {
+    results,
+    hasErrors,
+    usedPatterns: resolvedPatterns,
+    matchedFiles: files.map((f) => toPosix(path.relative(cwd, f))),
+  };
+}
+
+export function summarizeResults(results) {
+  let failures = 0;
+  let skipped = 0;
+  let passes = 0;
+  for (const result of results) {
+    if (result.skipped) {
+      skipped += 1;
+      continue;
+    }
+    if (result.errors && result.errors.length) {
+      failures += 1;
+    } else {
+      passes += 1;
+    }
+  }
+  return { passes, failures, skipped, total: results.length };
+}

--- a/scripts/policy-suite.mjs
+++ b/scripts/policy-suite.mjs
@@ -8,6 +8,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
 const outputDir = path.join(projectRoot, 'out', 'policy');
 fs.mkdirSync(outputDir, { recursive: true });
+const defaultSigillinDir = path.join('out', 'policy', 'sigillins');
+const sigillinReportDir = path.join(outputDir, 'sigillins');
+const sigillinReportRelRaw = path.relative(projectRoot, sigillinReportDir);
+const sigillinReportRel =
+  sigillinReportRelRaw && sigillinReportRelRaw !== '' ? sigillinReportRelRaw : defaultSigillinDir;
+const sigillinReportDisplay = sigillinReportRel.split(path.sep).join('/');
 
 const inputPath = process.env.POLICY_SUITE_INPUT || 'fixtures/events/example_input.json';
 const resolvedInputPath = path.isAbsolute(inputPath)
@@ -76,6 +82,20 @@ const checks = [
     successNote: 'Kyverno policies accepted the example fixture',
     failureHint:
       'Kyverno denied the input fixture. Inspect policies/kyverno.yaml or fixtures/events/example_input.json',
+  },
+  {
+    name: 'Sigillin Governance',
+    skip: () => {
+      const flag = (process.env.POLICY_SUITE_SKIP_SIGILLINS || '').toLowerCase();
+      return flag === '1' || flag === 'true';
+    },
+    skipNote: 'Sigillin report skipped via POLICY_SUITE_SKIP_SIGILLINS',
+    command: () => ({
+      cmd: 'pnpm',
+      args: ['sigillins:report', '--out-dir', sigillinReportRel],
+    }),
+    successNote: `Sigillin governance reports saved to ${sigillinReportDisplay}`,
+    failureHint: `Sigillin report failed – inspect ${sigillinReportDisplay} for Markdown/JUnit output.`,
   },
 ];
 
@@ -210,10 +230,19 @@ async function main() {
 
 await main();
 
+const artifacts = {
+  sigillins: {
+    reportDir: sigillinReportDisplay,
+    junit: `${sigillinReportDisplay}/sigillins-junit-report.xml`,
+    markdown: `${sigillinReportDisplay}/sigillins-report.md`,
+  },
+};
+
 const payload = {
   generatedAt: new Date().toISOString(),
   input: path.relative(projectRoot, resolvedInputPath),
   results,
+  artifacts,
 };
 
 const jsonPath = path.join(outputDir, 'policy-suite.json');

--- a/scripts/sigillins-generate-reports.mjs
+++ b/scripts/sigillins-generate-reports.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// Generates machine-readable (JUnit XML) and human-readable (Markdown)
+// reports for the Sigillin bridge catalogue. Builds on the shared
+// validator utilities so that CI pipelines and governance reviews can
+// publish consistent artefacts.
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+import { DEFAULT_PATTERNS, validatePatterns, summarizeResults } from './lib/sigillin-validator.mjs';
+import { PROVIDERS, bridgePaths, gatherBridgeSummary } from './lib/interai-bridges.mjs';
+
+function toPosix(p) {
+  return (p || '').replaceAll('\\', '/');
+}
+
+function escapeXml(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function statusToken(result) {
+  if (!result) return '–';
+  if (result.skipped) return '⏭️ Skip';
+  if (result.errors && result.errors.length) return '❌ Fail';
+  return '✅ Pass';
+}
+
+async function ensureDir(dir) {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+function deriveClassName(relativePath) {
+  if (!relativePath) return 'sigillin.validation';
+  const withoutExt = relativePath.replace(/\.[^.]+$/, '');
+  return `sigillin.${withoutExt.replace(/[\/]/g, '.')}`;
+}
+
+async function writeJUnitReport(results, outDir) {
+  const testResults = results.filter((result) => !result.skipped);
+  const summary = summarizeResults(results);
+
+  const suites = [];
+  for (const result of testResults) {
+    const failure =
+      result.errors && result.errors.length
+        ? `<failure message="${escapeXml(result.errors[0])}">${escapeXml(result.errors.join('\n'))}</failure>`
+        : '';
+    const testCase = `<testcase name="Validate ${escapeXml(result.relativePath)}" classname="${escapeXml(
+      deriveClassName(result.relativePath),
+    )}" time="0">${failure}</testcase>`;
+    suites.push(
+      `<testsuite name="Sigillin ${escapeXml(result.relativePath)}" tests="1" failures="${
+        result.errors && result.errors.length ? 1 : 0
+      }">${testCase}</testsuite>`,
+    );
+  }
+
+  const xml =
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<testsuites tests="${summary.total}" failures="${summary.failures}">\n${suites.join('\n')}\n</testsuites>\n`;
+
+  const target = path.join(outDir, 'sigillins-junit-report.xml');
+  await ensureDir(outDir);
+  await fs.writeFile(target, xml, 'utf8');
+  console.log(`✅ JUnit report geschrieben: ${toPosix(path.relative(process.cwd(), target))}`);
+}
+
+async function writeMarkdownReport(results, outDir) {
+  const resultByPath = new Map();
+  for (const result of results) {
+    resultByPath.set(result.relativePath, result);
+  }
+
+  const summary = await gatherBridgeSummary();
+
+  let markdown = `# 🛡️ Sigillin Validation Summary\n\n`;
+  markdown += `*Generiert am:* ${new Date().toUTCString()}\\n\n`;
+  markdown += `| Provider | YAML | JSON | Markdown | Avg CREP | Emergence | Next Action | Dharmakāya | Sambhogakāya | Nirmāṇakāya |\\n`;
+  markdown += `|---|---|---|---|---|---|---|---|---|---|\n`;
+
+  for (const provider of PROVIDERS) {
+    const paths = bridgePaths(provider);
+    const yamlRel = toPosix(path.relative(process.cwd(), paths.yaml));
+    const jsonRel = toPosix(path.relative(process.cwd(), paths.json));
+    const mdRel = toPosix(path.relative(process.cwd(), paths.markdown));
+    const yamlResult = resultByPath.get(yamlRel);
+    const jsonResult = resultByPath.get(jsonRel);
+    const mdResult = resultByPath.get(mdRel);
+
+    const providerSummary = summary.providers.find((entry) => entry.key === provider.key);
+    const avgCREP = providerSummary?.averageCREP ?? '–';
+    const emergence = providerSummary?.emergence_score ?? '–';
+    const nextAction = providerSummary?.nextActionRule ? '✅' : '⚠️';
+    const dharma = providerSummary?.trikaya?.dharmakāya ? '✅' : '⚠️';
+    const sambhoga = providerSummary?.trikaya?.sambhogakāya ? '✅' : '⚠️';
+    const nirmana = providerSummary?.trikaya?.nirmāṇakāya ? '✅' : '⚠️';
+
+    markdown += `| ${provider.label} | ${statusToken(yamlResult)} | ${statusToken(jsonResult)} | ${statusToken(mdResult)} | ${avgCREP} | ${emergence ?? '–'} | ${nextAction} | ${dharma} | ${sambhoga} | ${nirmana} |\n`;
+
+    for (const [label, result] of [
+      ['YAML', yamlResult],
+      ['JSON', jsonResult],
+      ['Markdown', mdResult],
+    ]) {
+      if (result && !result.skipped && result.errors && result.errors.length) {
+        markdown += `\n**Fehler (${provider.label} · ${label}):**\n`;
+        markdown += result.errors.map((error) => `* ${error}`).join('\n');
+        markdown += '\n';
+      }
+    }
+  }
+
+  const avgCrepText = summary.aggregates?.crep?.avg
+    ? ['C', 'R', 'E', 'P']
+        .map((metric) => `${metric}=${summary.aggregates.crep.avg[metric] ?? '–'}`)
+        .join(' | ')
+    : '–';
+  const trikayaCoverage = summary.aggregates?.trikayaCoverage
+    ? Object.entries(summary.aggregates.trikayaCoverage)
+        .map(([key, value]) => `${key}: ${value}`)
+        .join(' | ')
+    : '–';
+
+  markdown += '\n---\n\n';
+  markdown += `**Gesamt:** ${summary.providers.length} Provider · CREP Ø ${avgCrepText} · Next-Action-Rate ${summary.aggregates.nextActionRate}.\n`;
+  markdown += `Trikāya-Abdeckung: ${trikayaCoverage}\n`;
+
+  const target = path.join(outDir, 'sigillins-report.md');
+  await ensureDir(outDir);
+  await fs.writeFile(target, markdown, 'utf8');
+  console.log(`✅ Markdown report geschrieben: ${toPosix(path.relative(process.cwd(), target))}`);
+}
+
+async function main() {
+  const { values, positionals } = parseArgs({
+    options: {
+      junit: { type: 'boolean', default: true },
+      markdown: { type: 'boolean', default: true },
+      'out-dir': { type: 'string', default: 'reports' },
+    },
+    allowPositionals: true,
+  });
+
+  const patterns = positionals.length ? positionals : DEFAULT_PATTERNS;
+
+  const { results, hasErrors, matchedFiles } = await validatePatterns(patterns, {
+    cwd: process.cwd(),
+  });
+
+  if (!matchedFiles.length) {
+    console.log('ℹ️  Keine Sigillin-Dateien gefunden – Reports werden übersprungen.');
+    return;
+  }
+
+  const outDir = path.resolve(process.cwd(), values['out-dir']);
+  if (values.junit) {
+    await writeJUnitReport(results, outDir);
+  }
+  if (values.markdown) {
+    await writeMarkdownReport(results, outDir);
+  }
+
+  if (hasErrors) {
+    console.warn('⚠️  Einige Sigillin-Dateien sind fehlgeschlagen – siehe Report für Details.');
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error('sigillins-report failed:', error);
+  process.exit(1);
+});

--- a/scripts/sigillins-validate-changed.mjs
+++ b/scripts/sigillins-validate-changed.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// Detects staged Sigillin bridge files and runs the validator against
+// the changed subset. Intended for Git hooks and local QA workflows so
+// we do not have to lint the entire catalogue on every commit.
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import process from 'node:process';
+
+import { validatePatterns } from './lib/sigillin-validator.mjs';
+
+const execFileAsync = promisify(execFile);
+const PATH_FILTER = /^(sigils\/.*\.(?:json|ya?ml)|docs\/sigillin\/.*\.md)$/i;
+
+function logResult(result) {
+  const rel = result.relativePath || result.filePath;
+  if (result.skipped) {
+    const suffix = result.skipReason ? ` (skip: ${result.skipReason})` : '';
+    console.log(`⏭️  ${rel}${suffix}`);
+    return;
+  }
+  if (result.errors && result.errors.length) {
+    console.log(`❌ ${rel}`);
+    for (const error of result.errors) {
+      console.log(`   - ${error}`);
+    }
+    return;
+  }
+  console.log(`✅ ${rel}`);
+}
+
+async function getStagedFiles() {
+  try {
+    const { stdout } = await execFileAsync('git', [
+      'diff',
+      '--cached',
+      '--name-only',
+      '--diff-filter=ACMR',
+    ]);
+    return stdout
+      .split('\n')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      throw new Error('Git executable nicht gefunden – bitte in einem Git-Repository ausführen.');
+    }
+    throw new Error(`git diff --cached fehlgeschlagen: ${(error && error.message) || error}`);
+  }
+}
+
+function filterSigillinFiles(paths) {
+  return paths.filter((candidate) => PATH_FILTER.test(candidate));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const inputPaths = args.length ? args : await getStagedFiles();
+  const candidates = filterSigillinFiles(inputPaths);
+
+  if (!candidates.length) {
+    console.log('ℹ️  Keine geänderten Sigillin-Dateien gefunden.');
+    return;
+  }
+
+  const { results, hasErrors } = await validatePatterns(candidates, {
+    cwd: process.cwd(),
+  });
+
+  for (const result of results) {
+    logResult(result);
+  }
+
+  if (hasErrors) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error('validate-sigillins:changed failed:', error);
+  process.exit(1);
+});

--- a/scripts/validate-sigillins.mjs
+++ b/scripts/validate-sigillins.mjs
@@ -1,323 +1,51 @@
-// Node >=18, ESM. Cross-platform, keine Shell-Globs.
-import fs from 'node:fs/promises';
-import path from 'node:path';
+#!/usr/bin/env node
+// CLI wrapper around the shared sigillin validator utilities.
+// Keeps the original console output semantics while exposing the
+// validation logic as a reusable module (`scripts/lib/sigillin-validator.mjs`).
+
 import process from 'node:process';
-import yaml from 'js-yaml';
-import fg from 'fast-glob';
-import Ajv from 'ajv';
 
-const ROOT = process.cwd();
-const SCHEMA_PATH = path.join(ROOT, 'scripts', 'schemas', 'mandala-sigillin.schema.json');
+import { DEFAULT_PATTERNS, validatePatterns } from './lib/sigillin-validator.mjs';
 
-const CREP_KEYS = [
-  'Coherence',
-  'Resonance',
-  'Emergence',
-  'Poetics',
-  'CREP',
-  'Kohärenz',
-  'Resonanz',
-  'Emergenz',
-  'Poetik',
-];
-const TRIKAYA_KEYS = [
-  'Dharmakāya',
-  'Sambhogakāya',
-  'Nirmāṇakāya',
-  'Trikāya',
-  'Dharma',
-  'Sambhoga',
-  'Nirmāṇa',
-];
-const TRIKAYA_BASE_TERMS = ['dharmakāya', 'sambhogakāya', 'nirmāṇakāya'];
-const NEXT_KEYS = [
-  'nächste Handlung',
-  'nächste Schritte',
-  'nächster Schritt',
-  'next action',
-  'next steps',
-];
-
-const DEFAULT_PATTERNS = [
-  'sigils/bridges/**/*.json',
-  'sigils/bridges/**/*.yaml',
-  'sigils/bridges/**/*.yml',
-  'docs/sigillin/bridges/**/*.md',
-];
-
-const BRIDGE_SIGIL_REGEX = /(^|\/)sigils\/bridges\/.+\.(json|ya?ml)$/i;
-const BRIDGE_MD_REGEX = /(^|\/)docs\/sigillin\/bridges\/.+\.md$/i;
-
-function toPosix(p) {
-  return (p || '').replaceAll('\\', '/');
-}
-
-function isBridgeSigilPath(relativePath) {
-  return BRIDGE_SIGIL_REGEX.test(relativePath);
-}
-
-function isBridgeMarkdownPath(relativePath) {
-  return BRIDGE_MD_REGEX.test(relativePath);
-}
-
-function isRegistryOrArchiveSigil(candidate, relativePath) {
-  const sigillinType = (candidate?.sigillin_type ?? '').toString().toLowerCase();
-  if (sigillinType.includes('registry') || sigillinType.includes('archive')) {
-    return true;
-  }
-  if (relativePath && /bridges\.index\.ya?ml$/i.test(relativePath)) {
-    return true;
-  }
-  return false;
-}
-
-function applySemanticOverlay(candidate) {
-  const sigType = (candidate?.sigillin_type ?? '').toString().toLowerCase();
-  if (!sigType.includes('agent')) {
+function logResult(result) {
+  const rel = result.relativePath || result.filePath;
+  if (result.skipped) {
+    const suffix = result.skipReason ? ` (skip: ${result.skipReason})` : '';
+    console.log(`⏭️  ${rel}${suffix}`);
     return;
   }
-
-  if (!candidate.trace || typeof candidate.trace !== 'object') {
-    candidate.trace = {};
-  }
-  const trace = candidate.trace;
-  const crep = trace.CREP && typeof trace.CREP === 'object' ? trace.CREP : {};
-  const metricEntries = Object.entries(crep).filter(([, value]) => Number.isFinite(value));
-  if (metricEntries.length < 2) {
-    if (!Number.isFinite(crep.coherence)) crep.coherence = 0.5;
-    if (!Number.isFinite(crep.resonance)) crep.resonance = 0.5;
-  }
-  trace.CREP = crep;
-
-  if (!Array.isArray(candidate.trikaya) || candidate.trikaya.length === 0) {
-    candidate.trikaya = ['Nirmāṇakāya'];
-  }
-
-  if (!candidate.guidelines || typeof candidate.guidelines !== 'object') {
-    candidate.guidelines = { next_action: 'Lege ein Mini-Sigillin mit CREP-Hypothese an.' };
-  } else if (!candidate.guidelines.next_action) {
-    candidate.guidelines.next_action = 'Lege ein Mini-Sigillin mit CREP-Hypothese an.';
-  }
-}
-
-function includesAny(haystack, needles) {
-  const normalized = haystack.toLowerCase();
-  return needles.some((k) => normalized.includes(k.toLowerCase()));
-}
-
-function collectStrings(value, bucket) {
-  if (typeof value === 'string') {
-    bucket.push(value);
+  if (result.errors && result.errors.length) {
+    console.log(`❌ ${rel}`);
+    for (const error of result.errors) {
+      console.log(`   - ${error}`);
+    }
     return;
   }
-  if (Array.isArray(value)) {
-    for (const item of value) collectStrings(item, bucket);
-    return;
-  }
-  if (value && typeof value === 'object') {
-    for (const item of Object.values(value)) collectStrings(item, bucket);
-  }
-}
-
-async function readJson(p) {
-  const s = await fs.readFile(p, 'utf8');
-  return JSON.parse(s);
-}
-async function readYaml(p) {
-  const s = await fs.readFile(p, 'utf8');
-  return yaml.load(s);
-}
-async function readText(p) {
-  return fs.readFile(p, 'utf8');
-}
-
-async function loadSchema() {
-  const s = await fs.readFile(SCHEMA_PATH, 'utf8');
-  return JSON.parse(s);
-}
-
-async function validateStructured(obj, ajvValidate, relativePath) {
-  const errors = [];
-  const relPath = toPosix(relativePath || '');
-
-  if (!isBridgeSigilPath(relPath)) {
-    return { errors, skipped: true, reason: 'not bridge path' };
-  }
-
-  const ok = ajvValidate(obj);
-  if (!ok) {
-    for (const e of ajvValidate.errors || []) {
-      const loc = e.instancePath || e.dataPath || '';
-      errors.push(`Schema: ${loc} ${e.message}`);
-    }
-  }
-  const sigillin = obj?.sigillin ?? obj ?? {};
-  if (isRegistryOrArchiveSigil(sigillin, relPath)) {
-    return { errors, skipped: true, reason: 'registry/archive' };
-  }
-
-  applySemanticOverlay(sigillin);
-
-  const contentStr = JSON.stringify(obj);
-  if (!includesAny(contentStr, CREP_KEYS)) errors.push('Content: CREP-Begriffe fehlen.');
-  if (!includesAny(contentStr, TRIKAYA_KEYS)) errors.push('Content: Trikāya-Begriffe fehlen.');
-  if (!includesAny(contentStr, NEXT_KEYS)) errors.push("Content: 'Nächste Schritte' fehlen.");
-
-  const trace = sigillin.trace;
-  if (!trace || typeof trace !== 'object') {
-    errors.push('Trace: CREP-Struktur fehlt.');
-  } else {
-    const crep = trace.CREP;
-    if (!crep || typeof crep !== 'object') {
-      errors.push('Trace: CREP-Metriken fehlen.');
-    } else {
-      const metrics = Object.entries(crep).filter(([, value]) => Number.isFinite(value));
-      if (metrics.length < 2) {
-        errors.push('Trace: Mindestens zwei CREP-Metriken erforderlich.');
-      }
-      for (const [key, value] of metrics) {
-        if (value < 0 || value > 1) {
-          errors.push(`Trace: CREP-Wert ${key} außerhalb des erwarteten Bereichs (0–1).`);
-          break;
-        }
-      }
-    }
-    if ('emergence_score' in trace) {
-      const score = trace.emergence_score;
-      if (typeof score !== 'number' || Number.isNaN(score) || score < 0) {
-        errors.push('Trace: emergence_score muss eine nicht-negative Zahl sein.');
-      }
-    }
-  }
-
-  const sections = sigillin?.content?.sections;
-  if (Array.isArray(sections) && sections.length) {
-    const textFragments = [];
-    for (const section of sections) collectStrings(section, textFragments);
-    const trikayaHits = new Set();
-    for (const fragment of textFragments) {
-      const lower = fragment.toLowerCase();
-      for (const base of TRIKAYA_BASE_TERMS) {
-        if (lower.includes(base)) {
-          trikayaHits.add(base);
-        }
-      }
-    }
-    if (trikayaHits.size < 1) {
-      errors.push('Content: Mindestens eine Trikāya-Ebene muss konkret benannt sein.');
-    }
-    const guidelinesSection = sections.find((section) => {
-      const id = (section?.id ?? '').toString().toLowerCase();
-      const title = (section?.title ?? '').toString().toLowerCase();
-      return id.includes('guideline') || title.includes('leitlinie') || title.includes('guideline');
-    });
-    if (!guidelinesSection) {
-      errors.push('Content: Leitlinien-Sektion fehlt.');
-    } else {
-      const rules = Array.isArray(guidelinesSection.rules) ? guidelinesSection.rules : [];
-      if (!rules.length) {
-        errors.push('Content: Leitlinien enthalten keine Regeln.');
-      }
-      const hasNextAction = rules.some((rule) => {
-        if (typeof rule !== 'string') return false;
-        const lower = rule.toLowerCase();
-        return NEXT_KEYS.some((key) => lower.includes(key.toLowerCase()));
-      });
-      if (!hasNextAction) {
-        errors.push('Content: Leitlinien benennen keine nächste Handlung.');
-      }
-    }
-  } else {
-    errors.push('Content: sections fehlen oder sind leer.');
-  }
-
-  const links = obj?.sigillin?.links || [];
-  for (const link of links) {
-    if (link.startsWith('aeon://')) continue; // virtuelle Links
-    try {
-      const maybePath = path.isAbsolute(link) ? link : path.join(ROOT, link);
-      await fs.access(maybePath);
-    } catch {
-      errors.push(`Hint: Verlinkte Datei nicht gefunden (optional): ${link}`);
-    }
-  }
-  return { errors, skipped: false };
-}
-
-async function validateMarkdown(filepath) {
-  const content = await readText(filepath);
-  const errors = [];
-  if (!includesAny(content, CREP_KEYS)) errors.push('MD: CREP-Begriffe fehlen.');
-  if (!includesAny(content, TRIKAYA_KEYS)) errors.push('MD: Trikāya-Begriffe fehlen.');
-  if (!includesAny(content, NEXT_KEYS)) errors.push("MD: 'Nächste Schritte' fehlen.");
-  return errors;
+  console.log(`✅ ${rel}`);
 }
 
 async function main() {
-  const schema = await loadSchema();
-  const ajv = new Ajv({ allErrors: true, strict: false });
-  const ajvValidate = ajv.compile(schema);
+  const args = process.argv.slice(2);
+  const patterns = args.length ? args : DEFAULT_PATTERNS;
+  const { results, hasErrors, matchedFiles, usedPatterns } = await validatePatterns(patterns, {
+    cwd: process.cwd(),
+  });
 
-  const patterns = process.argv.slice(2).length ? process.argv.slice(2) : DEFAULT_PATTERNS;
-  const files = await fg(patterns, { cwd: ROOT, absolute: true, dot: false });
-
-  if (!files.length) {
-    console.log('ℹ️  Keine Sigillin-Dateien gefunden (Patterns):', patterns.join(', '));
-    process.exit(0);
+  if (!matchedFiles.length) {
+    console.log('ℹ️  Keine Sigillin-Dateien gefunden (Patterns):', usedPatterns.join(', '));
+    return;
   }
 
-  let hasErrors = false;
-  for (const f of files) {
-    const ext = path.extname(f).toLowerCase();
-    const rel = path.relative(ROOT, f);
-    const relNorm = toPosix(rel);
-    try {
-      let errs = [];
-      let skipped = false;
-      let skipReason = '';
-      if (ext === '.json') {
-        const obj = await readJson(f);
-        const result = await validateStructured(obj, ajvValidate, relNorm);
-        errs = result.errors;
-        skipped = result.skipped;
-        skipReason = result.reason || '';
-      } else if (ext === '.yml' || ext === '.yaml') {
-        const obj = await readYaml(f);
-        const result = await validateStructured(obj, ajvValidate, relNorm);
-        errs = result.errors;
-        skipped = result.skipped;
-        skipReason = result.reason || '';
-      } else if (ext === '.md') {
-        if (!isBridgeMarkdownPath(relNorm)) {
-          skipped = true;
-          skipReason = 'not bridge path';
-        } else {
-          errs = await validateMarkdown(f);
-        }
-      } else {
-        continue;
-      }
-      if (skipped) {
-        const suffix = skipReason ? ` (skip: ${skipReason})` : '';
-        console.log(`⏭️  ${relNorm}${suffix}`);
-        continue;
-      }
-      if (errs.length) {
-        hasErrors = true;
-        console.log(`❌ ${relNorm}`);
-        for (const e of errs) console.log(`   - ${e}`);
-      } else {
-        console.log(`✅ ${relNorm}`);
-      }
-    } catch (e) {
-      hasErrors = true;
-      console.log(`❌ ${relNorm}\n   - Fehler: ${(e && e.message) || e}`);
-    }
+  for (const result of results) {
+    logResult(result);
   }
-  process.exit(hasErrors ? 1 : 0);
+
+  if (hasErrors) {
+    process.exitCode = 1;
+  }
 }
 
-main().catch((e) => {
-  console.error('Validator fatal:', e);
+main().catch((error) => {
+  console.error('Validator fatal:', error);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- extend scripts/policy-suite.mjs with a Sigillin Governance check that runs `pnpm sigillins:report`, records the report locations, and allows skipping via POLICY_SUITE_SKIP_SIGILLINS
- document the new reporting flow across the policy-suite guide, command catalog (md/json/yaml), MandalaMap, and the stabilization playbook; update codexfeedback trackers and add the Fraktal60 log
- note the generated report path for both `scripts/` and `out/` entries in MandalaMap

## Testing
- pnpm policy:check
- pnpm sigillins:report --out-dir out/policy/sigillins

------
https://chatgpt.com/codex/tasks/task_e_68d0669c29148322b0265101b012cc65