### PR TITLE
chore: prepare v1.0.0 release (metadata, zenodo, governance docs, Dia…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report something that isn't working as expected
+title: "[BUG] "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to reproduce
+
+1. ...
+2. ...
+3. ...
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened (include full error messages / tracebacks if any).
+
+## Environment
+
+- Package version: (`pip show unified-mandala` or `git describe --tags`)
+- Python version:
+- OS:
+
+## Additional context
+
+Anything else relevant — logs, screenshots, related issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Suggest a new feature, module, or enhancement
+title: "[FEATURE] "
+labels: enhancement
+assignees: ""
+---
+
+## Summary
+
+A clear and concise description of the feature.
+
+## Motivation
+
+Why is this needed? What problem does it solve, or what new capability
+does it enable within the GenesisAeon ecosystem?
+
+## Proposed approach
+
+How might this be implemented? (Sketches, pseudocode, references to
+related GenesisAeon packages or Diamond Interface methods are welcome.)
+
+## Alternatives considered
+
+Any alternative approaches you've thought about.
+
+## Additional context
+
+Links to relevant papers, prior discussion, or related issues/PRs.

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
-  "title": "unified-mandala: NukleonScanner v2.1.0 + GreekMath v2.1.0 + FieldTheory v2.0.0 Reactivation",
-  "version": "0.3.2",
+  "title": "unified-mandala — P-MANDALA: Holistic self-reflecting Mandala orchestration core (v1.0.0)",
+  "version": "1.0.0",
   "doi": "10.5281/zenodo.19209147",
   "creators": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ Alle relevanten Änderungen dieses Projekts werden in diesem Dokument festgehalt
 - **CLI commands** – `unified-mandala nukleon`, `greekmath`, `fieldtheory` with `--entropy` and `--phases` flags
 - **+45 tests** – Unit + contract tests for all three adapters; adapter registry v0.3.0 test updated for v2.1.0/v2.0.0 versions
 
+## [1.0.0] - 2026
+
+### Added
+- Ecosystem-wide GenesisAeon v1.0.0 release: standardized release tooling
+  (`.zenodo.json`, GitHub Actions release workflow, `RELEASE_GUIDE.md`,
+  bug/feature issue templates).
+- Diamond Interface completed on `MandalaOrchestrator`: `get_crep_state`,
+  `get_utac_state`, `get_phase_events`, `to_zenodo_record` (joins the
+  pre-existing `run_cycle`).
+
+### Changed
+- Project metadata (`pyproject.toml`) version bumped to `1.0.0` as part of
+  the ecosystem-wide milestone.
+
 ## [Unreleased]
 
 - Verfeinerte Symbolzuordnung in `aeon_processor.assign_symbol`

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ AdapterRegistry + **Thermodynamics** (Landauer · Hatano-Sasa · Esposito-Van de
 
 ---
 
+## Installation
+
+```bash
+pip install unified-mandala
+```
+
+---
+
 ## Python Quick Start (v0.3.2)
 
 ```bash
@@ -531,6 +539,22 @@ Small, focused PRs (docs, adapters, agents). Before merge: `pnpm build:ui` + `pn
 ## License
 
 MIT. Data sources: respect their respective terms of use.
+
+## Citation
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.PLACEHOLDER.svg)](https://doi.org/10.5281/zenodo.PLACEHOLDER)
+
+DOI will be assigned automatically on first GitHub Release once
+Zenodo–GitHub integration is enabled for this repo. In the meantime, the
+DOI badge at the top of this README (`10.5281/zenodo.19219948`) points to
+the most recent published Zenodo record for this package.
+
+## Role in the GenesisAeon Ecosystem
+
+`unified-mandala` is **P-MANDALA** in the GenesisAeon ecosystem registry —
+the orchestration core (UI, CREP, agents) that wires the CREP evaluator,
+SigillinBridge, PolicyGate, and the 17+ adapter registry together into a
+single self-reflecting cycle (`MandalaOrchestrator.run_cycle`).
 
 ## Repo Cartography & Flows
 

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -1,0 +1,42 @@
+# Release Guide
+
+This package follows the GenesisAeon ecosystem release process.
+
+## Versioning
+
+We use [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`.
+
+- **MAJOR** — breaking changes to the public API or Diamond Interface
+  (`run_cycle`, `get_crep_state`, `get_utac_state`, `get_phase_events`,
+  `to_zenodo_record`).
+- **MINOR** — new features, backwards-compatible.
+- **PATCH** — bug fixes, documentation, dependency bumps.
+
+## Release types
+
+| Tag pattern | Channel | Where it publishes |
+|---|---|---|
+| `vX.Y.Z` | Production | PyPI, GitHub Release, Zenodo (if integration enabled) |
+| `vX.Y.Z-rc.N`, `-alpha.N`, `-beta.N` | Canary | TestPyPI, GitHub pre-release |
+
+## How to cut a release
+
+1. Ensure `CHANGELOG.md` has an entry for the new version under
+   `## [X.Y.Z]`.
+2. Ensure `pyproject.toml`'s `[project].version` matches.
+3. Ensure `.zenodo.json`'s `"version"` field matches.
+4. Commit these changes (if any) to `main`.
+5. Tag: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+6. The release workflow under `.github/workflows/` builds, tests, and
+   publishes automatically.
+7. For production releases, if Zenodo-GitHub integration is enabled for
+   this repo, a new Zenodo DOI version is minted automatically from the
+   GitHub Release using `.zenodo.json` metadata.
+
+## Dependency pins within the GenesisAeon ecosystem
+
+If this package depends on other `GenesisAeon/*` packages, pin them with
+`>=` lower bounds matching the minimum version that provides the API this
+package relies on. Do not pin exact versions (`==`) for ecosystem
+dependencies — this causes the version-conflict issues tracked in
+`genesis-os`'s `DEPENDENCY_REPORT.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "unified-mandala"
-version = "0.3.1"
+version = "1.0.0"
 description = "Holistic self-reflecting Mandala framework with CREP, Sigillin, thermodynamics, planetary coupling, and full GenesisAeon integration"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/unified_mandala/core/mandala.py
+++ b/src/unified_mandala/core/mandala.py
@@ -95,6 +95,8 @@ class MandalaOrchestrator:
         self._phi_prev: float = 0.0
         # Start 1 second in the past so first cycle has a sensible delta_t.
         self._t_prev: float = time.monotonic() - 1.0
+        self._history: list[CycleResult] = []
+        self._phase_events: list[dict[str, Any]] = []
 
     # ------------------------------------------------------------------
     # Public API
@@ -188,7 +190,7 @@ class MandalaOrchestrator:
             f"gov={'PASS' if gov_decision.passed else 'BLOCK'}"
         )
 
-        return CycleResult(
+        result = CycleResult(
             cycle_id=cid,
             entropy_input=entropy,
             crep=crep_result,
@@ -199,6 +201,18 @@ class MandalaOrchestrator:
             adapter_states=adapter_states,
             duration_s=duration,
         )
+        self._history.append(result)
+        if crep_result.emergence or not gov_decision.passed:
+            self._phase_events.append(
+                {
+                    "cycle_id": cid,
+                    "timestamp": result.timestamp,
+                    "kind": "emergence" if crep_result.emergence else "governance_block",
+                    "crep_score": crep_result.score,
+                    "governance_notes": list(gov_decision.notes),
+                }
+            )
+        return result
 
     def self_reflect(self) -> str:
         """Introspective report: CREP state, adapter health, cycle count.
@@ -218,6 +232,50 @@ class MandalaOrchestrator:
             lines.append(f"    · {name}")
         lines.append("╚══════════════════════════════════════════╝")
         return "\n".join(lines)
+
+    def get_crep_state(self) -> dict[str, Any]:
+        """Current CREP (resonance) state snapshot for the GenesisAeon Diamond Interface."""
+        last = self._history[-1] if self._history else None
+        return {
+            "cycle_id": self._cycle_counter,
+            "phi": self._phi_prev,
+            "score": last.crep.score if last else 0.0,
+            "emergence": last.crep.emergence if last else False,
+            "threshold": self._crep.threshold,
+            "channel_count": len(self._crep.channels),
+        }
+
+    def get_utac_state(self) -> dict[str, Any]:
+        """Current UTAC-analog (emergence-rate) state snapshot.
+
+        unified-mandala has no dedicated UTAC-ODE engine of its own; it
+        reports the :class:`EmergenceRate` computation it already performs
+        each cycle, which plays the equivalent role within this package.
+        """
+        last = self._history[-1] if self._history else None
+        return {
+            "cycle_id": self._cycle_counter,
+            "emergence_rate": last.emergence.rate if last else 0.0,
+            "phi_prev": self._phi_prev,
+            "adapter_count": len(self._registry),
+        }
+
+    def get_phase_events(self) -> list[dict[str, Any]]:
+        """Recorded phase-transition events (emergence onsets, governance blocks)."""
+        return list(self._phase_events)
+
+    def to_zenodo_record(self) -> dict[str, Any]:
+        """Export current orchestrator state as a Zenodo-style metadata record."""
+        last = self._history[-1] if self._history else None
+        return {
+            "title": "unified-mandala orchestrator state export",
+            "package_id": "P-MANDALA",
+            "cycles_completed": self._cycle_counter,
+            "crep_state": self.get_crep_state(),
+            "utac_state": self.get_utac_state(),
+            "phase_events": self.get_phase_events(),
+            "last_summary": last.summary if last else None,
+        }
 
     # ------------------------------------------------------------------
     # Private helpers


### PR DESCRIPTION
…mond Interface)

- Bump pyproject.toml version 0.3.1 -> 1.0.0 (this repo's confirmed-free target version per the GenesisAeon ecosystem release roadmap; T0 tier, no GenesisAeon-ecosystem dependency pins to update).
- Update .zenodo.json title/version to the 1.0.0 release while preserving the existing published DOI history (already real, not template placeholder data).
- Add CHANGELOG.md [1.0.0] section.
- Add RELEASE_GUIDE.md and the two missing issue templates (bug_report.md, feature_request.md); existing CONTRIBUTING.md, LICENSE, and PR template were left untouched since they already exist.
- README: add a plain "## Installation" (pip install unified-mandala) section, a "## Citation" section with Zenodo DOI badge placeholder, and a "## Role in the GenesisAeon Ecosystem" paragraph (P-MANDALA, orchestration core domain).
- Complete the GenesisAeon Diamond Interface on MandalaOrchestrator: add get_crep_state, get_utac_state, get_phase_events, and to_zenodo_record (joining the pre-existing run_cycle), backed by real per-cycle history/phase-event tracking rather than stubs.

Release workflows already exist in .github/workflows/ (release.yml, python-release.yml) covering PyPI + GitHub Release publication, so no new workflow file was added per the roadmap's "use existing tooling, don't overwrite" guidance.


Claude-Session: https://claude.ai/code/session_016APrXMSL5RTPGxrQP5VnHw

PR Checklist

- [ ] Update codexfeedback: `codexfeedback.md`, `codexfeedback.json`, `codexfeedback.yaml`
- [ ] Update roadmap: `docs/roadmap/v1.0-stabilization-playbook.md`, `docs/roadmap/v1.0-stabilization-playbook.yaml`
- [ ] Update MandalaMap artifacts: `MandalaMap.md`, `MandalaMap.json`, `MandalaMap.yaml`
- [ ] Update Fraktal‑Tagebuch (Fraktal‑Diary) with relevant notes
- [ ] Run tests (`pnpm test:unit`) and type checks (`npx tsc`, `npx pyright`)
- [ ] Verify dev stack (`pnpm start:all`) and health (`http://localhost:3999/health`)
- [ ] Optional: add PR label `mandala-strict` to enforce strict MandalaMap validation in CI
