### PR TITLE
fix: version drift and Windows Unicode crash across the CLI

### DIFF
--- a/src/unified_mandala/_version.py
+++ b/src/unified_mandala/_version.py
@@ -1,3 +1,9 @@
 """Package version — single source of truth."""
 
-__version__ = "0.3.2"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _version
+
+try:
+    __version__ = _version("unified-mandala")
+except PackageNotFoundError:  # pragma: no cover - not installed, e.g. running from source
+    __version__ = "0.0.0+unknown"

--- a/src/unified_mandala/cli/rituals.py
+++ b/src/unified_mandala/cli/rituals.py
@@ -30,6 +30,7 @@ fieldtheory
 
 from __future__ import annotations
 
+import sys
 from typing import Annotated
 
 import typer
@@ -38,6 +39,14 @@ from rich.panel import Panel
 from rich.table import Table
 
 from unified_mandala._version import __version__
+
+# Windows consoles default to a non-UTF-8 codepage, which breaks the Greek
+# letters and math symbols used throughout this CLI's output with
+# UnicodeEncodeError. Force UTF-8 stdout/stderr so behavior matches
+# Linux/macOS terminals.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
 from unified_mandala.core.mandala import CycleResult, MandalaOrchestrator
 from unified_mandala.governance.policy import EntropyGovernor, PolicyGate
 from unified_mandala.integrations.registry import AdapterRegistry
@@ -45,7 +54,7 @@ from unified_mandala.sigillin.bridge import SigillinBridge
 
 app = typer.Typer(
     name="unified-mandala",
-    help="Holistic self-reflecting mandala framework — GenesisAeon v0.3.2.",
+    help=f"Holistic self-reflecting mandala framework — GenesisAeon v{__version__}.",
     add_completion=False,
     rich_markup_mode="rich",
 )
@@ -69,7 +78,7 @@ def _build_orchestrator() -> MandalaOrchestrator:
 
 def _version_cb(value: bool) -> None:
     if value:
-        console.print(f"unified-mandala {__version__}")
+        console.print(f"unified-mandala {__version__}", highlight=False)
         raise typer.Exit()
 
 

--- a/tests/python/unit/cli/test_rituals.py
+++ b/tests/python/unit/cli/test_rituals.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
+from unified_mandala._version import __version__
 from unified_mandala.cli.rituals import app
 
 runner = CliRunner()
@@ -16,12 +17,12 @@ class TestVersionCommand:
     def test_version_flag(self):
         result = runner.invoke(app, ["--version"])
         assert result.exit_code == 0
-        assert "0.3.2" in result.output
+        assert __version__ in result.output
 
     def test_version_short_flag(self):
         result = runner.invoke(app, ["-V"])
         assert result.exit_code == 0
-        assert "0.3.2" in result.output
+        assert __version__ in result.output
 
 
 class TestCycleCommand:

--- a/tests/python/unit/core/test_version.py
+++ b/tests/python/unit/core/test_version.py
@@ -8,24 +8,29 @@ from unified_mandala._version import __version__
 
 class TestVersion:
     def test_version_string(self):
-        assert __version__ == "0.3.2"
+        assert isinstance(__version__, str)
+        assert __version__
 
     def test_version_importable(self):
         assert hasattr(unified_mandala, "__version__")
 
     def test_version_format_semver(self):
+        # Allow a trailing "+unknown" fallback suffix on the patch segment
+        # (used when the package isn't installed, e.g. running from source).
         parts = __version__.split(".")
         assert len(parts) == 3
-        assert all(p.isdigit() for p in parts)
+        assert parts[0].isdigit()
+        assert parts[1].isdigit()
+        assert parts[2].split("+")[0].isdigit()
 
     def test_major_version(self):
-        assert int(__version__.split(".")[0]) == 0
+        assert int(__version__.split(".")[0]) >= 0
 
     def test_minor_version(self):
-        assert int(__version__.split(".")[1]) == 3
+        assert int(__version__.split(".")[1]) >= 0
 
     def test_patch_version(self):
-        assert int(__version__.split(".")[2]) == 2
+        assert int(__version__.split(".")[2].split("+")[0]) >= 0
 
     def test_version_not_empty(self):
         assert __version__

--- a/tests/python/unit/core/test_version_v030.py
+++ b/tests/python/unit/core/test_version_v030.py
@@ -6,11 +6,9 @@ from unified_mandala._version import __version__
 
 
 class TestVersionV030:
-    def test_version_is_031(self):
-        assert __version__ == "0.3.2"
-
     def test_version_is_string(self):
         assert isinstance(__version__, str)
+        assert __version__
 
     def test_version_major_minor_patch(self):
         parts = __version__.split(".")
@@ -18,25 +16,20 @@ class TestVersionV030:
 
     def test_version_major_zero(self):
         major = int(__version__.split(".")[0])
-        assert major == 0
+        assert major >= 0
 
     def test_version_minor_three(self):
         minor = int(__version__.split(".")[1])
-        assert minor == 3
+        assert minor >= 0
 
     def test_version_patch_one(self):
-        patch = int(__version__.split(".")[2])
-        assert patch == 2
-
-    def test_version_gt_030(self):
-        parts = [int(x) for x in __version__.split(".")]
-        prev = [0, 3, 0]
-        assert parts > prev
+        patch = int(__version__.split(".")[2].split("+")[0])
+        assert patch >= 0
 
     def test_init_package_importable(self):
         import unified_mandala
 
-        assert unified_mandala.__version__ == "0.3.2"
+        assert unified_mandala.__version__ == __version__
 
     def test_new_modules_importable(self):
         from unified_mandala import planetary, sigillins, thermodynamics


### PR DESCRIPTION
1. __version__ hardcoded to "0.3.2" in src/unified_mandala/_version.py while the installed package is 1.0.0 -- leaked into the CLI's own --version/-V output and its help banner (which separately hardcoded "v0.3.2" as a literal string). Fixed __version__ to derive from importlib.metadata.version("unified-mandala"), and made the help banner reference it dynamically instead of a frozen literal. Updated three test files (test_version.py, test_version_v030.py, test_rituals.py) that hardcoded "0.3.2"/0/3/2 assertions -- some of which is exactly why the drift went uncaught for this long.

2. 8 of the CLI's 9 documented commands (cycle, thermodynamics, collapse, metaquest x2, planetary, nukleon, greekmath, fieldtheory) crashed with UnicodeEncodeError on Windows' default cp1252 console codepage due to the Greek letters and math symbols used throughout rituals.py's Rich output. Fixed by forcing UTF-8 stdout/stderr at startup, same pattern used elsewhere in the ecosystem. Also fixed the version callback's Rich highlighter splitting the version number into separately-colored fragments, which broke a plain substring check in the existing test suite.

All 1930 Python unit tests pass; manually verified all previously crashing commands now exit 0 without any PYTHONIOENCODING override.

Note: committed with --no-verify. The repo's pre-commit hook runs the full monorepo's TypeScript typecheck + vitest suite; 20 suites there are already failing (chat API, NATS client, health checks, fourier-router) for reasons entirely unrelated to this Python-only change (confirmed pre-existing, not introduced here). Skipped with explicit user approval rather than leaving this fix uncommitted.

## Summary

What does this PR do, in one or two sentences?

## Related issue(s)

Closes #...

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (Diamond Interface or other public API)
- [ ] Documentation
- [ ] Tooling / CI / release process
- [ ] Dependency update

## Checklist

- [ ] Tests added/updated and passing locally (`pytest`)
- [ ] `CHANGELOG.md` updated under `## [Unreleased]`
- [ ] Documentation updated (README, docstrings, notebooks if relevant)
- [ ] If this changes `run_cycle` / `get_crep_state` / `get_utac_state` /
      `get_phase_events` / `to_zenodo_record`: noted as a breaking change
      and version bump plan described above
- [ ] If this touches scientific claims/predictions: sources cited and
      speculative vs. validated status is clear

## Additional notes

Anything reviewers should know.
